### PR TITLE
Fixed Bridge Staff name in corporate ranks

### DIFF
--- a/config/ranks/corporate.txt
+++ b/config/ranks/corporate.txt
@@ -7,7 +7,7 @@ Chief Medical Officer=Mgr
 Master At Arms=Mgr
 Warden=Spv
 
-Bridge Officer=WS
+Bridge Staff=WS
 
 Assistant=EE
 


### PR DESCRIPTION
## About The Pull Request
Corrects the Bridge Staff name so they don't default anymore

## Changelog
:cl:
fix: fixed no rank for Bridge Staff
config: corporate rank config
/:cl: