### PR TITLE
Fix: use of overmap camera takes away mob's ability to move

### DIFF
--- a/nsv13/code/modules/overmap/camera.dm
+++ b/nsv13/code/modules/overmap/camera.dm
@@ -56,11 +56,8 @@
 	if(M.client)
 		M.client.check_view()
 	M.overmap_ship = null
-	var/mob/camera/aiEye/remote/overmap_observer/eyeobj = M.remote_control
-	if(eyeobj?.off_action)
-		qdel(eyeobj.off_action)
 	M.cancel_camera()
-	M.remote_control = null
+	QDEL_NULL(M.remote_control)
 	return TRUE
 
 /obj/structure/overmap/proc/CreateEye(mob/user)

--- a/nsv13/code/modules/overmap/camera.dm
+++ b/nsv13/code/modules/overmap/camera.dm
@@ -60,6 +60,7 @@
 	if(eyeobj?.off_action)
 		qdel(eyeobj.off_action)
 	M.cancel_camera()
+	M.remote_control = null
 	return TRUE
 
 /obj/structure/overmap/proc/CreateEye(mob/user)


### PR DESCRIPTION
## About The Pull Request
Following the ship vibe check the mob's relaymove wasn't reset after use of overmap cameras. This includes both bridge consoles and any seegson ship viewscreen. After stopping the use of the camera, the mob would be unable to move and use of movement keys would cause runtime errors.

## Why It's Good For The Game
Movement is good

## Changelog
:cl:
fix: mobs can move normally after exiting overmap camera view
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
