### PR TITLE
Fixing more Enterprise debt

### DIFF
--- a/_maps/map_files/Enterprise/Enterprise1.dmm
+++ b/_maps/map_files/Enterprise/Enterprise1.dmm
@@ -329,7 +329,6 @@
 /turf/open/floor/monotile,
 /area/crew_quarters/heads/captain)
 "aX" = (
-/obj/machinery/camera/autoname,
 /obj/structure/sign/plaques/golden/captain{
 	pixel_y = 26
 	},
@@ -588,6 +587,10 @@
 	dir = 4
 	},
 /obj/machinery/holopad,
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_y = -26
+	},
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/heads/captain)
 "bL" = (
@@ -830,6 +833,10 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_y = -26
+	},
 /turf/open/floor/monotile,
 /area/crew_quarters/heads/captain)
 "cJ" = (
@@ -967,6 +974,9 @@
 /obj/structure/table/glass,
 /turf/open/floor/circuit/red,
 /area/ai_monitored/turret_protected/ai_upload)
+"de" = (
+/turf/closed/wall/r_wall/ship,
+/area/hallway/nsv/deck1/hallway)
 "df" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -2318,6 +2328,9 @@
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/primary/aft)
 "gq" = (
@@ -3319,6 +3332,10 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_y = -26
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/primary/aft)
 "iK" = (
@@ -4176,9 +4193,9 @@
 	},
 /obj/machinery/requests_console{
 	announcementConsole = 1;
-	department = "Bridge";
+	department = "CIC";
 	departmentType = 5;
-	name = "Bridge RC";
+	name = "CIC RC";
 	pixel_y = -32
 	},
 /turf/open/floor/monotile,
@@ -4889,9 +4906,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
 /turf/open/floor/monotile/dark,
 /area/hallway/primary/aft)
 "lP" = (
@@ -5197,6 +5211,11 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"qd" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/door/airlock/turbolift/ship,
+/turf/open/floor/monotile/dark/airless,
+/area/maintenance/ship_exterior)
 "qB" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -5238,8 +5257,19 @@
 	},
 /turf/open/floor/plating,
 /area/bridge)
-"uy" = (
-/turf/closed/wall/r_wall/ship,
+"uj" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_x = -26
+	},
+/turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
 "vi" = (
 /obj/structure/cable{
@@ -5273,9 +5303,6 @@
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
 	})
-"xy" = (
-/turf/closed/wall/r_wall/ship,
-/area/maintenance/department/bridge)
 "yn" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_x = -32;
@@ -5327,11 +5354,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
-"Bw" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/door/airlock/turbolift/ship,
-/turf/open/floor/monotile/dark/airless,
-/area/maintenance/ship_exterior)
 "CA" = (
 /obj/machinery/camera/motion{
 	dir = 1
@@ -5440,6 +5462,9 @@
 	},
 /turf/open/floor/monotile,
 /area/ai_monitored/turret_protected/ai_upload)
+"PI" = (
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/department/bridge)
 "Qx" = (
 /obj/structure/table,
 /obj/item/stack/packageWrap,
@@ -5589,6 +5614,9 @@
 "Xd" = (
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/central)
+"Xv" = (
+/turf/closed/wall/r_wall/ship,
+/area/crew_quarters/heads/captain)
 "XX" = (
 /obj/effect/landmark/start/ai,
 /obj/item/radio/intercom{
@@ -5652,9 +5680,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/teleporter)
-"ZR" = (
-/turf/closed/wall/r_wall/ship,
-/area/crew_quarters/heads/captain)
 
 (1,1,1) = {"
 aa
@@ -32762,13 +32787,13 @@ at
 ak
 hz
 hT
-ZR
-ZR
-ZR
-ZR
-ZR
-ZR
-ZR
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
 bE
 bE
 bE
@@ -33019,10 +33044,10 @@ hK
 ak
 hz
 hT
-ZR
+Xv
 aR
 be
-ZR
+Xv
 bm
 bv
 yP
@@ -33276,7 +33301,7 @@ hJ
 iy
 hz
 hT
-ZR
+Xv
 aS
 bb
 bo
@@ -33533,10 +33558,10 @@ hK
 hJ
 hz
 hT
-ZR
+Xv
 aT
 aY
-ZR
+Xv
 bw
 kY
 bA
@@ -33790,10 +33815,10 @@ hK
 hJ
 hz
 hT
-ZR
-ZR
-ZR
-ZR
+Xv
+Xv
+Xv
+Xv
 bG
 aP
 aP
@@ -35332,14 +35357,14 @@ hK
 hJ
 hz
 hT
-ZR
-ZR
-ZR
-ZR
+Xv
+Xv
+Xv
+Xv
 cn
-ZR
-ZR
-xy
+Xv
+Xv
+PI
 bF
 bF
 bF
@@ -35589,16 +35614,16 @@ hK
 iy
 hz
 hT
-ZR
+Xv
 aU
 dh
 iK
 cG
 bz
 bB
-ZR
+Xv
 gx
-gz
+uj
 gz
 kX
 gA
@@ -36624,7 +36649,7 @@ bi
 bt
 aZ
 aV
-ZR
+Xv
 bY
 cl
 cl
@@ -36881,7 +36906,7 @@ aZ
 bu
 aZ
 cI
-ZR
+Xv
 es
 es
 es
@@ -37112,7 +37137,7 @@ aJ
 aJ
 aJ
 aJ
-Bw
+qd
 lC
 hK
 iC
@@ -37369,7 +37394,7 @@ aJ
 aJ
 aJ
 aJ
-Bw
+qd
 lC
 hK
 hK
@@ -37626,7 +37651,7 @@ aJ
 aJ
 aJ
 aJ
-Bw
+qd
 lC
 hK
 hK
@@ -37645,7 +37670,7 @@ hK
 iy
 hz
 hT
-ZR
+Xv
 aX
 aV
 aV
@@ -37883,7 +37908,7 @@ aJ
 aJ
 aJ
 aJ
-Bw
+qd
 lC
 hK
 iC
@@ -37902,14 +37927,14 @@ hK
 hJ
 hz
 hT
-ZR
-ZR
+Xv
+Xv
 aQ
 aQ
 aQ
 aQ
-ZR
-ZR
+Xv
+Xv
 eg
 gJ
 ck
@@ -38140,7 +38165,7 @@ aJ
 aJ
 aJ
 aJ
-Bw
+qd
 lC
 hK
 hK
@@ -38397,7 +38422,7 @@ aJ
 aJ
 aJ
 aJ
-Bw
+qd
 lC
 hK
 hK
@@ -38654,7 +38679,7 @@ aJ
 aJ
 aJ
 aJ
-Bw
+qd
 lC
 hK
 hK
@@ -38911,7 +38936,7 @@ aJ
 aJ
 aJ
 aJ
-Bw
+qd
 lC
 hK
 hK
@@ -38949,14 +38974,14 @@ ck
 ck
 kg
 cb
-uy
+de
 es
 es
 es
 es
 es
-uy
-uy
+de
+de
 hT
 hZ
 hK
@@ -39168,7 +39193,7 @@ aJ
 aJ
 aJ
 aJ
-Bw
+qd
 lC
 hK
 hK
@@ -39425,7 +39450,7 @@ aJ
 aJ
 aJ
 aJ
-Bw
+qd
 lC
 hK
 iC
@@ -39682,7 +39707,7 @@ aJ
 aJ
 aJ
 aJ
-Bw
+qd
 lC
 hK
 hK
@@ -39939,7 +39964,7 @@ aJ
 aJ
 aJ
 aJ
-Bw
+qd
 lC
 hK
 hK
@@ -40196,7 +40221,7 @@ aJ
 aJ
 aJ
 aJ
-Bw
+qd
 lC
 hK
 iC
@@ -40736,7 +40761,7 @@ hK
 hK
 hz
 hT
-uy
+de
 ev
 dp
 kF
@@ -40993,7 +41018,7 @@ hK
 hK
 hz
 hT
-uy
+de
 ew
 eH
 dq
@@ -41005,9 +41030,9 @@ kK
 lf
 kk
 lr
-uy
-uy
-uy
+de
+de
+de
 hT
 hT
 hT
@@ -41250,7 +41275,7 @@ hK
 hK
 hz
 hT
-uy
+de
 iH
 cb
 cb
@@ -41262,7 +41287,7 @@ dK
 kf
 kO
 cb
-uy
+de
 hT
 hT
 hU
@@ -41507,19 +41532,19 @@ hK
 hK
 hz
 hT
-uy
-uy
-uy
-uy
+de
+de
+de
+de
 fH
 fZ
-uy
+de
 iL
 iT
-uy
-uy
-uy
-uy
+de
+de
+de
+de
 iA
 hZ
 hK

--- a/_maps/map_files/Enterprise/Enterprise1.dmm
+++ b/_maps/map_files/Enterprise/Enterprise1.dmm
@@ -974,9 +974,6 @@
 /obj/structure/table/glass,
 /turf/open/floor/circuit/red,
 /area/ai_monitored/turret_protected/ai_upload)
-"de" = (
-/turf/closed/wall/r_wall/ship,
-/area/hallway/nsv/deck1/hallway)
 "df" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -1585,6 +1582,10 @@
 /obj/structure/chair{
 	dir = 4
 	},
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_x = -26
+	},
 /turf/open/floor/monotile,
 /area/bridge)
 "eM" = (
@@ -2032,6 +2033,10 @@
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-10"
 	},
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_x = -26
+	},
 /turf/open/floor/monotile,
 /area/crew_quarters/heads/hop{
 	name = "Executive officer's Office"
@@ -2423,6 +2428,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_x = -26
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
 "gA" = (
@@ -2573,6 +2582,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
+/obj/machinery/status_display/ai{
+	pixel_x = -32
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
 "gP" = (
@@ -2719,6 +2731,10 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
 /turf/open/floor/monotile,
 /area/bridge)
 "hc" = (
@@ -2979,6 +2995,10 @@
 "hM" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 26
+	},
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_x = -26
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/hallway)
@@ -4969,6 +4989,7 @@
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/hallway)
 "lV" = (
+/obj/machinery/status_display/ai,
 /turf/closed/wall/r_wall/ship,
 /area/storage/eva)
 "lW" = (
@@ -5047,6 +5068,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor,
 /turf/open/floor/monotile,
 /area/storage/eva)
 "mf" = (
@@ -5211,11 +5233,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/ai_upload)
-"qd" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/door/airlock/turbolift/ship,
-/turf/open/floor/monotile/dark/airless,
-/area/maintenance/ship_exterior)
 "qB" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -5257,7 +5274,7 @@
 	},
 /turf/open/floor/plating,
 /area/bridge)
-"uj" = (
+"tE" = (
 /obj/structure/railing{
 	dir = 4
 	},
@@ -5265,9 +5282,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/item/radio/intercom{
-	name = "intra ship intercom";
-	pixel_x = -26
+/obj/machinery/status_display/evac{
+	pixel_x = -32
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
@@ -5332,6 +5348,10 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/teleporter)
+"zv" = (
+/obj/machinery/status_display/evac,
+/turf/closed/wall/r_wall/ship,
+/area/hallway/nsv/deck1/hallway)
 "AF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -5354,6 +5374,9 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"BY" = (
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/department/bridge)
 "CA" = (
 /obj/machinery/camera/motion{
 	dir = 1
@@ -5404,6 +5427,9 @@
 	},
 /turf/open/floor/monotile/dark/airless,
 /area/maintenance/ship_exterior)
+"Iz" = (
+/turf/closed/wall/r_wall/ship,
+/area/crew_quarters/heads/captain)
 "IC" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	req_one_access_txt = "13"
@@ -5462,9 +5488,6 @@
 	},
 /turf/open/floor/monotile,
 /area/ai_monitored/turret_protected/ai_upload)
-"PI" = (
-/turf/closed/wall/r_wall/ship,
-/area/maintenance/department/bridge)
 "Qx" = (
 /obj/structure/table,
 /obj/item/stack/packageWrap,
@@ -5573,6 +5596,21 @@
 /obj/item/paper_bin,
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/aisat)
+"Vf" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/monotile,
+/area/storage/eva)
+"Vm" = (
+/turf/closed/wall/r_wall/ship,
+/area/hallway/nsv/deck1/hallway)
+"VA" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/door/airlock/turbolift/ship,
+/turf/open/floor/monotile/dark/airless,
+/area/maintenance/ship_exterior)
 "Wi" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile/ship,
@@ -5602,6 +5640,9 @@
 /obj/item/beacon,
 /turf/open/floor/monotile/dark,
 /area/teleporter)
+"WJ" = (
+/turf/closed/wall/r_wall/ship,
+/area/storage/eva)
 "WV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -5614,9 +5655,6 @@
 "Xd" = (
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/central)
-"Xv" = (
-/turf/closed/wall/r_wall/ship,
-/area/crew_quarters/heads/captain)
 "XX" = (
 /obj/effect/landmark/start/ai,
 /obj/item/radio/intercom{
@@ -32787,13 +32825,13 @@ at
 ak
 hz
 hT
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
 bE
 bE
 bE
@@ -33044,10 +33082,10 @@ hK
 ak
 hz
 hT
-Xv
+Iz
 aR
 be
-Xv
+Iz
 bm
 bv
 yP
@@ -33301,7 +33339,7 @@ hJ
 iy
 hz
 hT
-Xv
+Iz
 aS
 bb
 bo
@@ -33558,10 +33596,10 @@ hK
 hJ
 hz
 hT
-Xv
+Iz
 aT
 aY
-Xv
+Iz
 bw
 kY
 bA
@@ -33815,10 +33853,10 @@ hK
 hJ
 hz
 hT
-Xv
-Xv
-Xv
-Xv
+Iz
+Iz
+Iz
+Iz
 bG
 aP
 aP
@@ -35357,14 +35395,14 @@ hK
 hJ
 hz
 hT
-Xv
-Xv
-Xv
-Xv
+Iz
+Iz
+Iz
+Iz
 cn
-Xv
-Xv
-PI
+Iz
+Iz
+BY
 bF
 bF
 bF
@@ -35614,17 +35652,17 @@ hK
 iy
 hz
 hT
-Xv
+Iz
 aU
 dh
 iK
 cG
 bz
 bB
-Xv
+Iz
 gx
-uj
 gz
+tE
 kX
 gA
 iR
@@ -36649,7 +36687,7 @@ bi
 bt
 aZ
 aV
-Xv
+Iz
 bY
 cl
 cl
@@ -36906,7 +36944,7 @@ aZ
 bu
 aZ
 cI
-Xv
+Iz
 es
 es
 es
@@ -37137,7 +37175,7 @@ aJ
 aJ
 aJ
 aJ
-qd
+VA
 lC
 hK
 iC
@@ -37394,7 +37432,7 @@ aJ
 aJ
 aJ
 aJ
-qd
+VA
 lC
 hK
 hK
@@ -37651,7 +37689,7 @@ aJ
 aJ
 aJ
 aJ
-qd
+VA
 lC
 hK
 hK
@@ -37670,7 +37708,7 @@ hK
 iy
 hz
 hT
-Xv
+Iz
 aX
 aV
 aV
@@ -37908,7 +37946,7 @@ aJ
 aJ
 aJ
 aJ
-qd
+VA
 lC
 hK
 iC
@@ -37927,14 +37965,14 @@ hK
 hJ
 hz
 hT
-Xv
-Xv
+Iz
+Iz
 aQ
 aQ
 aQ
 aQ
-Xv
-Xv
+Iz
+Iz
 eg
 gJ
 ck
@@ -38165,7 +38203,7 @@ aJ
 aJ
 aJ
 aJ
-qd
+VA
 lC
 hK
 hK
@@ -38422,7 +38460,7 @@ aJ
 aJ
 aJ
 aJ
-qd
+VA
 lC
 hK
 hK
@@ -38679,7 +38717,7 @@ aJ
 aJ
 aJ
 aJ
-qd
+VA
 lC
 hK
 hK
@@ -38936,7 +38974,7 @@ aJ
 aJ
 aJ
 aJ
-qd
+VA
 lC
 hK
 hK
@@ -38974,14 +39012,14 @@ ck
 ck
 kg
 cb
-de
+zv
 es
 es
 es
 es
 es
-de
-de
+Vm
+Vm
 hT
 hZ
 hK
@@ -39193,7 +39231,7 @@ aJ
 aJ
 aJ
 aJ
-qd
+VA
 lC
 hK
 hK
@@ -39450,7 +39488,7 @@ aJ
 aJ
 aJ
 aJ
-qd
+VA
 lC
 hK
 iC
@@ -39707,7 +39745,7 @@ aJ
 aJ
 aJ
 aJ
-qd
+VA
 lC
 hK
 hK
@@ -39964,7 +40002,7 @@ aJ
 aJ
 aJ
 aJ
-qd
+VA
 lC
 hK
 hK
@@ -40221,7 +40259,7 @@ aJ
 aJ
 aJ
 aJ
-qd
+VA
 lC
 hK
 iC
@@ -40263,7 +40301,7 @@ bM
 lZ
 mi
 mj
-mT
+Vf
 lZ
 Gv
 hT
@@ -40517,12 +40555,12 @@ ck
 ma
 cb
 lV
-lV
-lV
-lV
-lV
-lV
-lV
+WJ
+WJ
+WJ
+WJ
+WJ
+WJ
 hT
 hZ
 hK
@@ -40761,7 +40799,7 @@ hK
 hK
 hz
 hT
-de
+Vm
 ev
 dp
 kF
@@ -41018,7 +41056,7 @@ hK
 hK
 hz
 hT
-de
+Vm
 ew
 eH
 dq
@@ -41030,9 +41068,9 @@ kK
 lf
 kk
 lr
-de
-de
-de
+Vm
+Vm
+Vm
 hT
 hT
 hT
@@ -41275,7 +41313,7 @@ hK
 hK
 hz
 hT
-de
+Vm
 iH
 cb
 cb
@@ -41287,7 +41325,7 @@ dK
 kf
 kO
 cb
-de
+Vm
 hT
 hT
 hU
@@ -41532,19 +41570,19 @@ hK
 hK
 hz
 hT
-de
-de
-de
-de
+Vm
+Vm
+Vm
+Vm
 fH
 fZ
-de
+Vm
 iL
 iT
-de
-de
-de
-de
+Vm
+Vm
+Vm
+Vm
 iA
 hZ
 hK

--- a/_maps/map_files/Enterprise/Enterprise1.dmm
+++ b/_maps/map_files/Enterprise/Enterprise1.dmm
@@ -5233,6 +5233,13 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"ob" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/monotile,
+/area/storage/eva)
 "qB" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -5274,19 +5281,6 @@
 	},
 /turf/open/floor/plating,
 /area/bridge)
-"tE" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
-/turf/open/floor/monotile/dark,
-/area/hallway/nsv/deck1/hallway)
 "vi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5319,6 +5313,9 @@
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
 	})
+"wG" = (
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/department/bridge)
 "yn" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_x = -32;
@@ -5338,6 +5335,9 @@
 /obj/item/hand_tele,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/heads/captain)
+"yZ" = (
+/turf/closed/wall/r_wall/ship,
+/area/hallway/nsv/deck1/hallway)
 "zk" = (
 /obj/machinery/teleport/station,
 /obj/effect/turf_decal/tile/neutral{
@@ -5348,10 +5348,11 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/teleporter)
-"zv" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/r_wall/ship,
-/area/hallway/nsv/deck1/hallway)
+"Ag" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/door/airlock/turbolift/ship,
+/turf/open/floor/monotile/dark/airless,
+/area/maintenance/ship_exterior)
 "AF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -5374,9 +5375,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
-"BY" = (
-/turf/closed/wall/r_wall/ship,
-/area/maintenance/department/bridge)
 "CA" = (
 /obj/machinery/camera/motion{
 	dir = 1
@@ -5427,9 +5425,6 @@
 	},
 /turf/open/floor/monotile/dark/airless,
 /area/maintenance/ship_exterior)
-"Iz" = (
-/turf/closed/wall/r_wall/ship,
-/area/crew_quarters/heads/captain)
 "IC" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	req_one_access_txt = "13"
@@ -5439,12 +5434,29 @@
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/hallway)
+"IR" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/status_display/evac{
+	pixel_x = -32
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck1/hallway)
 "IV" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/ai_monitored/turret_protected/aisat)
+"Jd" = (
+/obj/machinery/status_display/evac,
+/turf/closed/wall/r_wall/ship,
+/area/hallway/nsv/deck1/hallway)
 "JA" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5557,13 +5569,6 @@
 /area/crew_quarters/heads/hop{
 	name = "Executive officer's Office"
 	})
-"SD" = (
-/obj/machinery/light,
-/obj/machinery/suit_storage_unit/pilot,
-/turf/open/floor/monotile,
-/area/nsv/hanger/deck3{
-	name = "Air traffic control pod"
-	})
 "Tn" = (
 /obj/machinery/blackbox_recorder,
 /turf/open/floor/monotile/dark,
@@ -5596,21 +5601,6 @@
 /obj/item/paper_bin,
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/aisat)
-"Vf" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/monotile,
-/area/storage/eva)
-"Vm" = (
-/turf/closed/wall/r_wall/ship,
-/area/hallway/nsv/deck1/hallway)
-"VA" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/door/airlock/turbolift/ship,
-/turf/open/floor/monotile/dark/airless,
-/area/maintenance/ship_exterior)
 "Wi" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile/ship,
@@ -5640,9 +5630,6 @@
 /obj/item/beacon,
 /turf/open/floor/monotile/dark,
 /area/teleporter)
-"WJ" = (
-/turf/closed/wall/r_wall/ship,
-/area/storage/eva)
 "WV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -5705,10 +5692,16 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/aisat)
+"Ya" = (
+/turf/closed/wall/r_wall/ship,
+/area/crew_quarters/heads/captain)
 "Ye" = (
 /obj/machinery/holopad,
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/aisat)
+"Yf" = (
+/turf/closed/wall/r_wall/ship,
+/area/storage/eva)
 "Zb" = (
 /obj/machinery/computer/teleporter{
 	dir = 1
@@ -32825,13 +32818,13 @@ at
 ak
 hz
 hT
-Iz
-Iz
-Iz
-Iz
-Iz
-Iz
-Iz
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
 bE
 bE
 bE
@@ -33082,10 +33075,10 @@ hK
 ak
 hz
 hT
-Iz
+Ya
 aR
 be
-Iz
+Ya
 bm
 bv
 yP
@@ -33339,7 +33332,7 @@ hJ
 iy
 hz
 hT
-Iz
+Ya
 aS
 bb
 bo
@@ -33596,10 +33589,10 @@ hK
 hJ
 hz
 hT
-Iz
+Ya
 aT
 aY
-Iz
+Ya
 bw
 kY
 bA
@@ -33853,10 +33846,10 @@ hK
 hJ
 hz
 hT
-Iz
-Iz
-Iz
-Iz
+Ya
+Ya
+Ya
+Ya
 bG
 aP
 aP
@@ -35395,14 +35388,14 @@ hK
 hJ
 hz
 hT
-Iz
-Iz
-Iz
-Iz
+Ya
+Ya
+Ya
+Ya
 cn
-Iz
-Iz
-BY
+Ya
+Ya
+wG
 bF
 bF
 bF
@@ -35652,17 +35645,17 @@ hK
 iy
 hz
 hT
-Iz
+Ya
 aU
 dh
 iK
 cG
 bz
 bB
-Iz
+Ya
 gx
 gz
-tE
+IR
 kX
 gA
 iR
@@ -35886,7 +35879,7 @@ ic
 ic
 ie
 aC
-SD
+hl
 hl
 hl
 hl
@@ -36687,7 +36680,7 @@ bi
 bt
 aZ
 aV
-Iz
+Ya
 bY
 cl
 cl
@@ -36944,7 +36937,7 @@ aZ
 bu
 aZ
 cI
-Iz
+Ya
 es
 es
 es
@@ -37175,7 +37168,7 @@ aJ
 aJ
 aJ
 aJ
-VA
+Ag
 lC
 hK
 iC
@@ -37432,7 +37425,7 @@ aJ
 aJ
 aJ
 aJ
-VA
+Ag
 lC
 hK
 hK
@@ -37689,7 +37682,7 @@ aJ
 aJ
 aJ
 aJ
-VA
+Ag
 lC
 hK
 hK
@@ -37708,7 +37701,7 @@ hK
 iy
 hz
 hT
-Iz
+Ya
 aX
 aV
 aV
@@ -37946,7 +37939,7 @@ aJ
 aJ
 aJ
 aJ
-VA
+Ag
 lC
 hK
 iC
@@ -37965,14 +37958,14 @@ hK
 hJ
 hz
 hT
-Iz
-Iz
+Ya
+Ya
 aQ
 aQ
 aQ
 aQ
-Iz
-Iz
+Ya
+Ya
 eg
 gJ
 ck
@@ -38203,7 +38196,7 @@ aJ
 aJ
 aJ
 aJ
-VA
+Ag
 lC
 hK
 hK
@@ -38460,7 +38453,7 @@ aJ
 aJ
 aJ
 aJ
-VA
+Ag
 lC
 hK
 hK
@@ -38717,7 +38710,7 @@ aJ
 aJ
 aJ
 aJ
-VA
+Ag
 lC
 hK
 hK
@@ -38974,7 +38967,7 @@ aJ
 aJ
 aJ
 aJ
-VA
+Ag
 lC
 hK
 hK
@@ -39012,14 +39005,14 @@ ck
 ck
 kg
 cb
-zv
+Jd
 es
 es
 es
 es
 es
-Vm
-Vm
+yZ
+yZ
 hT
 hZ
 hK
@@ -39231,7 +39224,7 @@ aJ
 aJ
 aJ
 aJ
-VA
+Ag
 lC
 hK
 hK
@@ -39488,7 +39481,7 @@ aJ
 aJ
 aJ
 aJ
-VA
+Ag
 lC
 hK
 iC
@@ -39745,7 +39738,7 @@ aJ
 aJ
 aJ
 aJ
-VA
+Ag
 lC
 hK
 hK
@@ -40002,7 +39995,7 @@ aJ
 aJ
 aJ
 aJ
-VA
+Ag
 lC
 hK
 hK
@@ -40259,7 +40252,7 @@ aJ
 aJ
 aJ
 aJ
-VA
+Ag
 lC
 hK
 iC
@@ -40301,7 +40294,7 @@ bM
 lZ
 mi
 mj
-Vf
+ob
 lZ
 Gv
 hT
@@ -40555,12 +40548,12 @@ ck
 ma
 cb
 lV
-WJ
-WJ
-WJ
-WJ
-WJ
-WJ
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
 hT
 hZ
 hK
@@ -40799,7 +40792,7 @@ hK
 hK
 hz
 hT
-Vm
+yZ
 ev
 dp
 kF
@@ -41056,7 +41049,7 @@ hK
 hK
 hz
 hT
-Vm
+yZ
 ew
 eH
 dq
@@ -41068,9 +41061,9 @@ kK
 lf
 kk
 lr
-Vm
-Vm
-Vm
+yZ
+yZ
+yZ
 hT
 hT
 hT
@@ -41313,7 +41306,7 @@ hK
 hK
 hz
 hT
-Vm
+yZ
 iH
 cb
 cb
@@ -41325,7 +41318,7 @@ dK
 kf
 kO
 cb
-Vm
+yZ
 hT
 hT
 hU
@@ -41570,19 +41563,19 @@ hK
 hK
 hz
 hT
-Vm
-Vm
-Vm
-Vm
+yZ
+yZ
+yZ
+yZ
 fH
 fZ
-Vm
+yZ
 iL
 iT
-Vm
-Vm
-Vm
-Vm
+yZ
+yZ
+yZ
+yZ
 iA
 hZ
 hK

--- a/_maps/map_files/Enterprise/Enterprise2.dmm
+++ b/_maps/map_files/Enterprise/Enterprise2.dmm
@@ -840,6 +840,9 @@
 /turf/open/floor/monotile/dark,
 /area/chapel/office)
 "acE" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
 /turf/open/floor/monotile/dark,
 /area/chapel/office)
 "acF" = (
@@ -1197,7 +1200,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
+	dir = 5
 	},
 /turf/open/floor/monotile/dark,
 /area/chapel/office)
@@ -5190,9 +5193,6 @@
 /turf/open/floor/monotile/dark,
 /area/lawoffice)
 "anu" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /obj/structure/cable{
@@ -6352,6 +6352,7 @@
 /area/engine/storage)
 "aqv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/monotile,
 /area/engine/gravity_generator)
 "aqw" = (
@@ -9890,10 +9891,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
 	},
 /turf/open/floor/monotile,
 /area/engine/gravity_generator)
@@ -22239,6 +22236,15 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck2)
+"baB" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "baC" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -23519,6 +23525,9 @@
 "bcZ" = (
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
 	},
 /turf/open/floor/monotile/dark,
 /area/chapel/office)
@@ -27464,9 +27473,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
 /obj/effect/landmark/xeno_spawn,
@@ -40229,24 +40235,6 @@
 	},
 /turf/open/floor/monotile,
 /area/nsv/briefingroom)
-"bMM" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -27
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
-	},
-/turf/open/floor/monotile,
-/area/security/warden)
-"bMS" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -27
-	},
-/turf/open/floor/monotile/dark,
-/area/science/mixing{
-	name = "Prototype munitions bay"
-	})
 "bMT" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -40260,30 +40248,31 @@
 /obj/machinery/light,
 /turf/open/floor/monotile,
 /area/security/brig)
-"bPc" = (
-/turf/closed/wall/ship,
-/area/hallway/secondary/service)
 "bRy" = (
 /obj/item/beacon,
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"bVN" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
+"bRI" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/turf/open/floor/monotile/light,
-/area/medical/genetics)
-"cfS" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/status_display/ai{
+	pixel_x = -32
+	},
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck2/frame1/central)
+"bXD" = (
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/library)
 "cgt" = (
 /obj/machinery/holopad,
 /turf/open/floor/carpet/ship,
 /area/nsv/hanger/deck2)
-"cgU" = (
-/turf/closed/wall/r_wall/ship,
-/area/crew_quarters/fitness/recreation)
 "ciL" = (
 /obj/machinery/light{
 	dir = 4
@@ -40297,20 +40286,73 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"cjV" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "ckD" = (
 /obj/machinery/light,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"clk" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+"clK" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"cpq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/carpet/blue,
+/area/hallway/secondary/exit)
+"cmR" = (
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
+"cnE" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
+"cpn" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
+"cuG" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
+"czr" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -27
+	},
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
+"cAW" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/monotile/light,
+/area/medical/genetics)
+"cBE" = (
+/obj/structure/bookcase/random/religion,
+/turf/open/floor/wood,
+/area/library)
+"cDF" = (
+/obj/machinery/mineral/equipment_vendor,
+/turf/open/floor/plating,
+/area/quartermaster/miningdock)
+"cJo" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -40320,73 +40362,6 @@
 	},
 /turf/open/floor/monotile,
 /area/crew_quarters/fitness/recreation)
-"csF" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "hor_window";
-	name = "privacy shutter"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hor)
-"csH" = (
-/obj/machinery/airalarm/directional/south,
-/obj/structure/bookcase/manuals/research_and_development,
-/turf/open/floor/wood,
-/area/library)
-"ctk" = (
-/obj/machinery/bookbinder,
-/obj/machinery/camera/autoname,
-/turf/open/floor/wood,
-/area/library)
-"cuz" = (
-/obj/machinery/airalarm/directional/north,
-/obj/structure/table/wood,
-/obj/item/toy/cards/deck/cas,
-/obj/item/toy/cards/deck/cas/black{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/turf/open/floor/wood,
-/area/library)
-"cuG" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
-"cAH" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/turf/open/floor/monotile,
-/area/nsv/hanger/deck2)
-"cDF" = (
-/obj/machinery/mineral/equipment_vendor,
-/turf/open/floor/plating,
-/area/quartermaster/miningdock)
-"cHV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	name = "intra ship intercom";
-	pixel_y = -26
-	},
-/turf/open/floor/carpet/ship,
-/area/quartermaster/storage)
-"cIy" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/ship,
-/area/security/brig)
 "cJz" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 8
@@ -40395,6 +40370,14 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
+"cOn" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/structure/table/wood,
+/obj/item/paicard,
+/turf/open/floor/wood,
+/area/library)
 "cOu" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -40404,17 +40387,16 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"cRY" = (
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
-"cSw" = (
+"cXI" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/dorms)
+/obj/machinery/door/poddoor/preopen{
+	id = "xb_containment";
+	name = "Xenobiology Containment Shutter"
+	},
+/obj/machinery/shieldwallgen/xenobiologyaccess,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "cXV" = (
 /obj/machinery/light/small,
 /obj/structure/bed,
@@ -40425,12 +40407,30 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/security/prison)
+"cYy" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
 "daH" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
 /turf/open/floor/monotile/dark,
 /area/hydroponics)
+"daT" = (
+/obj/machinery/airalarm{
+	pixel_y = 26
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "dnd" = (
 /obj/machinery/gateway{
 	dir = 8
@@ -40444,24 +40444,39 @@
 	},
 /turf/closed/wall/r_wall/ship,
 /area/engine/atmospherics_engine)
-"dwf" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+"dyT" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/fitness/recreation)
+"dAz" = (
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/library)
+"dCK" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"dFe" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
 	},
 /turf/open/floor/monotile,
-/area/hallway/nsv/deck2/frame2/port)
-"dEz" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/turf/open/floor/monotile/light,
-/area/medical/medbay/lobby)
+/area/medical/surgery)
+"dHI" = (
+/obj/structure/table/wood,
+/obj/item/camera,
+/obj/item/taperecorder,
+/turf/open/floor/wood,
+/area/library)
 "dIo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -40473,24 +40488,18 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"dIw" = (
-/obj/effect/turf_decal/tile/neutral,
+"dKN" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/newscaster{
-	pixel_y = 32
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
-"dOP" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/library)
 "dSD" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	req_one_access_txt = "2"
@@ -40500,33 +40509,41 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"dVP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+"dZe" = (
+/obj/structure/chair{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"eaw" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment,
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_x = 26
 	},
-/turf/open/floor/wood,
-/area/library)
-"ebm" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
+/turf/open/floor/monotile/light,
+/area/medical/medbay/lobby)
+"dZf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
+"ebV" = (
+/obj/structure/bookcase/manuals/engineering,
+/turf/open/floor/wood,
 /area/library)
+"ecd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/chair/comfy/shuttle{
+	dir = 4;
+	name = "briefing room chair"
+	},
+/turf/open/floor/carpet/blue,
+/area/nsv/hanger/deck2)
 "ecN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -40560,22 +40577,22 @@
 /obj/item/clothing/mask/breath,
 /turf/open/floor/monotile/dark,
 /area/gateway)
-"erM" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+"etp" = (
+/obj/machinery/status_display/evac{
+	pixel_x = 32
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
+/area/nsv/briefingroom)
+"eux" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck2/frame1/central)
 "evj" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -40586,6 +40603,18 @@
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/port)
+"ewa" = (
+/obj/machinery/light,
+/turf/open/floor/monotile/dark,
+/area/hallway/secondary/exit)
+"exj" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"exK" = (
+/obj/structure/bookcase/random/fiction,
+/turf/open/floor/wood,
+/area/library)
 "eyu" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -40598,6 +40627,23 @@
 	},
 /turf/open/floor/monotile,
 /area/security/brig)
+"eyy" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_x = -26
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/fitness/recreation)
+"eCV" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "eEA" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	req_one_access_txt = "13"
@@ -40607,21 +40653,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"eGl" = (
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/monotile,
-/area/nsv/hanger/deck2)
-"eKR" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+"eJf" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -27
 	},
-/obj/structure/punching_bag,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/monotile/dark,
+/area/science/mixing{
+	name = "Prototype munitions bay"
+	})
+"eLT" = (
+/obj/structure/bookcase/manuals/medical,
+/obj/machinery/camera/autoname{
 	dir = 1
 	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
+/turf/open/floor/wood,
+/area/library)
 "ePo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -40659,6 +40705,13 @@
 	},
 /turf/closed/wall/r_wall/ship,
 /area/nsv/weapons/fore)
+"eWc" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "eXm" = (
 /obj/machinery/light/small,
 /obj/structure/bed,
@@ -40669,14 +40722,41 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/security/prison)
-"fgT" = (
-/obj/structure/lattice,
-/obj/machinery/camera/motion{
-	c_tag = "Armoury";
+"fbK" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/turf/open/floor/monotile,
+/area/nsv/briefingroom)
+"fdA" = (
+/obj/structure/displaycase/trophy,
+/obj/structure/sign/solgov_flag,
+/turf/open/floor/wood,
+/area/library)
+"feA" = (
+/turf/closed/wall/ship,
+/area/hallway/secondary/service)
+"fhy" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/turf/open/space/basic,
-/area/maintenance/ship_exterior)
+/turf/open/floor/wood,
+/area/library)
+"fhB" = (
+/obj/machinery/computer/libraryconsole/bookmanagement,
+/obj/structure/table/wood,
+/turf/open/floor/carpet,
+/area/library)
+"fjw" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/carpet,
+/area/library)
 "fjB" = (
 /obj/machinery/door/airlock/ship{
 	name = "Exothermic Chamber";
@@ -40695,62 +40775,54 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"fmp" = (
-/obj/structure/punching_bag,
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
-"fmQ" = (
-/obj/machinery/newscaster{
-	pixel_x = -28
-	},
+"fmU" = (
+/obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/wood,
 /area/library)
-"fps" = (
-/obj/structure/bookcase{
-	name = "Forbidden Knowledge"
+"fmZ" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"fuK" = (
+/obj/structure/lattice,
+/obj/machinery/camera/motion{
+	c_tag = "Armoury";
+	dir = 1
 	},
-/turf/open/floor/wood,
-/area/library)
-"fqI" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/ship,
-/area/crew_quarters/cafeteria{
-	name = "Mess hall"
-	})
-"frX" = (
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/carpet/ship,
-/area/crew_quarters/dorms)
+/turf/open/space/basic,
+/area/maintenance/ship_exterior)
 "fxX" = (
 /obj/structure/lattice,
 /turf/open/space,
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"fzb" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
-"fzg" = (
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "fEj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/closed/wall/r_wall/ship,
 /area/engine/atmospherics_engine)
-"fFh" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+"fGk" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/open/floor/monotile/dark,
+/area/science/mixing{
+	name = "Prototype munitions bay"
+	})
+"fGv" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
+"fHv" = (
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/starboard/fore)
 "fJP" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -40760,13 +40832,16 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmospherics_engine)
-"fMu" = (
-/obj/machinery/light{
-	dir = 8
+"fLO" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/port)
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/monotile,
+/area/security/brig)
 "fMP" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -40778,35 +40853,55 @@
 /obj/item/beacon,
 /turf/open/floor/monotile,
 /area/hallway/secondary/exit)
-"fOP" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
+"fOe" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
+"fOC" = (
+/obj/machinery/light_switch{
+	pixel_x = -28
 	},
-/turf/open/floor/plasteel/techmaint,
-/area/medical/chemistry)
-"fRt" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
-"fUo" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
-"fUW" = (
-/obj/machinery/door/morgue{
-	name = "Private Study";
-	req_access_txt = "37"
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/library)
+"fTx" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
+"fTy" = (
+/obj/machinery/door/airlock/ship/external/glass{
+	req_one_access_txt = "13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "fVu" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_y = -30
 	},
 /turf/open/floor/monotile,
 /area/security/warden)
+"fXa" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/segment,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/monotile,
+/area/security/brig)
 "fXQ" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
@@ -40817,31 +40912,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/service)
-"gbT" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/structure/table/wood,
-/obj/item/paicard,
-/turf/open/floor/wood,
-/area/library)
-"gfE" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"gkF" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
-/turf/open/floor/monotile/dark,
-/area/science/mixing{
-	name = "Prototype munitions bay"
-	})
-"gkG" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "glh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40854,15 +40924,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"goi" = (
-/obj/structure/disposalpipe/segment{
+"gnX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -27
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
 	},
-/turf/open/floor/plasteel/grid/steel,
-/area/quartermaster/storage)
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_y = -26
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/heads/chief)
 "gqp" = (
 /obj/machinery/newscaster,
 /turf/closed/wall/ship,
@@ -40876,23 +40950,15 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"gqR" = (
-/obj/machinery/vending/coffee,
-/obj/machinery/computer/ship/viewscreen,
-/turf/open/floor/wood,
-/area/library)
-"gsn" = (
-/obj/structure/reagent_dispensers/watertank,
+"gxQ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
-"gss" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/ship,
-/area/medical/medbay/lobby)
-"gAq" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/area/maintenance/starboard/fore)
 "gFl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -40911,12 +40977,6 @@
 /obj/item/hand_labeler,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/kitchen)
-"gGm" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/monotile,
-/area/maintenance/port)
 "gHK" = (
 /obj/machinery/requests_console{
 	department = "Engineering";
@@ -40925,6 +40985,12 @@
 	},
 /turf/closed/wall/r_wall/ship,
 /area/engine/storage_shared)
+"gJd" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/library)
 "gJU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -40933,11 +40999,13 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"gKy" = (
-/obj/structure/punching_bag,
-/obj/machinery/computer/ship/viewscreen,
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
+"gMd" = (
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "gMn" = (
 /obj/machinery/requests_console{
 	department = "Medbay";
@@ -40946,54 +41014,67 @@
 	},
 /turf/closed/wall/ship,
 /area/medical/medbay/central)
-"gOS" = (
-/obj/structure/cable{
-	icon_state = "2-8"
+"gOm" = (
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_x = -26
 	},
+/turf/open/floor/monotile,
+/area/security/prison)
+"gQz" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/carpet/ship,
-/area/crew_quarters/heads/hor)
-"gQy" = (
-/obj/machinery/photocopier{
-	pixel_y = 3
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/computer/ship/viewscreen,
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
+"gRv" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -27
+	},
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck2/frame1/central)
+"gRD" = (
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
+"gSC" = (
+/obj/machinery/status_display/ai,
+/turf/closed/wall/ship,
+/area/engine/break_room)
+"gWv" = (
+/obj/structure/destructible/cult/tome,
+/obj/item/book/codex_gigas,
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
 /turf/open/floor/wood,
 /area/library)
-"gUN" = (
-/obj/machinery/airalarm{
-	pixel_y = 26
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"gVX" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "gXS" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"gYL" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "gZS" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/monotile/dark,
 /area/security/brig)
-"hbm" = (
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/monotile,
-/area/crew_quarters/bar)
-"heA" = (
-/obj/structure/lattice,
-/obj/machinery/camera/motion{
-	c_tag = "Armoury";
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/maintenance/ship_exterior)
 "hhv" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8;
@@ -41013,35 +41094,6 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"hhw" = (
-/obj/structure/bed{
-	layer = 2.8
-	},
-/obj/structure/bed{
-	layer = 3;
-	pixel_y = 12
-	},
-/obj/item/bedsheet/black{
-	pixel_y = 12
-	},
-/obj/item/bedsheet/black{
-	layer = 2.85
-	},
-/obj/machinery/light_switch{
-	pixel_x = 28
-	},
-/turf/open/floor/carpet/ship,
-/area/crew_quarters/dorms/nsv/dorms_2)
-"hjM" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/iron/fifty{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/turf/open/floor/plating,
-/area/nsv/briefingroom)
 "hnv" = (
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 26
@@ -41058,32 +41110,21 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"hoO" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/door/window/eastright{
-	name = "Fitness Ring"
-	},
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/fitness/recreation)
+"hqB" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "hrv" = (
 /obj/machinery/newscaster/security_unit,
 /turf/closed/wall/ship,
 /area/security/brig)
-"hrA" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+"hwR" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/monotile,
-/area/security/brig)
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "hwV" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	req_one_access_txt = "13"
@@ -41093,13 +41134,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"hzD" = (
-/obj/machinery/door/airlock/ship/external/glass{
-	req_one_access_txt = "13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "hAu" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -41110,13 +41144,6 @@
 /obj/structure/closet/secure_closet/medical1,
 /turf/open/floor/monotile/dark,
 /area/gateway)
-"hBG" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/monotile,
-/area/nsv/hanger/deck2)
 "hCr" = (
 /obj/machinery/holopad,
 /turf/open/floor/monotile/dark,
@@ -41133,76 +41160,25 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"hMl" = (
-/obj/structure/bookcase/random/reference,
-/turf/open/floor/wood,
+"hES" = (
+/turf/closed/wall/r_wall/ship,
 /area/library)
-"hTx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	name = "intra ship intercom";
-	pixel_y = -26
-	},
-/turf/open/floor/monotile,
-/area/crew_quarters/heads/chief)
-"hXb" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/requests_console{
-	department = "Pilot lounge";
-	departmentType = 2;
-	pixel_y = 28
-	},
-/turf/open/floor/monotile/dark,
-/area/nsv/hanger/deck2)
-"hXE" = (
-/obj/structure/closet/lasertag/blue,
-/obj/machinery/light,
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
-"ilx" = (
-/obj/machinery/light,
-/turf/open/floor/monotile/dark,
-/area/hallway/secondary/exit)
-"ipa" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/turf/open/floor/monotile,
-/area/hallway/nsv/deck2/frame1/central)
-"iqn" = (
+"hNe" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/warehouse)
-"iqW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
+"hTa" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
+/turf/open/floor/plating,
+/area/nsv/briefingroom)
 "irj" = (
 /obj/structure/window/reinforced/fulltile/ship,
 /obj/structure/grille,
@@ -41220,14 +41196,24 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
-"iuj" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
-"iwh" = (
-/obj/structure/bookcase/random/adult,
-/turf/open/floor/wood,
-/area/library)
+"itE" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/machinery/newscaster{
+	pixel_x = 30
+	},
+/turf/open/floor/monotile,
+/area/hallway/secondary/exit)
+"iuh" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/engineering)
 "iyx" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /obj/machinery/camera/autoname,
@@ -41235,13 +41221,10 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"iFX" = (
-/obj/item/radio/intercom{
-	name = "intra ship intercom";
-	pixel_x = -26
-	},
-/turf/open/floor/monotile,
-/area/nsv/weapons/fore)
+"iLQ" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "iMe" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -41262,12 +41245,19 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/gateway)
-"iMo" = (
-/obj/machinery/status_display/evac{
-	pixel_x = 32
+"iMm" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
-/turf/open/floor/monotile,
-/area/nsv/briefingroom)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/engineering)
 "iSM" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -41282,56 +41272,45 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/monotile/dark,
 /area/gateway)
-"iTP" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
-"iUd" = (
-/obj/effect/turf_decal/tile/red{
+"iUQ" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/disposalpipe/segment,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/turf/open/floor/monotile,
-/area/security/brig)
-"iUU" = (
-/obj/item/radio/intercom{
-	name = "intra ship intercom";
-	pixel_y = -26
-	},
-/turf/open/floor/carpet/ship,
-/area/quartermaster/qm)
-"iXh" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/dorms)
-"jfr" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"jgp" = (
-/obj/structure/bookcase,
 /turf/open/floor/wood,
 /area/library)
+"iVe" = (
+/obj/machinery/camera/autoname,
+/obj/machinery/vending/games,
+/turf/open/floor/wood,
+/area/library)
+"iXP" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
+"iYO" = (
+/obj/machinery/bookbinder,
+/obj/machinery/camera/autoname,
+/turf/open/floor/wood,
+/area/library)
+"jeJ" = (
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/turf/open/floor/monotile,
+/area/maintenance/port)
 "jku" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
 /turf/closed/wall/r_wall/ship,
 /area/engine/atmospherics_engine)
+"jkZ" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "jlu" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_toxmix,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -41344,42 +41323,21 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"jnx" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/monotile,
-/area/medical/surgery)
-"joY" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
 "jtt" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"jvQ" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/department/science)
-"jwi" = (
-/turf/closed/wall/ship,
-/area/maintenance/starboard/fore)
-"jzd" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
+"juv" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/monotile,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/fitness/recreation)
+"jvv" = (
+/turf/closed/wall/r_wall/ship,
 /area/crew_quarters/fitness/recreation)
 "jAE" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -41395,13 +41353,21 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/break_room)
-"jBf" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
+"jDU" = (
+/obj/structure/displaycase/trophy,
+/obj/structure/sign/solgov_flag/right,
 /turf/open/floor/wood,
 /area/library)
-"jJz" = (
+"jDV" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/box,
+/obj/item/storage/belt/utility/full,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -27
+	},
+/turf/open/floor/plasteel/grid/steel,
+/area/nsv/hanger/deck2)
+"jGm" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -41444,28 +41410,32 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"jRw" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -27
+"jNU" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
 	},
 /turf/open/floor/monotile,
-/area/hallway/nsv/deck2/frame1/port)
-"jTG" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/machinery/firealarm{
-	pixel_y = 24
+/area/nsv/hanger/deck2)
+"jOa" = (
+/obj/machinery/newscaster{
+	pixel_x = 32
 	},
-/turf/open/floor/monotile/dark,
-/area/security/prison)
+/turf/open/floor/monotile,
+/area/nsv/briefingroom)
+"jRE" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"jSF" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
+"jTb" = (
+/turf/closed/wall/ship,
+/area/maintenance/starboard)
 "jYW" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -41490,23 +41460,35 @@
 	},
 /turf/open/floor/monotile,
 /area/gateway)
-"khS" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"kjz" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
+"kfl" = (
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	pixel_y = -28
 	},
 /turf/open/floor/monotile,
-/area/nsv/hanger/deck2)
-"kjW" = (
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/area/crew_quarters/fitness/recreation)
+"kiF" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
+"kmg" = (
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/department/engine)
 "knh" = (
 /obj/machinery/button/door{
 	dir = 8;
@@ -41517,29 +41499,14 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/security/execution/transfer)
-"koE" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
+"koM" = (
+/obj/structure/lattice,
+/obj/machinery/camera/motion{
+	c_tag = "Armoury";
+	dir = 8
 	},
-/turf/open/floor/carpet/ship,
-/area/crew_quarters/dorms)
-"krG" = (
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/turf/open/floor/monotile,
-/area/nsv/hanger/deck2)
-"ksv" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/port)
-"kuo" = (
-/obj/structure/closet/boxinggloves,
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
+/turf/open/space/basic,
+/area/maintenance/ship_exterior)
 "kyA" = (
 /obj/structure/table,
 /obj/item/disk/design_disk,
@@ -41551,18 +41518,12 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/science/research)
-"kCU" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+"kEA" = (
+/obj/machinery/newscaster{
+	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
+/turf/open/floor/carpet,
+/area/library)
 "kFm" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -41575,24 +41536,19 @@
 	},
 /turf/open/floor/monotile,
 /area/medical/chemistry)
-"kFM" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/box,
-/obj/item/storage/belt/utility/full,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -27
+"kJH" = (
+/obj/machinery/newscaster{
+	pixel_x = 32
 	},
-/turf/open/floor/plasteel/grid/steel,
+/turf/open/floor/monotile,
 /area/nsv/hanger/deck2)
-"kHi" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
+"kNf" = (
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_x = -26
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/turf/open/floor/carpet/blue,
-/area/hallway/secondary/exit)
+/turf/open/floor/monotile/light,
+/area/security/prison)
 "kOA" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light/small{
@@ -41622,31 +41578,6 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"lcZ" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
-	},
-/obj/machinery/light,
-/turf/open/floor/wood,
-/area/library)
-"ldX" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/carpet/ship,
-/area/crew_quarters/dorms)
 "lfX" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile/ship,
@@ -41658,59 +41589,26 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/engine/atmospherics_engine)
-"liO" = (
-/obj/structure/bookcase/manuals/engineering,
-/turf/open/floor/wood,
-/area/library)
-"liS" = (
-/obj/item/radio/intercom{
-	name = "intra ship intercom";
-	pixel_y = -26
-	},
-/turf/open/floor/monotile/dark,
-/area/science/nanite)
 "ljw" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"ljG" = (
+"low" = (
+/obj/structure/weightmachine/weightlifter,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"lln" = (
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/turf/open/floor/monotile,
-/area/nsv/briefingroom)
-"loN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/wood,
-/area/library)
-"lrS" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
 	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/fitness/recreation)
+"lsE" = (
+/obj/machinery/status_display/evac,
+/turf/closed/wall/ship,
+/area/medical/medbay/lobby)
 "lwJ" = (
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_interior,
 /obj/effect/mapping_helpers/airlock/locked,
@@ -41734,32 +41632,54 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"lCu" = (
+/obj/machinery/door/airlock/highsecurity/ship{
+	name = "Flight Deck Ladder Access";
+	req_one_access_txt = "3;69"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/monotile,
+/area/maintenance/port)
 "lCE" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/closed/wall/r_wall/ship,
 /area/science/xenobiology)
-"lEl" = (
-/obj/structure/closet/wardrobe/science_white,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
+"lIC" = (
+/turf/open/floor/wood,
+/area/library)
+"lKZ" = (
+/obj/structure/bed{
+	layer = 2.8
 	},
-/turf/open/floor/monotile/dark,
-/area/science/mixing{
-	name = "Prototype munitions bay"
-	})
-"lIS" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
-"lQj" = (
-/obj/effect/turf_decal/tile/red{
+/obj/structure/bed{
+	layer = 3;
+	pixel_y = 12
+	},
+/obj/item/bedsheet/black{
+	pixel_y = 12
+	},
+/obj/item/bedsheet/black{
+	layer = 2.85
+	},
+/obj/machinery/light_switch{
+	pixel_x = 28
+	},
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms/nsv/dorms_2)
+"lOY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
 	},
-/turf/open/floor/monotile,
-/area/security/brig)
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/wood,
+/area/library)
 "lRd" = (
 /obj/structure/sink{
 	dir = 8;
@@ -41768,6 +41688,12 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/science/xenobiology)
+"lTu" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "lTI" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -41785,10 +41711,13 @@
 	},
 /turf/open/floor/monotile/light,
 /area/medical/medbay/lobby)
-"mbh" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/carpet,
-/area/library)
+"lWU" = (
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/starboard)
+"lZa" = (
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "mbD" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -41820,31 +41749,12 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"mwl" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/library)
 "mwO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/starboard/fore)
-"mxW" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/turf/open/floor/monotile,
-/area/security/prison)
-"mzc" = (
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "mzP" = (
 /obj/machinery/requests_console{
 	department = "Chapel";
@@ -41852,6 +41762,10 @@
 	},
 /turf/closed/wall/ship,
 /area/chapel/office)
+"mAr" = (
+/obj/machinery/status_display/evac,
+/turf/closed/wall/ship,
+/area/security/brig)
 "mBj" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	dir = 4;
@@ -41862,31 +41776,59 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
-"mDl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
+"mCs" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"mGR" = (
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable{
-	icon_state = "0-2"
+/turf/open/floor/monotile,
+/area/security/prison)
+"mCI" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 26
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
+"mDS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/monotile,
+/area/crew_quarters/heads/chief)
+"mFV" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/newscaster{
+	pixel_x = 32
+	},
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck2/frame1/central)
 "mIw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
 /turf/closed/wall/r_wall/ship,
 /area/engine/atmospherics_engine)
-"mLr" = (
-/obj/machinery/light/small{
-	dir = 1
+"mJn" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/port)
+"mKB" = (
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/port)
 "mMv" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -41898,36 +41840,45 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard)
-"mVZ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
+"mQI" = (
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Patient Room B"
 	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
-"mYW" = (
-/obj/structure/weightmachine/weightlifter,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/monotile/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/monotile,
+/area/medical/medbay/central)
+"mTD" = (
+/obj/structure/bookcase/random/reference,
+/turf/open/floor/wood,
+/area/library)
+"ndg" = (
+/obj/structure/closet/lasertag/blue,
+/obj/machinery/light,
+/turf/open/floor/monotile,
 /area/crew_quarters/fitness/recreation)
 "ndL" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"nfu" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/ship,
-/area/engine/break_room)
+"nfi" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 4;
+	sortType = 16
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck2/frame2/port)
 "nfz" = (
 /obj/machinery/atmospherics/components/binary/pump/on,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -41939,12 +41890,27 @@
 	},
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
-"nhj" = (
-/obj/structure/chair/comfy/brown{
-	dir = 4
+"nmm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
-/turf/open/floor/wood,
-/area/library)
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"nms" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -27
+	},
+/turf/open/floor/monotile,
+/area/engine/engineering/hangar)
+"nmA" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
 "nqx" = (
 /obj/machinery/airalarm/mixingchamber{
 	dir = 4;
@@ -41962,25 +41928,16 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"nsw" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 4;
-	sortType = 16
-	},
-/turf/open/floor/monotile/dark,
-/area/hallway/nsv/deck2/frame2/port)
-"nvB" = (
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
+"nsg" = (
+/obj/structure/closet/boxinggloves,
 /turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
+"nuV" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
 /area/maintenance/port)
 "nvJ" = (
 /obj/machinery/light{
@@ -41988,33 +41945,13 @@
 	},
 /turf/open/floor/monotile/light,
 /area/security/prison)
-"nyz" = (
-/obj/machinery/status_display/evac{
-	pixel_x = -32
+"nyk" = (
+/obj/machinery/photocopier{
+	pixel_y = 3
 	},
-/turf/open/floor/monotile/dark,
-/area/nsv/briefingroom)
-"nBU" = (
-/obj/machinery/sleeper{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/open/floor/engine,
-/area/medical/medbay/lobby)
-"nGo" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "hor_window";
-	name = "privacy shutter"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hor)
+/obj/machinery/computer/ship/viewscreen,
+/turf/open/floor/wood,
+/area/library)
 "nHC" = (
 /obj/structure/table,
 /obj/item/stock_parts/micro_laser,
@@ -42025,13 +41962,10 @@
 /obj/item/stock_parts/manipulator,
 /turf/open/floor/monotile/dark,
 /area/science/research)
-"nIE" = (
-/obj/item/radio/intercom{
-	name = "intra ship intercom";
-	pixel_x = -26
-	},
-/turf/open/floor/monotile,
-/area/security/prison)
+"nJD" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "nLp" = (
 /obj/machinery/light{
 	dir = 8
@@ -42041,33 +41975,74 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/science/xenobiology)
-"nTO" = (
-/obj/machinery/status_display/ai,
-/turf/closed/wall/ship,
-/area/engine/break_room)
-"omC" = (
-/obj/effect/turf_decal/tile/red{
+"nML" = (
+/obj/structure/bookcase/random/nonfiction,
+/turf/open/floor/wood,
+/area/library)
+"nNg" = (
+/obj/structure/closet/lasertag/red,
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
+"nSo" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/monotile,
+/area/maintenance/port)
+"nUa" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
+"ocu" = (
+/obj/machinery/vending/coffee,
+/obj/machinery/computer/ship/viewscreen,
+/turf/open/floor/wood,
+/area/library)
+"oiq" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/monotile,
-/area/security/brig)
-"opr" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"ojE" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_y = 26
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/secondary/exit)
+"olz" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
+	dir = 4
 	},
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/monotile,
-/area/crew_quarters/heads/chief)
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "oqq" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
@@ -42077,12 +42052,12 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"ors" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+"oqB" = (
+/obj/machinery/status_display/evac{
+	pixel_x = -32
 	},
-/turf/open/floor/plating,
-/area/maintenance/port)
+/turf/open/floor/monotile/dark,
+/area/nsv/briefingroom)
 "oun" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	req_one_access_txt = "8;13"
@@ -42092,23 +42067,6 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"our" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"ovp" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"owZ" = (
-/obj/machinery/power/apc/auto_name/south,
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/library)
 "oyf" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -42121,14 +42079,23 @@
 	},
 /turf/open/floor/monotile,
 /area/hallway/secondary/exit)
-"oAb" = (
-/turf/closed/wall/r_wall/ship,
-/area/maintenance/starboard)
-"oBU" = (
-/obj/structure/displaycase/trophy,
-/obj/structure/sign/solgov_flag,
-/turf/open/floor/wood,
-/area/library)
+"ozk" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/ship,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/crew_quarters/fitness/recreation)
+"oCm" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "hor_window";
+	name = "privacy shutter"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hor)
 "oDq" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
@@ -42147,156 +42114,86 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"oKJ" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -27
-	},
-/turf/open/floor/monotile,
-/area/engine/engineering/hangar)
-"oMe" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
-"oMZ" = (
-/obj/structure/weightmachine/stacklifter,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/fitness/recreation)
-"oPf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/chair/comfy/shuttle{
-	dir = 4;
-	name = "briefing room chair"
-	},
-/turf/open/floor/carpet/blue,
-/area/nsv/hanger/deck2)
-"oQo" = (
-/obj/item/storage/crayons,
-/obj/structure/table/wood,
-/turf/open/floor/carpet,
-/area/library)
-"oQQ" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
+"oFa" = (
+/obj/machinery/status_display/ai,
+/turf/closed/wall/ship,
+/area/security/brig)
+"oNq" = (
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_y = -26
 	},
 /turf/open/floor/carpet/ship,
-/area/crew_quarters/dorms)
-"oRC" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood,
-/area/library)
-"oSp" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/ship,
-/obj/machinery/door/firedoor,
+/area/quartermaster/qm)
+"oPV" = (
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/crew_quarters/fitness/recreation)
-"oTN" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/machinery/newscaster{
-	pixel_x = 30
-	},
-/turf/open/floor/monotile,
-/area/hallway/secondary/exit)
-"pav" = (
+/area/maintenance/starboard)
+"oQR" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -27
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/nsv/weapons/fore)
-"pfW" = (
-/obj/machinery/light_switch{
+"oUr" = (
+/obj/machinery/newscaster{
 	pixel_x = -28
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/library)
-"phJ" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/port)
-"phY" = (
-/obj/structure/disposalpipe/segment,
+"oVe" = (
+/obj/machinery/status_display/evac,
 /turf/closed/wall/ship,
-/area/hallway/nsv/deck2/frame2/port)
-"pjh" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+/area/engine/break_room)
+"oYj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	department = "Pilot lounge";
+	departmentType = 2;
+	pixel_y = 28
 	},
 /turf/open/floor/monotile/dark,
-/area/science/nanite)
-"pne" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor/preopen{
-	id = "xb_containment";
-	name = "Xenobiology Containment Shutter"
-	},
-/obj/machinery/shieldwallgen/xenobiologyaccess,
-/obj/structure/cable,
+/area/nsv/hanger/deck2)
+"pdQ" = (
+/obj/structure/closet/firecloset,
 /turf/open/floor/plating,
-/area/science/xenobiology)
+/area/maintenance/department/medical)
+"plB" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	pixel_x = 32
+	},
+/turf/open/floor/monotile,
+/area/nsv/hanger/deck2)
 "poV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
 /turf/open/floor/monotile,
 /area/science/xenobiology)
-"pqM" = (
-/obj/structure/destructible/cult/tome,
-/obj/item/book/codex_gigas,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/turf/open/floor/wood,
-/area/library)
-"puz" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "xb_containment";
-	name = "Xenobiology Containment Shutter"
-	},
-/obj/machinery/shieldwallgen/xenobiologyaccess,
-/obj/structure/cable,
+"psQ" = (
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
-/area/science/xenobiology)
+/area/maintenance/starboard/fore)
 "pxy" = (
 /obj/machinery/newscaster,
 /turf/closed/wall/ship,
 /area/quartermaster/qm)
-"pBG" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
+"pAv" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/airalarm{
+	pixel_y = 23
 	},
 /turf/open/floor/monotile,
-/area/hallway/nsv/deck2/frame2/port)
-"pCU" = (
-/obj/structure/displaycase/trophy,
-/obj/structure/sign/solgov_flag/right,
-/turf/open/floor/wood,
-/area/library)
+/area/crew_quarters/fitness/recreation)
 "pFX" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess,
@@ -42304,33 +42201,33 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"pMv" = (
-/obj/structure/bookcase/random/religion,
-/turf/open/floor/wood,
-/area/library)
-"pMQ" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "pSV" = (
 /obj/machinery/newscaster,
 /turf/closed/wall/ship,
 /area/medical/genetics)
-"qau" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
 "qbw" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"qcO" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/status_display/ai{
+	pixel_x = -32
+	},
+/turf/open/floor/monotile/dark,
+/area/nsv/briefingroom)
+"qmG" = (
+/obj/machinery/sleeper{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/engine,
+/area/medical/medbay/lobby)
 "qmY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -42349,16 +42246,65 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmospherics_engine)
+"qpW" = (
+/obj/structure/lattice,
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/department/engine)
+"qus" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "qxl" = (
 /obj/effect/turf_decal/stripes/white/corner{
 	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/service)
-"qCx" = (
-/obj/structure/bookcase/random/nonfiction,
-/turf/open/floor/wood,
-/area/library)
+"qxO" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck2/frame2/port)
+"qBI" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 26
+	},
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_x = 26
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
+"qBT" = (
+/obj/item/reagent_containers/food/drinks/sillycup{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/drinks/sillycup,
+/obj/item/reagent_containers/food/drinks/sillycup{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/drinks/sillycup{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/drinks/sillycup{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/structure/table,
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
 "qEi" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
@@ -42372,23 +42318,26 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/monotile,
 /area/gateway)
-"qGu" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Patient Room B"
-	},
+"qGC" = (
+/obj/structure/closet/toolcloset,
+/turf/open/floor/plating,
+/area/nsv/briefingroom)
+"qGH" = (
+/obj/item/paper_bin,
+/obj/item/pen,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
-/turf/open/floor/monotile,
-/area/medical/medbay/central)
-"qHd" = (
-/obj/machinery/camera/autoname,
-/obj/machinery/vending/games,
-/turf/open/floor/wood,
+/obj/structure/table/wood,
+/turf/open/floor/carpet,
 /area/library)
+"qHX" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/fitness/recreation)
 "qLh" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -42397,15 +42346,13 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"qMQ" = (
-/obj/machinery/status_display/ai,
-/turf/closed/wall/ship,
-/area/security/brig)
-"qNG" = (
-/obj/structure/window/reinforced/fulltile/ship,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+"qNh" = (
+/obj/item/radio/intercom{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/wood,
+/area/library)
 "qOb" = (
 /obj/effect/turf_decal/box,
 /obj/machinery/requests_console{
@@ -42415,6 +42362,10 @@
 	},
 /turf/open/floor/monotile,
 /area/janitor)
+"qOo" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "qOI" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	req_one_access_txt = "13"
@@ -42442,23 +42393,49 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/gateway)
-"qSY" = (
-/turf/closed/wall/ship,
-/area/maintenance/starboard)
-"qSZ" = (
-/obj/machinery/door/airlock/highsecurity/ship{
-	name = "Flight Deck Ladder Access";
-	req_one_access_txt = "3;69"
+"qUo" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/monotile,
-/area/maintenance/port)
+/turf/open/floor/wood,
+/area/library)
 "qZd" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"rab" = (
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
+"rbG" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/structure/punching_bag,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
+"rfU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
 "riT" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -42469,54 +42446,66 @@
 	},
 /turf/open/floor/monotile,
 /area/science/xenobiology)
+"rmu" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/library)
 "rnf" = (
 /obj/machinery/igniter/incinerator_toxmix,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"roB" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
+"rtJ" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"rwx" = (
+/obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
 	},
 /obj/item/radio/intercom{
 	name = "intra ship intercom";
 	pixel_y = 26
 	},
-/turf/open/floor/monotile/dark,
-/area/hallway/secondary/exit)
-"rpO" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/fitness/recreation)
-"rqu" = (
-/obj/machinery/vending/wardrobe/curator_wardrobe,
-/turf/open/floor/wood,
-/area/library)
-"rxp" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
 /turf/open/floor/monotile,
-/area/hallway/nsv/deck2/frame1/central)
+/area/security/brig)
+"ryl" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/turf/open/floor/monotile/dark,
+/area/science/nanite)
+"rBX" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/techmaint,
+/area/medical/chemistry)
 "rCB" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"rCK" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/monotile,
+/area/security/brig)
 "rFe" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -42544,37 +42533,68 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
+"rHz" = (
+/obj/structure/window/reinforced/fulltile/ship,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"rLW" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
 "rMN" = (
 /obj/machinery/newscaster{
 	pixel_y = -30
 	},
 /turf/open/floor/monotile/dark,
 /area/science/nanite)
-"rPe" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"rRu" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
+"rPg" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/monotile,
+/area/security/brig)
+"rRz" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/obj/machinery/light,
 /turf/open/floor/wood,
 /area/library)
-"rWF" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "sax" = (
 /obj/machinery/newscaster{
 	pixel_x = 32
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit/departure_lounge)
+"sbi" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/library)
 "sfx" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -42598,26 +42618,25 @@
 	},
 /turf/open/floor/monotile,
 /area/medical/chemistry)
-"skz" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+"shz" = (
+/obj/machinery/light/small{
+	dir = 1
 	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
+"sjG" = (
+/obj/structure/punching_bag,
+/obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile,
-/area/nsv/briefingroom)
-"soc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/area/crew_quarters/fitness/recreation)
+"smL" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/carpet,
+/turf/open/floor/wood,
 /area/library)
 "srs" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -42637,11 +42656,6 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"ssa" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "ssf" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -42662,70 +42676,71 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"sBu" = (
-/obj/machinery/newscaster{
-	pixel_y = -32
+"sxI" = (
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/carpet,
-/area/library)
-"sBW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
+/turf/open/floor/plating,
+/area/maintenance/port)
+"sAb" = (
 /obj/item/radio/intercom{
 	name = "intra ship intercom";
 	pixel_y = -26
 	},
-/turf/open/floor/monotile,
-/area/engine/engineering/hangar)
-"tbQ" = (
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/fitness/recreation)
-"tcq" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 26
-	},
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/dorms)
-"tdw" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/east,
-/obj/structure/punching_bag,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
-"tdV" = (
-/obj/structure/table/wood,
-/obj/item/camera,
-/obj/item/taperecorder,
-/turf/open/floor/wood,
-/area/library)
-"tes" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -27
-	},
-/turf/open/floor/monotile,
-/area/hallway/nsv/deck2/frame1/central)
-"tgc" = (
+/area/science/nanite)
+"sCI" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/libraryconsole,
 /obj/machinery/computer/lore_terminal,
 /turf/open/floor/wood,
 /area/library)
+"sQp" = (
+/obj/structure/closet/secure_closet/brig,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/monotile/dark,
+/area/security/prison)
+"taH" = (
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall/ship,
+/area/hallway/nsv/deck2/frame2/port)
+"taR" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -27
+	},
+/turf/open/floor/carpet/ship,
+/area/quartermaster/qm)
+"tbe" = (
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_x = -26
+	},
+/turf/open/floor/monotile,
+/area/nsv/weapons/fore)
+"tds" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/nsv/observation)
+"tdO" = (
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"teO" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/monotile,
+/area/nsv/hanger/deck2)
 "tiu" = (
 /obj/machinery/requests_console{
 	department = "Genetics";
@@ -42743,6 +42758,24 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"tlx" = (
+/obj/structure/punching_bag,
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
+"tma" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_x = 26
+	},
+/turf/open/floor/monotile,
+/area/hallway/secondary/exit)
 "tnm" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -42755,54 +42788,36 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/break_room)
-"try" = (
-/obj/item/radio/intercom{
-	dir = 4;
-	pixel_x = 27
-	},
-/turf/open/floor/wood,
-/area/library)
 "txH" = (
 /obj/machinery/holopad,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo)
-"tDI" = (
-/turf/closed/wall/r_wall/ship,
-/area/library)
-"tMx" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+"tzB" = (
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	name = "intra ship intercom";
-	pixel_y = 26
-	},
-/turf/open/floor/monotile,
-/area/security/brig)
-"tNr" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/turf/open/floor/monotile/dark,
-/area/engine/engineering)
-"tUg" = (
-/obj/machinery/door/airlock/ship/external/glass{
-	req_one_access_txt = "13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/heads/hor)
+"tIn" = (
+/obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/starboard)
+"tJL" = (
+/obj/structure/bookcase,
+/turf/open/floor/wood,
+/area/library)
+"tNK" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "xb_containment";
+	name = "Xenobiology Containment Shutter"
+	},
+/obj/machinery/shieldwallgen/xenobiologyaccess,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "tUT" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -42836,36 +42851,71 @@
 	},
 /turf/open/floor/monotile,
 /area/science/xenobiology)
-"ucC" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"udB" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/storage/toolbox/emergency,
-/obj/item/clothing/gloves/color/fyellow,
-/turf/open/floor/plating,
-/area/nsv/briefingroom)
 "udH" = (
 /obj/machinery/gateway/centerstation,
 /turf/open/floor/monotile/dark,
 /area/gateway)
-"ufY" = (
+"ujl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/library)
+"ujv" = (
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/monotile,
+/area/engine/engineering/hangar)
+"uns" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_y = -26
+	},
+/turf/open/floor/carpet/ship,
+/area/quartermaster/storage)
+"uqd" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
-/turf/open/floor/plasteel/chapel{
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck2/frame2/port)
+"uqv" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/area/chapel/main)
-"ukv" = (
-/turf/closed/wall/ship,
-/area/library)
-"uoC" = (
-/obj/structure/bookcase/random/fiction,
-/turf/open/floor/wood,
-/area/library)
+/obj/machinery/door/window/eastright{
+	name = "Fitness Ring"
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/fitness/recreation)
+"usN" = (
+/obj/structure/punching_bag,
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
 "uts" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -42893,19 +42943,12 @@
 	},
 /turf/open/floor/monotile,
 /area/security/brig)
-"uAR" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+"utP" = (
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/item/radio/intercom{
-	name = "intra ship intercom";
-	pixel_x = -26
-	},
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/fitness/recreation)
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "uDe" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/closet/crate{
@@ -42913,22 +42956,31 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"uDu" = (
-/obj/structure/punching_bag,
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
-"uEa" = (
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+"uEu" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/table/wood,
-/turf/open/floor/carpet,
-/area/library)
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -27
+	},
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck2/frame1/port)
+"uER" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"uHP" = (
+/obj/machinery/status_display/evac,
+/turf/closed/wall/ship,
+/area/medical/genetics)
 "uIA" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable{
@@ -42946,18 +42998,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"uNo" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
 "uOY" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -42965,21 +43005,14 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"uSo" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+"uPi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
-/turf/open/floor/monotile,
-/area/hallway/nsv/deck2/frame1/central)
+/turf/open/floor/monotile/dark,
+/area/engine/engineering)
 "uTe" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -42988,27 +43021,19 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"uWp" = (
-/obj/machinery/computer/libraryconsole/bookmanagement,
+"uYx" = (
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/monotile,
+/area/crew_quarters/bar)
+"vbZ" = (
+/obj/machinery/vending/wardrobe/curator_wardrobe,
+/turf/open/floor/wood,
+/area/library)
+"vhq" = (
+/obj/item/storage/crayons,
 /obj/structure/table/wood,
 /turf/open/floor/carpet,
 /area/library)
-"uWC" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 26
-	},
-/obj/item/radio/intercom{
-	name = "intra ship intercom";
-	pixel_x = 26
-	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
-"vci" = (
-/turf/closed/wall/r_wall/ship,
-/area/maintenance/starboard/fore)
 "vii" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1;
@@ -43023,17 +43048,6 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"vkR" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
 "vlL" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/stripes/line{
@@ -43055,35 +43069,50 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"vqc" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"vqH" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/carpet,
-/area/library)
 "vtl" = (
 /obj/machinery/light,
 /turf/open/floor/monotile,
 /area/engine/engineering/hangar)
-"vCb" = (
-/obj/machinery/status_display/evac,
+"vtN" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
+"vxg" = (
+/obj/structure/closet/wardrobe/science_white,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/monotile/dark,
+/area/science/mixing{
+	name = "Prototype munitions bay"
+	})
+"vyX" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/chapel{
+	dir = 8
+	},
+/area/chapel/main)
+"vzf" = (
 /turf/closed/wall/ship,
-/area/medical/genetics)
-"vKM" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/area/library)
+"vFJ" = (
+/obj/machinery/door/airlock/ship/external/glass{
+	req_one_access_txt = "13"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/status_display/ai{
-	pixel_x = -32
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
 	},
-/turf/open/floor/monotile,
-/area/hallway/nsv/deck2/frame1/central)
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
+"vHs" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/storage/toolbox/emergency,
+/obj/item/clothing/gloves/color/fyellow,
+/turf/open/floor/plating,
+/area/nsv/briefingroom)
 "vPd" = (
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_exterior,
 /obj/effect/mapping_helpers/airlock/locked,
@@ -43091,32 +43120,11 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"vUj" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
-"vVm" = (
-/obj/item/beacon,
-/turf/open/floor/mineral/plastitanium/red/airless,
-/area/science/test_area)
-"vWe" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/status_display/ai{
-	pixel_x = -32
-	},
-/turf/open/floor/monotile/dark,
-/area/nsv/briefingroom)
-"vYs" = (
-/obj/machinery/camera/autoname,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/monotile/dark,
-/area/science/mixing{
-	name = "Prototype munitions bay"
-	})
-"wen" = (
+"vRM" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/carpet,
+/area/library)
+"vTw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
@@ -43128,13 +43136,39 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"wgO" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+"vVm" = (
+/obj/item/beacon,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/science/test_area)
+"vYs" = (
+/obj/machinery/camera/autoname,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/monotile/dark,
+/area/science/mixing{
+	name = "Prototype munitions bay"
+	})
+"vZE" = (
+/obj/machinery/status_display/evac,
+/turf/closed/wall/ship,
+/area/crew_quarters/cafeteria{
+	name = "Mess hall"
+	})
+"wbv" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "hor_window";
+	name = "privacy shutter"
 	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hor)
+"wfQ" = (
+/obj/machinery/airalarm/directional/south,
+/obj/structure/bookcase/manuals/research_and_development,
+/turf/open/floor/wood,
+/area/library)
 "wgS" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/toxin,
@@ -43148,6 +43182,19 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
+"wjg" = (
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/monotile,
+/area/nsv/hanger/deck2)
+"wjl" = (
+/turf/closed/wall/ship,
+/area/maintenance/starboard/fore)
+"wqj" = (
+/obj/structure/bookcase{
+	name = "Forbidden Knowledge"
+	},
+/turf/open/floor/wood,
+/area/library)
 "wqR" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/incinerator_input{
 	dir = 1
@@ -43162,25 +43209,25 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"wwK" = (
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/obj/machinery/light_switch{
-	pixel_y = -28
-	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
-"wwO" = (
-/obj/structure/lattice,
-/turf/closed/wall/r_wall/ship,
-/area/maintenance/department/engine)
 "wyO" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/science/xenobiology)
+"wCN" = (
+/obj/structure/weightmachine/stacklifter,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/fitness/recreation)
 "wEq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
@@ -43193,10 +43240,6 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"wHw" = (
-/obj/structure/closet/toolcloset,
-/turf/open/floor/plating,
-/area/nsv/briefingroom)
 "wId" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
@@ -43210,34 +43253,16 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"wKb" = (
-/obj/structure/bookcase/manuals/medical,
-/obj/machinery/camera/autoname{
-	dir = 1
+"wJW" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -27
 	},
-/turf/open/floor/wood,
-/area/library)
-"wLn" = (
-/obj/item/reagent_containers/food/drinks/sillycup{
-	pixel_x = -5;
-	pixel_y = 3
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
 	},
-/obj/item/reagent_containers/food/drinks/sillycup,
-/obj/item/reagent_containers/food/drinks/sillycup{
-	pixel_x = 5;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/food/drinks/sillycup{
-	pixel_x = 5;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/food/drinks/sillycup{
-	pixel_x = 5;
-	pixel_y = 3
-	},
-/obj/structure/table,
 /turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
+/area/security/warden)
 "wUv" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -43247,30 +43272,19 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/gateway)
-"wXr" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/item/radio/intercom{
-	name = "intra ship intercom";
-	pixel_x = 26
-	},
-/turf/open/floor/monotile,
-/area/hallway/secondary/exit)
 "wZp" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/nsv/observation)
-"xcN" = (
-/obj/effect/landmark/nuclear_waste_spawner,
-/turf/open/floor/wood,
-/area/library)
+"xcW" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
 "xdR" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -43292,13 +43306,18 @@
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"xfy" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+"xhv" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/nsv/observation)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
 "xhI" = (
 /turf/closed/wall/r_wall/ship,
 /area/science/nanite)
@@ -43308,12 +43327,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/science/research)
-"xqj" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "xqR" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -43333,6 +43346,20 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/briefingroom)
+"xsP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_y = -26
+	},
+/turf/open/floor/monotile,
+/area/engine/engineering/hangar)
+"xuL" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "xDQ" = (
 /obj/machinery/door/poddoor/incinerator_toxmix,
 /turf/open/floor/plating/airless,
@@ -43343,24 +43370,48 @@
 /obj/machinery/holopad,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms)
-"xHw" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"xJH" = (
-/obj/structure/closet/lasertag/red,
+"xHg" = (
+/obj/structure/bookcase/random/adult,
+/turf/open/floor/wood,
+/area/library)
+"xIh" = (
+/obj/structure/disposalpipe/segment,
 /obj/machinery/newscaster{
-	pixel_y = -30
-	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
-"xMq" = (
-/obj/item/radio/intercom{
-	name = "intra ship intercom";
-	pixel_x = -26
+	pixel_x = 32
 	},
 /turf/open/floor/monotile/light,
-/area/security/prison)
+/area/medical/medbay/lobby)
+"xMf" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"xMq" = (
+/obj/machinery/airalarm/directional/north,
+/obj/structure/table/wood,
+/obj/item/toy/cards/deck/cas,
+/obj/item/toy/cards/deck/cas/black{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/open/floor/wood,
+/area/library)
+"xOE" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck2/frame1/central)
 "xOP" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -43369,15 +43420,6 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"xPq" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
 "xPD" = (
 /obj/machinery/light/small,
 /obj/structure/bed,
@@ -43388,20 +43430,13 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/security/prison)
-"xSM" = (
+"xQv" = (
+/obj/machinery/door/morgue{
+	name = "Private Study";
+	req_access_txt = "37"
+	},
 /turf/open/floor/wood,
 /area/library)
-"xUy" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/item/radio/intercom{
-	name = "intra ship intercom";
-	pixel_x = 26
-	},
-/turf/open/floor/monotile/light,
-/area/medical/medbay/lobby)
 "xWe" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -43410,6 +43445,17 @@
 /obj/machinery/recharger,
 /turf/open/floor/monotile/dark,
 /area/gateway)
+"xXo" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/east,
+/obj/structure/punching_bag,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
 "xXX" = (
 /obj/effect/landmark/nuclear_waste_spawner,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -43425,16 +43471,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/science)
-"ydV" = (
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/monotile,
-/area/engine/engineering/hangar)
-"ykt" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 
 (1,1,1) = {"
 aaa
@@ -56672,7 +56708,7 @@ anb
 aaJ
 aFA
 alx
-nIE
+gOm
 aEo
 adM
 aFo
@@ -57185,7 +57221,7 @@ anb
 anb
 aaJ
 aFA
-jTG
+sQp
 aEl
 asW
 aEr
@@ -57695,7 +57731,7 @@ aaJ
 anb
 aFA
 beD
-xMq
+kNf
 bIN
 bIP
 bIT
@@ -57732,7 +57768,7 @@ aGZ
 aGZ
 aGZ
 aGZ
-bMS
+eJf
 aZe
 uTe
 vPd
@@ -57989,7 +58025,7 @@ aIA
 aGZ
 aGZ
 aGZ
-gkF
+fGk
 aZe
 cOu
 jlu
@@ -58214,7 +58250,7 @@ bIO
 bIS
 aFA
 aoQ
-mxW
+mCs
 asW
 adM
 aFo
@@ -59254,7 +59290,7 @@ aFQ
 aIm
 aFQ
 aFQ
-bMM
+wJW
 aDL
 aFA
 aFA
@@ -59274,7 +59310,7 @@ wIm
 bif
 bwT
 aKb
-lEl
+vxg
 aZe
 aZe
 fjB
@@ -60768,7 +60804,7 @@ anb
 anb
 anb
 anb
-heA
+koM
 anb
 anb
 anb
@@ -61040,7 +61076,7 @@ aBf
 aER
 aEY
 aHu
-tMx
+rwx
 aEX
 aHX
 aaV
@@ -61069,11 +61105,11 @@ bzA
 aKr
 aLb
 abB
-nGo
-nGo
-nGo
-nGo
-nGo
+wbv
+wbv
+wbv
+wbv
+wbv
 aXi
 alK
 lRd
@@ -61823,7 +61859,7 @@ bkJ
 bly
 bGu
 bkJ
-iUd
+fXa
 bkJ
 byO
 bmK
@@ -62101,7 +62137,7 @@ bjU
 bqK
 aLc
 aLc
-gOS
+tzB
 aaC
 bxf
 aKS
@@ -62306,7 +62342,7 @@ aaJ
 aaJ
 aaJ
 aaJ
-fgT
+fuK
 aac
 adT
 aDB
@@ -62586,7 +62622,7 @@ bEj
 bEo
 aaV
 aaV
-cIy
+mAr
 byJ
 aaV
 aaV
@@ -62597,7 +62633,7 @@ hrv
 aaV
 bFc
 agi
-omC
+rPg
 aHu
 aaw
 bwK
@@ -62612,10 +62648,10 @@ aKY
 bpG
 abB
 bdx
-csF
-csF
-csF
-csF
+oCm
+oCm
+oCm
+oCm
 aXi
 bgr
 aKS
@@ -62851,7 +62887,7 @@ aFO
 aXC
 aXC
 aXJ
-qMQ
+oFa
 bCD
 bzP
 bmL
@@ -62881,7 +62917,7 @@ brM
 bCP
 bCK
 aMi
-pne
+cXI
 aMQ
 aXi
 aXi
@@ -64423,7 +64459,7 @@ aMc
 bzW
 bdR
 aMF
-puz
+tNK
 aXi
 aXi
 aXi
@@ -64633,7 +64669,7 @@ anb
 aaJ
 aZa
 akL
-oMe
+pdQ
 aZa
 bgu
 bei
@@ -64648,7 +64684,7 @@ aFO
 bCX
 bgw
 aFO
-lQj
+rCK
 aXL
 aHu
 bmk
@@ -64671,7 +64707,7 @@ bqs
 bzx
 bwR
 aXm
-liS
+sAb
 xhI
 aJD
 aJB
@@ -64890,7 +64926,7 @@ anb
 anb
 aZa
 akL
-lIS
+iLQ
 aZa
 ayX
 bCZ
@@ -65147,7 +65183,7 @@ anb
 aaJ
 aZa
 baD
-iuj
+cjV
 aZa
 aEL
 bEc
@@ -65185,7 +65221,7 @@ bqu
 bwO
 aKv
 aMl
-pjh
+ryl
 xhI
 aXi
 aXi
@@ -65419,7 +65455,7 @@ aXy
 aXy
 aFP
 aIe
-hrA
+fLO
 aHu
 bku
 bwA
@@ -66445,10 +66481,10 @@ agX
 agX
 agX
 agX
-lIS
+iLQ
 bhN
 agX
-oMe
+pdQ
 afw
 bmo
 bmC
@@ -66475,7 +66511,7 @@ bbv
 lTI
 acs
 bbv
-jvQ
+qus
 bIF
 aMc
 bHP
@@ -67235,7 +67271,7 @@ agI
 aeb
 bHZ
 bpz
-fOP
+rBX
 bjr
 aOS
 aOS
@@ -67449,7 +67485,7 @@ afw
 ahm
 ahK
 ahm
-qGu
+mQI
 ahm
 ahm
 bfw
@@ -67460,7 +67496,7 @@ aic
 aUx
 afw
 aXN
-vUj
+cpn
 agP
 agW
 aki
@@ -67983,7 +68019,7 @@ afV
 bbe
 bwe
 amh
-nBU
+qmG
 akQ
 acF
 akh
@@ -69301,10 +69337,10 @@ brA
 bre
 bre
 bre
-gfE
+exj
 bst
-gAq
-gAq
+oPV
+oPV
 blG
 blI
 agZ
@@ -69549,19 +69585,19 @@ aaB
 aaB
 aaB
 aaB
-qSY
-qSY
-qSY
-qSY
+jTb
+jTb
+jTb
+jTb
 brl
 bre
 bre
-fFh
+jkZ
 bDQ
 bsl
 brZ
 bzZ
-qSY
+jTb
 adh
 blJ
 agZ
@@ -69806,18 +69842,18 @@ aWe
 agT
 aOT
 aWc
-qSY
+jTb
 bqx
-ssa
+dCK
 ssf
-jfr
-ucC
-fFh
-fFh
+oiq
+hqB
+jkZ
+jkZ
 brY
-dVP
-ssa
-qSY
+gYL
+dCK
+jTb
 afL
 adh
 aha
@@ -70039,7 +70075,7 @@ ahc
 ahc
 pSV
 akP
-vCb
+uHP
 ahc
 ahc
 alr
@@ -70063,18 +70099,18 @@ bxs
 bpg
 afE
 aWd
-qSY
-fFh
+jTb
+jkZ
 aZh
-clk
+eWc
 brn
-clk
+eWc
 brJ
-clk
+eWc
 brZ
-qSY
-qSY
-qSY
+jTb
+jTb
+jTb
 adh
 adh
 bda
@@ -70297,14 +70333,14 @@ ahC
 ajT
 alh
 ajY
-bVN
+cAW
 aCf
 ahf
 bhK
 bFU
 amb
 ahf
-gss
+lsE
 bCy
 bCz
 bmQ
@@ -70320,16 +70356,16 @@ afD
 bph
 afD
 bpL
-qSY
-fFh
-jfr
+jTb
+jkZ
+oiq
 bnn
-gVX
-ucC
-jfr
-fFh
-ssa
-qSY
+xMf
+hqB
+oiq
+jkZ
+dCK
+jTb
 adE
 aea
 afN
@@ -70577,16 +70613,16 @@ agR
 bpi
 agR
 bil
-qSY
-fFh
-jfr
-qSY
-qSY
-qSY
+jTb
+jkZ
+oiq
+jTb
+jTb
+jTb
 brK
-qSY
-qSY
-qSY
+jTb
+jTb
+jTb
 adK
 adh
 afO
@@ -70834,10 +70870,10 @@ agS
 bpj
 agS
 bpM
-qSY
-gUN
-jfr
-qSY
+jTb
+daT
+oiq
+jTb
 act
 acD
 bkL
@@ -70848,7 +70884,7 @@ adZ
 aef
 afY
 aef
-ufY
+vyX
 ahG
 bye
 ahG
@@ -71091,10 +71127,10 @@ bju
 bpk
 bpB
 bpN
-qSY
-mGR
+jTb
+tdO
 bsS
-qSY
+jTb
 acu
 acE
 bkQ
@@ -71336,22 +71372,22 @@ bCt
 bCu
 bCv
 bmS
-qSY
-qSY
-qSY
-qSY
-qSY
-qSY
-qSY
-qSY
-qSY
+jTb
+jTb
+jTb
+jTb
+jTb
+jTb
+jTb
+jTb
+jTb
 bpl
-qSY
-qSY
-qSY
-fFh
-jfr
-qSY
+jTb
+jTb
+jTb
+jkZ
+oiq
+jTb
 acv
 bcZ
 adw
@@ -71592,23 +71628,23 @@ bvl
 bwp
 bwq
 bCw
-jRw
-qSY
-xHw
-xHw
-qSY
-vqc
-fFh
-fFh
-fFh
-fFh
+uEu
+jTb
+rtJ
+rtJ
+jTb
+jRE
+jkZ
+jkZ
+jkZ
+jkZ
 bpm
-fFh
-fFh
-fFh
-fFh
-jfr
-qSY
+jkZ
+jkZ
+jkZ
+jkZ
+oiq
+jTb
 abF
 abF
 ahY
@@ -71850,22 +71886,22 @@ aTT
 acx
 bmE
 bmQ
-qSY
+jTb
 kSX
-clk
+eWc
 bnY
-clk
-clk
-clk
-clk
-clk
+eWc
+eWc
+eWc
+eWc
+eWc
 bsJ
-clk
-clk
-clk
-clk
+eWc
+eWc
+eWc
+eWc
 brZ
-qSY
+jTb
 acP
 bJk
 beR
@@ -72070,11 +72106,11 @@ aYT
 aYT
 bne
 brm
-phJ
+xuL
 bne
 amK
 amM
-jnx
+dFe
 aoO
 aUH
 aaK
@@ -72098,8 +72134,8 @@ azf
 azf
 azf
 bkT
-dEz
-xUy
+xIh
+dZe
 lVV
 bFy
 blQ
@@ -72107,22 +72143,22 @@ afV
 afS
 bmE
 bmQ
-qSY
+jTb
 mMv
 bnH
-qSY
+jTb
 boq
 boq
-oAb
+lWU
 boq
 boq
 boq
 boq
 boq
-oAb
+lWU
 boq
 boq
-oAb
+lWU
 acA
 acG
 bkM
@@ -72315,7 +72351,7 @@ aaJ
 aaJ
 aaJ
 bHp
-phJ
+xuL
 brB
 bnm
 aYR
@@ -72324,7 +72360,7 @@ bne
 bne
 bne
 bne
-qSZ
+lCu
 bne
 aAt
 bne
@@ -72364,9 +72400,9 @@ aae
 aPg
 buO
 bmT
-qSY
+jTb
 xfd
-rWF
+tIn
 bnZ
 aaa
 aaa
@@ -72576,11 +72612,11 @@ bne
 bne
 bne
 bne
-kjW
+rab
 bne
-xqj
-mzc
-gGm
+mKB
+sxI
+nSo
 ajN
 anu
 aqU
@@ -72589,13 +72625,13 @@ bsy
 bsy
 bsy
 bsy
-fMu
+nuV
 bsy
 bsy
 bsy
 bsy
 bsy
-fMu
+nuV
 bsy
 bsy
 bsy
@@ -72621,9 +72657,9 @@ aae
 aeT
 buJ
 bmU
-qSY
+jTb
 ecN
-vqc
+jRE
 bnZ
 aaa
 aaa
@@ -72830,32 +72866,32 @@ bne
 bnm
 bne
 bIm
-xqj
-ors
+mKB
+jSF
 aZV
 bhp
-ors
+jSF
 bDI
 bne
-nvB
+jeJ
 akc
 bne
-bDH
-ors
-ors
-ors
-ors
-ors
-ors
-ors
-ors
-ors
-ors
-ors
-ors
-ors
-ors
-ors
+baB
+jSF
+jSF
+jSF
+jSF
+jSF
+jSF
+jSF
+jSF
+jSF
+jSF
+jSF
+jSF
+jSF
+jSF
+jSF
 aYV
 jtt
 bHp
@@ -72878,8 +72914,8 @@ bFG
 bFH
 bFI
 bmU
-qSY
-jfr
+jTb
+oiq
 kOA
 bnZ
 aaa
@@ -73135,9 +73171,9 @@ aae
 bIw
 buJ
 bmU
-qSY
+jTb
 bct
-qSY
+jTb
 bnZ
 aaa
 aaa
@@ -73354,7 +73390,7 @@ bHp
 aTD
 akR
 abx
-kjz
+teO
 bgP
 bgF
 abx
@@ -73378,11 +73414,11 @@ bcy
 aMv
 aaj
 bfi
-nyz
+oqB
 bFX
 bji
 biZ
-vWe
+qcO
 blf
 aaj
 aSC
@@ -73598,7 +73634,7 @@ aiH
 aAl
 aAp
 bne
-phJ
+xuL
 bne
 bhm
 aZO
@@ -74142,7 +74178,7 @@ abx
 abA
 aev
 bao
-eGl
+wjg
 aam
 aeT
 bcy
@@ -74195,7 +74231,7 @@ aNX
 acc
 aOe
 acc
-ilx
+ewa
 aOe
 aaJ
 aaJ
@@ -74371,7 +74407,7 @@ aaJ
 aaJ
 bHp
 bHp
-xqj
+mKB
 bDI
 bHp
 aaq
@@ -74421,9 +74457,9 @@ aPx
 bIu
 bmU
 aad
-roB
+ojE
 abT
-kHi
+clK
 afq
 aOg
 aaa
@@ -74933,7 +74969,7 @@ abn
 xsC
 aeT
 buJ
-tes
+gRv
 aad
 bGI
 abT
@@ -75141,7 +75177,7 @@ jtt
 jtt
 jtt
 bne
-phJ
+xuL
 aZO
 bHp
 bip
@@ -75447,7 +75483,7 @@ abn
 aaj
 buR
 buM
-uSo
+xOE
 aad
 bpn
 bjA
@@ -76251,7 +76287,7 @@ aNX
 acc
 aOe
 acc
-ilx
+ewa
 aOe
 aaJ
 aaJ
@@ -76699,7 +76735,7 @@ abx
 abx
 abx
 agh
-kFM
+jDV
 agr
 agv
 agv
@@ -77251,7 +77287,7 @@ bHo
 bnr
 bnL
 bqz
-oTN
+itE
 acd
 bxH
 bDo
@@ -77271,7 +77307,7 @@ bsf
 bsn
 bro
 bro
-wXr
+tma
 bro
 bsn
 bsM
@@ -78240,7 +78276,7 @@ bDS
 abx
 bBy
 abx
-hBG
+jNU
 abx
 aKi
 bau
@@ -78250,7 +78286,7 @@ baw
 abx
 abx
 abx
-krG
+kJH
 abx
 abx
 abx
@@ -78513,7 +78549,7 @@ agm
 agm
 agm
 agm
-dIw
+eux
 bcy
 aMv
 aaj
@@ -78761,7 +78797,7 @@ agw
 aTk
 bBp
 bgV
-iFX
+tbe
 agm
 bai
 bak
@@ -79000,7 +79036,7 @@ bHp
 bnm
 aZO
 bHp
-hXb
+oYj
 aat
 aat
 aba
@@ -79025,7 +79061,7 @@ bal
 aTp
 aTp
 aTp
-pav
+oQR
 agm
 bgf
 bcy
@@ -79034,12 +79070,12 @@ aaT
 abn
 byA
 bvj
-skz
+fbK
 biX
 bJo
 bLb
-lln
-iMo
+jOa
+etp
 byA
 abn
 aaT
@@ -79264,7 +79300,7 @@ abh
 aeD
 atO
 bBk
-oPf
+ecd
 atY
 bBB
 age
@@ -79546,9 +79582,9 @@ bcy
 aMv
 aaj
 acI
-hjM
+hTa
 abJ
-udB
+vHs
 aaj
 buQ
 ada
@@ -80088,7 +80124,7 @@ aes
 bcr
 bqf
 bqB
-cHV
+uns
 bIC
 bID
 bID
@@ -80345,7 +80381,7 @@ aes
 bcr
 bqe
 bqc
-goi
+czr
 bIC
 aaJ
 bID
@@ -80550,7 +80586,7 @@ aam
 bfj
 adO
 bgT
-cAH
+plB
 bBF
 agg
 agm
@@ -80573,7 +80609,7 @@ ahz
 bcy
 aMv
 abf
-wHw
+qGC
 abs
 aaf
 acm
@@ -81052,7 +81088,7 @@ bHp
 bHp
 anP
 bnm
-ksv
+mJn
 jtt
 aZO
 bne
@@ -81089,7 +81125,7 @@ aPh
 buU
 bbG
 bcE
-vKM
+bRI
 bjy
 bjy
 bbG
@@ -81304,19 +81340,19 @@ aaJ
 aaJ
 aaJ
 bHp
-xqj
-ors
-ors
-ors
-ors
-ors
-ors
+mKB
+jSF
+jSF
+jSF
+jSF
+jSF
+jSF
 aZQ
 aZR
-ors
-ors
-ors
-ors
+jSF
+jSF
+jSF
+jSF
 aZR
 aZS
 aLk
@@ -81559,11 +81595,11 @@ aaJ
 aaJ
 aaJ
 aaJ
-cgU
-cgU
-kjW
-cgU
-cgU
+jvv
+jvv
+rab
+jvv
+jvv
 anN
 anN
 anN
@@ -81586,7 +81622,7 @@ ach
 avi
 btP
 ars
-rxp
+mFV
 acn
 amj
 aPj
@@ -81605,14 +81641,14 @@ acn
 bfz
 acn
 acn
-rxp
+mFV
 acn
 acn
 acn
 acn
 acn
 acn
-ipa
+dKN
 acn
 acn
 aPn
@@ -81816,12 +81852,12 @@ aaJ
 aaJ
 aaJ
 aaJ
-cgU
-fzb
-qau
+jvv
+pAv
+nmA
 auA
 auG
-uAR
+eyy
 aRH
 anN
 bqZ
@@ -81860,7 +81896,7 @@ bde
 bbI
 aVl
 bde
-fqI
+vZE
 abZ
 aaY
 aaY
@@ -82073,9 +82109,9 @@ aaJ
 aaJ
 aaJ
 aaJ
-oSp
-wLn
-xPq
+ozk
+qBT
+gQz
 auB
 auH
 aAA
@@ -82107,7 +82143,7 @@ aMJ
 aMH
 abd
 abR
-hbm
+uYx
 ajS
 baI
 abZ
@@ -82143,7 +82179,7 @@ ajO
 aka
 bGD
 aka
-aka
+taR
 aEf
 aaJ
 aaJ
@@ -82330,9 +82366,9 @@ aaJ
 aaJ
 bJe
 aaJ
-oSp
-fUo
-xPq
+ozk
+cnE
+gQz
 auz
 auH
 auJ
@@ -82400,7 +82436,7 @@ ajP
 akd
 aOj
 aOr
-iUU
+oNq
 aEf
 aaJ
 aaJ
@@ -82587,10 +82623,10 @@ aaJ
 aaJ
 aaJ
 aaJ
-oSp
+ozk
 aup
-xPq
-mVZ
+gQz
+fTx
 auI
 aRE
 aRJ
@@ -82844,12 +82880,12 @@ aaJ
 aaJ
 aaJ
 aaJ
-cgU
+jvv
 auk
-xPq
-vkR
-uNo
-hoO
+gQz
+fGv
+cYy
+uqv
 aRG
 anN
 aQw
@@ -82909,12 +82945,12 @@ adr
 adr
 adr
 adp
-jwi
-jwi
-jwi
-jwi
-jwi
-jwi
+wjl
+wjl
+wjl
+wjl
+wjl
+wjl
 aij
 aij
 aij
@@ -83101,9 +83137,9 @@ aaJ
 aaJ
 aaJ
 aaJ
-cgU
-gKy
-xPq
+jvv
+sjG
+gQz
 aqI
 aqI
 aqI
@@ -83160,18 +83196,18 @@ aMw
 aVV
 aaY
 adp
-iqn
+hNe
 adp
 bHR
 adp
 adp
 adp
-jwi
+wjl
 api
-khS
-ovp
-khS
-khS
+fmZ
+utP
+fmZ
+fmZ
 aih
 aim
 aim
@@ -83358,13 +83394,13 @@ aaJ
 aaJ
 aaJ
 aaJ
-cgU
-fmp
-erM
-wgO
-joY
-fRt
-kuo
+jvv
+usN
+kiF
+rLW
+xcW
+iXP
+nsg
 anN
 auZ
 aeY
@@ -83415,17 +83451,17 @@ aaY
 aaY
 aaY
 aaY
-jwi
-jwi
-jwi
-jwi
-jwi
-jwi
-jwi
-jwi
-jwi
-khS
-khS
+wjl
+wjl
+wjl
+wjl
+wjl
+wjl
+wjl
+wjl
+wjl
+fmZ
+fmZ
 bqD
 bcn
 bsG
@@ -83615,13 +83651,13 @@ aaJ
 aaJ
 aaJ
 aaJ
-oSp
-iTP
-rpO
+ozk
+cmR
+dyT
 auJ
 auJ
-jzd
-hXE
+cJo
+ndg
 anN
 auh
 agd
@@ -83629,7 +83665,7 @@ ava
 ams
 bhJ
 btT
-hhw
+lKZ
 amq
 any
 aSb
@@ -83672,20 +83708,20 @@ aaY
 bcc
 bmJ
 buw
-jwi
-rPe
-gkG
-jwi
+wjl
+psQ
+qOo
+wjl
 aiN
 bjH
 api
 apo
-jwi
-khS
-pMQ
+wjl
+fmZ
+nJD
 brC
-pMQ
-ljG
+nJD
+gxQ
 aih
 aih
 aih
@@ -83872,13 +83908,13 @@ aaJ
 aaJ
 aaJ
 aaJ
-oSp
-iTP
-mYW
+ozk
+cmR
+low
 auJ
 auK
-cpq
-xJH
+dZf
+nNg
 anN
 ams
 agA
@@ -83931,25 +83967,25 @@ bsh
 bux
 bAT
 bnw
-khS
-jwi
+fmZ
+wjl
 aiO
 aiZ
 apl
-khS
-jwi
-khS
-khS
+fmZ
+wjl
+fmZ
+fmZ
 brT
 uOY
-ljG
-jwi
+gxQ
+wjl
 awc
 aAb
 aYx
 aYA
 aYA
-vci
+fHv
 ndL
 aij
 aAy
@@ -84129,19 +84165,19 @@ aaJ
 aaJ
 aaJ
 aaJ
-oSp
-iTP
-rpO
+ozk
+cmR
+dyT
 auJ
 auJ
-cpq
-wwK
+dZf
+kfl
 anN
 bfr
 atz
 bhD
-oQQ
-frX
+hwR
+gRD
 atz
 aoe
 ami
@@ -84186,12 +84222,12 @@ aaY
 aaY
 aaY
 aaY
-jwi
+wjl
 bnx
-khS
-jwi
-khS
-khS
+fmZ
+wjl
+fmZ
+fmZ
 asa
 avp
 awT
@@ -84204,9 +84240,9 @@ bzF
 bJp
 bJq
 bJw
-khS
+fmZ
 aYA
-vci
+fHv
 tjC
 aij
 aAy
@@ -84386,20 +84422,20 @@ aaJ
 aaJ
 aaJ
 aaJ
-oSp
-iTP
-oMZ
+ozk
+cmR
+wCN
 auJ
 auL
-iqW
+rfU
 aqI
 amr
 aqy
 atz
-koE
+nUa
 xEa
 aqy
-ldX
+olz
 ahe
 aip
 aiJ
@@ -84443,27 +84479,27 @@ are
 byW
 atn
 aMz
-jwi
-ljG
-khS
-jwi
-khS
-khS
-khS
-khS
-jwi
-khS
+wjl
+gxQ
+fmZ
+wjl
+fmZ
+fmZ
+fmZ
+fmZ
+wjl
+fmZ
 aiK
 brT
-pMQ
-ljG
-jwi
+nJD
+gxQ
+wjl
 axG
-khS
+fmZ
 aBh
 aBh
 aYA
-vci
+fHv
 aAy
 aAy
 aAy
@@ -84643,11 +84679,11 @@ aaJ
 aaJ
 aaJ
 aaJ
-oSp
-iTP
-lrS
-tbQ
-tbQ
+ozk
+cmR
+juv
+qHX
+qHX
 bFP
 auV
 aqB
@@ -84668,12 +84704,12 @@ aZo
 aZw
 bhF
 btF
-iXh
-cSw
+fOe
+vtN
 bhA
-phY
+taH
 bGj
-nsw
+nfi
 bkj
 acR
 afc
@@ -84700,27 +84736,27 @@ bkd
 buE
 atp
 aMS
-jwi
-ljG
-khS
-jwi
+wjl
+gxQ
+fmZ
+wjl
 aiP
 aiP
-gkG
-rPe
-jwi
-khS
-khS
+qOo
+psQ
+wjl
+fmZ
+fmZ
 brT
-khS
-ljG
-jwi
+fmZ
+gxQ
+wjl
 azy
 aBh
 bHM
 aBh
 aYD
-vci
+fHv
 aaJ
 aaJ
 aaJ
@@ -84900,13 +84936,13 @@ aaJ
 aaJ
 aaJ
 aaJ
-cgU
-uWC
-jJz
-kCU
-tdw
-eKR
-uDu
+jvv
+qBI
+jGm
+xhv
+xXo
+rbG
+tlx
 anN
 bIx
 aqy
@@ -84957,27 +84993,27 @@ bbV
 arl
 atu
 aVA
-jwi
-ljG
-khS
-jwi
-jwi
-jwi
-jwi
-jwi
-jwi
-khS
-khS
+wjl
+gxQ
+fmZ
+wjl
+wjl
+wjl
+wjl
+wjl
+wjl
+fmZ
+fmZ
 brT
-khS
-ljG
-jwi
+fmZ
+gxQ
+wjl
 azM
 aBh
 aBh
 aBh
 aYE
-vci
+fHv
 aaJ
 aaJ
 aaJ
@@ -85157,21 +85193,21 @@ aaJ
 aaJ
 aaJ
 aaJ
-cgU
+jvv
 anN
-cRY
+gMd
 anN
-ukv
-ukv
-ukv
-ukv
-ukv
-ukv
+vzf
+vzf
+vzf
+vzf
+vzf
+vzf
 bAI
 aZm
 aum
-ukv
-ukv
+vzf
+vzf
 ami
 aqE
 aro
@@ -85214,7 +85250,7 @@ bmb
 bmx
 atF
 aVB
-jwi
+wjl
 bnz
 bkZ
 bob
@@ -85228,13 +85264,13 @@ boW
 lAV
 bob
 bqE
-jwi
+wjl
 azN
-khS
-khS
-khS
+fmZ
+fmZ
+fmZ
 aYF
-vci
+fHv
 aaJ
 aaJ
 aaJ
@@ -85418,19 +85454,19 @@ asL
 aHP
 aYN
 aYM
-ukv
-oBU
-xSM
-fmQ
-xSM
+vzf
+fdA
+lIC
+oUr
+lIC
 afx
 bAJ
 aZr
 bhE
-pfW
-rRu
+fOC
+fhy
 ami
-tcq
+mCI
 art
 bfS
 aRM
@@ -85471,8 +85507,8 @@ bbX
 bmy
 aMy
 aVC
-jwi
-our
+wjl
+uER
 ail
 ail
 bGi
@@ -85491,7 +85527,7 @@ aCh
 aBh
 aYB
 aYG
-vci
+fHv
 aaJ
 aaJ
 aaJ
@@ -85675,17 +85711,17 @@ asL
 aoZ
 aoZ
 aJp
-ukv
-pCU
-xSM
-uoC
-xSM
-iwh
-xSM
-ebm
+vzf
+jDU
+lIC
+exK
+lIC
+xHg
+lIC
+sbi
 auD
-xSM
-liO
+lIC
+ebV
 ami
 bgk
 ayT
@@ -85705,7 +85741,7 @@ aMJ
 aMH
 acR
 bGb
-xfy
+tds
 acS
 acS
 abZ
@@ -85723,12 +85759,12 @@ buc
 buj
 buC
 arb
-jwi
-jwi
+wjl
+wjl
 bmz
-jwi
-jwi
-jwi
+wjl
+wjl
+wjl
 bnA
 bkZ
 bob
@@ -85742,13 +85778,13 @@ bkZ
 ciL
 ljw
 bqG
-jwi
+wjl
 azX
 aCi
 aYy
 aYC
 aYH
-vci
+fHv
 aaJ
 aaJ
 aaJ
@@ -85932,17 +85968,17 @@ asL
 asL
 aoZ
 aJp
-ukv
-tgc
-xSM
-qCx
-xSM
-pMv
-xcN
+vzf
+sCI
+lIC
+nML
+lIC
+cBE
+fmU
 aMI
 auD
-xSM
-wKb
+lIC
+eLT
 ami
 aqF
 bbR
@@ -85980,8 +86016,8 @@ aqM
 bzC
 aqT
 arc
-jwi
-khS
+wjl
+fmZ
 blp
 bzD
 bkZ
@@ -85997,15 +86033,15 @@ apV
 apV
 bzE
 apV
-vci
+fHv
 glh
-jwi
-jwi
+wjl
+wjl
 aPw
 bzG
-vci
-vci
-vci
+fHv
+fHv
+fHv
 aaJ
 aaJ
 aaJ
@@ -86189,17 +86225,17 @@ aaJ
 asL
 aoZ
 aJp
-ukv
-gQy
-xSM
-jgp
-xSM
-hMl
-xSM
-soc
+vzf
+nyk
+lIC
+tJL
+lIC
+mTD
+lIC
+ujl
 auD
-xSM
-csH
+lIC
+wfQ
 ami
 aqH
 arv
@@ -86229,18 +86265,18 @@ aVt
 bue
 aVt
 bfT
-bPc
+feA
 bjq
-bPc
-bPc
-bPc
-bPc
-jwi
-jwi
-jwi
-khS
-vci
-vci
+feA
+feA
+feA
+feA
+wjl
+wjl
+wjl
+fmZ
+fHv
+fHv
 apV
 apV
 apV
@@ -86254,13 +86290,13 @@ aCo
 aWb
 aWb
 aWb
-vci
+fHv
 glh
-jwi
-khS
+wjl
+fmZ
 aVK
-khS
-vci
+fmZ
+fHv
 aaJ
 aaJ
 aaJ
@@ -86444,19 +86480,19 @@ aaJ
 aaJ
 aaJ
 asL
-mLr
+shz
 aJp
-ukv
-ctk
-xSM
-mwl
-xSM
-wen
+vzf
+iYO
+lIC
+gJd
+lIC
+vTw
 bAK
 aYW
-oRC
-eaw
-owZ
+smL
+qUo
+bXD
 ami
 ami
 ami
@@ -86486,17 +86522,17 @@ bbP
 buy
 aVu
 bgg
-bPc
+feA
 bjz
 amY
 aVE
 aVH
 aVJ
-jwi
+wjl
 uDe
-jwi
-khS
-vci
+wjl
+fmZ
+fHv
 bFj
 azC
 azP
@@ -86511,13 +86547,13 @@ apV
 apV
 apV
 aWa
-vci
+fHv
 glh
-jwi
+wjl
 aAa
 aVW
 aYz
-vci
+fHv
 aaJ
 aaJ
 aaJ
@@ -86703,14 +86739,14 @@ aaJ
 asL
 aoZ
 aJp
-ukv
-ukv
-ukv
-ukv
-ukv
+vzf
+vzf
+vzf
+vzf
+vzf
 aJN
-ukv
-ukv
+vzf
+vzf
 auE
 auM
 aRF
@@ -86743,17 +86779,17 @@ bdp
 bzB
 bdp
 bgo
-bPc
+feA
 bjG
 bkF
 bkY
 bkY
 fXQ
 blz
-mDl
-jwi
-khS
-vci
+nmm
+wjl
+fmZ
+fHv
 aWb
 azO
 azR
@@ -86768,13 +86804,13 @@ aDU
 aVY
 aVZ
 aWb
-vci
+fHv
 bqH
-jwi
-jwi
-jwi
-jwi
-vci
+wjl
+wjl
+wjl
+wjl
+fHv
 aaJ
 aaJ
 aaJ
@@ -86962,15 +86998,15 @@ aoZ
 aYN
 aYK
 aYM
-ukv
+vzf
 aJL
 aLs
-loN
-xSM
-ukv
+lOY
+lIC
+vzf
 auF
 auD
-sBu
+kEA
 ami
 ami
 ami
@@ -87000,7 +87036,7 @@ aVv
 bkg
 aVv
 aVz
-bPc
+feA
 amP
 qxl
 aMA
@@ -87009,8 +87045,8 @@ aMA
 air
 blL
 ais
-khS
-vci
+fmZ
+fHv
 aWb
 azO
 azS
@@ -87025,13 +87061,13 @@ apV
 apV
 apV
 aWa
-vci
+fHv
 glh
 bHw
-khS
+fmZ
 bHx
 bHx
-qNG
+rHz
 aaJ
 aaJ
 aaJ
@@ -87216,16 +87252,16 @@ aaJ
 aaJ
 asL
 asL
-wwO
+qpW
 asL
 aJp
-ukv
-cuz
+vzf
+xMq
 aul
-uEa
+qGH
 auo
-ukv
-uWp
+vzf
+fhB
 auD
 auD
 ami
@@ -87257,17 +87293,17 @@ aeL
 aeL
 aeL
 aeL
-bPc
+feA
 arz
 aVD
 aVG
 aVI
 bln
-jwi
+wjl
 blL
-jwi
-jwi
-vci
+wjl
+wjl
+fHv
 aWb
 azO
 azT
@@ -87282,13 +87318,13 @@ aCo
 aWb
 aWb
 aWb
-vci
+fHv
 glh
-jwi
-khS
-khS
-khS
-qNG
+wjl
+fmZ
+fmZ
+fmZ
+rHz
 aaJ
 aaJ
 aaJ
@@ -87476,15 +87512,15 @@ aaJ
 aAy
 asL
 aJp
-ukv
-gbT
-vqH
+vzf
+cOn
+fjw
 bhH
-lcZ
-ukv
-ukv
-fUW
-ukv
+rRz
+vzf
+vzf
+xQv
+vzf
 aqC
 aqC
 aqC
@@ -87508,44 +87544,44 @@ btd
 btf
 byt
 byt
-dwf
+uqd
 bAy
 aXr
 bkh
-pBG
+qxO
 aPp
-jwi
-jwi
+wjl
+wjl
 bzG
-jwi
-jwi
+wjl
+wjl
 blo
-jwi
+wjl
 blL
 ait
 aix
-vci
-vci
-vci
-vci
-vci
+fHv
+fHv
+fHv
+fHv
+fHv
 aiE
-vci
-vci
+fHv
+fHv
 mwO
-vci
-vci
-vci
-vci
-vci
-vci
-vci
+fHv
+fHv
+fHv
+fHv
+fHv
+fHv
+fHv
 glh
-vci
-vci
-qNG
-qNG
-qNG
+fHv
+fHv
+rHz
+rHz
+rHz
 aaJ
 aaJ
 aaJ
@@ -87733,15 +87769,15 @@ aaJ
 aAy
 asL
 aJp
-ukv
-qHd
-mbh
-oQo
-jBf
-ukv
-pqM
-nhj
-rqu
+vzf
+iVe
+vRM
+vhq
+rmu
+vzf
+gWv
+dAz
+vbZ
 anp
 aSn
 aqi
@@ -87775,17 +87811,17 @@ aii
 bjI
 bkG
 bkZ
-mDl
+nmm
 blp
-mDl
+nmm
 blL
 aiu
 aiy
-khS
-khS
-khS
-khS
-khS
+fmZ
+fmZ
+fmZ
+fmZ
+fmZ
 aiI
 aiL
 aiL
@@ -87798,7 +87834,7 @@ ljw
 pFX
 ljw
 vpr
-vci
+fHv
 aaJ
 aaJ
 aaJ
@@ -87990,15 +88026,15 @@ aaJ
 aAy
 asL
 aJp
-ukv
-gqR
-try
-xSM
-xSM
-ukv
-fps
-dOP
-tdV
+vzf
+ocu
+qNh
+lIC
+lIC
+vzf
+wqj
+iUQ
+dHI
 anp
 aoa
 azq
@@ -88028,8 +88064,8 @@ aBJ
 aBJ
 aBJ
 aBJ
-jwi
-pMQ
+wjl
+nJD
 aiW
 ail
 blk
@@ -88051,11 +88087,11 @@ bkZ
 bkZ
 boN
 bpp
-khS
-vci
-pMQ
-khS
-vci
+fmZ
+fHv
+nJD
+fmZ
+fHv
 aaJ
 aaJ
 aaJ
@@ -88247,12 +88283,12 @@ aaJ
 aAy
 asL
 aJp
-ukv
-ukv
-ukv
-fzg
-ukv
-tDI
+vzf
+vzf
+vzf
+lZa
+vzf
+hES
 anp
 anp
 anp
@@ -88272,11 +88308,11 @@ aBg
 aey
 arW
 arW
-nfu
+oVe
 afk
 aPz
 aNd
-nTO
+gSC
 arW
 arW
 aPt
@@ -88285,34 +88321,34 @@ bGo
 bGo
 byq
 aPt
-vci
-vci
-vci
-vci
-vci
+fHv
+fHv
+fHv
+fHv
+fHv
 blr
-vci
-vci
+fHv
+fHv
 aiw
 aiA
-vci
-vci
-vci
-vci
+fHv
+fHv
+fHv
+fHv
 aiD
-vci
-vci
-vci
+fHv
+fHv
+fHv
 amt
-vci
-vci
-vci
+fHv
+fHv
+fHv
 avo
-vci
-vci
-vci
-vci
-vci
+fHv
+fHv
+fHv
+fHv
+fHv
 aaJ
 aaJ
 aaJ
@@ -89017,9 +89053,9 @@ aaJ
 aaJ
 anb
 anb
-hzD
-ykt
-tUg
+fTy
+lTu
+vFJ
 aoZ
 aJp
 aoZ
@@ -89028,7 +89064,7 @@ apP
 agC
 ayS
 aSl
-hTx
+gnX
 anp
 awj
 ayO
@@ -89542,7 +89578,7 @@ apU
 aqe
 ayU
 aqe
-opr
+mDS
 anp
 anQ
 aQE
@@ -90565,7 +90601,7 @@ aHJ
 asL
 aJp
 aoZ
-cfS
+eCV
 asL
 anW
 anZ
@@ -90822,7 +90858,7 @@ asL
 asL
 bhn
 aoZ
-gsn
+kmg
 asL
 aqb
 aAU
@@ -91346,7 +91382,7 @@ aHw
 aHw
 aQL
 aBw
-aQV
+iMm
 amC
 aBs
 aLv
@@ -91850,7 +91886,7 @@ aJK
 asL
 amA
 aob
-apd
+uPi
 ape
 aQF
 bAq
@@ -92368,7 +92404,7 @@ anO
 anQ
 anZ
 bkp
-tNr
+iuh
 aBb
 bhv
 aHy
@@ -93652,7 +93688,7 @@ anm
 aoX
 aQl
 aQs
-sBW
+xsP
 anj
 aaJ
 aRc
@@ -94166,7 +94202,7 @@ anm
 anM
 apX
 aQq
-ydV
+ujv
 anj
 aaJ
 aRc
@@ -94680,7 +94716,7 @@ anm
 aoX
 aQl
 aQs
-oKJ
+nms
 anj
 aaJ
 aey

--- a/_maps/map_files/Enterprise/Enterprise2.dmm
+++ b/_maps/map_files/Enterprise/Enterprise2.dmm
@@ -4070,7 +4070,7 @@
 "akB" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Cryogenics";
-	req_one_access_txt = "5"
+	req_one_access_txt = "9"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -40235,6 +40235,22 @@
 	},
 /turf/open/floor/monotile,
 /area/nsv/briefingroom)
+"bMH" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/library)
+"bMO" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/structure/table/wood,
+/obj/item/paicard,
+/turf/open/floor/wood,
+/area/library)
 "bMT" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -40248,27 +40264,19 @@
 /obj/machinery/light,
 /turf/open/floor/monotile,
 /area/security/brig)
+"bNa" = (
+/turf/closed/wall/r_wall/ship,
+/area/library)
 "bRy" = (
 /obj/item/beacon,
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"bRI" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+"cer" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/status_display/ai{
-	pixel_x = -32
-	},
-/turf/open/floor/monotile,
-/area/hallway/nsv/deck2/frame1/central)
-"bXD" = (
-/obj/machinery/power/apc/auto_name/south,
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/library)
+/turf/open/floor/plating,
+/area/maintenance/port)
 "cgt" = (
 /obj/machinery/holopad,
 /turf/open/floor/carpet/ship,
@@ -40286,108 +40294,76 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"cjV" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "ckD" = (
 /obj/machinery/light,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"clK" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/turf/open/floor/carpet/blue,
-/area/hallway/secondary/exit)
-"cmR" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
-"cnE" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
-"cpn" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/obj/effect/spawner/lootdrop/maintenance,
+"cms" = (
+/obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"cuG" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
-"czr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -27
-	},
-/turf/open/floor/plasteel/grid/steel,
-/area/quartermaster/storage)
-"cAW" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/turf/open/floor/monotile/light,
-/area/medical/genetics)
-"cBE" = (
-/obj/structure/bookcase/random/religion,
-/turf/open/floor/wood,
-/area/library)
-"cDF" = (
-/obj/machinery/mineral/equipment_vendor,
-/turf/open/floor/plating,
-/area/quartermaster/miningdock)
-"cJo" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
-	},
+"cmZ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
-"cJz" = (
-/obj/structure/shuttle/engine/heater{
-	dir = 8
-	},
-/turf/closed/wall/r_wall/ship,
-/area/science/mixing{
-	name = "Prototype munitions bay"
-	})
-"cOn" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/structure/table/wood,
-/obj/item/paicard,
-/turf/open/floor/wood,
-/area/library)
-"cOu" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/engine,
-/area/science/mixing{
-	name = "Prototype munitions bay"
-	})
-"cXI" = (
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck2/frame1/central)
+"cri" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/library)
+"csB" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
+"cuG" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
+"czo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"cDF" = (
+/obj/machinery/mineral/equipment_vendor,
+/turf/open/floor/plating,
+/area/quartermaster/miningdock)
+"cFg" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"cFj" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/poddoor/preopen{
 	id = "xb_containment";
@@ -40397,6 +40373,50 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"cIa" = (
+/obj/structure/bookcase/random/religion,
+/turf/open/floor/wood,
+/area/library)
+"cJz" = (
+/obj/structure/shuttle/engine/heater{
+	dir = 8
+	},
+/turf/closed/wall/r_wall/ship,
+/area/science/mixing{
+	name = "Prototype munitions bay"
+	})
+"cOu" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/engine,
+/area/science/mixing{
+	name = "Prototype munitions bay"
+	})
+"cPU" = (
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_y = -26
+	},
+/turf/open/floor/monotile/dark,
+/area/science/nanite)
+"cTt" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
+"cWr" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/carpet,
+/area/library)
 "cXV" = (
 /obj/machinery/light/small,
 /obj/structure/bed,
@@ -40407,30 +40427,24 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/security/prison)
-"cYy" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
+"cZf" = (
+/obj/structure/chair/comfy/brown{
+	dir = 4
 	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
+/turf/open/floor/wood,
+/area/library)
 "daH" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
 /turf/open/floor/monotile/dark,
 /area/hydroponics)
-"daT" = (
-/obj/machinery/airalarm{
-	pixel_y = 26
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+"dmA" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "dnd" = (
 /obj/machinery/gateway{
 	dir = 8
@@ -40444,39 +40458,19 @@
 	},
 /turf/closed/wall/r_wall/ship,
 /area/engine/atmospherics_engine)
-"dyT" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+"dyj" = (
+/obj/structure/bookcase/manuals/medical,
+/obj/machinery/camera/autoname{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/turf/open/floor/wood,
+/area/library)
+"dHB" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 26
 	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/fitness/recreation)
-"dAz" = (
-/obj/structure/chair/comfy/brown{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/library)
-"dCK" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"dFe" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/monotile,
-/area/medical/surgery)
-"dHI" = (
-/obj/structure/table/wood,
-/obj/item/camera,
-/obj/item/taperecorder,
-/turf/open/floor/wood,
-/area/library)
+/area/crew_quarters/dorms)
 "dIo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -40488,18 +40482,16 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"dKN" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
+"dLe" = (
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/monotile,
-/area/hallway/nsv/deck2/frame1/central)
+/area/security/brig)
 "dSD" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	req_one_access_txt = "2"
@@ -40509,41 +40501,37 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"dZe" = (
-/obj/structure/chair{
-	dir = 8
+"dUS" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
 	},
-/obj/structure/disposalpipe/segment,
-/obj/item/radio/intercom{
-	name = "intra ship intercom";
-	pixel_x = 26
+/turf/open/floor/monotile/dark,
+/area/science/mixing{
+	name = "Prototype munitions bay"
+	})
+"dXv" = (
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Patient Room B"
 	},
-/turf/open/floor/monotile/light,
-/area/medical/medbay/lobby)
-"dZf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/monotile,
+/area/medical/medbay/central)
+"dXL" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"eam" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
-"ebV" = (
-/obj/structure/bookcase/manuals/engineering,
-/turf/open/floor/wood,
-/area/library)
-"ecd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/chair/comfy/shuttle{
-	dir = 4;
-	name = "briefing room chair"
-	},
-/turf/open/floor/carpet/blue,
-/area/nsv/hanger/deck2)
+/area/nsv/briefingroom)
 "ecN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -40571,28 +40559,45 @@
 /area/crew_quarters/cafeteria{
 	name = "Mess hall"
 	})
+"emm" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
+"enx" = (
+/obj/item/reagent_containers/food/drinks/sillycup{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/drinks/sillycup,
+/obj/item/reagent_containers/food/drinks/sillycup{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/drinks/sillycup{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/drinks/sillycup{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/structure/table,
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
 "eqA" = (
 /obj/structure/table,
 /obj/item/clothing/suit/hazardvest,
 /obj/item/clothing/mask/breath,
 /turf/open/floor/monotile/dark,
 /area/gateway)
-"etp" = (
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
-/turf/open/floor/monotile,
-/area/nsv/briefingroom)
-"eux" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/turf/open/floor/monotile,
-/area/hallway/nsv/deck2/frame1/central)
 "evj" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -40603,15 +40608,7 @@
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/port)
-"ewa" = (
-/obj/machinery/light,
-/turf/open/floor/monotile/dark,
-/area/hallway/secondary/exit)
-"exj" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"exK" = (
+"exT" = (
 /obj/structure/bookcase/random/fiction,
 /turf/open/floor/wood,
 /area/library)
@@ -40627,23 +40624,28 @@
 	},
 /turf/open/floor/monotile,
 /area/security/brig)
-"eyy" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	name = "intra ship intercom";
-	pixel_x = -26
+"eyz" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
 	},
 /turf/open/floor/monotile/dark,
+/area/engine/engineering)
+"eDI" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/monotile,
 /area/crew_quarters/fitness/recreation)
-"eCV" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "eEA" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	req_one_access_txt = "13"
@@ -40653,19 +40655,27 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"eJf" = (
+"eFj" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"eHZ" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/carpet/blue,
+/area/hallway/secondary/exit)
+"eJW" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -27
 	},
-/turf/open/floor/monotile/dark,
-/area/science/mixing{
-	name = "Prototype munitions bay"
-	})
-"eLT" = (
-/obj/structure/bookcase/manuals/medical,
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
+/turf/open/floor/carpet/ship,
+/area/quartermaster/qm)
+"eLv" = (
+/obj/structure/bookcase,
 /turf/open/floor/wood,
 /area/library)
 "ePo" = (
@@ -40682,6 +40692,23 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit/departure_lounge)
+"eRG" = (
+/obj/machinery/bookbinder,
+/obj/machinery/camera/autoname,
+/turf/open/floor/wood,
+/area/library)
+"eSk" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck2/frame1/central)
 "eTv" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -40705,13 +40732,6 @@
 	},
 /turf/closed/wall/r_wall/ship,
 /area/nsv/weapons/fore)
-"eWc" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "eXm" = (
 /obj/machinery/light/small,
 /obj/structure/bed,
@@ -40722,41 +40742,10 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/security/prison)
-"fbK" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
+"fex" = (
+/obj/structure/punching_bag,
 /turf/open/floor/monotile,
-/area/nsv/briefingroom)
-"fdA" = (
-/obj/structure/displaycase/trophy,
-/obj/structure/sign/solgov_flag,
-/turf/open/floor/wood,
-/area/library)
-"feA" = (
-/turf/closed/wall/ship,
-/area/hallway/secondary/service)
-"fhy" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/library)
-"fhB" = (
-/obj/machinery/computer/libraryconsole/bookmanagement,
-/obj/structure/table/wood,
-/turf/open/floor/carpet,
-/area/library)
-"fjw" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/carpet,
-/area/library)
+/area/crew_quarters/fitness/recreation)
 "fjB" = (
 /obj/machinery/door/airlock/ship{
 	name = "Exothermic Chamber";
@@ -40775,21 +40764,32 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"fmU" = (
-/obj/effect/landmark/nuclear_waste_spawner,
-/turf/open/floor/wood,
-/area/library)
-"fmZ" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"fuK" = (
-/obj/structure/lattice,
-/obj/machinery/camera/motion{
-	c_tag = "Armoury";
-	dir = 1
+"fjX" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/space/basic,
-/area/maintenance/ship_exterior)
+/obj/machinery/requests_console{
+	department = "Pilot lounge";
+	departmentType = 2;
+	pixel_y = 28
+	},
+/turf/open/floor/monotile/dark,
+/area/nsv/hanger/deck2)
+"foc" = (
+/obj/structure/closet/lasertag/red,
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
+"ful" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
+"fvp" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
 "fxX" = (
 /obj/structure/lattice,
 /turf/open/space,
@@ -40800,29 +40800,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/closed/wall/r_wall/ship,
 /area/engine/atmospherics_engine)
-"fGk" = (
+"fFd" = (
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
-/turf/open/floor/monotile/dark,
-/area/science/mixing{
-	name = "Prototype munitions bay"
-	})
-"fGv" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
+	dir = 8;
+	pixel_x = 24
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
-"fHv" = (
-/turf/closed/wall/r_wall/ship,
-/area/maintenance/starboard/fore)
+/area/nsv/hanger/deck2)
+"fGo" = (
+/obj/structure/displaycase/trophy,
+/obj/structure/sign/solgov_flag/right,
+/turf/open/floor/wood,
+/area/library)
 "fJP" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -40832,16 +40821,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmospherics_engine)
-"fLO" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/monotile,
-/area/security/brig)
 "fMP" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -40853,55 +40832,36 @@
 /obj/item/beacon,
 /turf/open/floor/monotile,
 /area/hallway/secondary/exit)
-"fOe" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/dorms)
-"fOC" = (
-/obj/machinery/light_switch{
-	pixel_x = -28
+"fPZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
-/area/library)
-"fTx" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_y = -26
 	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/obj/structure/window/reinforced,
 /turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
-"fTy" = (
-/obj/machinery/door/airlock/ship/external/glass{
-	req_one_access_txt = "13"
+/area/engine/engineering/hangar)
+"fSB" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/port)
 "fVu" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_y = -30
 	},
 /turf/open/floor/monotile,
 /area/security/warden)
-"fXa" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+"fXp" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/disposalpipe/segment,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/turf/open/floor/monotile,
-/area/security/brig)
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "fXQ" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
@@ -40912,6 +40872,11 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/service)
+"gbK" = (
+/obj/machinery/computer/libraryconsole/bookmanagement,
+/obj/structure/table/wood,
+/turf/open/floor/carpet,
+/area/library)
 "glh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40924,19 +40889,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"gnX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+"glX" = (
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/item/radio/intercom{
-	name = "intra ship intercom";
-	pixel_y = -26
-	},
-/turf/open/floor/monotile,
-/area/crew_quarters/heads/chief)
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/heads/hor)
 "gqp" = (
 /obj/machinery/newscaster,
 /turf/closed/wall/ship,
@@ -40950,15 +40911,10 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"gxQ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+"gvw" = (
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/monotile,
+/area/crew_quarters/bar)
 "gFl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -40985,12 +40941,6 @@
 	},
 /turf/closed/wall/r_wall/ship,
 /area/engine/storage_shared)
-"gJd" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/library)
 "gJU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -40999,13 +40949,6 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"gMd" = (
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "gMn" = (
 /obj/machinery/requests_console{
 	department = "Medbay";
@@ -41014,23 +40957,43 @@
 	},
 /turf/closed/wall/ship,
 /area/medical/medbay/central)
-"gOm" = (
-/obj/item/radio/intercom{
-	name = "intra ship intercom";
-	pixel_x = -26
+"gMB" = (
+/obj/machinery/photocopier{
+	pixel_y = 3
+	},
+/obj/machinery/computer/ship/viewscreen,
+/turf/open/floor/wood,
+/area/library)
+"gNY" = (
+/obj/machinery/vending/coffee,
+/obj/machinery/computer/ship/viewscreen,
+/turf/open/floor/wood,
+/area/library)
+"gOD" = (
+/obj/machinery/status_display/evac,
+/turf/closed/wall/ship,
+/area/security/brig)
+"gUy" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
 	},
 /turf/open/floor/monotile,
-/area/security/prison)
-"gQz" = (
+/area/crew_quarters/fitness/recreation)
+"gUD" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/monotile,
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/fitness/recreation)
-"gRv" = (
+"gVA" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -41045,36 +41008,46 @@
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
-"gRD" = (
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/carpet/ship,
-/area/crew_quarters/dorms)
-"gSC" = (
-/obj/machinery/status_display/ai,
-/turf/closed/wall/ship,
-/area/engine/break_room)
-"gWv" = (
-/obj/structure/destructible/cult/tome,
-/obj/item/book/codex_gigas,
-/obj/machinery/newscaster{
-	pixel_y = 32
+"gVX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
 	},
-/turf/open/floor/wood,
-/area/library)
+/turf/open/floor/monotile/dark,
+/area/engine/engineering)
+"gWF" = (
+/obj/machinery/newscaster{
+	pixel_x = 32
+	},
+/turf/open/floor/monotile,
+/area/nsv/hanger/deck2)
 "gXS" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"gYL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "gZS" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/monotile/dark,
 /area/security/brig)
+"haf" = (
+/turf/closed/wall/ship,
+/area/library)
+"hdp" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/east,
+/obj/structure/punching_bag,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
+"hgn" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/fitness/recreation)
 "hhv" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8;
@@ -41094,6 +41067,16 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
+"hhQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/monotile,
+/area/crew_quarters/heads/chief)
 "hnv" = (
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 26
@@ -41110,21 +41093,25 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"hqB" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+"hpX" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
 "hrv" = (
 /obj/machinery/newscaster/security_unit,
 /turf/closed/wall/ship,
 /area/security/brig)
-"hwR" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/open/floor/carpet/ship,
-/area/crew_quarters/dorms)
+"hvH" = (
+/turf/open/floor/wood,
+/area/library)
 "hwV" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	req_one_access_txt = "13"
@@ -41134,6 +41121,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"hzd" = (
+/obj/machinery/status_display/evac,
+/turf/closed/wall/ship,
+/area/medical/genetics)
 "hAu" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -41144,6 +41135,13 @@
 /obj/structure/closet/secure_closet/medical1,
 /turf/open/floor/monotile/dark,
 /area/gateway)
+"hCf" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
 "hCr" = (
 /obj/machinery/holopad,
 /turf/open/floor/monotile/dark,
@@ -41160,25 +41158,43 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"hES" = (
-/turf/closed/wall/r_wall/ship,
+"hLd" = (
+/turf/closed/wall/ship,
+/area/hallway/secondary/service)
+"hNP" = (
+/obj/machinery/vending/wardrobe/curator_wardrobe,
+/turf/open/floor/wood,
 /area/library)
-"hNe" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+"hOZ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/techmaint,
-/area/quartermaster/warehouse)
-"hTa" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/iron/fifty{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/machinery/light{
+	dir = 8
 	},
+/turf/open/floor/monotile,
+/area/maintenance/port)
+"hPT" = (
+/obj/structure/closet/toolcloset,
 /turf/open/floor/plating,
 /area/nsv/briefingroom)
+"iey" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/chair/comfy/shuttle{
+	dir = 4;
+	name = "briefing room chair"
+	},
+/turf/open/floor/carpet/blue,
+/area/nsv/hanger/deck2)
+"ilA" = (
+/obj/structure/window/reinforced/fulltile/ship,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"iov" = (
+/obj/structure/lattice,
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/department/engine)
 "irj" = (
 /obj/structure/window/reinforced/fulltile/ship,
 /obj/structure/grille,
@@ -41196,24 +41212,15 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
-"itE" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
+"isj" = (
+/obj/machinery/airalarm{
+	pixel_y = 26
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/machinery/newscaster{
-	pixel_x = 30
-	},
-/turf/open/floor/monotile,
-/area/hallway/secondary/exit)
-"iuh" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/turf/open/floor/monotile/dark,
-/area/engine/engineering)
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"iuA" = (
+/turf/closed/wall/ship,
+/area/maintenance/starboard/fore)
 "iyx" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /obj/machinery/camera/autoname,
@@ -41221,10 +41228,38 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"iLQ" = (
-/obj/effect/spawner/lootdrop/maintenance,
+"iyL" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/ship,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/maintenance/department/medical)
+/area/crew_quarters/fitness/recreation)
+"iCD" = (
+/obj/structure/closet/lasertag/blue,
+/obj/machinery/light,
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
+"iDb" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/monotile,
+/area/nsv/hanger/deck2)
+"iDJ" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/newscaster{
+	pixel_x = 32
+	},
+/turf/open/floor/monotile/light,
+/area/medical/medbay/lobby)
+"iLl" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
 "iMe" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -41245,19 +41280,21 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/gateway)
-"iMm" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+"iNo" = (
+/obj/structure/bookcase/random/nonfiction,
+/turf/open/floor/wood,
+/area/library)
+"iNZ" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"iQX" = (
+/obj/machinery/door/airlock/ship/external/glass{
+	req_one_access_txt = "13"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/monotile/dark,
-/area/engine/engineering)
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "iSM" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -41272,45 +41309,72 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/monotile/dark,
 /area/gateway)
-"iUQ" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/machinery/light/small{
+"iVI" = (
+/obj/machinery/light,
+/turf/open/floor/monotile/dark,
+/area/hallway/secondary/exit)
+"iYd" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/library)
-"iVe" = (
-/obj/machinery/camera/autoname,
-/obj/machinery/vending/games,
-/turf/open/floor/wood,
-/area/library)
-"iXP" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_y = -26
 	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
-"iYO" = (
-/obj/machinery/bookbinder,
-/obj/machinery/camera/autoname,
-/turf/open/floor/wood,
-/area/library)
-"jeJ" = (
-/obj/machinery/camera/autoname{
+/turf/open/floor/carpet/ship,
+/area/quartermaster/storage)
+"iZE" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 4;
+	sortType = 16
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck2/frame2/port)
+"jbU" = (
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
+"jiL" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
 	dir = 8
 	},
 /turf/open/floor/monotile,
-/area/maintenance/port)
+/area/crew_quarters/fitness/recreation)
 "jku" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
 /turf/closed/wall/r_wall/ship,
 /area/engine/atmospherics_engine)
-"jkZ" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+"jld" = (
+/obj/structure/weightmachine/stacklifter,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/fitness/recreation)
 "jlu" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_toxmix,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -41323,22 +41387,32 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
+"jmH" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood,
+/area/library)
+"jmS" = (
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/starboard)
+"jsE" = (
+/obj/machinery/status_display/evac{
+	pixel_x = -32
+	},
+/turf/open/floor/monotile/dark,
+/area/nsv/briefingroom)
 "jtt" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"juv" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+"jxT" = (
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/fitness/recreation)
-"jvv" = (
-/turf/closed/wall/r_wall/ship,
-/area/crew_quarters/fitness/recreation)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "jAE" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -41353,32 +41427,18 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/break_room)
-"jDU" = (
-/obj/structure/displaycase/trophy,
-/obj/structure/sign/solgov_flag/right,
-/turf/open/floor/wood,
-/area/library)
-"jDV" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/box,
-/obj/item/storage/belt/utility/full,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -27
-	},
-/turf/open/floor/plasteel/grid/steel,
-/area/nsv/hanger/deck2)
-"jGm" = (
+"jEi" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/newscaster{
+	pixel_x = 32
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
+/area/nsv/hanger/deck2)
 "jKS" = (
 /obj/machinery/requests_console{
 	department = "Science";
@@ -41410,31 +41470,12 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"jNU" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/monotile,
-/area/nsv/hanger/deck2)
-"jOa" = (
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/turf/open/floor/monotile,
-/area/nsv/briefingroom)
-"jRE" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"jSF" = (
+"jVR" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/maintenance/port)
-"jTb" = (
-/turf/closed/wall/ship,
 /area/maintenance/starboard)
 "jYW" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -41460,35 +41501,38 @@
 	},
 /turf/open/floor/monotile,
 /area/gateway)
-"kfl" = (
-/obj/machinery/camera/autoname{
+"keR" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"khE" = (
+/obj/structure/punching_bag,
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
+"kmy" = (
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/light_switch{
-	pixel_y = -28
-	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
-"kiF" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/turf/open/floor/monotile/dark,
+/area/engine/engineering)
+"kng" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
-"kmg" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/security/prison)
 "knh" = (
 /obj/machinery/button/door{
 	dir = 8;
@@ -41499,14 +41543,34 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/security/execution/transfer)
-"koM" = (
-/obj/structure/lattice,
-/obj/machinery/camera/motion{
-	c_tag = "Armoury";
+"kqZ" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/status_display/ai{
+	pixel_x = -32
+	},
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck2/frame1/central)
+"ksH" = (
+/turf/closed/wall/r_wall/ship,
+/area/crew_quarters/fitness/recreation)
+"ksY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
-/turf/open/space/basic,
-/area/maintenance/ship_exterior)
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_y = -26
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/heads/chief)
 "kyA" = (
 /obj/structure/table,
 /obj/item/disk/design_disk,
@@ -41518,12 +41582,25 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/science/research)
-"kEA" = (
-/obj/machinery/newscaster{
-	pixel_y = -32
+"kBg" = (
+/obj/structure/closet/wardrobe/science_white,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
 	},
-/turf/open/floor/carpet,
-/area/library)
+/turf/open/floor/monotile/dark,
+/area/science/mixing{
+	name = "Prototype munitions bay"
+	})
+"kEU" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck2/frame1/central)
 "kFm" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -41536,19 +41613,19 @@
 	},
 /turf/open/floor/monotile,
 /area/medical/chemistry)
-"kJH" = (
-/obj/machinery/newscaster{
-	pixel_x = 32
+"kJA" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/techmaint,
+/area/medical/chemistry)
+"kLw" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
 /turf/open/floor/monotile,
-/area/nsv/hanger/deck2)
-"kNf" = (
-/obj/item/radio/intercom{
-	name = "intra ship intercom";
-	pixel_x = -26
-	},
-/turf/open/floor/monotile/light,
-/area/security/prison)
+/area/crew_quarters/fitness/recreation)
 "kOA" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light/small{
@@ -41566,6 +41643,10 @@
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"kVJ" = (
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/monotile,
+/area/nsv/hanger/deck2)
 "kZu" = (
 /obj/machinery/portable_atmospherics/scrubber/huge,
 /obj/machinery/light{
@@ -41575,6 +41656,32 @@
 	dir = 4
 	},
 /turf/open/floor/monotile,
+/area/science/mixing{
+	name = "Prototype munitions bay"
+	})
+"laZ" = (
+/turf/closed/wall/ship,
+/area/maintenance/starboard)
+"lcf" = (
+/obj/structure/table/wood,
+/obj/item/camera,
+/obj/item/taperecorder,
+/turf/open/floor/wood,
+/area/library)
+"ldc" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "xb_containment";
+	name = "Xenobiology Containment Shutter"
+	},
+/obj/machinery/shieldwallgen/xenobiologyaccess,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/science/xenobiology)
+"lff" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -27
+	},
+/turf/open/floor/monotile/dark,
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
@@ -41589,13 +41696,7 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/engine/atmospherics_engine)
-"ljw" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"low" = (
+"ljk" = (
 /obj/structure/weightmachine/weightlifter,
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -41605,10 +41706,16 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/fitness/recreation)
-"lsE" = (
-/obj/machinery/status_display/evac,
+"ljw" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"ltR" = (
+/obj/machinery/status_display/ai,
 /turf/closed/wall/ship,
-/area/medical/medbay/lobby)
+/area/engine/break_room)
 "lwJ" = (
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_interior,
 /obj/effect/mapping_helpers/airlock/locked,
@@ -41622,6 +41729,19 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
+"lzn" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -27
+	},
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
+"lAs" = (
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "lAV" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -41632,51 +41752,24 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"lCu" = (
-/obj/machinery/door/airlock/highsecurity/ship{
-	name = "Flight Deck Ladder Access";
-	req_one_access_txt = "3;69"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/monotile,
-/area/maintenance/port)
 "lCE" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/closed/wall/r_wall/ship,
 /area/science/xenobiology)
-"lIC" = (
-/turf/open/floor/wood,
-/area/library)
-"lKZ" = (
-/obj/structure/bed{
-	layer = 2.8
+"lEy" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "hor_window";
+	name = "privacy shutter"
 	},
-/obj/structure/bed{
-	layer = 3;
-	pixel_y = 12
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
-/obj/item/bedsheet/black{
-	pixel_y = 12
-	},
-/obj/item/bedsheet/black{
-	layer = 2.85
-	},
-/obj/machinery/light_switch{
-	pixel_x = 28
-	},
-/turf/open/floor/carpet/ship,
-/area/crew_quarters/dorms/nsv/dorms_2)
-"lOY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hor)
+"lKI" = (
+/obj/structure/bookcase{
+	name = "Forbidden Knowledge"
 	},
 /turf/open/floor/wood,
 /area/library)
@@ -41688,12 +41781,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/science/xenobiology)
-"lTu" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "lTI" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -41711,13 +41798,6 @@
 	},
 /turf/open/floor/monotile/light,
 /area/medical/medbay/lobby)
-"lWU" = (
-/turf/closed/wall/r_wall/ship,
-/area/maintenance/starboard)
-"lZa" = (
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "mbD" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -41755,6 +41835,12 @@
 	},
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/starboard/fore)
+"mys" = (
+/obj/machinery/status_display/evac{
+	pixel_x = 32
+	},
+/turf/open/floor/monotile,
+/area/nsv/briefingroom)
 "mzP" = (
 /obj/machinery/requests_console{
 	department = "Chapel";
@@ -41762,10 +41848,18 @@
 	},
 /turf/closed/wall/ship,
 /area/chapel/office)
-"mAr" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/ship,
-/area/security/brig)
+"mAn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
 "mBj" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	dir = 4;
@@ -41776,59 +41870,35 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
-"mCs" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/turf/open/floor/monotile,
-/area/security/prison)
-"mCI" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 26
-	},
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/dorms)
-"mDS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+"mDA" = (
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
+/obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/segment,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
 	},
-/obj/machinery/airalarm/directional/south,
 /turf/open/floor/monotile,
-/area/crew_quarters/heads/chief)
-"mFV" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
+/area/security/brig)
+"mHC" = (
+/obj/machinery/camera/autoname{
 	dir = 1
 	},
-/obj/machinery/newscaster{
-	pixel_x = 32
+/obj/machinery/light_switch{
+	pixel_y = -28
 	},
 /turf/open/floor/monotile,
-/area/hallway/nsv/deck2/frame1/central)
+/area/crew_quarters/fitness/recreation)
+"mIj" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "mIw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
 /turf/closed/wall/r_wall/ship,
 /area/engine/atmospherics_engine)
-"mJn" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/port)
-"mKB" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "mMv" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -41840,45 +41910,55 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard)
-"mQI" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Patient Room B"
+"mOp" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/library)
+"mPw" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"mPU" = (
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/monotile,
+/area/engine/engineering/hangar)
+"mWK" = (
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_x = -26
+	},
+/turf/open/floor/monotile,
+/area/security/prison)
+"mXe" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
+	dir = 4
 	},
-/turf/open/floor/monotile,
-/area/medical/medbay/central)
-"mTD" = (
-/obj/structure/bookcase/random/reference,
-/turf/open/floor/wood,
-/area/library)
-"ndg" = (
-/obj/structure/closet/lasertag/blue,
-/obj/machinery/light,
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "ndL" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"nfi" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 4;
-	sortType = 16
-	},
-/turf/open/floor/monotile/dark,
-/area/hallway/nsv/deck2/frame2/port)
+"neD" = (
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "nfz" = (
 /obj/machinery/atmospherics/components/binary/pump/on,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -41890,27 +41970,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
-"nmm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"nms" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -27
-	},
-/turf/open/floor/monotile,
-/area/engine/engineering/hangar)
-"nmA" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
 "nqx" = (
 /obj/machinery/airalarm/mixingchamber{
 	dir = 4;
@@ -41928,30 +41987,24 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"nsg" = (
-/obj/structure/closet/boxinggloves,
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
-"nuV" = (
-/obj/machinery/light{
-	dir = 8
-	},
+"ntS" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/port)
+/turf/closed/wall/ship,
+/area/hallway/nsv/deck2/frame2/port)
 "nvJ" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/monotile/light,
 /area/security/prison)
-"nyk" = (
-/obj/machinery/photocopier{
-	pixel_y = 3
+"nFf" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
 	},
-/obj/machinery/computer/ship/viewscreen,
-/turf/open/floor/wood,
-/area/library)
+/turf/open/floor/plasteel/chapel{
+	dir = 8
+	},
+/area/chapel/main)
 "nHC" = (
 /obj/structure/table,
 /obj/item/stock_parts/micro_laser,
@@ -41962,10 +42015,27 @@
 /obj/item/stock_parts/manipulator,
 /turf/open/floor/monotile/dark,
 /area/science/research)
-"nJD" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+"nHQ" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -27
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/nsv/weapons/fore)
+"nJo" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck2/frame2/port)
+"nJu" = (
+/obj/structure/bookcase/random/adult,
+/turf/open/floor/wood,
+/area/library)
 "nLp" = (
 /obj/machinery/light{
 	dir = 8
@@ -41975,74 +42045,67 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/science/xenobiology)
-"nML" = (
-/obj/structure/bookcase/random/nonfiction,
-/turf/open/floor/wood,
-/area/library)
-"nNg" = (
-/obj/structure/closet/lasertag/red,
-/obj/machinery/newscaster{
-	pixel_y = -30
+"nLB" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/structure/punching_bag,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/crew_quarters/fitness/recreation)
-"nSo" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 8
+"nNs" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/airalarm{
+	pixel_y = 23
 	},
 /turf/open/floor/monotile,
-/area/maintenance/port)
-"nUa" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+/area/crew_quarters/fitness/recreation)
+"nQO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship,
-/area/crew_quarters/dorms)
-"ocu" = (
-/obj/machinery/vending/coffee,
-/obj/machinery/computer/ship/viewscreen,
-/turf/open/floor/wood,
-/area/library)
-"oiq" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
+"nUJ" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 5
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard)
-"ojE" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/area/maintenance/starboard/fore)
+"nYT" = (
+/obj/machinery/door/morgue{
+	name = "Private Study";
+	req_access_txt = "37"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/turf/open/floor/wood,
+/area/library)
+"ohw" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
 	},
-/obj/item/radio/intercom{
-	name = "intra ship intercom";
-	pixel_y = 26
+/turf/open/floor/plasteel/techmaint,
+/area/quartermaster/warehouse)
+"onI" = (
+/obj/structure/lattice,
+/obj/machinery/camera/motion{
+	c_tag = "Armoury";
+	dir = 1
 	},
-/turf/open/floor/monotile/dark,
-/area/hallway/secondary/exit)
-"olz" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/carpet/ship,
-/area/crew_quarters/dorms)
+/turf/open/space/basic,
+/area/maintenance/ship_exterior)
 "oqq" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
@@ -42052,12 +42115,12 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"oqB" = (
-/obj/machinery/status_display/evac{
-	pixel_x = -32
+"osW" = (
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/monotile/dark,
-/area/nsv/briefingroom)
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "oun" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	req_one_access_txt = "8;13"
@@ -42079,23 +42142,16 @@
 	},
 /turf/open/floor/monotile,
 /area/hallway/secondary/exit)
-"ozk" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/ship,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/crew_quarters/fitness/recreation)
-"oCm" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "hor_window";
-	name = "privacy shutter"
+"oyi" = (
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/starboard/fore)
+"oBT" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
-/area/crew_quarters/heads/hor)
+/area/maintenance/department/medical)
 "oDq" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
@@ -42114,86 +42170,96 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"oFa" = (
-/obj/machinery/status_display/ai,
-/turf/closed/wall/ship,
-/area/security/brig)
-"oNq" = (
+"oHz" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /obj/item/radio/intercom{
 	name = "intra ship intercom";
-	pixel_y = -26
+	pixel_x = -26
 	},
-/turf/open/floor/carpet/ship,
-/area/quartermaster/qm)
-"oPV" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"oQR" = (
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/fitness/recreation)
+"oUM" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -27
 	},
-/turf/open/floor/plasteel/tech/grid,
-/area/nsv/weapons/fore)
-"oUr" = (
-/obj/machinery/newscaster{
-	pixel_x = -28
-	},
-/turf/open/floor/wood,
-/area/library)
-"oVe" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/ship,
-/area/engine/break_room)
-"oYj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/requests_console{
-	department = "Pilot lounge";
-	departmentType = 2;
-	pixel_y = 28
-	},
-/turf/open/floor/monotile/dark,
-/area/nsv/hanger/deck2)
-"pdQ" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
-"plB" = (
+/turf/open/floor/monotile,
+/area/engine/engineering/hangar)
+"paV" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/newscaster{
-	pixel_x = 32
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/monotile,
-/area/nsv/hanger/deck2)
+/area/crew_quarters/fitness/recreation)
+"pgF" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/libraryconsole,
+/obj/machinery/computer/lore_terminal,
+/turf/open/floor/wood,
+/area/library)
+"phM" = (
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_y = -26
+	},
+/turf/open/floor/carpet/ship,
+/area/quartermaster/qm)
+"pjr" = (
+/obj/structure/displaycase/trophy,
+/obj/structure/sign/solgov_flag,
+/turf/open/floor/wood,
+/area/library)
 "poV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
 /turf/open/floor/monotile,
 /area/science/xenobiology)
-"psQ" = (
-/obj/structure/reagent_dispensers/fueltank,
+"pqr" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_x = 26
+	},
+/turf/open/floor/monotile,
+/area/hallway/secondary/exit)
+"psk" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/starboard)
 "pxy" = (
 /obj/machinery/newscaster,
 /turf/closed/wall/ship,
 /area/quartermaster/qm)
-"pAv" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/airalarm{
-	pixel_y = 23
+"pCV" = (
+/obj/item/radio/intercom{
+	dir = 4;
+	pixel_x = 27
 	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
+/turf/open/floor/wood,
+/area/library)
+"pFQ" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "pFX" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess,
@@ -42201,33 +42267,31 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"pPw" = (
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "pSV" = (
 /obj/machinery/newscaster,
 /turf/closed/wall/ship,
 /area/medical/genetics)
+"pVN" = (
+/obj/structure/closet/boxinggloves,
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
 "qbw" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"qcO" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/status_display/ai{
-	pixel_x = -32
-	},
-/turf/open/floor/monotile/dark,
-/area/nsv/briefingroom)
-"qmG" = (
-/obj/machinery/sleeper{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/open/floor/engine,
-/area/medical/medbay/lobby)
+"qeW" = (
+/obj/effect/landmark/nuclear_waste_spawner,
+/turf/open/floor/wood,
+/area/library)
 "qmY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -42246,71 +42310,37 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmospherics_engine)
-"qpW" = (
-/obj/structure/lattice,
-/turf/closed/wall/r_wall/ship,
-/area/maintenance/department/engine)
-"qus" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/department/science)
+"qth" = (
+/obj/machinery/door/airlock/highsecurity/ship{
+	name = "Flight Deck Ladder Access";
+	req_one_access_txt = "3;69"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/monotile,
+/area/maintenance/port)
+"qvd" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "qxl" = (
 /obj/effect/turf_decal/stripes/white/corner{
 	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/service)
-"qxO" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
-	},
-/turf/open/floor/monotile,
-/area/hallway/nsv/deck2/frame2/port)
-"qBI" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 26
-	},
-/obj/item/radio/intercom{
-	name = "intra ship intercom";
-	pixel_x = 26
-	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
-"qBT" = (
-/obj/item/reagent_containers/food/drinks/sillycup{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/food/drinks/sillycup,
-/obj/item/reagent_containers/food/drinks/sillycup{
-	pixel_x = 5;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/food/drinks/sillycup{
-	pixel_x = 5;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/food/drinks/sillycup{
-	pixel_x = 5;
-	pixel_y = 3
-	},
-/obj/structure/table,
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
 "qEi" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
+"qEO" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "qFG" = (
 /obj/machinery/gateway{
 	dir = 4
@@ -42318,26 +42348,14 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/monotile,
 /area/gateway)
-"qGC" = (
-/obj/structure/closet/toolcloset,
+"qHc" = (
+/obj/machinery/status_display/ai,
+/turf/closed/wall/ship,
+/area/security/brig)
+"qKl" = (
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
-/area/nsv/briefingroom)
-"qGH" = (
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/table/wood,
-/turf/open/floor/carpet,
-/area/library)
-"qHX" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/fitness/recreation)
+/area/maintenance/department/engine)
 "qLh" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -42346,13 +42364,25 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"qNh" = (
-/obj/item/radio/intercom{
-	dir = 4;
-	pixel_x = 27
+"qNS" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/turf/open/floor/wood,
-/area/library)
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_y = 26
+	},
+/turf/open/floor/monotile,
+/area/security/brig)
 "qOb" = (
 /obj/effect/turf_decal/box,
 /obj/machinery/requests_console{
@@ -42362,10 +42392,6 @@
 	},
 /turf/open/floor/monotile,
 /area/janitor)
-"qOo" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "qOI" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	req_one_access_txt = "13"
@@ -42375,6 +42401,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"qOP" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/machinery/newscaster{
+	pixel_x = 30
+	},
+/turf/open/floor/monotile,
+/area/hallway/secondary/exit)
 "qOQ" = (
 /obj/machinery/gateway{
 	dir = 6
@@ -42393,47 +42431,20 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/gateway)
-"qUo" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood,
-/area/library)
 "qZd" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"rab" = (
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+"rdE" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/storage/toolbox/emergency,
+/obj/item/clothing/gloves/color/fyellow,
 /turf/open/floor/plating,
-/area/maintenance/port)
-"rbG" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
+/area/nsv/briefingroom)
+"rel" = (
 /obj/structure/punching_bag,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
-"rfU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
+/obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile,
 /area/crew_quarters/fitness/recreation)
 "riT" = (
@@ -42446,66 +42457,54 @@
 	},
 /turf/open/floor/monotile,
 /area/science/xenobiology)
-"rmu" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/library)
 "rnf" = (
 /obj/machinery/igniter/incinerator_toxmix,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"rtJ" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"rwx" = (
+"rnZ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	name = "intra ship intercom";
-	pixel_y = 26
-	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/monotile,
 /area/security/brig)
-"ryl" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+"roY" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/turf/open/floor/monotile/dark,
-/area/science/nanite)
-"rBX" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
+/turf/open/floor/plating,
+/area/nsv/briefingroom)
+"ruX" = (
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/techmaint,
-/area/medical/chemistry)
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"rxn" = (
+/obj/machinery/door/airlock/ship/external/glass{
+	req_one_access_txt = "13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "rCB" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"rCK" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/turf/open/floor/monotile,
-/area/security/brig)
 "rFe" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -42533,68 +42532,60 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"rHz" = (
-/obj/structure/window/reinforced/fulltile/ship,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"rLW" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
 "rMN" = (
 /obj/machinery/newscaster{
 	pixel_y = -30
 	},
 /turf/open/floor/monotile/dark,
 /area/science/nanite)
-"rPg" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+"rUk" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"rXW" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/newscaster{
+	pixel_x = 32
 	},
-/obj/machinery/airalarm/directional/south,
 /turf/open/floor/monotile,
-/area/security/brig)
-"rRz" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
-	},
-/obj/machinery/light,
-/turf/open/floor/wood,
-/area/library)
+/area/hallway/nsv/deck2/frame1/central)
 "sax" = (
 /obj/machinery/newscaster{
 	pixel_x = 32
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit/departure_lounge)
-"sbi" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/carpet,
+"saB" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
+"sbl" = (
+/obj/structure/bookcase/random/reference,
+/turf/open/floor/wood,
 /area/library)
+"sdX" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck2/frame2/port)
+"sem" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/nsv/observation)
 "sfx" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -42618,26 +42609,13 @@
 	},
 /turf/open/floor/monotile,
 /area/medical/chemistry)
-"shz" = (
-/obj/machinery/light/small{
-	dir = 1
+"sjd" = (
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_x = -26
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
-"sjG" = (
-/obj/structure/punching_bag,
-/obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
-"smL" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood,
-/area/library)
+/area/nsv/weapons/fore)
 "srs" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/structure/cable{
@@ -42660,6 +42638,10 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"ssH" = (
+/obj/machinery/status_display/evac,
+/turf/closed/wall/ship,
+/area/medical/medbay/lobby)
 "stk" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/machinery/meter,
@@ -42668,6 +42650,16 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmospherics_engine)
+"svo" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/library)
+"svX" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "swR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -42676,71 +42668,68 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"sxI" = (
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
-"sAb" = (
-/obj/item/radio/intercom{
-	name = "intra ship intercom";
-	pixel_y = -26
-	},
-/turf/open/floor/monotile/dark,
-/area/science/nanite)
-"sCI" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/libraryconsole,
-/obj/machinery/computer/lore_terminal,
-/turf/open/floor/wood,
-/area/library)
-"sQp" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/open/floor/monotile/dark,
-/area/security/prison)
-"taH" = (
-/obj/structure/disposalpipe/segment,
-/turf/closed/wall/ship,
-/area/hallway/nsv/deck2/frame2/port)
-"taR" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -27
-	},
-/turf/open/floor/carpet/ship,
-/area/quartermaster/qm)
-"tbe" = (
-/obj/item/radio/intercom{
-	name = "intra ship intercom";
-	pixel_x = -26
-	},
-/turf/open/floor/monotile,
-/area/nsv/weapons/fore)
-"tds" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/nsv/observation)
-"tdO" = (
+"sxM" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"teO" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
+"sBR" = (
+/obj/machinery/camera/autoname,
+/obj/machinery/vending/games,
+/turf/open/floor/wood,
+/area/library)
+"sCC" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/monotile/light,
+/area/medical/genetics)
+"sFd" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"sJI" = (
+/obj/machinery/status_display/evac,
+/turf/closed/wall/ship,
+/area/crew_quarters/cafeteria{
+	name = "Mess hall"
+	})
+"sMC" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
 /turf/open/floor/monotile,
-/area/nsv/hanger/deck2)
+/area/crew_quarters/fitness/recreation)
+"sSl" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/port)
+"sYQ" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/open/floor/wood,
+/area/library)
+"tcb" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood,
+/area/library)
+"tfj" = (
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/library)
 "tiu" = (
 /obj/machinery/requests_console{
 	department = "Genetics";
@@ -42758,24 +42747,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"tlx" = (
-/obj/structure/punching_bag,
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
-"tma" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+"tlE" = (
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
-/obj/item/radio/intercom{
-	name = "intra ship intercom";
-	pixel_x = 26
-	},
-/turf/open/floor/monotile,
-/area/hallway/secondary/exit)
+/obj/structure/table/wood,
+/turf/open/floor/carpet,
+/area/library)
 "tnm" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -42788,36 +42771,66 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/break_room)
+"tux" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
+"tuz" = (
+/obj/machinery/status_display/evac,
+/turf/closed/wall/ship,
+/area/engine/break_room)
 "txH" = (
 /obj/machinery/holopad,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo)
-"tzB" = (
-/obj/structure/cable{
-	icon_state = "2-8"
+"tBx" = (
+/obj/machinery/airalarm/directional/south,
+/obj/structure/bookcase/manuals/research_and_development,
+/turf/open/floor/wood,
+/area/library)
+"tDB" = (
+/obj/machinery/sleeper{
+	dir = 4
 	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/engine,
+/area/medical/medbay/lobby)
+"tGC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/carpet/ship,
-/area/crew_quarters/heads/hor)
-"tIn" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"tJL" = (
-/obj/structure/bookcase,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
+"tIg" = (
+/obj/machinery/light_switch{
+	pixel_x = -28
+	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/library)
-"tNK" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "xb_containment";
-	name = "Xenobiology Containment Shutter"
+"tKA" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
-/obj/machinery/shieldwallgen/xenobiologyaccess,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/science/xenobiology)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/door/window/eastright{
+	name = "Fitness Ring"
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/fitness/recreation)
 "tUT" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -42855,67 +42868,45 @@
 /obj/machinery/gateway/centerstation,
 /turf/open/floor/monotile/dark,
 /area/gateway)
-"ujl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+"uee" = (
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 26
 	},
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_x = 26
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
+"uhg" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/library)
-"ujv" = (
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/monotile,
-/area/engine/engineering/hangar)
-"uns" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	name = "intra ship intercom";
-	pixel_y = -26
-	},
-/turf/open/floor/carpet/ship,
-/area/quartermaster/storage)
-"uqd" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/turf/open/floor/monotile,
-/area/hallway/nsv/deck2/frame2/port)
-"uqv" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/door/window/eastright{
-	name = "Fitness Ring"
+	dir = 10
 	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/fitness/recreation)
-"usN" = (
-/obj/structure/punching_bag,
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable{
-	icon_state = "0-2"
+"uiz" = (
+/obj/machinery/newscaster{
+	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
+/turf/open/floor/carpet,
+/area/library)
+"uqx" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
+"uqS" = (
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "uts" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -42943,12 +42934,6 @@
 	},
 /turf/open/floor/monotile,
 /area/security/brig)
-"utP" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "uDe" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/closet/crate{
@@ -42956,31 +42941,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"uEu" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -27
-	},
-/turf/open/floor/monotile,
-/area/hallway/nsv/deck2/frame1/port)
-"uER" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"uHP" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/ship,
-/area/medical/genetics)
 "uIA" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable{
@@ -42992,6 +42952,12 @@
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/monotile/dark,
 /area/engine/atmospherics_engine)
+"uMm" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/turf/open/floor/monotile/dark,
+/area/science/nanite)
 "uNi" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -43005,14 +42971,13 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"uPi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
+"uQh" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/status_display/ai{
+	pixel_x = -32
 	},
 /turf/open/floor/monotile/dark,
-/area/engine/engineering)
+/area/nsv/briefingroom)
 "uTe" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -43021,19 +42986,36 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"uYx" = (
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/monotile,
-/area/crew_quarters/bar)
-"vbZ" = (
-/obj/machinery/vending/wardrobe/curator_wardrobe,
-/turf/open/floor/wood,
-/area/library)
-"vhq" = (
-/obj/item/storage/crayons,
-/obj/structure/table/wood,
-/turf/open/floor/carpet,
-/area/library)
+"uWe" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_x = 26
+	},
+/turf/open/floor/monotile/light,
+/area/medical/medbay/lobby)
+"vew" = (
+/obj/structure/bed{
+	layer = 2.8
+	},
+/obj/structure/bed{
+	layer = 3;
+	pixel_y = 12
+	},
+/obj/item/bedsheet/black{
+	pixel_y = 12
+	},
+/obj/item/bedsheet/black{
+	layer = 2.85
+	},
+/obj/machinery/light_switch{
+	pixel_x = 28
+	},
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms/nsv/dorms_2)
 "vii" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1;
@@ -43048,6 +43030,27 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
+"vjc" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"vjN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/wood,
+/area/library)
 "vlL" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/stripes/line{
@@ -43073,46 +43076,21 @@
 /obj/machinery/light,
 /turf/open/floor/monotile,
 /area/engine/engineering/hangar)
-"vtN" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/dorms)
-"vxg" = (
-/obj/structure/closet/wardrobe/science_white,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/turf/open/floor/monotile/dark,
-/area/science/mixing{
-	name = "Prototype munitions bay"
-	})
-"vyX" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/turf/open/floor/plasteel/chapel{
-	dir = 8
-	},
-/area/chapel/main)
-"vzf" = (
-/turf/closed/wall/ship,
-/area/library)
-"vFJ" = (
-/obj/machinery/door/airlock/ship/external/glass{
-	req_one_access_txt = "13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+"vtW" = (
+/obj/structure/chair/office/light{
 	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
-"vHs" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/storage/toolbox/emergency,
-/obj/item/clothing/gloves/color/fyellow,
-/turf/open/floor/plating,
-/area/nsv/briefingroom)
+/turf/open/floor/wood,
+/area/library)
+"vEp" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/box,
+/obj/item/storage/belt/utility/full,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -27
+	},
+/turf/open/floor/plasteel/grid/steel,
+/area/nsv/hanger/deck2)
 "vPd" = (
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_exterior,
 /obj/effect/mapping_helpers/airlock/locked,
@@ -43120,22 +43098,14 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"vRM" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/carpet,
-/area/library)
-"vTw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
+"vPG" = (
+/obj/structure/lattice,
+/obj/machinery/camera/motion{
+	c_tag = "Armoury";
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/wood,
-/area/library)
+/turf/open/space/basic,
+/area/maintenance/ship_exterior)
 "vVm" = (
 /obj/item/beacon,
 /turf/open/floor/mineral/plastitanium/red/airless,
@@ -43147,28 +43117,19 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"vZE" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/ship,
-/area/crew_quarters/cafeteria{
-	name = "Mess hall"
-	})
-"wbv" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "hor_window";
-	name = "privacy shutter"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
+"vZc" = (
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/plating,
-/area/crew_quarters/heads/hor)
-"wfQ" = (
-/obj/machinery/airalarm/directional/south,
-/obj/structure/bookcase/manuals/research_and_development,
-/turf/open/floor/wood,
-/area/library)
+/area/maintenance/starboard/fore)
+"weE" = (
+/obj/structure/closet/secure_closet/brig,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/monotile/dark,
+/area/security/prison)
 "wgS" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/toxin,
@@ -43182,19 +43143,22 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"wjg" = (
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/monotile,
-/area/nsv/hanger/deck2)
-"wjl" = (
-/turf/closed/wall/ship,
-/area/maintenance/starboard/fore)
-"wqj" = (
-/obj/structure/bookcase{
-	name = "Forbidden Knowledge"
+"wlb" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -27
 	},
-/turf/open/floor/wood,
-/area/library)
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/monotile,
+/area/security/warden)
+"wmY" = (
+/obj/machinery/newscaster{
+	pixel_x = 32
+	},
+/turf/open/floor/monotile,
+/area/nsv/briefingroom)
 "wqR" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/incinerator_input{
 	dir = 1
@@ -43209,25 +43173,42 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
+"wwf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/wood,
+/area/library)
 "wyO" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/science/xenobiology)
-"wCN" = (
-/obj/structure/weightmachine/stacklifter,
-/obj/structure/cable{
-	icon_state = "4-8"
+"wzI" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "hor_window";
+	name = "privacy shutter"
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "0-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hor)
+"wAa" = (
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_x = -26
 	},
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/fitness/recreation)
+/turf/open/floor/monotile/light,
+/area/security/prison)
 "wEq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
@@ -43253,16 +43234,22 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"wJW" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -27
+"wLz" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
 	},
 /turf/open/floor/monotile,
-/area/security/warden)
+/area/security/brig)
+"wQJ" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/monotile,
+/area/medical/surgery)
 "wUv" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -43272,19 +43259,28 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/gateway)
+"wXi" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"wXk" = (
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/turf/open/floor/monotile,
+/area/maintenance/port)
+"wZc" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "wZp" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/nsv/observation)
-"xcW" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
 "xdR" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -43296,6 +43292,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile,
 /area/science/xenobiology)
+"xdT" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "xfd" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -43306,27 +43307,46 @@
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"xhv" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
 "xhI" = (
 /turf/closed/wall/r_wall/ship,
 /area/science/nanite)
+"xhM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/library)
 "xhY" = (
 /obj/machinery/newscaster{
 	pixel_x = 30
 	},
 /turf/open/floor/monotile/dark,
 /area/science/research)
+"xjA" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/carpet,
+/area/library)
+"xmt" = (
+/obj/machinery/newscaster{
+	pixel_x = -28
+	},
+/turf/open/floor/wood,
+/area/library)
+"xpw" = (
+/obj/item/storage/crayons,
+/obj/structure/table/wood,
+/turf/open/floor/carpet,
+/area/library)
 "xqR" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -43346,20 +43366,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/briefingroom)
-"xsP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	name = "intra ship intercom";
-	pixel_y = -26
-	},
-/turf/open/floor/monotile,
-/area/engine/engineering/hangar)
-"xuL" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/port)
 "xDQ" = (
 /obj/machinery/door/poddoor/incinerator_toxmix,
 /turf/open/floor/plating/airless,
@@ -43370,24 +43376,20 @@
 /obj/machinery/holopad,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms)
-"xHg" = (
-/obj/structure/bookcase/random/adult,
-/turf/open/floor/wood,
-/area/library)
-"xIh" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/newscaster{
-	pixel_x = 32
+"xFZ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/monotile/light,
-/area/medical/medbay/lobby)
-"xMf" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"xMq" = (
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_y = 26
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/secondary/exit)
+"xHc" = (
 /obj/machinery/airalarm/directional/north,
 /obj/structure/table/wood,
 /obj/item/toy/cards/deck/cas,
@@ -43397,21 +43399,21 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"xOE" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+"xMG" = (
+/obj/effect/turf_decal/tile/green{
 	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/newscaster{
-	pixel_y = -32
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -27
 	},
 /turf/open/floor/monotile,
-/area/hallway/nsv/deck2/frame1/central)
+/area/hallway/nsv/deck2/frame1/port)
 "xOP" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -43430,13 +43432,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/security/prison)
-"xQv" = (
-/obj/machinery/door/morgue{
-	name = "Private Study";
-	req_access_txt = "37"
-	},
-/turf/open/floor/wood,
-/area/library)
 "xWe" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -43445,22 +43440,23 @@
 /obj/machinery/recharger,
 /turf/open/floor/monotile/dark,
 /area/gateway)
-"xXo" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/east,
-/obj/structure/punching_bag,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
 "xXX" = (
 /obj/effect/landmark/nuclear_waste_spawner,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/closed/wall/r_wall/ship,
 /area/engine/atmospherics_engine)
+"xYa" = (
+/obj/structure/destructible/cult/tome,
+/obj/item/book/codex_gigas,
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/open/floor/wood,
+/area/library)
+"xYh" = (
+/obj/structure/bookcase/manuals/engineering,
+/turf/open/floor/wood,
+/area/library)
 "xYC" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -43471,6 +43467,10 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/science)
+"yfo" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 
 (1,1,1) = {"
 aaa
@@ -56708,7 +56708,7 @@ anb
 aaJ
 aFA
 alx
-gOm
+mWK
 aEo
 adM
 aFo
@@ -57221,7 +57221,7 @@ anb
 anb
 aaJ
 aFA
-sQp
+weE
 aEl
 asW
 aEr
@@ -57731,7 +57731,7 @@ aaJ
 anb
 aFA
 beD
-kNf
+wAa
 bIN
 bIP
 bIT
@@ -57768,7 +57768,7 @@ aGZ
 aGZ
 aGZ
 aGZ
-eJf
+lff
 aZe
 uTe
 vPd
@@ -58025,7 +58025,7 @@ aIA
 aGZ
 aGZ
 aGZ
-fGk
+dUS
 aZe
 cOu
 jlu
@@ -58250,7 +58250,7 @@ bIO
 bIS
 aFA
 aoQ
-mCs
+kng
 asW
 adM
 aFo
@@ -59290,7 +59290,7 @@ aFQ
 aIm
 aFQ
 aFQ
-wJW
+wlb
 aDL
 aFA
 aFA
@@ -59310,7 +59310,7 @@ wIm
 bif
 bwT
 aKb
-vxg
+kBg
 aZe
 aZe
 fjB
@@ -60804,7 +60804,7 @@ anb
 anb
 anb
 anb
-koM
+vPG
 anb
 anb
 anb
@@ -61076,7 +61076,7 @@ aBf
 aER
 aEY
 aHu
-rwx
+qNS
 aEX
 aHX
 aaV
@@ -61105,11 +61105,11 @@ bzA
 aKr
 aLb
 abB
-wbv
-wbv
-wbv
-wbv
-wbv
+wzI
+wzI
+wzI
+wzI
+wzI
 aXi
 alK
 lRd
@@ -61859,7 +61859,7 @@ bkJ
 bly
 bGu
 bkJ
-fXa
+mDA
 bkJ
 byO
 bmK
@@ -62137,7 +62137,7 @@ bjU
 bqK
 aLc
 aLc
-tzB
+glX
 aaC
 bxf
 aKS
@@ -62342,7 +62342,7 @@ aaJ
 aaJ
 aaJ
 aaJ
-fuK
+onI
 aac
 adT
 aDB
@@ -62622,7 +62622,7 @@ bEj
 bEo
 aaV
 aaV
-mAr
+gOD
 byJ
 aaV
 aaV
@@ -62633,7 +62633,7 @@ hrv
 aaV
 bFc
 agi
-rPg
+rnZ
 aHu
 aaw
 bwK
@@ -62648,10 +62648,10 @@ aKY
 bpG
 abB
 bdx
-oCm
-oCm
-oCm
-oCm
+lEy
+lEy
+lEy
+lEy
 aXi
 bgr
 aKS
@@ -62887,7 +62887,7 @@ aFO
 aXC
 aXC
 aXJ
-oFa
+qHc
 bCD
 bzP
 bmL
@@ -62917,7 +62917,7 @@ brM
 bCP
 bCK
 aMi
-cXI
+cFj
 aMQ
 aXi
 aXi
@@ -64459,7 +64459,7 @@ aMc
 bzW
 bdR
 aMF
-tNK
+ldc
 aXi
 aXi
 aXi
@@ -64669,7 +64669,7 @@ anb
 aaJ
 aZa
 akL
-pdQ
+cms
 aZa
 bgu
 bei
@@ -64684,7 +64684,7 @@ aFO
 bCX
 bgw
 aFO
-rCK
+wLz
 aXL
 aHu
 bmk
@@ -64707,7 +64707,7 @@ bqs
 bzx
 bwR
 aXm
-sAb
+cPU
 xhI
 aJD
 aJB
@@ -64926,7 +64926,7 @@ anb
 anb
 aZa
 akL
-iLQ
+pFQ
 aZa
 ayX
 bCZ
@@ -65183,7 +65183,7 @@ anb
 aaJ
 aZa
 baD
-cjV
+uqx
 aZa
 aEL
 bEc
@@ -65221,7 +65221,7 @@ bqu
 bwO
 aKv
 aMl
-ryl
+uMm
 xhI
 aXi
 aXi
@@ -65455,7 +65455,7 @@ aXy
 aXy
 aFP
 aIe
-fLO
+dLe
 aHu
 bku
 bwA
@@ -66481,10 +66481,10 @@ agX
 agX
 agX
 agX
-iLQ
+pFQ
 bhN
 agX
-pdQ
+cms
 afw
 bmo
 bmC
@@ -66511,7 +66511,7 @@ bbv
 lTI
 acs
 bbv
-qus
+mPw
 bIF
 aMc
 bHP
@@ -67271,7 +67271,7 @@ agI
 aeb
 bHZ
 bpz
-rBX
+kJA
 bjr
 aOS
 aOS
@@ -67485,7 +67485,7 @@ afw
 ahm
 ahK
 ahm
-mQI
+dXv
 ahm
 ahm
 bfw
@@ -67496,7 +67496,7 @@ aic
 aUx
 afw
 aXN
-cpn
+oBT
 agP
 agW
 aki
@@ -68019,7 +68019,7 @@ afV
 bbe
 bwe
 amh
-qmG
+tDB
 akQ
 acF
 akh
@@ -69337,10 +69337,10 @@ brA
 bre
 bre
 bre
-exj
+rUk
 bst
-oPV
-oPV
+svX
+svX
 blG
 blI
 agZ
@@ -69585,19 +69585,19 @@ aaB
 aaB
 aaB
 aaB
-jTb
-jTb
-jTb
-jTb
+laZ
+laZ
+laZ
+laZ
 brl
 bre
 bre
-jkZ
+mIj
 bDQ
 bsl
 brZ
 bzZ
-jTb
+laZ
 adh
 blJ
 agZ
@@ -69842,18 +69842,18 @@ aWe
 agT
 aOT
 aWc
-jTb
+laZ
 bqx
-dCK
+xdT
 ssf
-oiq
-hqB
-jkZ
-jkZ
+cFg
+sFd
+mIj
+mIj
 brY
-gYL
-dCK
-jTb
+czo
+xdT
+laZ
 afL
 adh
 aha
@@ -70075,7 +70075,7 @@ ahc
 ahc
 pSV
 akP
-uHP
+hzd
 ahc
 ahc
 alr
@@ -70099,18 +70099,18 @@ bxs
 bpg
 afE
 aWd
-jTb
-jkZ
+laZ
+mIj
 aZh
-eWc
+jVR
 brn
-eWc
+jVR
 brJ
-eWc
+jVR
 brZ
-jTb
-jTb
-jTb
+laZ
+laZ
+laZ
 adh
 adh
 bda
@@ -70333,14 +70333,14 @@ ahC
 ajT
 alh
 ajY
-cAW
+sCC
 aCf
 ahf
 bhK
 bFU
 amb
 ahf
-lsE
+ssH
 bCy
 bCz
 bmQ
@@ -70356,16 +70356,16 @@ afD
 bph
 afD
 bpL
-jTb
-jkZ
-oiq
+laZ
+mIj
+cFg
 bnn
-xMf
-hqB
-oiq
-jkZ
-dCK
-jTb
+psk
+sFd
+cFg
+mIj
+xdT
+laZ
 adE
 aea
 afN
@@ -70613,16 +70613,16 @@ agR
 bpi
 agR
 bil
-jTb
-jkZ
-oiq
-jTb
-jTb
-jTb
+laZ
+mIj
+cFg
+laZ
+laZ
+laZ
 brK
-jTb
-jTb
-jTb
+laZ
+laZ
+laZ
 adK
 adh
 afO
@@ -70870,10 +70870,10 @@ agS
 bpj
 agS
 bpM
-jTb
-daT
-oiq
-jTb
+laZ
+isj
+cFg
+laZ
 act
 acD
 bkL
@@ -70884,7 +70884,7 @@ adZ
 aef
 afY
 aef
-vyX
+nFf
 ahG
 bye
 ahG
@@ -71127,10 +71127,10 @@ bju
 bpk
 bpB
 bpN
-jTb
-tdO
+laZ
+sxM
 bsS
-jTb
+laZ
 acu
 acE
 bkQ
@@ -71372,22 +71372,22 @@ bCt
 bCu
 bCv
 bmS
-jTb
-jTb
-jTb
-jTb
-jTb
-jTb
-jTb
-jTb
-jTb
+laZ
+laZ
+laZ
+laZ
+laZ
+laZ
+laZ
+laZ
+laZ
 bpl
-jTb
-jTb
-jTb
-jkZ
-oiq
-jTb
+laZ
+laZ
+laZ
+mIj
+cFg
+laZ
 acv
 bcZ
 adw
@@ -71628,23 +71628,23 @@ bvl
 bwp
 bwq
 bCw
-uEu
-jTb
-rtJ
-rtJ
-jTb
-jRE
-jkZ
-jkZ
-jkZ
-jkZ
+xMG
+laZ
+yfo
+yfo
+laZ
+iNZ
+mIj
+mIj
+mIj
+mIj
 bpm
-jkZ
-jkZ
-jkZ
-jkZ
-oiq
-jTb
+mIj
+mIj
+mIj
+mIj
+cFg
+laZ
 abF
 abF
 ahY
@@ -71886,22 +71886,22 @@ aTT
 acx
 bmE
 bmQ
-jTb
+laZ
 kSX
-eWc
+jVR
 bnY
-eWc
-eWc
-eWc
-eWc
-eWc
+jVR
+jVR
+jVR
+jVR
+jVR
 bsJ
-eWc
-eWc
-eWc
-eWc
+jVR
+jVR
+jVR
+jVR
 brZ
-jTb
+laZ
 acP
 bJk
 beR
@@ -72106,11 +72106,11 @@ aYT
 aYT
 bne
 brm
-xuL
+sSl
 bne
 amK
 amM
-dFe
+wQJ
 aoO
 aUH
 aaK
@@ -72134,8 +72134,8 @@ azf
 azf
 azf
 bkT
-xIh
-dZe
+iDJ
+uWe
 lVV
 bFy
 blQ
@@ -72143,22 +72143,22 @@ afV
 afS
 bmE
 bmQ
-jTb
+laZ
 mMv
 bnH
-jTb
+laZ
 boq
 boq
-lWU
+jmS
 boq
 boq
 boq
 boq
 boq
-lWU
+jmS
 boq
 boq
-lWU
+jmS
 acA
 acG
 bkM
@@ -72351,7 +72351,7 @@ aaJ
 aaJ
 aaJ
 bHp
-xuL
+sSl
 brB
 bnm
 aYR
@@ -72360,7 +72360,7 @@ bne
 bne
 bne
 bne
-lCu
+qth
 bne
 aAt
 bne
@@ -72400,9 +72400,9 @@ aae
 aPg
 buO
 bmT
-jTb
+laZ
 xfd
-tIn
+keR
 bnZ
 aaa
 aaa
@@ -72612,11 +72612,11 @@ bne
 bne
 bne
 bne
-rab
+pPw
 bne
-mKB
-sxI
-nSo
+wZc
+uqS
+hOZ
 ajN
 anu
 aqU
@@ -72625,13 +72625,13 @@ bsy
 bsy
 bsy
 bsy
-nuV
+jxT
 bsy
 bsy
 bsy
 bsy
 bsy
-nuV
+jxT
 bsy
 bsy
 bsy
@@ -72657,9 +72657,9 @@ aae
 aeT
 buJ
 bmU
-jTb
+laZ
 ecN
-jRE
+iNZ
 bnZ
 aaa
 aaa
@@ -72866,32 +72866,32 @@ bne
 bnm
 bne
 bIm
-mKB
-jSF
+wZc
+cer
 aZV
 bhp
-jSF
+cer
 bDI
 bne
-jeJ
+wXk
 akc
 bne
 baB
-jSF
-jSF
-jSF
-jSF
-jSF
-jSF
-jSF
-jSF
-jSF
-jSF
-jSF
-jSF
-jSF
-jSF
-jSF
+cer
+cer
+cer
+cer
+cer
+cer
+cer
+cer
+cer
+cer
+cer
+cer
+cer
+cer
+cer
 aYV
 jtt
 bHp
@@ -72914,8 +72914,8 @@ bFG
 bFH
 bFI
 bmU
-jTb
-oiq
+laZ
+cFg
 kOA
 bnZ
 aaa
@@ -73171,9 +73171,9 @@ aae
 bIw
 buJ
 bmU
-jTb
+laZ
 bct
-jTb
+laZ
 bnZ
 aaa
 aaa
@@ -73390,7 +73390,7 @@ bHp
 aTD
 akR
 abx
-teO
+iDb
 bgP
 bgF
 abx
@@ -73414,11 +73414,11 @@ bcy
 aMv
 aaj
 bfi
-oqB
+jsE
 bFX
 bji
 biZ
-qcO
+uQh
 blf
 aaj
 aSC
@@ -73634,7 +73634,7 @@ aiH
 aAl
 aAp
 bne
-xuL
+sSl
 bne
 bhm
 aZO
@@ -74178,7 +74178,7 @@ abx
 abA
 aev
 bao
-wjg
+kVJ
 aam
 aeT
 bcy
@@ -74231,7 +74231,7 @@ aNX
 acc
 aOe
 acc
-ewa
+iVI
 aOe
 aaJ
 aaJ
@@ -74407,7 +74407,7 @@ aaJ
 aaJ
 bHp
 bHp
-mKB
+wZc
 bDI
 bHp
 aaq
@@ -74457,9 +74457,9 @@ aPx
 bIu
 bmU
 aad
-ojE
+xFZ
 abT
-clK
+eHZ
 afq
 aOg
 aaa
@@ -74969,7 +74969,7 @@ abn
 xsC
 aeT
 buJ
-gRv
+gVA
 aad
 bGI
 abT
@@ -75177,7 +75177,7 @@ jtt
 jtt
 jtt
 bne
-xuL
+sSl
 aZO
 bHp
 bip
@@ -75483,7 +75483,7 @@ abn
 aaj
 buR
 buM
-xOE
+cmZ
 aad
 bpn
 bjA
@@ -76287,7 +76287,7 @@ aNX
 acc
 aOe
 acc
-ewa
+iVI
 aOe
 aaJ
 aaJ
@@ -76735,7 +76735,7 @@ abx
 abx
 abx
 agh
-jDV
+vEp
 agr
 agv
 agv
@@ -77287,7 +77287,7 @@ bHo
 bnr
 bnL
 bqz
-itE
+qOP
 acd
 bxH
 bDo
@@ -77307,7 +77307,7 @@ bsf
 bsn
 bro
 bro
-tma
+pqr
 bro
 bsn
 bsM
@@ -78276,7 +78276,7 @@ bDS
 abx
 bBy
 abx
-jNU
+fFd
 abx
 aKi
 bau
@@ -78286,7 +78286,7 @@ baw
 abx
 abx
 abx
-kJH
+gWF
 abx
 abx
 abx
@@ -78549,7 +78549,7 @@ agm
 agm
 agm
 agm
-eux
+kEU
 bcy
 aMv
 aaj
@@ -78797,7 +78797,7 @@ agw
 aTk
 bBp
 bgV
-tbe
+sjd
 agm
 bai
 bak
@@ -79036,7 +79036,7 @@ bHp
 bnm
 aZO
 bHp
-oYj
+fjX
 aat
 aat
 aba
@@ -79061,7 +79061,7 @@ bal
 aTp
 aTp
 aTp
-oQR
+nHQ
 agm
 bgf
 bcy
@@ -79070,12 +79070,12 @@ aaT
 abn
 byA
 bvj
-fbK
+eam
 biX
 bJo
 bLb
-jOa
-etp
+wmY
+mys
 byA
 abn
 aaT
@@ -79300,7 +79300,7 @@ abh
 aeD
 atO
 bBk
-ecd
+iey
 atY
 bBB
 age
@@ -79582,9 +79582,9 @@ bcy
 aMv
 aaj
 acI
-hTa
+roY
 abJ
-vHs
+rdE
 aaj
 buQ
 ada
@@ -80124,7 +80124,7 @@ aes
 bcr
 bqf
 bqB
-uns
+iYd
 bIC
 bID
 bID
@@ -80381,7 +80381,7 @@ aes
 bcr
 bqe
 bqc
-czr
+lzn
 bIC
 aaJ
 bID
@@ -80586,7 +80586,7 @@ aam
 bfj
 adO
 bgT
-plB
+jEi
 bBF
 agg
 agm
@@ -80609,7 +80609,7 @@ ahz
 bcy
 aMv
 abf
-qGC
+hPT
 abs
 aaf
 acm
@@ -81088,7 +81088,7 @@ bHp
 bHp
 anP
 bnm
-mJn
+fSB
 jtt
 aZO
 bne
@@ -81125,7 +81125,7 @@ aPh
 buU
 bbG
 bcE
-bRI
+kqZ
 bjy
 bjy
 bbG
@@ -81340,19 +81340,19 @@ aaJ
 aaJ
 aaJ
 bHp
-mKB
-jSF
-jSF
-jSF
-jSF
-jSF
-jSF
+wZc
+cer
+cer
+cer
+cer
+cer
+cer
 aZQ
 aZR
-jSF
-jSF
-jSF
-jSF
+cer
+cer
+cer
+cer
 aZR
 aZS
 aLk
@@ -81595,11 +81595,11 @@ aaJ
 aaJ
 aaJ
 aaJ
-jvv
-jvv
-rab
-jvv
-jvv
+ksH
+ksH
+pPw
+ksH
+ksH
 anN
 anN
 anN
@@ -81622,7 +81622,7 @@ ach
 avi
 btP
 ars
-mFV
+rXW
 acn
 amj
 aPj
@@ -81641,14 +81641,14 @@ acn
 bfz
 acn
 acn
-mFV
+rXW
 acn
 acn
 acn
 acn
 acn
 acn
-dKN
+eSk
 acn
 acn
 aPn
@@ -81852,12 +81852,12 @@ aaJ
 aaJ
 aaJ
 aaJ
-jvv
-pAv
-nmA
+ksH
+nNs
+tGC
 auA
 auG
-eyy
+oHz
 aRH
 anN
 bqZ
@@ -81896,7 +81896,7 @@ bde
 bbI
 aVl
 bde
-vZE
+sJI
 abZ
 aaY
 aaY
@@ -82109,9 +82109,9 @@ aaJ
 aaJ
 aaJ
 aaJ
-ozk
-qBT
-gQz
+iyL
+enx
+tux
 auB
 auH
 aAA
@@ -82143,7 +82143,7 @@ aMJ
 aMH
 abd
 abR
-uYx
+gvw
 ajS
 baI
 abZ
@@ -82179,7 +82179,7 @@ ajO
 aka
 bGD
 aka
-taR
+eJW
 aEf
 aaJ
 aaJ
@@ -82366,9 +82366,9 @@ aaJ
 aaJ
 bJe
 aaJ
-ozk
-cnE
-gQz
+iyL
+fvp
+tux
 auz
 auH
 auJ
@@ -82436,7 +82436,7 @@ ajP
 akd
 aOj
 aOr
-oNq
+phM
 aEf
 aaJ
 aaJ
@@ -82623,10 +82623,10 @@ aaJ
 aaJ
 aaJ
 aaJ
-ozk
+iyL
 aup
-gQz
-fTx
+tux
+emm
 auI
 aRE
 aRJ
@@ -82880,12 +82880,12 @@ aaJ
 aaJ
 aaJ
 aaJ
-jvv
+ksH
 auk
-gQz
-fGv
-cYy
-uqv
+tux
+gUy
+jiL
+tKA
 aRG
 anN
 aQw
@@ -82945,12 +82945,12 @@ adr
 adr
 adr
 adp
-wjl
-wjl
-wjl
-wjl
-wjl
-wjl
+iuA
+iuA
+iuA
+iuA
+iuA
+iuA
 aij
 aij
 aij
@@ -83137,9 +83137,9 @@ aaJ
 aaJ
 aaJ
 aaJ
-jvv
-sjG
-gQz
+ksH
+rel
+tux
 aqI
 aqI
 aqI
@@ -83196,18 +83196,18 @@ aMw
 aVV
 aaY
 adp
-hNe
+ohw
 adp
 bHR
 adp
 adp
 adp
-wjl
+iuA
 api
-fmZ
-utP
-fmZ
-fmZ
+qEO
+vZc
+qEO
+qEO
 aih
 aim
 aim
@@ -83394,13 +83394,13 @@ aaJ
 aaJ
 aaJ
 aaJ
-jvv
-usN
-kiF
-rLW
-xcW
-iXP
-nsg
+ksH
+khE
+eDI
+kLw
+hCf
+sMC
+pVN
 anN
 auZ
 aeY
@@ -83451,17 +83451,17 @@ aaY
 aaY
 aaY
 aaY
-wjl
-wjl
-wjl
-wjl
-wjl
-wjl
-wjl
-wjl
-wjl
-fmZ
-fmZ
+iuA
+iuA
+iuA
+iuA
+iuA
+iuA
+iuA
+iuA
+iuA
+qEO
+qEO
 bqD
 bcn
 bsG
@@ -83651,13 +83651,13 @@ aaJ
 aaJ
 aaJ
 aaJ
-ozk
-cmR
-dyT
+iyL
+iLl
+gUD
 auJ
 auJ
-cJo
-ndg
+hpX
+iCD
 anN
 auh
 agd
@@ -83665,7 +83665,7 @@ ava
 ams
 bhJ
 btT
-lKZ
+vew
 amq
 any
 aSb
@@ -83708,20 +83708,20 @@ aaY
 bcc
 bmJ
 buw
-wjl
-psQ
-qOo
-wjl
+iuA
+wXi
+dXL
+iuA
 aiN
 bjH
 api
 apo
-wjl
-fmZ
-nJD
+iuA
+qEO
+eFj
 brC
-nJD
-gxQ
+eFj
+vjc
 aih
 aih
 aih
@@ -83908,13 +83908,13 @@ aaJ
 aaJ
 aaJ
 aaJ
-ozk
-cmR
-low
+iyL
+iLl
+ljk
 auJ
 auK
-dZf
-nNg
+mAn
+foc
 anN
 ams
 agA
@@ -83967,25 +83967,25 @@ bsh
 bux
 bAT
 bnw
-fmZ
-wjl
+qEO
+iuA
 aiO
 aiZ
 apl
-fmZ
-wjl
-fmZ
-fmZ
+qEO
+iuA
+qEO
+qEO
 brT
 uOY
-gxQ
-wjl
+vjc
+iuA
 awc
 aAb
 aYx
 aYA
 aYA
-fHv
+oyi
 ndL
 aij
 aAy
@@ -84165,19 +84165,19 @@ aaJ
 aaJ
 aaJ
 aaJ
-ozk
-cmR
-dyT
+iyL
+iLl
+gUD
 auJ
 auJ
-dZf
-kfl
+mAn
+mHC
 anN
 bfr
 atz
 bhD
-hwR
-gRD
+fXp
+lAs
 atz
 aoe
 ami
@@ -84222,12 +84222,12 @@ aaY
 aaY
 aaY
 aaY
-wjl
+iuA
 bnx
-fmZ
-wjl
-fmZ
-fmZ
+qEO
+iuA
+qEO
+qEO
 asa
 avp
 awT
@@ -84240,9 +84240,9 @@ bzF
 bJp
 bJq
 bJw
-fmZ
+qEO
 aYA
-fHv
+oyi
 tjC
 aij
 aAy
@@ -84422,20 +84422,20 @@ aaJ
 aaJ
 aaJ
 aaJ
-ozk
-cmR
-wCN
+iyL
+iLl
+jld
 auJ
 auL
-rfU
+nQO
 aqI
 amr
 aqy
 atz
-nUa
+qvd
 xEa
 aqy
-olz
+mXe
 ahe
 aip
 aiJ
@@ -84479,27 +84479,27 @@ are
 byW
 atn
 aMz
-wjl
-gxQ
-fmZ
-wjl
-fmZ
-fmZ
-fmZ
-fmZ
-wjl
-fmZ
+iuA
+vjc
+qEO
+iuA
+qEO
+qEO
+qEO
+qEO
+iuA
+qEO
 aiK
 brT
-nJD
-gxQ
-wjl
+eFj
+vjc
+iuA
 axG
-fmZ
+qEO
 aBh
 aBh
 aYA
-fHv
+oyi
 aAy
 aAy
 aAy
@@ -84679,11 +84679,11 @@ aaJ
 aaJ
 aaJ
 aaJ
-ozk
-cmR
-juv
-qHX
-qHX
+iyL
+iLl
+uhg
+hgn
+hgn
 bFP
 auV
 aqB
@@ -84704,12 +84704,12 @@ aZo
 aZw
 bhF
 btF
-fOe
-vtN
+dmA
+ful
 bhA
-taH
+ntS
 bGj
-nfi
+iZE
 bkj
 acR
 afc
@@ -84736,27 +84736,27 @@ bkd
 buE
 atp
 aMS
-wjl
-gxQ
-fmZ
-wjl
+iuA
+vjc
+qEO
+iuA
 aiP
 aiP
-qOo
-psQ
-wjl
-fmZ
-fmZ
+dXL
+wXi
+iuA
+qEO
+qEO
 brT
-fmZ
-gxQ
-wjl
+qEO
+vjc
+iuA
 azy
 aBh
 bHM
 aBh
 aYD
-fHv
+oyi
 aaJ
 aaJ
 aaJ
@@ -84936,13 +84936,13 @@ aaJ
 aaJ
 aaJ
 aaJ
-jvv
-qBI
-jGm
-xhv
-xXo
-rbG
-tlx
+ksH
+uee
+cTt
+paV
+hdp
+nLB
+fex
 anN
 bIx
 aqy
@@ -84993,27 +84993,27 @@ bbV
 arl
 atu
 aVA
-wjl
-gxQ
-fmZ
-wjl
-wjl
-wjl
-wjl
-wjl
-wjl
-fmZ
-fmZ
+iuA
+vjc
+qEO
+iuA
+iuA
+iuA
+iuA
+iuA
+iuA
+qEO
+qEO
 brT
-fmZ
-gxQ
-wjl
+qEO
+vjc
+iuA
 azM
 aBh
 aBh
 aBh
 aYE
-fHv
+oyi
 aaJ
 aaJ
 aaJ
@@ -85193,21 +85193,21 @@ aaJ
 aaJ
 aaJ
 aaJ
-jvv
+ksH
 anN
-gMd
+jbU
 anN
-vzf
-vzf
-vzf
-vzf
-vzf
-vzf
+haf
+haf
+haf
+haf
+haf
+haf
 bAI
 aZm
 aum
-vzf
-vzf
+haf
+haf
 ami
 aqE
 aro
@@ -85250,7 +85250,7 @@ bmb
 bmx
 atF
 aVB
-wjl
+iuA
 bnz
 bkZ
 bob
@@ -85264,13 +85264,13 @@ boW
 lAV
 bob
 bqE
-wjl
+iuA
 azN
-fmZ
-fmZ
-fmZ
+qEO
+qEO
+qEO
 aYF
-fHv
+oyi
 aaJ
 aaJ
 aaJ
@@ -85454,19 +85454,19 @@ asL
 aHP
 aYN
 aYM
-vzf
-fdA
-lIC
-oUr
-lIC
+haf
+pjr
+hvH
+xmt
+hvH
 afx
 bAJ
 aZr
 bhE
-fOC
-fhy
+tIg
+mOp
 ami
-mCI
+dHB
 art
 bfS
 aRM
@@ -85507,8 +85507,8 @@ bbX
 bmy
 aMy
 aVC
-wjl
-uER
+iuA
+ruX
 ail
 ail
 bGi
@@ -85527,7 +85527,7 @@ aCh
 aBh
 aYB
 aYG
-fHv
+oyi
 aaJ
 aaJ
 aaJ
@@ -85711,17 +85711,17 @@ asL
 aoZ
 aoZ
 aJp
-vzf
-jDU
-lIC
-exK
-lIC
-xHg
-lIC
-sbi
+haf
+fGo
+hvH
+exT
+hvH
+nJu
+hvH
+cri
 auD
-lIC
-ebV
+hvH
+xYh
 ami
 bgk
 ayT
@@ -85741,7 +85741,7 @@ aMJ
 aMH
 acR
 bGb
-tds
+sem
 acS
 acS
 abZ
@@ -85759,12 +85759,12 @@ buc
 buj
 buC
 arb
-wjl
-wjl
+iuA
+iuA
 bmz
-wjl
-wjl
-wjl
+iuA
+iuA
+iuA
 bnA
 bkZ
 bob
@@ -85778,13 +85778,13 @@ bkZ
 ciL
 ljw
 bqG
-wjl
+iuA
 azX
 aCi
 aYy
 aYC
 aYH
-fHv
+oyi
 aaJ
 aaJ
 aaJ
@@ -85968,17 +85968,17 @@ asL
 asL
 aoZ
 aJp
-vzf
-sCI
-lIC
-nML
-lIC
-cBE
-fmU
+haf
+pgF
+hvH
+iNo
+hvH
+cIa
+qeW
 aMI
 auD
-lIC
-eLT
+hvH
+dyj
 ami
 aqF
 bbR
@@ -86016,8 +86016,8 @@ aqM
 bzC
 aqT
 arc
-wjl
-fmZ
+iuA
+qEO
 blp
 bzD
 bkZ
@@ -86033,15 +86033,15 @@ apV
 apV
 bzE
 apV
-fHv
+oyi
 glh
-wjl
-wjl
+iuA
+iuA
 aPw
 bzG
-fHv
-fHv
-fHv
+oyi
+oyi
+oyi
 aaJ
 aaJ
 aaJ
@@ -86225,17 +86225,17 @@ aaJ
 asL
 aoZ
 aJp
-vzf
-nyk
-lIC
-tJL
-lIC
-mTD
-lIC
-ujl
+haf
+gMB
+hvH
+eLv
+hvH
+sbl
+hvH
+xhM
 auD
-lIC
-wfQ
+hvH
+tBx
 ami
 aqH
 arv
@@ -86265,18 +86265,18 @@ aVt
 bue
 aVt
 bfT
-feA
+hLd
 bjq
-feA
-feA
-feA
-feA
-wjl
-wjl
-wjl
-fmZ
-fHv
-fHv
+hLd
+hLd
+hLd
+hLd
+iuA
+iuA
+iuA
+qEO
+oyi
+oyi
 apV
 apV
 apV
@@ -86290,13 +86290,13 @@ aCo
 aWb
 aWb
 aWb
-fHv
+oyi
 glh
-wjl
-fmZ
+iuA
+qEO
 aVK
-fmZ
-fHv
+qEO
+oyi
 aaJ
 aaJ
 aaJ
@@ -86480,19 +86480,19 @@ aaJ
 aaJ
 aaJ
 asL
-shz
+osW
 aJp
-vzf
-iYO
-lIC
-gJd
-lIC
-vTw
+haf
+eRG
+hvH
+svo
+hvH
+vjN
 bAK
 aYW
-smL
-qUo
-bXD
+tcb
+jmH
+tfj
 ami
 ami
 ami
@@ -86522,17 +86522,17 @@ bbP
 buy
 aVu
 bgg
-feA
+hLd
 bjz
 amY
 aVE
 aVH
 aVJ
-wjl
+iuA
 uDe
-wjl
-fmZ
-fHv
+iuA
+qEO
+oyi
 bFj
 azC
 azP
@@ -86547,13 +86547,13 @@ apV
 apV
 apV
 aWa
-fHv
+oyi
 glh
-wjl
+iuA
 aAa
 aVW
 aYz
-fHv
+oyi
 aaJ
 aaJ
 aaJ
@@ -86739,14 +86739,14 @@ aaJ
 asL
 aoZ
 aJp
-vzf
-vzf
-vzf
-vzf
-vzf
+haf
+haf
+haf
+haf
+haf
 aJN
-vzf
-vzf
+haf
+haf
 auE
 auM
 aRF
@@ -86779,17 +86779,17 @@ bdp
 bzB
 bdp
 bgo
-feA
+hLd
 bjG
 bkF
 bkY
 bkY
 fXQ
 blz
-nmm
-wjl
-fmZ
-fHv
+nUJ
+iuA
+qEO
+oyi
 aWb
 azO
 azR
@@ -86804,13 +86804,13 @@ aDU
 aVY
 aVZ
 aWb
-fHv
+oyi
 bqH
-wjl
-wjl
-wjl
-wjl
-fHv
+iuA
+iuA
+iuA
+iuA
+oyi
 aaJ
 aaJ
 aaJ
@@ -86998,15 +86998,15 @@ aoZ
 aYN
 aYK
 aYM
-vzf
+haf
 aJL
 aLs
-lOY
-lIC
-vzf
+wwf
+hvH
+haf
 auF
 auD
-kEA
+uiz
 ami
 ami
 ami
@@ -87036,7 +87036,7 @@ aVv
 bkg
 aVv
 aVz
-feA
+hLd
 amP
 qxl
 aMA
@@ -87045,8 +87045,8 @@ aMA
 air
 blL
 ais
-fmZ
-fHv
+qEO
+oyi
 aWb
 azO
 azS
@@ -87061,13 +87061,13 @@ apV
 apV
 apV
 aWa
-fHv
+oyi
 glh
 bHw
-fmZ
+qEO
 bHx
 bHx
-rHz
+ilA
 aaJ
 aaJ
 aaJ
@@ -87252,16 +87252,16 @@ aaJ
 aaJ
 asL
 asL
-qpW
+iov
 asL
 aJp
-vzf
-xMq
+haf
+xHc
 aul
-qGH
+tlE
 auo
-vzf
-fhB
+haf
+gbK
 auD
 auD
 ami
@@ -87293,17 +87293,17 @@ aeL
 aeL
 aeL
 aeL
-feA
+hLd
 arz
 aVD
 aVG
 aVI
 bln
-wjl
+iuA
 blL
-wjl
-wjl
-fHv
+iuA
+iuA
+oyi
 aWb
 azO
 azT
@@ -87318,13 +87318,13 @@ aCo
 aWb
 aWb
 aWb
-fHv
+oyi
 glh
-wjl
-fmZ
-fmZ
-fmZ
-rHz
+iuA
+qEO
+qEO
+qEO
+ilA
 aaJ
 aaJ
 aaJ
@@ -87512,15 +87512,15 @@ aaJ
 aAy
 asL
 aJp
-vzf
-cOn
-fjw
+haf
+bMO
+xjA
 bhH
-rRz
-vzf
-vzf
-xQv
-vzf
+sYQ
+haf
+haf
+nYT
+haf
 aqC
 aqC
 aqC
@@ -87544,44 +87544,44 @@ btd
 btf
 byt
 byt
-uqd
+sdX
 bAy
 aXr
 bkh
-qxO
+nJo
 aPp
-wjl
-wjl
+iuA
+iuA
 bzG
-wjl
-wjl
+iuA
+iuA
 blo
-wjl
+iuA
 blL
 ait
 aix
-fHv
-fHv
-fHv
-fHv
-fHv
+oyi
+oyi
+oyi
+oyi
+oyi
 aiE
-fHv
-fHv
+oyi
+oyi
 mwO
-fHv
-fHv
-fHv
-fHv
-fHv
-fHv
-fHv
+oyi
+oyi
+oyi
+oyi
+oyi
+oyi
+oyi
 glh
-fHv
-fHv
-rHz
-rHz
-rHz
+oyi
+oyi
+ilA
+ilA
+ilA
 aaJ
 aaJ
 aaJ
@@ -87769,15 +87769,15 @@ aaJ
 aAy
 asL
 aJp
-vzf
-iVe
-vRM
-vhq
-rmu
-vzf
-gWv
-dAz
-vbZ
+haf
+sBR
+cWr
+xpw
+vtW
+haf
+xYa
+cZf
+hNP
 anp
 aSn
 aqi
@@ -87811,17 +87811,17 @@ aii
 bjI
 bkG
 bkZ
-nmm
+nUJ
 blp
-nmm
+nUJ
 blL
 aiu
 aiy
-fmZ
-fmZ
-fmZ
-fmZ
-fmZ
+qEO
+qEO
+qEO
+qEO
+qEO
 aiI
 aiL
 aiL
@@ -87834,7 +87834,7 @@ ljw
 pFX
 ljw
 vpr
-fHv
+oyi
 aaJ
 aaJ
 aaJ
@@ -88026,15 +88026,15 @@ aaJ
 aAy
 asL
 aJp
-vzf
-ocu
-qNh
-lIC
-lIC
-vzf
-wqj
-iUQ
-dHI
+haf
+gNY
+pCV
+hvH
+hvH
+haf
+lKI
+bMH
+lcf
 anp
 aoa
 azq
@@ -88064,8 +88064,8 @@ aBJ
 aBJ
 aBJ
 aBJ
-wjl
-nJD
+iuA
+eFj
 aiW
 ail
 blk
@@ -88087,11 +88087,11 @@ bkZ
 bkZ
 boN
 bpp
-fmZ
-fHv
-nJD
-fmZ
-fHv
+qEO
+oyi
+eFj
+qEO
+oyi
 aaJ
 aaJ
 aaJ
@@ -88283,12 +88283,12 @@ aaJ
 aAy
 asL
 aJp
-vzf
-vzf
-vzf
-lZa
-vzf
-hES
+haf
+haf
+haf
+neD
+haf
+bNa
 anp
 anp
 anp
@@ -88308,11 +88308,11 @@ aBg
 aey
 arW
 arW
-oVe
+tuz
 afk
 aPz
 aNd
-gSC
+ltR
 arW
 arW
 aPt
@@ -88321,34 +88321,34 @@ bGo
 bGo
 byq
 aPt
-fHv
-fHv
-fHv
-fHv
-fHv
+oyi
+oyi
+oyi
+oyi
+oyi
 blr
-fHv
-fHv
+oyi
+oyi
 aiw
 aiA
-fHv
-fHv
-fHv
-fHv
+oyi
+oyi
+oyi
+oyi
 aiD
-fHv
-fHv
-fHv
+oyi
+oyi
+oyi
 amt
-fHv
-fHv
-fHv
+oyi
+oyi
+oyi
 avo
-fHv
-fHv
-fHv
-fHv
-fHv
+oyi
+oyi
+oyi
+oyi
+oyi
 aaJ
 aaJ
 aaJ
@@ -89053,9 +89053,9 @@ aaJ
 aaJ
 anb
 anb
-fTy
-lTu
-vFJ
+iQX
+csB
+rxn
 aoZ
 aJp
 aoZ
@@ -89064,7 +89064,7 @@ apP
 agC
 ayS
 aSl
-gnX
+ksY
 anp
 awj
 ayO
@@ -89578,7 +89578,7 @@ apU
 aqe
 ayU
 aqe
-mDS
+hhQ
 anp
 anQ
 aQE
@@ -90601,7 +90601,7 @@ aHJ
 asL
 aJp
 aoZ
-eCV
+qKl
 asL
 anW
 anZ
@@ -90858,7 +90858,7 @@ asL
 asL
 bhn
 aoZ
-kmg
+saB
 asL
 aqb
 aAU
@@ -91382,7 +91382,7 @@ aHw
 aHw
 aQL
 aBw
-iMm
+kmy
 amC
 aBs
 aLv
@@ -91886,7 +91886,7 @@ aJK
 asL
 amA
 aob
-uPi
+gVX
 ape
 aQF
 bAq
@@ -92404,7 +92404,7 @@ anO
 anQ
 anZ
 bkp
-iuh
+eyz
 aBb
 bhv
 aHy
@@ -93688,7 +93688,7 @@ anm
 aoX
 aQl
 aQs
-xsP
+fPZ
 anj
 aaJ
 aRc
@@ -94202,7 +94202,7 @@ anm
 anM
 apX
 aQq
-ujv
+mPU
 anj
 aaJ
 aRc
@@ -94716,7 +94716,7 @@ anm
 aoX
 aQl
 aQs
-nms
+oUM
 anj
 aaJ
 aey

--- a/_maps/map_files/Enterprise/Enterprise2.dmm
+++ b/_maps/map_files/Enterprise/Enterprise2.dmm
@@ -6,7 +6,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/closed/wall/ship,
-/area/maintenance/port)
+/area/maintenance/central)
 "aac" = (
 /turf/closed/wall/r_wall/ship,
 /area/ai_monitored/security/armory)
@@ -26,7 +26,7 @@
 	dir = 9
 	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/port)
 "aah" = (
 /turf/closed/wall/ship,
 /area/maintenance/department/science)
@@ -55,7 +55,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/port)
 "aam" = (
 /turf/closed/wall/r_wall/ship,
 /area/nsv/hanger/deck2)
@@ -67,6 +67,10 @@
 	},
 /obj/machinery/camera/autoname,
 /obj/structure/closet/secure_closet/master_at_arms,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
 /turf/open/floor/carpet/ship,
 /area/nsv/hanger/deck2)
 "aao" = (
@@ -201,6 +205,10 @@
 "aaM" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/blue,
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_x = 26
+	},
 /turf/open/floor/carpet/ship,
 /area/nsv/hanger/deck2)
 "aaN" = (
@@ -217,6 +225,7 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/carpet/ship,
 /area/nsv/hanger/deck2)
 "aaP" = (
@@ -389,7 +398,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/central)
 "abu" = (
 /obj/structure/chair/comfy/black,
 /obj/effect/landmark/start/captain,
@@ -912,6 +921,10 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
 /turf/open/floor/carpet/ship,
 /area/chapel/office)
 "acQ" = (
@@ -998,6 +1011,10 @@
 /area/nsv/briefingroom)
 "adb" = (
 /obj/structure/table,
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_y = -26
+	},
 /turf/open/floor/monotile/dark,
 /area/chapel/office)
 "adc" = (
@@ -2008,6 +2025,9 @@
 	dir = 8
 	},
 /obj/machinery/chem_master,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
 /turf/open/floor/monotile,
 /area/medical/chemistry)
 "afu" = (
@@ -2054,10 +2074,18 @@
 /obj/structure/sign/warning/biohazard{
 	pixel_y = 26
 	},
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_x = 26
+	},
 /turf/open/floor/monotile,
 /area/janitor)
 "afC" = (
 /obj/effect/turf_decal/box,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/open/floor/monotile,
 /area/janitor)
 "afD" = (
@@ -2999,16 +3027,6 @@
 	},
 /turf/open/floor/engine,
 /area/medical/medbay/lobby)
-"ahU" = (
-/obj/effect/turf_decal/box,
-/obj/structure/bed/roller,
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = 26
-	},
-/turf/open/floor/monotile/dark,
-/area/medical/medbay/zone2{
-	name = "Intensive care unit"
-	})
 "ahV" = (
 /obj/machinery/computer/crew,
 /obj/machinery/power/apc/auto_name/north,
@@ -3137,7 +3155,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "aij" = (
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/department/cargo)
@@ -3147,13 +3165,13 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/port)
 "ail" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "aim" = (
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
@@ -3186,11 +3204,11 @@
 "air" = (
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /turf/open/floor/monotile/dark,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "ais" = (
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "ait" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -3203,13 +3221,13 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "aiu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "aiv" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
@@ -3226,7 +3244,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall/ship,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "aix" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -3237,13 +3255,13 @@
 	},
 /obj/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "aiy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "aiz" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile,
@@ -3253,7 +3271,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall/ship,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "aiB" = (
 /obj/machinery/airalarm{
 	pixel_y = 26
@@ -3279,7 +3297,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/monotile,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "aiE" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 8
@@ -3299,7 +3317,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "aiF" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/structure/cable{
@@ -3317,7 +3335,7 @@
 	dir = 5
 	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/port)
 "aiI" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 10
@@ -3332,7 +3350,7 @@
 	dir = 10
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "aiJ" = (
 /obj/machinery/camera/autoname,
 /obj/structure/disposalpipe/segment,
@@ -3341,42 +3359,42 @@
 "aiK" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "aiL" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "aiM" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/port)
 "aiN" = (
 /obj/structure/table,
 /obj/item/stock_parts/manipulator,
 /obj/item/disk/holodisk/enterprise_log,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "aiO" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "aiP" = (
 /obj/structure/table,
 /obj/item/poster/random_contraband,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "aiQ" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/port)
 "aiR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/curtain/obscuring/grey,
@@ -3417,7 +3435,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "aiX" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -3433,7 +3451,7 @@
 "aiZ" = (
 /obj/item/cigbutt,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "aja" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/effect/turf_decal/stripes/white/line{
@@ -3722,8 +3740,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/plating,
-/area/maintenance/central)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/monotile,
+/area/maintenance/port)
 "ajO" = (
 /obj/structure/sign/solgov_flag,
 /turf/open/floor/carpet/ship,
@@ -3812,17 +3836,14 @@
 /turf/closed/wall/ship,
 /area/quartermaster/storage)
 "akc" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/central)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/monotile,
+/area/maintenance/port)
 "akd" = (
 /obj/machinery/computer/cargo{
 	dir = 4
@@ -3955,7 +3976,7 @@
 	req_one_access_txt = "3;69"
 	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/port)
 "aks" = (
 /obj/structure/sign/solgov_seal,
 /obj/structure/cable{
@@ -4298,6 +4319,14 @@
 "alc" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/monkeycubes,
+/obj/item/storage/box/monkeycubes{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
 /turf/open/floor/monotile/light,
 /area/medical/genetics)
 "ald" = (
@@ -4386,6 +4415,9 @@
 /obj/structure/closet/secure_closet/medical3,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
 	},
 /turf/open/floor/monotile,
 /area/medical/medbay/central)
@@ -4531,6 +4563,7 @@
 "alG" = (
 /obj/structure/bed,
 /obj/item/bedsheet/cmo,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/heads/cmo)
 "alH" = (
@@ -4565,6 +4598,9 @@
 /turf/open/floor/monotile/light,
 /area/medical/medbay/lobby)
 "alM" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo)
 "alN" = (
@@ -4622,6 +4658,9 @@
 /obj/item/storage/pill_bottle/mannitol,
 /obj/item/storage/pill_bottle/mutadone,
 /obj/item/storage/box/disks,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
 /turf/open/floor/monotile/light,
 /area/medical/genetics)
 "alT" = (
@@ -4790,8 +4829,12 @@
 /turf/closed/wall/ship,
 /area/lawoffice)
 "amr" = (
-/turf/closed/wall/ship,
-/area/maintenance/department/engine)
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_large/ship{
+	name = "Gym"
+	},
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/fitness/recreation)
 "ams" = (
 /turf/closed/wall/ship,
 /area/crew_quarters/dorms/nsv/dorms_1)
@@ -4800,7 +4843,7 @@
 	icon_state = "4-8"
 	},
 /turf/closed/wall/r_wall/ship,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "amu" = (
 /turf/closed/wall/r_wall/ship,
 /area/tcommsat/computer)
@@ -5085,8 +5128,19 @@
 /turf/open/floor/monotile,
 /area/medical/virology)
 "ani" = (
+/obj/item/cartridge/engineering{
+	pixel_x = 4;
+	pixel_y = 5
+	},
+/obj/item/cartridge/engineering{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/cartridge/engineering{
+	pixel_x = 3
+	},
 /obj/structure/table/reinforced,
-/obj/item/reagent_containers/pill/patch/silver_sulf,
+/obj/item/cartridge/atmos,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/chief)
 "anj" = (
@@ -5097,12 +5151,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
-"anl" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "anm" = (
 /turf/open/floor/monotile,
 /area/engine/engineering/hangar)
@@ -5146,8 +5194,12 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/port)
 "anv" = (
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching Prison Wing holding areas.";
@@ -5287,7 +5339,7 @@
 	icon_state = "crateopen"
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/port)
 "anQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
@@ -5790,7 +5842,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile,
-/area/maintenance/central)
+/area/maintenance/port)
 "apb" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5852,7 +5904,7 @@
 "api" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "apj" = (
 /turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
@@ -5868,11 +5920,7 @@
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/maintenance/department/cargo)
-"apm" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "apn" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/medical,
@@ -5889,7 +5937,7 @@
 	amount = 5
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "app" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
@@ -5910,15 +5958,6 @@
 /obj/structure/lattice,
 /turf/open/space,
 /area/engine/atmos)
-"apu" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/central)
 "apv" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6165,7 +6204,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/port)
 "apZ" = (
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/monotile/dark,
@@ -6228,6 +6267,7 @@
 "aqh" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/yellow,
+/obj/item/reagent_containers/pill/patch/silver_sulf,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/chief)
 "aqi" = (
@@ -6301,10 +6341,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/storage)
-"aqt" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "aqu" = (
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -6322,13 +6358,6 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/monotile,
 /area/engine/gravity_generator)
-"aqx" = (
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/central)
 "aqy" = (
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms)
@@ -6504,6 +6533,9 @@
 /area/crew_quarters/kitchen)
 "aqT" = (
 /obj/machinery/processor,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
 /turf/open/floor/monotile/light,
 /area/crew_quarters/kitchen)
 "aqU" = (
@@ -6511,8 +6543,11 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/junction,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/port)
 "aqV" = (
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/theatre)
@@ -7041,7 +7076,7 @@
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "asb" = (
 /turf/open/floor/plating,
 /area/engine/storage)
@@ -7946,6 +7981,9 @@
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
+/obj/machinery/light_switch{
+	pixel_x = 28
+	},
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms/nsv/dorms_1)
 "aui" = (
@@ -8407,12 +8445,12 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall/ship,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "avp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "avq" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -8426,7 +8464,7 @@
 /obj/structure/barricade/wooden/crude,
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "avs" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrous_output{
 	dir = 8
@@ -8705,7 +8743,7 @@
 	},
 /obj/item/reagent_containers/food/condiment/flour,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "awd" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2o{
 	dir = 1
@@ -9076,7 +9114,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "awU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -9461,7 +9499,7 @@
 	pixel_x = 3
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "axH" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/tile/yellow{
@@ -10120,6 +10158,9 @@
 	pixel_x = 4;
 	pixel_y = -4
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
 /turf/open/floor/monotile,
 /area/crew_quarters/dorms)
 "ayN" = (
@@ -10428,7 +10469,7 @@
 	name = "ST13 source code"
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "azz" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 4
@@ -10512,11 +10553,11 @@
 	amount = 5
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "azN" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "azO" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
@@ -10533,7 +10574,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "azR" = (
 /obj/machinery/power/smes{
 	capacity = 9e+006;
@@ -10593,7 +10634,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "azY" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	req_one_access_txt = "24"
@@ -10612,7 +10653,7 @@
 "aAa" = (
 /obj/item/clothing/under/rank/engineer/hazard,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "aAb" = (
 /obj/structure/table,
 /obj/item/kitchen/rollingpin,
@@ -10620,7 +10661,7 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "aAc" = (
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -10687,29 +10728,29 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/port)
 "aAm" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/port)
 "aAn" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/port)
 "aAo" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/port)
 "aAp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/port)
 "aAq" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/tinted,
@@ -10717,17 +10758,13 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/port)
 "aAr" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	name = "Potted plant storage"
 	},
 /turf/open/floor/plating,
-/area/maintenance/central)
-"aAs" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/port)
 "aAt" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10737,15 +10774,24 @@
 	},
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/port)
 "aAu" = (
 /obj/item/cigbutt,
 /obj/item/clothing/head/cone,
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/port)
 "aAv" = (
+/obj/docking_port/stationary/turbolift{
+	dir = 2;
+	dwidth = 7;
+	height = 6;
+	id = "turbolift_primary";
+	name = "aircraft hangar";
+	roundstart_template = /datum/map_template/shuttle/turbolift/nsv/enterprise;
+	width = 15
+	},
 /turf/closed/wall/r_wall/ship,
-/area/maintenance/central)
+/area/maintenance/port)
 "aAw" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -11080,6 +11126,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmospherics_engine)
 "aBd" = (
@@ -11117,13 +11166,16 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -27
+	},
 /turf/open/floor/plasteel/ship,
 /area/engine/engineering)
 "aBh" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "aBi" = (
 /obj/machinery/button/door/incinerator_vent_atmos_aux{
 	pixel_x = -8;
@@ -11192,6 +11244,9 @@
 /obj/structure/sign/solgov_flag,
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
 /turf/open/floor/monotile,
 /area/nsv/weapons/fore)
 "aBr" = (
@@ -11364,6 +11419,7 @@
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /obj/item/pen,
+/obj/machinery/door/firedoor,
 /turf/open/floor/monotile/light,
 /area/medical/medbay/lobby)
 "aBM" = (
@@ -11531,11 +11587,11 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "aCi" = (
 /obj/machinery/atmospherics/components/trinary/filter,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "aCj" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on,
 /turf/open/floor/plating/airless,
@@ -13127,7 +13183,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/port)
 "aFM" = (
 /turf/open/floor/plating,
 /area/security/execution/transfer)
@@ -14109,6 +14165,9 @@
 "aIk" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/machinery/status_display/evac{
+	pixel_y = 32
 	},
 /turf/open/floor/monotile,
 /area/security/prison)
@@ -15479,7 +15538,7 @@
 /area/medical/chemistry)
 "aLr" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	name = "Medbay lobby access"
+	name = "Medbay Lobby Access"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -15513,7 +15572,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/port)
 "aLv" = (
 /obj/effect/landmark/start/station_engineer,
 /obj/structure/cable{
@@ -15773,9 +15832,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/junction/flip{
-	dir = 1
-	},
+/obj/structure/disposalpipe/junction,
 /turf/open/floor/monotile,
 /area/science/xenobiology)
 "aLW" = (
@@ -15868,6 +15925,9 @@
 "aMi" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile/dark,
 /area/science/xenobiology)
 "aMj" = (
@@ -15955,6 +16015,9 @@
 /area/crew_quarters/heads/hor)
 "aMr" = (
 /obj/machinery/suit_storage_unit/standard_unit,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 26
+	},
 /turf/open/floor/monotile/dark,
 /area/science/mixing{
 	name = "Prototype munitions bay"
@@ -15982,6 +16045,9 @@
 /area/hallway/nsv/deck2/frame1/central)
 "aMw" = (
 /obj/machinery/biogenerator,
+/obj/machinery/newscaster{
+	pixel_x = 32
+	},
 /turf/open/floor/monotile,
 /area/hydroponics)
 "aMx" = (
@@ -16001,6 +16067,9 @@
 	dir = 4
 	},
 /obj/machinery/icecream_vat,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen)
 "aMz" = (
@@ -16065,6 +16134,9 @@
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/monotile,
 /area/science/xenobiology)
@@ -16627,6 +16699,9 @@
 	},
 /obj/item/borg/upgrade/rename,
 /obj/item/clothing/glasses/welding,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
 /turf/open/floor/monotile/dark,
 /area/science/robotics)
 "aNL" = (
@@ -16961,6 +17036,10 @@
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/camera/autoname,
 /obj/structure/closet/secure_closet/miner,
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_x = -26
+	},
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
 "aOF" = (
@@ -17349,7 +17428,7 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "aPx" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -18884,6 +18963,9 @@
 "aTf" = (
 /obj/structure/tank_dispenser/oxygen,
 /obj/effect/turf_decal/box,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 26
+	},
 /turf/open/floor/plasteel/grid/steel,
 /area/nsv/hanger/deck2)
 "aTh" = (
@@ -19152,6 +19234,7 @@
 "aTQ" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/drinks/solgovcup,
+/obj/machinery/door/firedoor,
 /turf/open/floor/monotile/light,
 /area/medical/medbay/lobby)
 "aTR" = (
@@ -19191,6 +19274,7 @@
 /obj/structure/table/glass,
 /obj/item/wrench/medical,
 /obj/item/storage/box/bodybags,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/monotile/dark,
 /area/medical/medbay/lobby)
 "aTW" = (
@@ -19213,6 +19297,15 @@
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable{
 	icon_state = "0-4"
+	},
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/dropper,
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_x = -26
 	},
 /turf/open/floor/monotile/light,
 /area/medical/genetics)
@@ -19374,6 +19467,10 @@
 "aUr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
 /turf/open/floor/monotile,
 /area/medical/medbay/zone2{
 	name = "Intensive care unit"
@@ -19473,10 +19570,11 @@
 /turf/open/floor/monotile/dark,
 /area/medical/surgery)
 "aUG" = (
-/obj/machinery/iv_drip,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
 /turf/open/floor/monotile/dark,
 /area/medical/medbay/zone2{
 	name = "Intensive care unit"
@@ -19950,6 +20048,9 @@
 /area/hallway/secondary/service)
 "aVI" = (
 /obj/structure/table/reinforced,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/service)
 "aVJ" = (
@@ -19961,7 +20062,7 @@
 "aVK" = (
 /obj/item/disk/holodisk/enterprise_log/two,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "aVL" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -20078,7 +20179,7 @@
 /obj/item/crowbar,
 /obj/structure/table,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "aVX" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -20512,6 +20613,9 @@
 	dir = 9
 	},
 /obj/machinery/light,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
 /turf/open/floor/monotile,
 /area/science/server)
 "aWT" = (
@@ -20585,6 +20689,10 @@
 	},
 /obj/effect/turf_decal/loading_area/red{
 	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
 	},
 /turf/open/floor/monotile,
 /area/science/mixing{
@@ -20790,6 +20898,9 @@
 "aXt" = (
 /obj/machinery/computer/rdconsole/core{
 	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/science/research)
@@ -21256,39 +21367,39 @@
 	pixel_y = 6
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "aYy" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "aYz" = (
 /obj/item/reagent_containers/food/drinks/solgovcup,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "aYA" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "aYB" = (
 /obj/item/crowbar,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "aYC" = (
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "aYD" = (
 /obj/structure/closet/secure_closet/freezer/kitchen/maintenance,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "aYE" = (
 /obj/structure/kitchenspike_frame,
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "aYF" = (
 /obj/structure/rack,
 /obj/item/stack/rods{
@@ -21297,7 +21408,7 @@
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "aYG" = (
 /obj/item/paper{
 	desc = "You can make out a few squiggles that look like a ragnarok class heavy cruiser with an approval seal hastily crayon'd in. The ship looks like a mess.";
@@ -21307,11 +21418,11 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "aYH" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "aYI" = (
 /obj/structure/window/reinforced/fulltile/ship,
 /obj/structure/grille,
@@ -21332,13 +21443,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"aYL" = (
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/central)
 "aYM" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -21392,15 +21496,15 @@
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/maintenance/central)
+/area/maintenance/port)
 "aYS" = (
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/maintenance/central)
+/area/maintenance/port)
 "aYT" = (
 /turf/open/floor/monotile,
-/area/maintenance/central)
+/area/maintenance/port)
 "aYU" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	name = "Virology maintenance"
@@ -21418,7 +21522,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/port)
 "aYW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
@@ -21437,11 +21541,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"aYX" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "aYY" = (
 /obj/structure/rack,
 /turf/open/floor/plating,
@@ -21470,6 +21569,10 @@
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable{
 	icon_state = "0-2"
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
 	},
 /turf/open/floor/carpet/ship,
 /area/medical/exam_room)
@@ -21524,7 +21627,7 @@
 	dir = 6
 	},
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/starboard)
 "aZi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -21542,7 +21645,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/port)
 "aZk" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -21550,12 +21653,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck2)
-"aZl" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/central)
 "aZm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -21817,14 +21914,14 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/port)
 "aZP" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/port)
 "aZQ" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -21836,14 +21933,14 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/port)
 "aZR" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/port)
 "aZS" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -21870,13 +21967,16 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/port)
 "aZV" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/port)
 "aZW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -21900,7 +22000,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/port)
 "aZZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -22139,15 +22239,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck2)
-"baB" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/central)
 "baC" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -22261,6 +22352,9 @@
 	},
 /obj/structure/table/wood/fancy,
 /obj/item/camera,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/theatre)
 "baO" = (
@@ -22330,7 +22424,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile,
-/area/maintenance/central)
+/area/maintenance/port)
 "baW" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -22407,6 +22501,9 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
 /turf/open/floor/engine,
 /area/medical/medbay/lobby)
 "bbf" = (
@@ -22459,7 +22556,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/multiz,
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/central)
 "bbl" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -22489,12 +22586,12 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/central)
 "bbo" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/central)
 "bbp" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
@@ -22997,7 +23094,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "bco" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -23083,7 +23180,7 @@
 	name = "Arrivals Emergency Storage"
 	},
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/starboard)
 "bcu" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -23762,7 +23859,7 @@
 	dir = 5
 	},
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/central)
 "bdD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -23772,7 +23869,7 @@
 	dir = 9
 	},
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/central)
 "bdE" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/bag/tray,
@@ -23934,9 +24031,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -23953,31 +24047,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/monotile,
-/area/science/xenobiology)
-"bdS" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/monotile/dark,
-/area/science/xenobiology)
-"bdT" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/monotile,
-/area/science/xenobiology)
-"bdU" = (
-/obj/machinery/shieldwallgen/xenobiologyaccess,
-/obj/machinery/door/poddoor/preopen{
-	id = "xb_containment";
-	name = "Xenobiology Containment Shutter"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
 /area/science/xenobiology)
 "bdV" = (
 /obj/structure/cable{
@@ -24451,7 +24520,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/central)
 "beO" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -24464,7 +24533,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/central)
 "beP" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -24658,6 +24727,9 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
 /turf/open/floor/monotile/dark,
 /area/nsv/briefingroom)
 "bfj" = (
@@ -24802,6 +24874,7 @@
 /obj/machinery/airalarm{
 	pixel_y = 26
 	},
+/obj/item/roller,
 /turf/open/floor/carpet/ship,
 /area/medical/medbay/zone2{
 	name = "Intensive care unit"
@@ -25002,7 +25075,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/central)
 "bfR" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -25158,6 +25231,9 @@
 	maxcharge = 15000
 	},
 /obj/item/stack/sheet/glass,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
 /turf/open/floor/monotile/dark,
 /area/science)
 "bgj" = (
@@ -25645,13 +25721,13 @@
 "bhk" = (
 /obj/structure/ladder,
 /turf/open/floor/monotile/dark,
-/area/maintenance/central)
+/area/maintenance/port)
 "bhm" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/port)
 "bhn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -25667,11 +25743,8 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/port)
 "bhp" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -25679,7 +25752,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/port)
 "bhq" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -25989,7 +26062,7 @@
 	dir = 6
 	},
 /turf/closed/wall/ship,
-/area/maintenance/port)
+/area/maintenance/central)
 "bhW" = (
 /obj/structure/sign/solgov_seal,
 /obj/machinery/light{
@@ -26477,7 +26550,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/central)
 "bjd" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -26487,7 +26560,7 @@
 	dir = 10
 	},
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/central)
 "bje" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -26582,6 +26655,9 @@
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
 	},
 /turf/open/floor/monotile,
 /area/crew_quarters/cafeteria{
@@ -26774,14 +26850,14 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "bjI" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "bjJ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -27150,7 +27226,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/port)
 "bkt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -27264,7 +27340,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "bkH" = (
 /obj/structure/table,
 /obj/item/clothing/head/welding{
@@ -27501,7 +27577,7 @@
 "bkZ" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "bla" = (
 /obj/structure/closet{
 	name = "'Evidence Closet'"
@@ -27597,7 +27673,7 @@
 	dir = 10
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "bll" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile,
@@ -27605,7 +27681,7 @@
 "blm" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/closed/wall/ship,
-/area/maintenance/port)
+/area/maintenance/central)
 "bln" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -27618,13 +27694,13 @@
 	dir = 4
 	},
 /turf/closed/wall/ship,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "blp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "blq" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -27634,7 +27710,7 @@
 	},
 /obj/structure/disposalpipe/sorting/mail/flip,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "blr" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	name = "Atmospherics maintenance";
@@ -27648,7 +27724,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "bls" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -27714,14 +27790,14 @@
 "blz" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/ship,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "blA" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/junction,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "blB" = (
 /obj/structure/rack,
 /obj/item/circuitboard/machine/cell_charger,
@@ -27766,7 +27842,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/maintenance/starboard)
 "blH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -27774,7 +27850,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/central)
 "blI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -27801,7 +27877,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "blM" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -27813,7 +27889,7 @@
 	sortType = 18
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "blN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 6
@@ -27924,7 +28000,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "blY" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
@@ -27977,7 +28053,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "bmd" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
@@ -28236,7 +28312,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "bmA" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -28332,7 +28408,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/multiz,
 /turf/closed/wall/ship,
-/area/maintenance/port)
+/area/maintenance/central)
 "bmI" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -28556,7 +28632,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "bnb" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -28604,7 +28680,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "bnh" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -28663,7 +28739,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/starboard)
 "bno" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -28763,7 +28839,7 @@
 	dir = 5
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "bnx" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable{
@@ -28776,7 +28852,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "bny" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -28794,19 +28870,19 @@
 	dir = 10
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "bnA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "bnB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "bnC" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -28874,7 +28950,7 @@
 /obj/machinery/light,
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/starboard)
 "bnI" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -28995,7 +29071,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "bnV" = (
 /obj/machinery/vending/wardrobe/atmos_wardrobe,
 /obj/effect/turf_decal/tile/yellow{
@@ -29033,12 +29109,12 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/starboard)
 "bnZ" = (
 /obj/structure/window/reinforced/fulltile/ship,
 /obj/structure/grille,
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/starboard)
 "boa" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -29051,7 +29127,7 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "boc" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/tile/yellow{
@@ -29213,7 +29289,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile/ship,
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/starboard)
 "bor" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/disposalpipe/segment{
@@ -29418,7 +29494,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "boO" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/disposal/bin,
@@ -29491,7 +29567,7 @@
 /obj/structure/grille,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "boX" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -29658,7 +29734,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/starboard)
 "bpm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -29667,7 +29743,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/starboard)
 "bpn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -29693,7 +29769,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "bpp" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 4
@@ -29702,7 +29778,7 @@
 	dir = 9
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "bpq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -29829,6 +29905,10 @@
 /area/medical/chemistry)
 "bpB" = (
 /obj/structure/disposalpipe/segment,
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_x = 26
+	},
 /turf/open/floor/plasteel/techmaint,
 /area/janitor)
 "bpC" = (
@@ -30383,7 +30463,7 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/rack,
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/starboard)
 "bqy" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable{
@@ -30438,7 +30518,7 @@
 	dir = 6
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "bqE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -30448,7 +30528,7 @@
 	sortType = 21
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "bqF" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -30457,7 +30537,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "bqG" = (
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 8;
@@ -30470,7 +30550,7 @@
 	dir = 5
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "bqH" = (
 /obj/machinery/light{
 	dir = 1
@@ -30485,7 +30565,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "bqI" = (
 /obj/machinery/computer/card/minor/rd{
 	dir = 4
@@ -30779,7 +30859,7 @@
 	sortType = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/starboard)
 "bro" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -30920,7 +31000,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "brD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -30995,7 +31075,7 @@
 	sortType = 17
 	},
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/starboard)
 "brK" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	name = "Crematorium";
@@ -31009,7 +31089,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/maintenance/port)
+/area/maintenance/starboard)
 "brL" = (
 /obj/effect/landmark/nuclear_waste_spawner,
 /turf/closed/wall/ship,
@@ -31098,7 +31178,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "brU" = (
 /obj/structure/disposaloutlet{
 	dir = 1
@@ -31140,7 +31220,7 @@
 	dir = 6
 	},
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/starboard)
 "brZ" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -31149,7 +31229,7 @@
 	dir = 9
 	},
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/starboard)
 "bsa" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -31223,7 +31303,7 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "bsj" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -31241,13 +31321,13 @@
 	dir = 6
 	},
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/starboard)
 "bsm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/central)
 "bsn" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -31325,7 +31405,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/starboard)
 "bsu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -31425,7 +31505,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "bsH" = (
 /obj/machinery/conveyor{
 	id = "garbage_space"
@@ -31458,7 +31538,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/starboard)
 "bsK" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/disposal/bin,
@@ -31543,7 +31623,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/starboard)
 "bsT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -31555,8 +31635,11 @@
 	name = "Flight Deck Ladder Access";
 	req_one_access_txt = "3;69"
 	},
-/turf/open/floor/plating,
-/area/maintenance/central)
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/monotile,
+/area/maintenance/port)
 "bsU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -31567,20 +31650,16 @@
 	},
 /turf/open/floor/plasteel/grid/steel,
 /area/hallway/secondary/exit)
-"bsV" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "bsW" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/monotile,
-/area/maintenance/central)
+/area/maintenance/port)
 "bsX" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/monotile/dark,
-/area/maintenance/central)
+/area/maintenance/port)
 "bsY" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/structure/cable{
@@ -31871,6 +31950,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
 "btE" = (
@@ -32786,6 +32866,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
+/obj/machinery/status_display/ai{
+	pixel_x = 32
+	},
 /turf/open/floor/monotile,
 /area/nsv/briefingroom)
 "bvk" = (
@@ -32886,6 +32969,9 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
 /turf/open/floor/monotile,
 /area/medical/medbay/zone2{
 	name = "Intensive care unit"
@@ -33793,15 +33879,15 @@
 /area/science/xenobiology)
 "bxc" = (
 /obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/monotile,
 /area/science/xenobiology)
 "bxd" = (
@@ -33823,11 +33909,14 @@
 /turf/open/floor/monotile,
 /area/science)
 "bxe" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/monotile/dark,
 /area/science/xenobiology)
@@ -34147,7 +34236,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "bxL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -35090,13 +35179,16 @@
 	dir = 4
 	},
 /obj/effect/landmark/nuclear_waste_spawner,
+/obj/machinery/newscaster{
+	pixel_x = 32
+	},
 /turf/open/floor/monotile/light,
 /area/crew_quarters/kitchen)
 "bzD" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "bzE" = (
 /obj/effect/landmark/nuclear_waste_spawner,
 /turf/closed/wall/r_wall/ship,
@@ -35107,11 +35199,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "bzG" = (
 /obj/effect/landmark/nuclear_waste_spawner,
 /turf/closed/wall/ship,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "bzH" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	id_tag = "commissarydoor";
@@ -35241,6 +35333,9 @@
 	dir = 4
 	},
 /obj/effect/landmark/nuclear_waste_spawner,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/monotile/dark,
 /area/science/xenobiology)
 "bzX" = (
@@ -35254,7 +35349,7 @@
 "bzZ" = (
 /obj/effect/landmark/nuclear_waste_spawner,
 /turf/closed/wall/ship,
-/area/maintenance/port)
+/area/maintenance/starboard)
 "bAa" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
@@ -35687,17 +35782,17 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /turf/open/floor/wood,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "bAU" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
 /obj/machinery/camera/autoname,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/nsv/hanger/deck2)
@@ -36469,7 +36564,6 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/machinery/computer/ship/viewscreen,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/port)
@@ -36612,6 +36706,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile,
 /area/science/xenobiology)
 "bCL" = (
@@ -36662,6 +36759,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/monotile,
 /area/science/xenobiology)
@@ -37044,15 +37144,15 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "bDB" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1;
-	name = "briefing room chair"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 1;
+	name = "briefing room chair"
 	},
 /turf/open/floor/carpet/blue,
 /area/nsv/hanger/deck2)
@@ -37112,19 +37212,19 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/port)
 "bDI" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/port)
 "bDJ" = (
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/port)
 "bDK" = (
 /obj/machinery/camera/autoname,
 /obj/machinery/turbolift_button{
@@ -37175,7 +37275,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/starboard)
 "bDR" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/disposalpipe/segment{
@@ -37923,6 +38023,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/monotile,
 /area/security/brig)
 "bFe" = (
@@ -38074,6 +38175,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/monotile,
 /area/security/brig)
 "bFr" = (
@@ -38143,20 +38245,20 @@
 	name = "Deck 1 access maintenance"
 	},
 /turf/open/floor/monotile,
-/area/maintenance/port)
+/area/maintenance/central)
 "bFA" = (
 /obj/structure/disposalpipe/trunk/multiz{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/closed/wall/ship,
-/area/maintenance/port)
+/area/maintenance/central)
 "bFB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/central)
 "bFC" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -38166,7 +38268,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/central)
 "bFD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
@@ -38176,7 +38278,7 @@
 	icon_state = "0-4"
 	},
 /turf/closed/wall/ship,
-/area/maintenance/port)
+/area/maintenance/central)
 "bFE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -38185,7 +38287,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/central)
 "bFF" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -38197,7 +38299,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/central)
 "bFG" = (
 /obj/machinery/door/airlock/ship/maintenance,
 /obj/structure/cable{
@@ -38205,7 +38307,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/central)
 "bFH" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -38288,12 +38390,6 @@
 	},
 /turf/open/floor/monotile,
 /area/crew_quarters/fitness/recreation)
-"bFQ" = (
-/obj/machinery/airalarm{
-	pixel_y = 26
-	},
-/turf/open/floor/plating,
-/area/maintenance/central)
 "bFR" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -38314,7 +38410,7 @@
 	pixel_y = 26
 	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/port)
 "bFT" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -38452,7 +38548,7 @@
 	},
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "bGj" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -38775,16 +38871,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile,
-/area/maintenance/central)
-"bGR" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/port)
 "bGS" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -39080,13 +39167,13 @@
 	name = "Abandoned observation post"
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "bHx" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "bHy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable{
@@ -39136,10 +39223,11 @@
 	name = "Intensive care unit"
 	})
 "bHE" = (
-/obj/machinery/iv_drip,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
 /turf/open/floor/monotile/dark,
 /area/medical/medbay/zone2{
 	name = "Intensive care unit"
@@ -39213,7 +39301,7 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "bHN" = (
 /obj/machinery/computer/bounty{
 	dir = 1
@@ -39410,32 +39498,24 @@
 "bIl" = (
 /obj/structure/closet/radiation,
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/port)
 "bIm" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/port)
 "bIn" = (
 /obj/structure/closet/radiation,
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/port)
 "bIo" = (
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess{
 	name = "Damage control closet"
 	},
 /turf/open/floor/plating,
-/area/maintenance/central)
-"bIp" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/plating,
-/area/maintenance/central)
-"bIq" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/port)
 "bIr" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -39604,6 +39684,9 @@
 "bIO" = (
 /obj/structure/window/reinforced,
 /obj/machinery/iv_drip,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
 /turf/open/floor/monotile/light,
 /area/security/prison)
 "bIP" = (
@@ -39647,6 +39730,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor,
 /turf/open/floor/monotile,
 /area/security/prison)
 "bIU" = (
@@ -39849,14 +39933,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "bJq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "bJr" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -39924,7 +40008,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "bJx" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -40145,6 +40229,24 @@
 	},
 /turf/open/floor/monotile,
 /area/nsv/briefingroom)
+"bMM" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -27
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/monotile,
+/area/security/warden)
+"bMS" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -27
+	},
+/turf/open/floor/monotile/dark,
+/area/science/mixing{
+	name = "Prototype munitions bay"
+	})
 "bMT" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -40158,21 +40260,30 @@
 /obj/machinery/light,
 /turf/open/floor/monotile,
 /area/security/brig)
-"bPL" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
+"bPc" = (
+/turf/closed/wall/ship,
+/area/hallway/secondary/service)
 "bRy" = (
 /obj/item/beacon,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"bVN" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/monotile/light,
+/area/medical/genetics)
+"cfS" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "cgt" = (
 /obj/machinery/holopad,
 /turf/open/floor/carpet/ship,
 /area/nsv/hanger/deck2)
+"cgU" = (
+/turf/closed/wall/r_wall/ship,
+/area/crew_quarters/fitness/recreation)
 "ciL" = (
 /obj/machinery/light{
 	dir = 4
@@ -40185,32 +40296,97 @@
 	dir = 10
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "ckD" = (
 /obj/machinery/light,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"ckJ" = (
-/obj/structure/bookcase/random/religion,
+"clk" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"cpq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
+"csF" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "hor_window";
+	name = "privacy shutter"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hor)
+"csH" = (
+/obj/machinery/airalarm/directional/south,
+/obj/structure/bookcase/manuals/research_and_development,
 /turf/open/floor/wood,
 /area/library)
-"cqG" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/storage/toolbox/emergency,
-/obj/item/clothing/gloves/color/fyellow,
-/turf/open/floor/plating,
-/area/nsv/briefingroom)
+"ctk" = (
+/obj/machinery/bookbinder,
+/obj/machinery/camera/autoname,
+/turf/open/floor/wood,
+/area/library)
+"cuz" = (
+/obj/machinery/airalarm/directional/north,
+/obj/structure/table/wood,
+/obj/item/toy/cards/deck/cas,
+/obj/item/toy/cards/deck/cas/black{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/open/floor/wood,
+/area/library)
 "cuG" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"cAH" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	pixel_x = 32
+	},
+/turf/open/floor/monotile,
+/area/nsv/hanger/deck2)
 "cDF" = (
 /obj/machinery/mineral/equipment_vendor,
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
+"cHV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_y = -26
+	},
+/turf/open/floor/carpet/ship,
+/area/quartermaster/storage)
+"cIy" = (
+/obj/machinery/status_display/evac,
+/turf/closed/wall/ship,
+/area/security/brig)
 "cJz" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 8
@@ -40228,16 +40404,17 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"cWx" = (
-/obj/structure/chair/office/light{
-	dir = 1
+"cRY" = (
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
-	},
-/obj/machinery/light,
-/turf/open/floor/wood,
-/area/library)
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
+"cSw" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "cXV" = (
 /obj/machinery/light/small,
 /obj/structure/bed,
@@ -40248,31 +40425,12 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/security/prison)
-"daY" = (
-/obj/item/reagent_containers/food/drinks/sillycup{
-	pixel_x = -5;
-	pixel_y = 3
+"daH" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
 	},
-/obj/item/reagent_containers/food/drinks/sillycup,
-/obj/item/reagent_containers/food/drinks/sillycup{
-	pixel_x = 5;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/food/drinks/sillycup{
-	pixel_x = 5;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/food/drinks/sillycup{
-	pixel_x = 5;
-	pixel_y = 3
-	},
-/obj/structure/table,
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
-"dmM" = (
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/turf/open/floor/monotile/dark,
+/area/hydroponics)
 "dnd" = (
 /obj/machinery/gateway{
 	dir = 8
@@ -40286,18 +40444,24 @@
 	},
 /turf/closed/wall/r_wall/ship,
 /area/engine/atmospherics_engine)
-"dCx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
+"dwf" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck2/frame2/port)
+"dEz" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/newscaster{
+	pixel_x = 32
 	},
-/turf/open/floor/wood,
-/area/library)
+/turf/open/floor/monotile/light,
+/area/medical/medbay/lobby)
 "dIo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -40309,17 +40473,24 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"dPL" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "hor_window";
-	name = "privacy shutter"
+"dIw" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/machinery/newscaster{
+	pixel_y = 32
 	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hor)
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck2/frame1/central)
+"dOP" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/library)
 "dSD" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	req_one_access_txt = "2"
@@ -40329,10 +40500,33 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"dUE" = (
-/obj/structure/closet/toolcloset,
+"dVP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/plating,
-/area/nsv/briefingroom)
+/area/maintenance/starboard)
+"eaw" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood,
+/area/library)
+"ebm" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/library)
 "ecN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -40345,7 +40539,7 @@
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/mask/breath,
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/starboard)
 "eeJ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -40366,6 +40560,22 @@
 /obj/item/clothing/mask/breath,
 /turf/open/floor/monotile/dark,
 /area/gateway)
+"erM" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
 "evj" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -40388,11 +40598,20 @@
 	},
 /turf/open/floor/monotile,
 /area/security/brig)
-"ezB" = (
-/obj/structure/punching_bag,
+"eEA" = (
+/obj/machinery/door/airlock/ship/external/glass{
+	req_one_access_txt = "13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"eGl" = (
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
-"eBS" = (
+/area/nsv/hanger/deck2)
+"eKR" = (
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 24
@@ -40403,20 +40622,6 @@
 	},
 /turf/open/floor/monotile,
 /area/crew_quarters/fitness/recreation)
-"eEA" = (
-/obj/machinery/door/airlock/ship/external/glass{
-	req_one_access_txt = "13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
-"eKP" = (
-/obj/machinery/bookbinder,
-/obj/machinery/camera/autoname,
-/turf/open/floor/wood,
-/area/library)
 "ePo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -40424,10 +40629,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/light,
 /area/medical/virology)
-"eQM" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
 "eQZ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/ship/public/glass{
@@ -40451,10 +40652,6 @@
 /obj/item/stack/cable_coil,
 /turf/open/floor/monotile,
 /area/medical/chemistry)
-"eUj" = (
-/obj/structure/disposalpipe/segment,
-/turf/closed/wall/ship,
-/area/hallway/nsv/deck2/frame2/port)
 "eUK" = (
 /obj/machinery/requests_console{
 	department = "Munitions bay";
@@ -40462,12 +40659,6 @@
 	},
 /turf/closed/wall/r_wall/ship,
 /area/nsv/weapons/fore)
-"eVy" = (
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
 "eXm" = (
 /obj/machinery/light/small,
 /obj/structure/bed,
@@ -40478,14 +40669,14 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/security/prison)
-"eYp" = (
+"fgT" = (
 /obj/structure/lattice,
-/turf/closed/wall/r_wall/ship,
-/area/maintenance/department/engine)
-"fdx" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/machinery/camera/motion{
+	c_tag = "Armoury";
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/maintenance/ship_exterior)
 "fjB" = (
 /obj/machinery/door/airlock/ship{
 	name = "Exothermic Chamber";
@@ -40504,27 +40695,62 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"fwk" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/east,
+"fmp" = (
 /obj/structure/punching_bag,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/monotile,
 /area/crew_quarters/fitness/recreation)
+"fmQ" = (
+/obj/machinery/newscaster{
+	pixel_x = -28
+	},
+/turf/open/floor/wood,
+/area/library)
+"fps" = (
+/obj/structure/bookcase{
+	name = "Forbidden Knowledge"
+	},
+/turf/open/floor/wood,
+/area/library)
+"fqI" = (
+/obj/machinery/status_display/evac,
+/turf/closed/wall/ship,
+/area/crew_quarters/cafeteria{
+	name = "Mess hall"
+	})
+"frX" = (
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "fxX" = (
 /obj/structure/lattice,
 /turf/open/space,
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
+"fzb" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
+"fzg" = (
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "fEj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/closed/wall/r_wall/ship,
 /area/engine/atmospherics_engine)
+"fFh" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "fJP" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -40534,16 +40760,13 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmospherics_engine)
-"fLW" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/iron/fifty{
-	pixel_x = 3;
-	pixel_y = 3
+"fMu" = (
+/obj/machinery/light{
+	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/nsv/briefingroom)
+/area/maintenance/port)
 "fMP" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -40555,6 +40778,29 @@
 /obj/item/beacon,
 /turf/open/floor/monotile,
 /area/hallway/secondary/exit)
+"fOP" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/techmaint,
+/area/medical/chemistry)
+"fRt" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
+"fUo" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
+"fUW" = (
+/obj/machinery/door/morgue{
+	name = "Private Study";
+	req_access_txt = "37"
+	},
+/turf/open/floor/wood,
+/area/library)
 "fVu" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_y = -30
@@ -40571,6 +40817,31 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/service)
+"gbT" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/structure/table/wood,
+/obj/item/paicard,
+/turf/open/floor/wood,
+/area/library)
+"gfE" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"gkF" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/open/floor/monotile/dark,
+/area/science/mixing{
+	name = "Prototype munitions bay"
+	})
+"gkG" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "glh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40582,7 +40853,16 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
+"goi" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -27
+	},
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
 "gqp" = (
 /obj/machinery/newscaster,
 /turf/closed/wall/ship,
@@ -40596,16 +40876,23 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"gqT" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+"gqR" = (
+/obj/machinery/vending/coffee,
+/obj/machinery/computer/ship/viewscreen,
+/turf/open/floor/wood,
+/area/library)
+"gsn" = (
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"gsk" = (
-/obj/structure/closet/boxinggloves,
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
+"gss" = (
+/obj/machinery/status_display/evac,
+/turf/closed/wall/ship,
+/area/medical/medbay/lobby)
+"gAq" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "gFl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -40624,6 +40911,12 @@
 /obj/item/hand_labeler,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/kitchen)
+"gGm" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/monotile,
+/area/maintenance/port)
 "gHK" = (
 /obj/machinery/requests_console{
 	department = "Engineering";
@@ -40640,6 +40933,11 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
+"gKy" = (
+/obj/structure/punching_bag,
+/obj/machinery/computer/ship/viewscreen,
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
 "gMn" = (
 /obj/machinery/requests_console{
 	department = "Medbay";
@@ -40648,15 +40946,34 @@
 	},
 /turf/closed/wall/ship,
 /area/medical/medbay/central)
-"gRc" = (
-/turf/closed/wall/r_wall/ship,
-/area/crew_quarters/fitness/recreation)
-"gUv" = (
+"gOS" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/heads/hor)
+"gQy" = (
+/obj/machinery/photocopier{
+	pixel_y = 3
+	},
+/obj/machinery/computer/ship/viewscreen,
+/turf/open/floor/wood,
+/area/library)
+"gUN" = (
+/obj/machinery/airalarm{
+	pixel_y = 26
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"gVX" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
 	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/starboard)
 "gXS" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -40665,31 +40982,18 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/monotile/dark,
 /area/security/brig)
-"hbf" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
-"hgJ" = (
+"hbm" = (
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/monotile,
+/area/crew_quarters/bar)
+"heA" = (
 /obj/structure/lattice,
 /obj/machinery/camera/motion{
 	c_tag = "Armoury";
-	dir = 1
+	dir = 8
 	},
 /turf/open/space/basic,
 /area/maintenance/ship_exterior)
-"hhp" = (
-/obj/structure/weightmachine/stacklifter,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/fitness/recreation)
 "hhv" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8;
@@ -40709,6 +41013,35 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
+"hhw" = (
+/obj/structure/bed{
+	layer = 2.8
+	},
+/obj/structure/bed{
+	layer = 3;
+	pixel_y = 12
+	},
+/obj/item/bedsheet/black{
+	pixel_y = 12
+	},
+/obj/item/bedsheet/black{
+	layer = 2.85
+	},
+/obj/machinery/light_switch{
+	pixel_x = 28
+	},
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms/nsv/dorms_2)
+"hjM" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/open/floor/plating,
+/area/nsv/briefingroom)
 "hnv" = (
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 26
@@ -40725,9 +41058,31 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
+"hoO" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/door/window/eastright{
+	name = "Fitness Ring"
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/fitness/recreation)
 "hrv" = (
 /obj/machinery/newscaster/security_unit,
 /turf/closed/wall/ship,
+/area/security/brig)
+"hrA" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/monotile,
 /area/security/brig)
 "hwV" = (
 /obj/machinery/door/airlock/ship/external/glass{
@@ -40738,6 +41093,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"hzD" = (
+/obj/machinery/door/airlock/ship/external/glass{
+	req_one_access_txt = "13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "hAu" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -40748,6 +41110,13 @@
 /obj/structure/closet/secure_closet/medical1,
 /turf/open/floor/monotile/dark,
 /area/gateway)
+"hBG" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/monotile,
+/area/nsv/hanger/deck2)
 "hCr" = (
 /obj/machinery/holopad,
 /turf/open/floor/monotile/dark,
@@ -40763,47 +41132,77 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
-"hCK" = (
-/obj/item/storage/crayons,
-/obj/structure/table/wood,
-/turf/open/floor/carpet,
-/area/library)
-"hVt" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/library)
-"hWr" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
-"iaE" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/ship,
-/area/crew_quarters/cafeteria{
-	name = "Mess hall"
-	})
-"imp" = (
+/area/maintenance/starboard/fore)
+"hMl" = (
 /obj/structure/bookcase/random/reference,
 /turf/open/floor/wood,
 /area/library)
-"ini" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plating,
-/area/maintenance/central)
-"ioY" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+"hTx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_y = -26
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/heads/chief)
+"hXb" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	department = "Pilot lounge";
+	departmentType = 2;
+	pixel_y = 28
+	},
+/turf/open/floor/monotile/dark,
+/area/nsv/hanger/deck2)
+"hXE" = (
+/obj/structure/closet/lasertag/blue,
+/obj/machinery/light,
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
+"ilx" = (
+/obj/machinery/light,
+/turf/open/floor/monotile/dark,
+/area/hallway/secondary/exit)
+"ipa" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck2/frame1/central)
+"iqn" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel/techmaint,
+/area/quartermaster/warehouse)
+"iqW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
 "irj" = (
 /obj/structure/window/reinforced/fulltile/ship,
 /obj/structure/grille,
@@ -40821,13 +41220,14 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
-"iwB" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
+"iuj" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
+"iwh" = (
+/obj/structure/bookcase/random/adult,
+/turf/open/floor/wood,
+/area/library)
 "iyx" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /obj/machinery/camera/autoname,
@@ -40835,6 +41235,13 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
+"iFX" = (
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_x = -26
+	},
+/turf/open/floor/monotile,
+/area/nsv/weapons/fore)
 "iMe" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -40850,8 +41257,17 @@
 /obj/item/stack/medical/bruise_pack,
 /obj/item/stack/medical/ointment,
 /obj/item/stack/medical/gauze,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -27
+	},
 /turf/open/floor/monotile/dark,
 /area/gateway)
+"iMo" = (
+/obj/machinery/status_display/evac{
+	pixel_x = 32
+	},
+/turf/open/floor/monotile,
+/area/nsv/briefingroom)
 "iSM" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -40866,14 +41282,48 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/monotile/dark,
 /area/gateway)
-"jbX" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
-"jcZ" = (
-/obj/machinery/light{
+"iTP" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
+"iUd" = (
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/segment,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/monotile,
+/area/security/brig)
+"iUU" = (
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_y = -26
+	},
+/turf/open/floor/carpet/ship,
+/area/quartermaster/qm)
+"iXh" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
+"jfr" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"jgp" = (
+/obj/structure/bookcase,
 /turf/open/floor/wood,
 /area/library)
 "jku" = (
@@ -40894,26 +41344,43 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"jns" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/monotile/dark,
+"jnx" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/monotile,
+/area/medical/surgery)
+"joY" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/monotile,
 /area/crew_quarters/fitness/recreation)
 "jtt" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"jup" = (
-/obj/structure/bookcase/random/nonfiction,
-/turf/open/floor/wood,
-/area/library)
-"juD" = (
-/obj/structure/destructible/cult/tome,
-/obj/item/book/codex_gigas,
-/obj/machinery/newscaster{
-	pixel_y = 32
+"jvQ" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"jwi" = (
+/turf/closed/wall/ship,
+/area/maintenance/starboard/fore)
+"jzd" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
 	},
-/turf/open/floor/wood,
-/area/library)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
 "jAE" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -40928,23 +41395,21 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/break_room)
-"jCa" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "hor_window";
-	name = "privacy shutter"
+"jBf" = (
+/obj/structure/chair/office/light{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
+/turf/open/floor/wood,
+/area/library)
+"jJz" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hor)
-"jGN" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
 	},
 /turf/open/floor/monotile,
 /area/crew_quarters/fitness/recreation)
@@ -40979,18 +41444,28 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"jVl" = (
-/obj/docking_port/stationary/turbolift{
-	dir = 2;
-	dwidth = 7;
-	height = 6;
-	id = "turbolift_primary";
-	name = "aircraft hangar";
-	roundstart_template = /datum/map_template/shuttle/turbolift/nsv/enterprise;
-	width = 15
+"jRw" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
-/turf/closed/wall/r_wall/ship,
-/area/maintenance/central)
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -27
+	},
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck2/frame1/port)
+"jTG" = (
+/obj/structure/closet/secure_closet/brig,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/monotile/dark,
+/area/security/prison)
 "jYW" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -41015,27 +41490,23 @@
 	},
 /turf/open/floor/monotile,
 /area/gateway)
-"kdP" = (
+"khS" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"kjz" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/monotile,
+/area/nsv/hanger/deck2)
+"kjW" = (
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/fitness/recreation)
-"kga" = (
-/obj/structure/bookcase/manuals/medical,
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/library)
-"klv" = (
-/obj/machinery/computer/libraryconsole/bookmanagement,
-/obj/structure/table/wood,
-/turf/open/floor/carpet,
-/area/library)
+/turf/open/floor/plating,
+/area/maintenance/port)
 "knh" = (
 /obj/machinery/button/door{
 	dir = 8;
@@ -41046,11 +41517,29 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/security/execution/transfer)
-"kuE" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/carpet,
-/area/library)
+"koE" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
+"krG" = (
+/obj/machinery/newscaster{
+	pixel_x = 32
+	},
+/turf/open/floor/monotile,
+/area/nsv/hanger/deck2)
+"ksv" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/port)
+"kuo" = (
+/obj/structure/closet/boxinggloves,
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
 "kyA" = (
 /obj/structure/table,
 /obj/item/disk/design_disk,
@@ -41062,9 +41551,18 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/science/research)
-"kCr" = (
-/turf/closed/wall/ship,
-/area/library)
+"kCU" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
 "kFm" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -41077,25 +41575,31 @@
 	},
 /turf/open/floor/monotile,
 /area/medical/chemistry)
-"kIZ" = (
-/obj/structure/bookcase{
-	name = "Forbidden Knowledge"
+"kFM" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/box,
+/obj/item/storage/belt/utility/full,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -27
 	},
-/turf/open/floor/wood,
-/area/library)
-"kNj" = (
-/obj/machinery/newscaster{
-	pixel_x = -28
+/turf/open/floor/plasteel/grid/steel,
+/area/nsv/hanger/deck2)
+"kHi" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
 	},
-/turf/open/floor/wood,
-/area/library)
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/carpet/blue,
+/area/hallway/secondary/exit)
 "kOA" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/starboard)
 "kSX" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -41105,7 +41609,7 @@
 	},
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/starboard)
 "kZu" = (
 /obj/machinery/portable_atmospherics/scrubber/huge,
 /obj/machinery/light{
@@ -41118,6 +41622,31 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
+"lcZ" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/open/floor/wood,
+/area/library)
+"ldX" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "lfX" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile/ship,
@@ -41129,12 +41658,59 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/engine/atmospherics_engine)
+"liO" = (
+/obj/structure/bookcase/manuals/engineering,
+/turf/open/floor/wood,
+/area/library)
+"liS" = (
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_y = -26
+	},
+/turf/open/floor/monotile/dark,
+/area/science/nanite)
 "ljw" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
+"ljG" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"lln" = (
+/obj/machinery/newscaster{
+	pixel_x = 32
+	},
+/turf/open/floor/monotile,
+/area/nsv/briefingroom)
+"loN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/wood,
+/area/library)
+"lrS" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/fitness/recreation)
 "lwJ" = (
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_interior,
 /obj/effect/mapping_helpers/airlock/locked,
@@ -41157,31 +41733,33 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "lCE" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/closed/wall/r_wall/ship,
 /area/science/xenobiology)
-"lHm" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
+"lEl" = (
+/obj/structure/closet/wardrobe/science_white,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
 	},
+/turf/open/floor/monotile/dark,
+/area/science/mixing{
+	name = "Prototype munitions bay"
+	})
+"lIS" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
-"lJl" = (
-/obj/machinery/airalarm/directional/south,
-/obj/structure/bookcase/manuals/research_and_development,
-/turf/open/floor/wood,
-/area/library)
-"lNi" = (
-/obj/structure/lattice,
-/obj/machinery/camera/motion{
-	c_tag = "Armoury";
-	dir = 8
+/area/maintenance/department/medical)
+"lQj" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/turf/open/space/basic,
-/area/maintenance/ship_exterior)
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/monotile,
+/area/security/brig)
 "lRd" = (
 /obj/structure/sink{
 	dir = 8;
@@ -41190,19 +41768,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/science/xenobiology)
-"lRC" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/fitness/recreation)
-"lSg" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/dorms)
 "lTI" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -41210,19 +41775,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"lUm" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	name = "intra ship intercom";
-	pixel_x = -26
-	},
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/fitness/recreation)
 "lVV" = (
 /obj/structure/chair{
 	dir = 8
@@ -41233,6 +41785,10 @@
 	},
 /turf/open/floor/monotile/light,
 /area/medical/medbay/lobby)
+"mbh" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/carpet,
+/area/library)
 "mbD" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -41247,33 +41803,12 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"mgd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
 "mlk" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
 /area/maintenance/ship_exterior)
-"moP" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
 "mrY" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	req_one_access_txt = "8;13"
@@ -41285,12 +41820,31 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
+"mwl" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/library)
 "mwO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/closed/wall/r_wall/ship,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
+"mxW" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/turf/open/floor/monotile,
+/area/security/prison)
+"mzc" = (
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "mzP" = (
 /obj/machinery/requests_console{
 	department = "Chapel";
@@ -41308,12 +41862,31 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
+"mDl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"mGR" = (
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "mIw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
 /turf/closed/wall/r_wall/ship,
 /area/engine/atmospherics_engine)
+"mLr" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "mMv" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -41324,12 +41897,20 @@
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/maintenance/port)
-"mTn" = (
-/obj/structure/bookcase/random/fiction,
-/turf/open/floor/wood,
-/area/library)
-"mWo" = (
+/area/maintenance/starboard)
+"mVZ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
+"mYW" = (
 /obj/structure/weightmachine/weightlifter,
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -41343,6 +41924,10 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"nfu" = (
+/obj/machinery/status_display/evac,
+/turf/closed/wall/ship,
+/area/engine/break_room)
 "nfz" = (
 /obj/machinery/atmospherics/components/binary/pump/on,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -41354,9 +41939,9 @@
 	},
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
-"niU" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+"nhj" = (
+/obj/structure/chair/comfy/brown{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/library)
@@ -41377,21 +41962,59 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
+"nsw" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 4;
+	sortType = 16
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck2/frame2/port)
+"nvB" = (
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/turf/open/floor/monotile,
+/area/maintenance/port)
 "nvJ" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/monotile/light,
 /area/security/prison)
-"nzF" = (
-/obj/structure/reagent_dispensers/watertank,
+"nyz" = (
+/obj/machinery/status_display/evac{
+	pixel_x = -32
+	},
+/turf/open/floor/monotile/dark,
+/area/nsv/briefingroom)
+"nBU" = (
+/obj/machinery/sleeper{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/engine,
+/area/medical/medbay/lobby)
+"nGo" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "hor_window";
+	name = "privacy shutter"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
 /turf/open/floor/plating,
-/area/maintenance/port)
-"nGX" = (
-/obj/structure/closet/lasertag/blue,
-/obj/machinery/light,
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
+/area/crew_quarters/heads/hor)
 "nHC" = (
 /obj/structure/table,
 /obj/item/stock_parts/micro_laser,
@@ -41402,6 +42025,13 @@
 /obj/item/stock_parts/manipulator,
 /turf/open/floor/monotile/dark,
 /area/science/research)
+"nIE" = (
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_x = -26
+	},
+/turf/open/floor/monotile,
+/area/security/prison)
 "nLp" = (
 /obj/machinery/light{
 	dir = 8
@@ -41411,6 +42041,33 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/science/xenobiology)
+"nTO" = (
+/obj/machinery/status_display/ai,
+/turf/closed/wall/ship,
+/area/engine/break_room)
+"omC" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/monotile,
+/area/security/brig)
+"opr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/monotile,
+/area/crew_quarters/heads/chief)
 "oqq" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
@@ -41420,6 +42077,12 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
+"ors" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "oun" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	req_one_access_txt = "8;13"
@@ -41429,6 +42092,23 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
+"our" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"ovp" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"owZ" = (
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/library)
 "oyf" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -41441,14 +42121,12 @@
 	},
 /turf/open/floor/monotile,
 /area/hallway/secondary/exit)
-"oAc" = (
-/obj/machinery/airalarm/directional/north,
-/obj/structure/table/wood,
-/obj/item/toy/cards/deck/cas,
-/obj/item/toy/cards/deck/cas/black{
-	pixel_x = 3;
-	pixel_y = 3
-	},
+"oAb" = (
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/starboard)
+"oBU" = (
+/obj/structure/displaycase/trophy,
+/obj/structure/sign/solgov_flag,
 /turf/open/floor/wood,
 /area/library)
 "oDq" = (
@@ -41469,134 +42147,190 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"oGv" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+"oKJ" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -27
 	},
 /turf/open/floor/monotile,
+/area/engine/engineering/hangar)
+"oMe" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
+"oMZ" = (
+/obj/structure/weightmachine/stacklifter,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/fitness/recreation)
-"pam" = (
+"oPf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/chair/comfy/shuttle{
+	dir = 4;
+	name = "briefing room chair"
+	},
+/turf/open/floor/carpet/blue,
+/area/nsv/hanger/deck2)
+"oQo" = (
+/obj/item/storage/crayons,
+/obj/structure/table/wood,
+/turf/open/floor/carpet,
+/area/library)
+"oQQ" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
+"oRC" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood,
+/area/library)
+"oSp" = (
 /obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+/obj/structure/window/reinforced/fulltile/ship,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/crew_quarters/fitness/recreation)
+"oTN" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
 	},
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/machinery/newscaster{
+	pixel_x = 30
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
-"pgD" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/area/hallway/secondary/exit)
+"pav" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -27
 	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
+/turf/open/floor/plasteel/tech/grid,
+/area/nsv/weapons/fore)
+"pfW" = (
+/obj/machinery/light_switch{
+	pixel_x = -28
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood,
+/area/library)
+"phJ" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/port)
+"phY" = (
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall/ship,
+/area/hallway/nsv/deck2/frame2/port)
+"pjh" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/turf/open/floor/monotile/dark,
+/area/science/nanite)
+"pne" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/poddoor/preopen{
+	id = "xb_containment";
+	name = "Xenobiology Containment Shutter"
+	},
+/obj/machinery/shieldwallgen/xenobiologyaccess,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "poV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
 /turf/open/floor/monotile,
 /area/science/xenobiology)
-"pus" = (
-/obj/structure/reagent_dispensers/fueltank,
+"pqM" = (
+/obj/structure/destructible/cult/tome,
+/obj/item/book/codex_gigas,
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/open/floor/wood,
+/area/library)
+"puz" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "xb_containment";
+	name = "Xenobiology Containment Shutter"
+	},
+/obj/machinery/shieldwallgen/xenobiologyaccess,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/science/xenobiology)
 "pxy" = (
 /obj/machinery/newscaster,
 /turf/closed/wall/ship,
 /area/quartermaster/qm)
-"pxK" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/status_display/ai{
-	pixel_x = -32
+"pBG" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
-/turf/open/floor/monotile/dark,
-/area/nsv/briefingroom)
-"pCp" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/central)
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck2/frame2/port)
+"pCU" = (
+/obj/structure/displaycase/trophy,
+/obj/structure/sign/solgov_flag/right,
+/turf/open/floor/wood,
+/area/library)
 "pFX" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
-"pGG" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/carpet/ship,
-/area/crew_quarters/heads/hor)
-"pPg" = (
-/obj/machinery/door/airlock/ship/external/glass{
-	req_one_access_txt = "13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/area/maintenance/starboard/fore)
+"pMv" = (
+/obj/structure/bookcase/random/religion,
+/turf/open/floor/wood,
+/area/library)
+"pMQ" = (
+/obj/structure/grille,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/starboard/fore)
 "pSV" = (
 /obj/machinery/newscaster,
 /turf/closed/wall/ship,
 /area/medical/genetics)
-"pWv" = (
-/obj/structure/displaycase/trophy,
-/obj/structure/sign/solgov_flag,
-/turf/open/floor/wood,
-/area/library)
-"pZt" = (
-/obj/machinery/newscaster{
-	pixel_y = -32
+"qau" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/carpet,
-/area/library)
-"qav" = (
-/obj/machinery/vending/coffee,
-/obj/machinery/computer/ship/viewscreen,
-/turf/open/floor/wood,
-/area/library)
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
 "qbw" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"qfQ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
-"qgD" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
-"qiZ" = (
-/obj/structure/chair/comfy/brown{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/library)
 "qmY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -41621,6 +42355,10 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/service)
+"qCx" = (
+/obj/structure/bookcase/random/nonfiction,
+/turf/open/floor/wood,
+/area/library)
 "qEi" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
@@ -41634,6 +42372,23 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/monotile,
 /area/gateway)
+"qGu" = (
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Patient Room B"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/monotile,
+/area/medical/medbay/central)
+"qHd" = (
+/obj/machinery/camera/autoname,
+/obj/machinery/vending/games,
+/turf/open/floor/wood,
+/area/library)
 "qLh" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -41642,11 +42397,20 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
+"qMQ" = (
+/obj/machinery/status_display/ai,
+/turf/closed/wall/ship,
+/area/security/brig)
+"qNG" = (
+/obj/structure/window/reinforced/fulltile/ship,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "qOb" = (
 /obj/effect/turf_decal/box,
 /obj/machinery/requests_console{
-	department = "Janitorial";
-	departmentType = 1;
+	department = "Custodial Closet";
+	departmentType = 3;
 	pixel_x = -28
 	},
 /turf/open/floor/monotile,
@@ -41659,7 +42423,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/port)
 "qOQ" = (
 /obj/machinery/gateway{
 	dir = 6
@@ -41678,27 +42442,23 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/gateway)
-"qRm" = (
-/obj/structure/bookcase,
-/turf/open/floor/wood,
-/area/library)
+"qSY" = (
+/turf/closed/wall/ship,
+/area/maintenance/starboard)
+"qSZ" = (
+/obj/machinery/door/airlock/highsecurity/ship{
+	name = "Flight Deck Ladder Access";
+	req_one_access_txt = "3;69"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/monotile,
+/area/maintenance/port)
 "qZd" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"reN" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/ship,
-/area/medical/genetics)
-"rgA" = (
-/obj/structure/punching_bag,
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
 "riT" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -41709,60 +42469,54 @@
 	},
 /turf/open/floor/monotile,
 /area/science/xenobiology)
-"rjx" = (
-/obj/effect/landmark/nuclear_waste_spawner,
-/turf/open/floor/wood,
-/area/library)
-"rlQ" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Patient Room B"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/turf/open/floor/monotile,
-/area/medical/medbay/central)
 "rnf" = (
 /obj/machinery/igniter/incinerator_toxmix,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"rqk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
+"roB" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_y = 26
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/secondary/exit)
+"rpO" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/fitness/recreation)
+"rqu" = (
+/obj/machinery/vending/wardrobe/curator_wardrobe,
+/turf/open/floor/wood,
+/area/library)
+"rxp" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
+/obj/machinery/newscaster{
+	pixel_x = 32
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
-"rqy" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/ship,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/crew_quarters/fitness/recreation)
-"rsw" = (
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/hallway/nsv/deck2/frame1/central)
 "rCB" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/port)
 "rFe" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -41776,13 +42530,6 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/monotile,
 /area/gateway)
-"rHh" = (
-/obj/machinery/door/airlock/highsecurity/ship{
-	name = "Flight Deck Ladder Access";
-	req_one_access_txt = "3;69"
-	},
-/turf/open/floor/plating,
-/area/maintenance/central)
 "rHk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -41797,31 +42544,31 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"rIm" = (
-/obj/machinery/light,
-/turf/open/floor/monotile/dark,
-/area/hallway/secondary/exit)
 "rMN" = (
 /obj/machinery/newscaster{
 	pixel_y = -30
 	},
 /turf/open/floor/monotile/dark,
 /area/science/nanite)
-"rXQ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+"rPe" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"rRu" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/carpet,
+/turf/open/floor/wood,
 /area/library)
+"rWF" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "sax" = (
 /obj/machinery/newscaster{
 	pixel_x = 32
@@ -41851,14 +42598,26 @@
 	},
 /turf/open/floor/monotile,
 /area/medical/chemistry)
-"sjw" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/dorms)
-"sqV" = (
-/turf/open/floor/wood,
+"skz" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/turf/open/floor/monotile,
+/area/nsv/briefingroom)
+"soc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/carpet,
 /area/library)
 "srs" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -41878,10 +42637,15 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
+"ssa" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "ssf" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/starboard)
 "stk" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/machinery/meter,
@@ -41898,56 +42662,69 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"szq" = (
-/obj/structure/closet/lasertag/red,
+"sBu" = (
 /obj/machinery/newscaster{
-	pixel_y = -30
+	pixel_y = -32
 	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
-"sBm" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/structure/table/wood,
-/obj/item/paicard,
-/turf/open/floor/wood,
+/turf/open/floor/carpet,
 /area/library)
-"sBA" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/light{
+"sBW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_y = -26
+	},
 /turf/open/floor/monotile,
+/area/engine/engineering/hangar)
+"tbQ" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/fitness/recreation)
-"sCm" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/library)
-"sHQ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 4;
-	sortType = 16
+"tcq" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 26
 	},
 /turf/open/floor/monotile/dark,
-/area/hallway/nsv/deck2/frame2/port)
-"sRo" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/carpet,
+/area/crew_quarters/dorms)
+"tdw" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/east,
+/obj/structure/punching_bag,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
+"tdV" = (
+/obj/structure/table/wood,
+/obj/item/camera,
+/obj/item/taperecorder,
+/turf/open/floor/wood,
+/area/library)
+"tes" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -27
+	},
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck2/frame1/central)
+"tgc" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/libraryconsole,
+/obj/machinery/computer/lore_terminal,
+/turf/open/floor/wood,
 /area/library)
 "tiu" = (
 /obj/machinery/requests_console{
@@ -41966,18 +42743,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"tjX" = (
-/obj/structure/table/wood,
-/obj/item/camera,
-/obj/item/taperecorder,
-/turf/open/floor/wood,
-/area/library)
-"tmG" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
-	},
-/turf/open/floor/carpet/ship,
-/area/crew_quarters/dorms)
 "tnm" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -41990,59 +42755,54 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/break_room)
-"twJ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_large/ship{
-	name = "Gym"
+"try" = (
+/obj/item/radio/intercom{
+	dir = 4;
+	pixel_x = 27
 	},
-/turf/open/floor/carpet/ship,
-/area/crew_quarters/fitness/recreation)
-"txB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/carpet,
+/turf/open/floor/wood,
 /area/library)
 "txH" = (
 /obj/machinery/holopad,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo)
-"tyN" = (
-/obj/structure/displaycase/trophy,
-/obj/structure/sign/solgov_flag/right,
-/turf/open/floor/wood,
+"tDI" = (
+/turf/closed/wall/r_wall/ship,
 /area/library)
-"tBs" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+"tMx" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_y = 26
 	},
-/turf/open/floor/carpet/ship,
-/area/crew_quarters/dorms)
-"tCn" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
+/turf/open/floor/monotile,
+/area/security/brig)
+"tNr" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
 	},
-/turf/open/floor/carpet/ship,
-/area/crew_quarters/dorms)
+/turf/open/floor/monotile/dark,
+/area/engine/engineering)
+"tUg" = (
+/obj/machinery/door/airlock/ship/external/glass{
+	req_one_access_txt = "13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "tUT" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -42063,15 +42823,6 @@
 /obj/machinery/status_display/supply,
 /turf/closed/wall/ship,
 /area/quartermaster/storage)
-"tWY" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood,
-/area/library)
 "tXO" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -42085,41 +42836,34 @@
 	},
 /turf/open/floor/monotile,
 /area/science/xenobiology)
-"tYd" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/door/window/eastright{
-	name = "Fitness Ring"
-	},
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/fitness/recreation)
-"tZM" = (
-/obj/machinery/camera/autoname,
-/obj/machinery/vending/games,
-/turf/open/floor/wood,
-/area/library)
-"tZW" = (
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/monotile,
-/area/crew_quarters/bar)
+"ucC" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"udB" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/storage/toolbox/emergency,
+/obj/item/clothing/gloves/color/fyellow,
+/turf/open/floor/plating,
+/area/nsv/briefingroom)
 "udH" = (
 /obj/machinery/gateway/centerstation,
 /turf/open/floor/monotile/dark,
 /area/gateway)
-"uif" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/machinery/light/small{
-	dir = 4
+"ufY" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
 	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel/chapel{
+	dir = 8
+	},
+/area/chapel/main)
+"ukv" = (
+/turf/closed/wall/ship,
 /area/library)
-"urK" = (
-/obj/machinery/vending/wardrobe/curator_wardrobe,
+"uoC" = (
+/obj/structure/bookcase/random/fiction,
 /turf/open/floor/wood,
 /area/library)
 "uts" = (
@@ -42129,7 +42873,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
 "uty" = (
 /obj/machinery/door/airlock/ship/security/glass{
 	req_one_access_txt = "2"
@@ -42149,16 +42893,42 @@
 	},
 /turf/open/floor/monotile,
 /area/security/brig)
-"uyq" = (
-/turf/closed/wall/r_wall/ship,
-/area/library)
+"uAR" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_x = -26
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/fitness/recreation)
 "uDe" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
+"uDu" = (
+/obj/structure/punching_bag,
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
+"uEa" = (
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/table/wood,
+/turf/open/floor/carpet,
+/area/library)
 "uIA" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable{
@@ -42176,13 +42946,40 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"uNo" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
 "uOY" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
 	},
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
+"uSo" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck2/frame1/central)
 "uTe" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -42191,45 +42988,52 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"uXW" = (
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
-/turf/open/floor/monotile/dark,
-/area/nsv/briefingroom)
-"uZp" = (
-/obj/machinery/photocopier{
-	pixel_y = 3
-	},
-/obj/machinery/computer/ship/viewscreen,
-/turf/open/floor/wood,
+"uWp" = (
+/obj/machinery/computer/libraryconsole/bookmanagement,
+/obj/structure/table/wood,
+/turf/open/floor/carpet,
 /area/library)
-"vcn" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
+"uWC" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
-"vdf" = (
-/obj/machinery/power/apc/auto_name/south,
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/library)
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 26
+	},
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_x = 26
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
+"vci" = (
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/starboard/fore)
 "vii" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1;
 	name = "toxins output"
 	},
 /obj/effect/turf_decal/delivery/red,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
 /turf/open/floor/monotile/dark,
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"vlm" = (
-/obj/structure/bookcase/random/adult,
-/turf/open/floor/wood,
-/area/library)
+"vkR" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
 "vlL" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/stripes/line{
@@ -42250,31 +43054,36 @@
 	dir = 9
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/starboard/fore)
+"vqc" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"vqH" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/carpet,
+/area/library)
 "vtl" = (
 /obj/machinery/light,
 /turf/open/floor/monotile,
 /area/engine/engineering/hangar)
-"vzE" = (
+"vCb" = (
+/obj/machinery/status_display/evac,
+/turf/closed/wall/ship,
+/area/medical/genetics)
+"vKM" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/status_display/ai{
+	pixel_x = -32
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
-"vKU" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/department/science)
+/area/hallway/nsv/deck2/frame1/central)
 "vPd" = (
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_exterior,
 /obj/effect/mapping_helpers/airlock/locked,
@@ -42282,10 +43091,24 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
+"vUj" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "vVm" = (
 /obj/item/beacon,
 /turf/open/floor/mineral/plastitanium/red/airless,
 /area/science/test_area)
+"vWe" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/status_display/ai{
+	pixel_x = -32
+	},
+/turf/open/floor/monotile/dark,
+/area/nsv/briefingroom)
 "vYs" = (
 /obj/machinery/camera/autoname,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
@@ -42293,19 +43116,25 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"vYw" = (
-/obj/machinery/door/airlock/ship/external/glass{
-	req_one_access_txt = "13"
+"wen" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
-"wgx" = (
-/obj/structure/bookcase/manuals/engineering,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/wood,
 /area/library)
+"wgO" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
 "wgS" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/toxin,
@@ -42319,9 +43148,6 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"wjY" = (
-/turf/closed/wall/ship,
-/area/hallway/secondary/service)
 "wqR" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/incinerator_input{
 	dir = 1
@@ -42336,39 +43162,41 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"wsS" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+"wwK" = (
+/obj/machinery/camera/autoname{
+	dir = 1
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 26
-	},
-/obj/item/radio/intercom{
-	name = "intra ship intercom";
-	pixel_x = 26
+/obj/machinery/light_switch{
+	pixel_y = -28
 	},
 /turf/open/floor/monotile,
 /area/crew_quarters/fitness/recreation)
+"wwO" = (
+/obj/structure/lattice,
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/department/engine)
 "wyO" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/science/xenobiology)
-"wzZ" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/libraryconsole,
-/obj/machinery/computer/lore_terminal,
-/turf/open/floor/wood,
-/area/library)
 "wEq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
+	},
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_y = -26
 	},
 /turf/open/floor/monotile,
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
+"wHw" = (
+/obj/structure/closet/toolcloset,
+/turf/open/floor/plating,
+/area/nsv/briefingroom)
 "wId" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
@@ -42382,20 +43210,32 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"wNN" = (
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/carpet/ship,
-/area/crew_quarters/dorms)
-"wOm" = (
-/obj/effect/turf_decal/tile/neutral{
+"wKb" = (
+/obj/structure/bookcase/manuals/medical,
+/obj/machinery/camera/autoname{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/turf/open/floor/wood,
+/area/library)
+"wLn" = (
+/obj/item/reagent_containers/food/drinks/sillycup{
+	pixel_x = -5;
+	pixel_y = 3
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/item/reagent_containers/food/drinks/sillycup,
+/obj/item/reagent_containers/food/drinks/sillycup{
+	pixel_x = 5;
+	pixel_y = 3
 	},
+/obj/item/reagent_containers/food/drinks/sillycup{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/drinks/sillycup{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/structure/table,
 /turf/open/floor/monotile,
 /area/crew_quarters/fitness/recreation)
 "wUv" = (
@@ -42407,12 +43247,30 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/gateway)
+"wXr" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_x = 26
+	},
+/turf/open/floor/monotile,
+/area/hallway/secondary/exit)
 "wZp" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/nsv/observation)
+"xcN" = (
+/obj/effect/landmark/nuclear_waste_spawner,
+/turf/open/floor/wood,
+/area/library)
 "xdR" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -42433,7 +43291,14 @@
 	},
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/starboard)
+"xfy" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/nsv/observation)
 "xhI" = (
 /turf/closed/wall/r_wall/ship,
 /area/science/nanite)
@@ -42443,26 +43308,12 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/science/research)
-"xiH" = (
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+"xqj" = (
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/table/wood,
-/turf/open/floor/carpet,
-/area/library)
-"xjX" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
+/turf/open/floor/plating,
+/area/maintenance/port)
 "xqR" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -42482,11 +43333,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/briefingroom)
-"xwk" = (
-/obj/structure/punching_bag,
-/obj/machinery/computer/ship/viewscreen,
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
 "xDQ" = (
 /obj/machinery/door/poddoor/incinerator_toxmix,
 /turf/open/floor/plating/airless,
@@ -42497,29 +43343,24 @@
 /obj/machinery/holopad,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms)
-"xIM" = (
-/obj/machinery/door/morgue{
-	name = "Private Study";
-	req_access_txt = "37"
-	},
-/turf/open/floor/wood,
-/area/library)
-"xNv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/wood,
-/area/library)
-"xOj" = (
-/obj/structure/reagent_dispensers/watertank,
+"xHw" = (
+/obj/machinery/space_heater,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/starboard)
+"xJH" = (
+/obj/structure/closet/lasertag/red,
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
+"xMq" = (
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_x = -26
+	},
+/turf/open/floor/monotile/light,
+/area/security/prison)
 "xOP" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -42528,6 +43369,15 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
+"xPq" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
 "xPD" = (
 /obj/machinery/light/small,
 /obj/structure/bed,
@@ -42538,6 +43388,20 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/security/prison)
+"xSM" = (
+/turf/open/floor/wood,
+/area/library)
+"xUy" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_x = 26
+	},
+/turf/open/floor/monotile/light,
+/area/medical/medbay/lobby)
 "xWe" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -42551,13 +43415,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/closed/wall/r_wall/ship,
 /area/engine/atmospherics_engine)
-"xYl" = (
-/obj/item/radio/intercom{
-	dir = 4;
-	pixel_x = 27
-	},
-/turf/open/floor/wood,
-/area/library)
 "xYC" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -42568,25 +43425,16 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/science)
-"ybZ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
+"ydV" = (
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
-"yjB" = (
-/obj/machinery/light_switch{
-	pixel_x = -28
+/area/engine/engineering/hangar)
+"ykt" = (
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
-/area/library)
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 
 (1,1,1) = {"
 aaa
@@ -55824,7 +56672,7 @@ anb
 aaJ
 aFA
 alx
-asW
+nIE
 aEo
 adM
 aFo
@@ -56337,7 +57185,7 @@ anb
 anb
 aaJ
 aFA
-amE
+jTG
 aEl
 asW
 aEr
@@ -56847,7 +57695,7 @@ aaJ
 anb
 aFA
 beD
-bIM
+xMq
 bIN
 bIP
 bIT
@@ -56884,7 +57732,7 @@ aGZ
 aGZ
 aGZ
 aGZ
-aGZ
+bMS
 aZe
 uTe
 vPd
@@ -57141,7 +57989,7 @@ aIA
 aGZ
 aGZ
 aGZ
-aGZ
+gkF
 aZe
 cOu
 jlu
@@ -57366,7 +58214,7 @@ bIO
 bIS
 aFA
 aoQ
-asW
+mxW
 asW
 adM
 aFo
@@ -57887,12 +58735,12 @@ aFl
 agi
 aHr
 aHu
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+anb
+anb
+anb
+anb
+anb
+anb
 aFA
 bie
 aYh
@@ -58406,7 +59254,7 @@ aFQ
 aIm
 aFQ
 aFQ
-aFQ
+bMM
 aDL
 aFA
 aFA
@@ -58426,7 +59274,7 @@ wIm
 bif
 bwT
 aKb
-aKb
+lEl
 aZe
 aZe
 fjB
@@ -58665,9 +59513,9 @@ aIu
 aFT
 fVu
 aDL
-avv
-avv
-avv
+anb
+anb
+anb
 anb
 aaJ
 aaJ
@@ -59179,9 +60027,9 @@ beJ
 aYr
 beK
 aDL
-aaa
-aaa
-aaa
+aaJ
+aaJ
+aaJ
 aCJ
 aaD
 aLC
@@ -59436,9 +60284,9 @@ aFT
 aFT
 aYs
 aDL
-aaa
-aaa
-aaa
+aaJ
+aaJ
+aaJ
 aCJ
 bgm
 aJY
@@ -59920,7 +60768,7 @@ anb
 anb
 anb
 anb
-lNi
+heA
 anb
 anb
 anb
@@ -60192,7 +61040,7 @@ aBf
 aER
 aEY
 aHu
-aFk
+tMx
 aEX
 aHX
 aaV
@@ -60221,11 +61069,11 @@ bzA
 aKr
 aLb
 abB
-jCa
-jCa
-jCa
-jCa
-jCa
+nGo
+nGo
+nGo
+nGo
+nGo
 aXi
 alK
 lRd
@@ -60457,12 +61305,12 @@ aFm
 bko
 aHr
 aHu
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+anb
+anb
+anb
+anb
+anb
+anb
 aau
 aFZ
 aJz
@@ -60975,7 +61823,7 @@ bkJ
 bly
 bGu
 bkJ
-bkJ
+iUd
 bkJ
 byO
 bmK
@@ -61253,7 +62101,7 @@ bjU
 bqK
 aLc
 aLc
-pGG
+gOS
 aaC
 bxf
 aKS
@@ -61458,7 +62306,7 @@ aaJ
 aaJ
 aaJ
 aaJ
-hgJ
+fgT
 aac
 adT
 aDB
@@ -61738,7 +62586,7 @@ bEj
 bEo
 aaV
 aaV
-aaV
+cIy
 byJ
 aaV
 aaV
@@ -61749,7 +62597,7 @@ hrv
 aaV
 bFc
 agi
-bmL
+omC
 aHu
 aaw
 bwK
@@ -61764,10 +62612,10 @@ aKY
 bpG
 abB
 bdx
-dPL
-dPL
-dPL
-dPL
+csF
+csF
+csF
+csF
 aXi
 bgr
 aKS
@@ -62003,7 +62851,7 @@ aFO
 aXC
 aXC
 aXJ
-aaV
+qMQ
 bCD
 bzP
 bmL
@@ -62033,7 +62881,7 @@ brM
 bCP
 bCK
 aMi
-bJQ
+pne
 aMQ
 aXi
 aXi
@@ -62289,8 +63137,8 @@ aLV
 aLz
 bxc
 bdQ
-bdS
-bdU
+aeI
+aeI
 aWD
 aJB
 aJB
@@ -63316,9 +64164,9 @@ aXi
 aXi
 aXi
 bxe
-bdR
-bdT
-bdU
+aKS
+aMj
+aeI
 aXf
 aLF
 bxn
@@ -63573,9 +64421,9 @@ aJB
 aJB
 aMc
 bzW
-aKS
+bdR
 aMF
-aXi
+puz
 aXi
 aXi
 aXi
@@ -63785,7 +64633,7 @@ anb
 aaJ
 aZa
 akL
-fdx
+oMe
 aZa
 bgu
 bei
@@ -63800,7 +64648,7 @@ aFO
 bCX
 bgw
 aFO
-aXJ
+lQj
 aXL
 aHu
 bmk
@@ -63823,7 +64671,7 @@ bqs
 bzx
 bwR
 aXm
-alZ
+liS
 xhI
 aJD
 aJB
@@ -64042,7 +64890,7 @@ anb
 anb
 aZa
 akL
-hbf
+lIS
 aZa
 ayX
 bCZ
@@ -64299,7 +65147,7 @@ anb
 aaJ
 aZa
 baD
-ioY
+iuj
 aZa
 aEL
 bEc
@@ -64337,7 +65185,7 @@ bqu
 bwO
 aKv
 aMl
-alZ
+pjh
 xhI
 aXi
 aXi
@@ -64571,7 +65419,7 @@ aXy
 aXy
 aFP
 aIe
-aHq
+hrA
 aHu
 bku
 bwA
@@ -65597,10 +66445,10 @@ agX
 agX
 agX
 agX
-hbf
+lIS
 bhN
 agX
-fdx
+oMe
 afw
 bmo
 bmC
@@ -65627,7 +66475,7 @@ bbv
 lTI
 acs
 bbv
-vKU
+jvQ
 bIF
 aMc
 bHP
@@ -66387,7 +67235,7 @@ agI
 aeb
 bHZ
 bpz
-aOS
+fOP
 bjr
 aOS
 aOS
@@ -66601,7 +67449,7 @@ afw
 ahm
 ahK
 ahm
-rlQ
+qGu
 ahm
 ahm
 bfw
@@ -66612,7 +67460,7 @@ aic
 aUx
 afw
 aXN
-vcn
+vUj
 agP
 agW
 aki
@@ -67135,7 +67983,7 @@ afV
 bbe
 bwe
 amh
-akQ
+nBU
 akQ
 acF
 akh
@@ -67144,7 +67992,7 @@ alj
 alN
 alQ
 acF
-acx
+byC
 bmC
 aOP
 aeb
@@ -68453,10 +69301,10 @@ brA
 bre
 bre
 bre
-nzF
+gfE
 bst
-bsy
-bsy
+gAq
+gAq
 blG
 blI
 agZ
@@ -68701,19 +69549,19 @@ aaB
 aaB
 aaB
 aaB
-bne
-bne
-bne
-bne
+qSY
+qSY
+qSY
+qSY
 brl
 bre
 bre
-bnm
+fFh
 bDQ
 bsl
 brZ
 bzZ
-bne
+qSY
 adh
 blJ
 agZ
@@ -68907,10 +69755,10 @@ anb
 anb
 anb
 abY
-aAv
+bHp
 apa
-aae
-aae
+bne
+bne
 amN
 aUK
 bvD
@@ -68958,18 +69806,18 @@ aWe
 agT
 aOT
 aWc
-bne
+qSY
 bqx
-bqO
+ssa
 ssf
-brm
-brB
-bnm
-bnm
+jfr
+ucC
+fFh
+fFh
 brY
-bsm
-bqO
-bne
+dVP
+ssa
+qSY
 afL
 adh
 aha
@@ -69164,10 +70012,10 @@ anb
 aaJ
 aaJ
 aaJ
-aAv
-apu
-bIp
-aae
+bHp
+brm
+jtt
+bne
 ahk
 ahi
 bvE
@@ -69191,7 +70039,7 @@ ahc
 ahc
 pSV
 akP
-reN
+vCb
 ahc
 ahc
 alr
@@ -69215,18 +70063,18 @@ bxs
 bpg
 afE
 aWd
-bne
-bnm
+qSY
+fFh
 aZh
-bqY
+clk
 brn
-bqY
+clk
 brJ
-bqY
+clk
 brZ
-bne
-bne
-bne
+qSY
+qSY
+qSY
 adh
 adh
 bda
@@ -69421,10 +70269,10 @@ anb
 aaJ
 aaJ
 aaJ
-aAv
-apu
-aAk
-aae
+bHp
+brm
+bnm
+bne
 ahp
 amL
 aUs
@@ -69449,14 +70297,14 @@ ahC
 ajT
 alh
 ajY
-ajY
+bVN
 aCf
 ahf
 bhK
 bFU
 amb
 ahf
-afV
+gss
 bCy
 bCz
 bmQ
@@ -69472,16 +70320,16 @@ afD
 bph
 afD
 bpL
-bne
-bnm
-brm
+qSY
+fFh
+jfr
 bnn
-cuG
-brB
-brm
-bnm
-bqO
-bne
+gVX
+ucC
+jfr
+fFh
+ssa
+qSY
 adE
 aea
 afN
@@ -69678,10 +70526,10 @@ anb
 aaJ
 aaJ
 aaJ
-aAv
-apu
-aAk
-aae
+bHp
+brm
+bnm
+bne
 ahq
 ahq
 amO
@@ -69729,16 +70577,16 @@ agR
 bpi
 agR
 bil
-bne
-bnm
-brm
-bne
-bne
-bne
+qSY
+fFh
+jfr
+qSY
+qSY
+qSY
 brK
-bne
-bne
-bne
+qSY
+qSY
+qSY
 adK
 adh
 afO
@@ -69935,10 +70783,10 @@ anb
 aaJ
 aaJ
 aaJ
-aAv
-apu
-aAk
-aae
+bHp
+brm
+bnm
+bne
 bfv
 amM
 amT
@@ -69986,10 +70834,10 @@ agS
 bpj
 agS
 bpM
-bne
-bFV
-brm
-bne
+qSY
+gUN
+jfr
+qSY
 act
 acD
 bkL
@@ -70000,7 +70848,7 @@ adZ
 aef
 afY
 aef
-afY
+ufY
 ahG
 bye
 ahG
@@ -70192,10 +71040,10 @@ anb
 aaJ
 aaJ
 aaJ
-aAv
+bHp
 bFS
-aAk
-aae
+bnm
+bne
 ahR
 amM
 amM
@@ -70243,10 +71091,10 @@ bju
 bpk
 bpB
 bpN
-bne
-bqy
+qSY
+mGR
 bsS
-bne
+qSY
 acu
 acE
 bkQ
@@ -70444,15 +71292,15 @@ aaJ
 aaJ
 aaJ
 aaJ
-aAv
-aAv
-aAv
-aAv
-aAv
-aAv
+bHp
+bHp
+bHp
+bHp
+bHp
+bHp
 apY
-aAk
-aae
+bnm
+bne
 akC
 amM
 amM
@@ -70488,22 +71336,22 @@ bCt
 bCu
 bCv
 bmS
-bne
-bne
-bne
-bne
-bne
-bne
-bne
-bne
-bne
+qSY
+qSY
+qSY
+qSY
+qSY
+qSY
+qSY
+qSY
+qSY
 bpl
-bne
-bne
-bne
-bnm
-brm
-bne
+qSY
+qSY
+qSY
+fFh
+jfr
+qSY
 acv
 bcZ
 adw
@@ -70701,15 +71549,15 @@ aaJ
 aaJ
 aaJ
 aaJ
-aAv
+bHp
 aYT
 bGQ
 bsW
 aYT
-aae
-apu
-gUv
-aae
+bne
+brm
+cuG
+bne
 akD
 amM
 amM
@@ -70744,23 +71592,23 @@ bvl
 bwp
 bwq
 bCw
-bmQ
-bne
-gXS
-gXS
-bne
-jtt
-bnm
-bnm
-bnm
-bnm
+jRw
+qSY
+xHw
+xHw
+qSY
+vqc
+fFh
+fFh
+fFh
+fFh
 bpm
-bnm
-bnm
-bnm
-bnm
-brm
-bne
+fFh
+fFh
+fFh
+fFh
+jfr
+qSY
 abF
 abF
 ahY
@@ -70954,19 +71802,19 @@ aaJ
 aaJ
 aaJ
 aaJ
-aAv
-aAv
-aAv
-aAv
-aAv
+bHp
+bHp
+bHp
+bHp
+bHp
 aYT
 bhk
 bsX
 aYT
-aae
-apu
-aAk
-aae
+bne
+brm
+bnm
+bne
 akH
 amM
 aht
@@ -71002,22 +71850,22 @@ aTT
 acx
 bmE
 bmQ
-bne
+qSY
 kSX
-bqY
+clk
 bnY
-bqY
-bqY
-bqY
-bqY
-bqY
+clk
+clk
+clk
+clk
+clk
 bsJ
-bqY
-bqY
-bqY
-bqY
+clk
+clk
+clk
+clk
 brZ
-bne
+qSY
 acP
 bJk
 beR
@@ -71209,9 +72057,9 @@ aaJ
 aaJ
 aaJ
 aaJ
-aAv
-aAv
-aAv
+bHp
+bHp
+bHp
 aAu
 bho
 aYS
@@ -71220,17 +72068,17 @@ aYT
 aYT
 aYT
 aYT
-aae
-apu
-pCp
-aae
+bne
+brm
+phJ
+bne
 amK
 amM
-amM
+jnx
 aoO
 aUH
 aaK
-ahU
+aUo
 aUo
 aUG
 bHE
@@ -71250,8 +72098,8 @@ azf
 azf
 azf
 bkT
-bgO
-bFy
+dEz
+xUy
 lVV
 bFy
 blQ
@@ -71259,22 +72107,22 @@ afV
 afS
 bmE
 bmQ
-bne
+qSY
 mMv
 bnH
-bne
+qSY
 boq
 boq
-bHp
+oAb
 boq
 boq
 boq
 boq
 boq
-bHp
+oAb
 boq
 boq
-bHp
+oAb
 acA
 acG
 bkM
@@ -71466,59 +72314,59 @@ aaJ
 aaJ
 aaJ
 aaJ
-aAv
-pCp
-aAs
-aAk
+bHp
+phJ
+brB
+bnm
 aYR
 bDJ
-aae
-bsV
-bsV
-rHh
-aae
-aae
+bne
+bne
+bne
+bne
+qSZ
+bne
 aAt
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+bne
+bne
+bne
+bne
+bne
+bne
+bne
+bne
+bne
+bne
+bne
+bne
+bne
+bne
+bne
+bne
+bne
+bne
 bca
 aLr
 aeR
-bne
-bne
-bne
-bne
-bne
-bne
-bne
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 bhV
 blm
 bmH
 bFA
 bFD
-bne
+aae
 aPg
 buO
 bmT
-bne
+qSY
 xfd
-fMP
+rWF
 bnZ
 aaa
 aaa
@@ -71717,42 +72565,42 @@ aaJ
 aaJ
 aaJ
 aaJ
-aAv
-aAv
-aAv
-aAv
-aAv
-aAv
-aAv
-aae
-aae
-aae
-aae
-aqx
-aae
-aAk
-aAk
-aAk
+bHp
+bHp
+bHp
+bHp
+bHp
+bHp
+bHp
+bne
+bne
+bne
+bne
+kjW
+bne
+xqj
+mzc
+gGm
 ajN
 anu
 aqU
-asv
-asv
-asv
-asv
-asv
-anu
-asv
-asv
-asv
-asv
-asv
-anu
-asv
-asv
-asv
+bsy
+bsy
+bsy
+bsy
+bsy
+fMu
+bsy
+bsy
+bsy
+bsy
+bsy
+fMu
+bsy
+bsy
+bsy
 aZj
-aZZ
+bqY
 baV
 bcb
 bcq
@@ -71762,20 +72610,20 @@ bbk
 bbo
 bdC
 beN
-bsy
-bsy
+asv
+asv
 bjc
-bsy
+asv
 bsm
 bFB
 bFE
-bne
+aae
 aeT
 buJ
 bmU
-bne
+qSY
 ecN
-jtt
+vqc
 bnZ
 aaa
 aaa
@@ -71974,43 +72822,43 @@ aaJ
 aaJ
 aaJ
 aaJ
-aAv
+bHp
 aag
 aiM
 aAm
-aae
-aAk
-aae
+bne
+bnm
+bne
 bIm
-aZl
-aZV
+xqj
+ors
 aZV
 bhp
-aZV
-aZV
-bGR
-aZV
+ors
+bDI
+bne
+nvB
 akc
-aZV
-baB
-aZV
-aZV
-aZV
-aZV
-aZV
-aZV
-aZV
-aZV
-aZV
-aZV
-aZV
-aZV
-aZV
-aZV
-aZV
+bne
+bDH
+ors
+ors
+ors
+ors
+ors
+ors
+ors
+ors
+ors
+ors
+ors
+ors
+ors
+ors
+ors
 aYV
-bIp
-aAv
+jtt
+bHp
 bjt
 bcw
 bcX
@@ -72019,8 +72867,8 @@ bbn
 bbn
 bdD
 beO
-bqY
-bqY
+aZZ
+aZZ
 bjd
 blH
 blH
@@ -72030,8 +72878,8 @@ bFG
 bFH
 bFI
 bmU
-bne
-brm
+qSY
+jfr
 kOA
 bnZ
 aaa
@@ -72231,7 +73079,7 @@ aaJ
 aaJ
 aaJ
 aaJ
-aAv
+bHp
 aLu
 aiQ
 aAn
@@ -72240,56 +73088,56 @@ aAn
 aAr
 aal
 aZO
-aAk
-aAk
-aAk
-aAk
-gUv
-aAv
-aAv
+bnm
+bnm
+bnm
+bnm
+cuG
+bHp
+bHp
 bsT
-aAv
-aAv
-aAv
-aAv
-aAv
-aAv
-aAv
-aAv
-aAv
-aAv
-aAv
-aAv
-aAv
-aAv
-aAv
-aAv
-aAv
+bHp
+bHp
+bHp
+bHp
+bHp
+bHp
+bHp
+bHp
+bHp
+bHp
+bHp
+bHp
+bHp
+bHp
+bHp
+bHp
+bHp
 aZY
-aAv
-aAv
+bHp
+bHp
 ahz
 bcx
 bdc
-bne
-bne
-bne
-bne
+aae
+aae
+aae
+aae
 bfQ
-bne
-bne
-bne
-bne
+aae
+aae
+aae
+aae
 bFz
-bne
-bnm
-bne
+aae
+aAk
+aae
 bIw
 buJ
 bmU
-bne
+qSY
 bct
-bne
+qSY
 bnZ
 aaa
 aaa
@@ -72488,25 +73336,25 @@ aaJ
 aaJ
 aaJ
 aaJ
-aAv
+bHp
 aik
-aAk
+bnm
 aAo
 aAq
-aAk
-aae
-aAk
+bnm
+bne
+bnm
 aZO
-aAv
-aAv
-aAv
-aAv
-aAv
-aAv
+bHp
+bHp
+bHp
+bHp
+bHp
+bHp
 aTD
 akR
 abx
-abx
+kjz
 bgP
 bgF
 abx
@@ -72530,11 +73378,11 @@ bcy
 aMv
 aaj
 bfi
-uXW
+nyz
 bFX
 bji
 biZ
-pxK
+vWe
 blf
 aaj
 aSC
@@ -72745,16 +73593,16 @@ aaJ
 aaJ
 aaJ
 aaJ
-aAv
+bHp
 aiH
 aAl
 aAp
-aae
-pCp
-aae
+bne
+phJ
+bne
 bhm
 aZO
-aAv
+bHp
 aan
 baj
 aaO
@@ -73002,16 +73850,16 @@ aaJ
 aaJ
 aaJ
 aaJ
-aAv
-aAv
-aAv
-aAv
-aAv
-aAv
-aAv
-aAk
+bHp
+bHp
+bHp
+bHp
+bHp
+bHp
+bHp
+bnm
 aZO
-aAv
+bHp
 aao
 aaH
 aaH
@@ -73265,10 +74113,10 @@ aaJ
 aaJ
 aaJ
 aaJ
-aAv
-aAk
+bHp
+bnm
 aZO
-aAv
+bHp
 aap
 aaL
 cgt
@@ -73294,7 +74142,7 @@ abx
 abA
 aev
 bao
-abx
+eGl
 aam
 aeT
 bcy
@@ -73347,7 +74195,7 @@ aNX
 acc
 aOe
 acc
-rIm
+ilx
 aOe
 aaJ
 aaJ
@@ -73521,11 +74369,11 @@ aaJ
 aaJ
 aaJ
 aaJ
-aAv
-aAv
-aZl
+bHp
+bHp
+xqj
 bDI
-aAv
+bHp
 aaq
 aaM
 aaQ
@@ -73573,9 +74421,9 @@ aPx
 bIu
 bmU
 aad
-bcL
+roB
 abT
-afq
+kHi
 afq
 aOg
 aaa
@@ -73778,10 +74626,10 @@ aaJ
 aaJ
 aaJ
 aaJ
-aAv
-aAk
+bHp
+bnm
 aZO
-aAv
+bHp
 aam
 aam
 aam
@@ -74031,14 +74879,14 @@ aaJ
 aaJ
 aaJ
 aaJ
-aAv
-aAv
-aAv
-aAv
-aAv
-aAk
+bHp
+bHp
+bHp
+bHp
+bHp
+bnm
 aZO
-aAv
+bHp
 bip
 bip
 bip
@@ -74085,7 +74933,7 @@ abn
 xsC
 aeT
 buJ
-bmU
+tes
 aad
 bGI
 abT
@@ -74288,14 +75136,14 @@ aaJ
 aaJ
 aaJ
 aaJ
-aAv
-bIp
-bIp
-bIp
-aae
-pCp
+bHp
+jtt
+jtt
+jtt
+bne
+phJ
 aZO
-aAv
+bHp
 bip
 bip
 bip
@@ -74545,14 +75393,14 @@ aaJ
 aaJ
 aaJ
 aaJ
-aAv
+bHp
 bhm
-aAk
-aAk
+bnm
+bnm
 bIo
-aAk
+bnm
 aZO
-aAv
+bHp
 bip
 bip
 bip
@@ -74599,7 +75447,7 @@ abn
 aaj
 buR
 buM
-bmU
+uSo
 aad
 bpn
 bjA
@@ -74802,14 +75650,14 @@ aaJ
 aaJ
 aaJ
 aaJ
-aAv
+bHp
 bIm
-aAk
-aAk
-aae
-aAk
+bnm
+bnm
+bne
+bnm
 aZO
-aAv
+bHp
 bip
 bip
 bip
@@ -75059,14 +75907,14 @@ aaJ
 aaJ
 aaJ
 aaJ
-aAv
+bHp
 bIl
-aAk
-aAk
-aae
+bnm
+bnm
+bne
 bhm
 aZO
-aAv
+bHp
 bip
 bip
 bip
@@ -75316,14 +76164,14 @@ aaJ
 aaJ
 aaJ
 aaJ
-aAv
+bHp
 bIl
-aAk
-ini
-aae
-aAk
+bnm
+fMP
+bne
+bnm
 aZO
-aAv
+bHp
 bip
 bip
 bip
@@ -75403,7 +76251,7 @@ aNX
 acc
 aOe
 acc
-rIm
+ilx
 aOe
 aaJ
 aaJ
@@ -75573,14 +76421,14 @@ aaJ
 aaJ
 aaJ
 aaJ
-aAv
+bHp
 bIn
-aAk
-ini
-aae
-bFQ
+bnm
+fMP
+bne
+bFV
 aZO
-jVl
+aAv
 bip
 bip
 bip
@@ -75830,14 +76678,14 @@ aaJ
 aaJ
 aaJ
 aaJ
-aAv
+bHp
 bIl
-aAk
-ini
-aae
-aAk
+bnm
+fMP
+bne
+bnm
 aZO
-aAv
+bHp
 bip
 bip
 bip
@@ -75851,7 +76699,7 @@ abx
 abx
 abx
 agh
-agj
+kFM
 agr
 agv
 agv
@@ -76087,14 +76935,14 @@ aaJ
 aaJ
 aaJ
 aaJ
-aAv
+bHp
 bIl
-aAk
-aAk
-aae
-aAk
+bnm
+bnm
+bne
+bnm
 aZO
-aAv
+bHp
 bip
 bip
 bip
@@ -76344,14 +77192,14 @@ aaJ
 aaJ
 aaJ
 aaJ
-aAv
+bHp
 bIm
-aAk
-aAk
-aae
-aAk
+bnm
+bnm
+bne
+bnm
 aZO
-aAv
+bHp
 bip
 bip
 bip
@@ -76403,7 +77251,7 @@ bHo
 bnr
 bnL
 bqz
-acd
+oTN
 acd
 bxH
 bDo
@@ -76423,7 +77271,7 @@ bsf
 bsn
 bro
 bro
-bro
+wXr
 bro
 bsn
 bsM
@@ -76601,14 +77449,14 @@ aaJ
 aaJ
 aaJ
 aaJ
-aAv
+bHp
 bhm
-aAk
-aAk
+bnm
+bnm
 bIo
-aAk
+bnm
 aZO
-aAv
+bHp
 bip
 bip
 bip
@@ -76858,14 +77706,14 @@ aaJ
 aaJ
 aaJ
 aaJ
-aAv
-bIq
-bIq
-bIp
-aae
+bHp
+gXS
+gXS
+jtt
+bne
 bhm
 aZO
-aAv
+bHp
 bip
 bip
 bip
@@ -77115,14 +77963,14 @@ aaJ
 aaJ
 aaJ
 aaJ
-aAv
-aAv
-aAv
-aAv
-aAv
-aAk
+bHp
+bHp
+bHp
+bHp
+bHp
+bnm
 aZO
-aAv
+bHp
 bip
 bip
 bip
@@ -77376,10 +78224,10 @@ aaJ
 aaJ
 aaJ
 aaJ
-aAv
-aAk
+bHp
+bnm
 aZO
-aAv
+bHp
 aam
 aam
 aam
@@ -77392,7 +78240,7 @@ bDS
 abx
 bBy
 abx
-abx
+hBG
 abx
 aKi
 bau
@@ -77402,7 +78250,7 @@ baw
 abx
 abx
 abx
-abx
+krG
 abx
 abx
 abx
@@ -77633,11 +78481,11 @@ aaJ
 aaJ
 aaJ
 aaJ
-aAv
-aAv
+bHp
+bHp
 bDH
 bDJ
-aAv
+bHp
 aam
 aam
 aam
@@ -77665,7 +78513,7 @@ agm
 agm
 agm
 agm
-aeT
+dIw
 bcy
 aMv
 aaj
@@ -77891,10 +78739,10 @@ aaJ
 aaJ
 aaJ
 aAy
-aAv
-aAk
+bHp
+bnm
 aZO
-aAv
+bHp
 aas
 bgQ
 aaz
@@ -77913,7 +78761,7 @@ agw
 aTk
 bBp
 bgV
-agw
+iFX
 agm
 bai
 bak
@@ -78148,11 +78996,11 @@ aaJ
 aaJ
 aaJ
 aAy
-aAv
-aAk
+bHp
+bnm
 aZO
-aAv
-aat
+bHp
+hXb
 aat
 aat
 aba
@@ -78177,7 +79025,7 @@ bal
 aTp
 aTp
 aTp
-aTp
+pav
 agm
 bgf
 bcy
@@ -78186,12 +79034,12 @@ aaT
 abn
 byA
 bvj
-abn
+skz
 biX
 bJo
 bLb
-abn
-abn
+lln
+iMo
 byA
 abn
 aaT
@@ -78405,10 +79253,10 @@ aaJ
 aaJ
 aaJ
 aAy
-aAv
-aAk
+bHp
+bnm
 aZO
-aAv
+bHp
 aaE
 aav
 bBC
@@ -78416,7 +79264,7 @@ abh
 aeD
 atO
 bBk
-atY
+oPf
 atY
 bBB
 age
@@ -78662,10 +79510,10 @@ aaJ
 aaJ
 aaJ
 aAy
-aAv
+bHp
 bhm
 aZO
-aAv
+bHp
 aaz
 aaz
 aaz
@@ -78698,9 +79546,9 @@ bcy
 aMv
 aaj
 acI
-fLW
+hjM
 abJ
-cqG
+udB
 aaj
 buQ
 ada
@@ -78919,10 +79767,10 @@ aaJ
 aaJ
 aaJ
 aAy
-aAv
-aAk
+bHp
+bnm
 aZO
-aAv
+bHp
 aam
 aam
 aam
@@ -79176,10 +80024,10 @@ aaJ
 aaJ
 aaJ
 aAy
-aAv
-aAk
+bHp
+bnm
 aZO
-aAv
+bHp
 aby
 bgR
 aaN
@@ -79240,7 +80088,7 @@ aes
 bcr
 bqf
 bqB
-bqS
+cHV
 bIC
 bID
 bID
@@ -79431,12 +80279,12 @@ aaJ
 aaJ
 aaJ
 aaJ
-asL
+bHp
 aFL
-aAv
-aYL
+bHp
+bqy
 aZU
-aAv
+bHp
 abD
 aaF
 bBD
@@ -79497,7 +80345,7 @@ aes
 bcr
 bqe
 bqc
-bqc
+goi
 bIC
 aaJ
 bID
@@ -79688,12 +80536,12 @@ aaJ
 aaJ
 aaJ
 aaJ
-asL
+bHp
 rCB
-aAv
-aAk
+bHp
+bnm
 aZO
-aAv
+bHp
 bIy
 aaG
 aaR
@@ -79702,7 +80550,7 @@ aam
 bfj
 adO
 bgT
-adO
+cAH
 bBF
 agg
 agm
@@ -79725,7 +80573,7 @@ ahz
 bcy
 aMv
 abf
-dUE
+wHw
 abs
 aaf
 acm
@@ -79944,13 +80792,13 @@ aaJ
 aaJ
 aaJ
 aaJ
-asL
-asL
+bHp
+bHp
 qOI
-aAv
-aae
+bHp
+bne
 aZP
-aAv
+bHp
 aam
 aam
 aam
@@ -80198,21 +81046,21 @@ aaJ
 aaJ
 aaJ
 aaJ
-asL
-asL
-asL
-asL
+bHp
+bHp
+bHp
+bHp
 anP
-aoZ
-lHm
-jbX
-aJp
-amr
-aYX
+bnm
+ksv
+jtt
+aZO
+bne
+bqO
 bks
-aoZ
-aYX
-amr
+bnm
+bqO
+bne
 acg
 acg
 bgX
@@ -80241,7 +81089,7 @@ aPh
 buU
 bbG
 bcE
-bjy
+vKM
 bjy
 bjy
 bbG
@@ -80455,20 +81303,20 @@ aaJ
 aaJ
 aaJ
 aaJ
-asL
-anl
-aYK
-aYK
-aYK
-aYK
-aYK
-aYK
+bHp
+xqj
+ors
+ors
+ors
+ors
+ors
+ors
 aZQ
 aZR
-aYK
-aYK
-aYK
-aYK
+ors
+ors
+ors
+ors
 aZR
 aZS
 aLk
@@ -80711,22 +81559,22 @@ aaJ
 aaJ
 aaJ
 aaJ
-gRc
-gRc
-rsw
-gRc
-gRc
+cgU
+cgU
+kjW
+cgU
+cgU
 anN
 anN
 anN
-amr
-amr
-amr
-amr
-amr
-amr
-amr
-amr
+bne
+bne
+bne
+bne
+bne
+bne
+bne
+bne
 aay
 acn
 acn
@@ -80738,7 +81586,7 @@ ach
 avi
 btP
 ars
-acn
+rxp
 acn
 amj
 aPj
@@ -80757,14 +81605,14 @@ acn
 bfz
 acn
 acn
+rxp
 acn
 acn
 acn
 acn
 acn
 acn
-acn
-acn
+ipa
 acn
 acn
 aPn
@@ -80968,12 +81816,12 @@ aaJ
 aaJ
 aaJ
 aaJ
-gRc
-xjX
-jGN
+cgU
+fzb
+qau
 auA
 auG
-lUm
+uAR
 aRH
 anN
 bqZ
@@ -81012,7 +81860,7 @@ bde
 bbI
 aVl
 bde
-iaE
+fqI
 abZ
 aaY
 aaY
@@ -81225,9 +82073,9 @@ aaJ
 aaJ
 aaJ
 aaJ
-rqy
-daY
-moP
+oSp
+wLn
+xPq
 auB
 auH
 aAA
@@ -81259,7 +82107,7 @@ aMJ
 aMH
 abd
 abR
-tZW
+hbm
 ajS
 baI
 abZ
@@ -81276,7 +82124,7 @@ aeX
 atE
 alW
 alW
-alW
+daH
 aqO
 aaY
 bbZ
@@ -81482,9 +82330,9 @@ aaJ
 aaJ
 bJe
 aaJ
-rqy
-eQM
-moP
+oSp
+fUo
+xPq
 auz
 auH
 auJ
@@ -81552,7 +82400,7 @@ ajP
 akd
 aOj
 aOr
-aka
+iUU
 aEf
 aaJ
 aaJ
@@ -81739,10 +82587,10 @@ aaJ
 aaJ
 aaJ
 aaJ
-rqy
+oSp
 aup
-moP
-qgD
+xPq
+mVZ
 auI
 aRE
 aRJ
@@ -81996,12 +82844,12 @@ aaJ
 aaJ
 aaJ
 aaJ
-gRc
+cgU
 auk
-moP
-pam
-qfQ
-tYd
+xPq
+vkR
+uNo
+hoO
 aRG
 anN
 aQw
@@ -82061,12 +82909,12 @@ adr
 adr
 adr
 adp
-aih
-aih
-aih
-aih
-aih
-aih
+jwi
+jwi
+jwi
+jwi
+jwi
+jwi
 aij
 aij
 aij
@@ -82253,9 +83101,9 @@ aaJ
 aaJ
 aaJ
 aaJ
-gRc
-xwk
-moP
+cgU
+gKy
+xPq
 aqI
 aqI
 aqI
@@ -82312,18 +83160,18 @@ aMw
 aVV
 aaY
 adp
-adp
+iqn
 adp
 bHR
 adp
 adp
 adp
-aih
-aim
-aim
-aNP
-aim
-aim
+jwi
+api
+khS
+ovp
+khS
+khS
 aih
 aim
 aim
@@ -82510,13 +83358,13 @@ aaJ
 aaJ
 aaJ
 aaJ
-gRc
-rgA
-vzE
-oGv
-iwB
-pgD
-gsk
+cgU
+fmp
+erM
+wgO
+joY
+fRt
+kuo
 anN
 auZ
 aeY
@@ -82567,17 +83415,17 @@ aaY
 aaY
 aaY
 aaY
-aih
-aih
-aih
-aih
-aih
-aih
-aih
-aih
-aih
-aim
-aim
+jwi
+jwi
+jwi
+jwi
+jwi
+jwi
+jwi
+jwi
+jwi
+khS
+khS
 bqD
 bcn
 bsG
@@ -82767,13 +83615,13 @@ aaJ
 aaJ
 aaJ
 aaJ
-rqy
-bPL
-kdP
+oSp
+iTP
+rpO
 auJ
 auJ
-ybZ
-nGX
+jzd
+hXE
 anN
 auh
 agd
@@ -82781,7 +83629,7 @@ ava
 ams
 bhJ
 btT
-aRx
+hhw
 amq
 any
 aSb
@@ -82824,20 +83672,20 @@ aaY
 bcc
 bmJ
 buw
-aih
-aqt
-apm
-aih
+jwi
+rPe
+gkG
+jwi
 aiN
 bjH
 api
 apo
-aih
-aim
-atf
+jwi
+khS
+pMQ
 brC
-atf
-bny
+pMQ
+ljG
 aih
 aih
 aih
@@ -83024,13 +83872,13 @@ aaJ
 aaJ
 aaJ
 aaJ
-rqy
-bPL
-mWo
+oSp
+iTP
+mYW
 auJ
 auK
-mgd
-szq
+cpq
+xJH
 anN
 ams
 agA
@@ -83083,25 +83931,25 @@ bsh
 bux
 bAT
 bnw
-aim
-aih
+khS
+jwi
 aiO
 aiZ
 apl
-aim
-aih
-aim
-aim
+khS
+jwi
+khS
+khS
 brT
 uOY
-bny
-aih
+ljG
+jwi
 awc
 aAb
 aYx
 aYA
 aYA
-aij
+vci
 ndL
 aij
 aAy
@@ -83281,19 +84129,19 @@ aaJ
 aaJ
 aaJ
 aaJ
-rqy
-bPL
-kdP
+oSp
+iTP
+rpO
 auJ
 auJ
-mgd
-eVy
+cpq
+wwK
 anN
 bfr
 atz
 bhD
-tCn
-wNN
+oQQ
+frX
 atz
 aoe
 ami
@@ -83338,12 +84186,12 @@ aaY
 aaY
 aaY
 aaY
-aih
+jwi
 bnx
-aim
-aih
-aim
-aim
+khS
+jwi
+khS
+khS
 asa
 avp
 awT
@@ -83356,9 +84204,9 @@ bzF
 bJp
 bJq
 bJw
-aim
+khS
 aYA
-aij
+vci
 tjC
 aij
 aAy
@@ -83538,20 +84386,20 @@ aaJ
 aaJ
 aaJ
 aaJ
-rqy
-bPL
-hhp
+oSp
+iTP
+oMZ
 auJ
 auL
-rqk
+iqW
 aqI
-twJ
+amr
 aqy
 atz
-tmG
+koE
 xEa
 aqy
-tBs
+ldX
 ahe
 aip
 aiJ
@@ -83595,27 +84443,27 @@ are
 byW
 atn
 aMz
-aih
-bny
-aim
-aih
-aim
-aim
-aim
-aim
-aih
-aim
+jwi
+ljG
+khS
+jwi
+khS
+khS
+khS
+khS
+jwi
+khS
 aiK
 brT
-atf
-bny
-aih
+pMQ
+ljG
+jwi
 axG
-aim
+khS
 aBh
 aBh
 aYA
-aij
+vci
 aAy
 aAy
 aAy
@@ -83795,11 +84643,11 @@ aaJ
 aaJ
 aaJ
 aaJ
-rqy
-bPL
-lRC
-jns
-jns
+oSp
+iTP
+lrS
+tbQ
+tbQ
 bFP
 auV
 aqB
@@ -83820,12 +84668,12 @@ aZo
 aZw
 bhF
 btF
-sjw
-lSg
+iXh
+cSw
 bhA
-eUj
+phY
 bGj
-sHQ
+nsw
 bkj
 acR
 afc
@@ -83852,27 +84700,27 @@ bkd
 buE
 atp
 aMS
-aih
-bny
-aim
-aih
+jwi
+ljG
+khS
+jwi
 aiP
 aiP
-apm
-aqt
-aih
-aim
-aim
+gkG
+rPe
+jwi
+khS
+khS
 brT
-aim
-bny
-aih
+khS
+ljG
+jwi
 azy
 aBh
 bHM
 aBh
 aYD
-aij
+vci
 aaJ
 aaJ
 aaJ
@@ -84052,13 +84900,13 @@ aaJ
 aaJ
 aaJ
 aaJ
-gRc
-wsS
-wOm
-sBA
-fwk
-eBS
-ezB
+cgU
+uWC
+jJz
+kCU
+tdw
+eKR
+uDu
 anN
 bIx
 aqy
@@ -84109,27 +84957,27 @@ bbV
 arl
 atu
 aVA
-aih
-bny
-aim
-aih
-aih
-aih
-aih
-aih
-aih
-aim
-aim
+jwi
+ljG
+khS
+jwi
+jwi
+jwi
+jwi
+jwi
+jwi
+khS
+khS
 brT
-aim
-bny
-aih
+khS
+ljG
+jwi
 azM
 aBh
 aBh
 aBh
 aYE
-aij
+vci
 aaJ
 aaJ
 aaJ
@@ -84309,21 +85157,21 @@ aaJ
 aaJ
 aaJ
 aaJ
-gRc
+cgU
 anN
-rsw
+cRY
 anN
-kCr
-kCr
-kCr
-kCr
-kCr
-kCr
+ukv
+ukv
+ukv
+ukv
+ukv
+ukv
 bAI
 aZm
 aum
-kCr
-kCr
+ukv
+ukv
 ami
 aqE
 aro
@@ -84366,7 +85214,7 @@ bmb
 bmx
 atF
 aVB
-aih
+jwi
 bnz
 bkZ
 bob
@@ -84380,13 +85228,13 @@ boW
 lAV
 bob
 bqE
-aih
+jwi
 azN
-aim
-aim
-aim
+khS
+khS
+khS
 aYF
-aij
+vci
 aaJ
 aaJ
 aaJ
@@ -84570,19 +85418,19 @@ asL
 aHP
 aYN
 aYM
-kCr
-pWv
-sqV
-kNj
-sqV
+ukv
+oBU
+xSM
+fmQ
+xSM
 afx
 bAJ
 aZr
 bhE
-yjB
-hVt
+pfW
+rRu
 ami
-aqF
+tcq
 art
 bfS
 aRM
@@ -84623,8 +85471,8 @@ bbX
 bmy
 aMy
 aVC
-aih
-aio
+jwi
+our
 ail
 ail
 bGi
@@ -84643,7 +85491,7 @@ aCh
 aBh
 aYB
 aYG
-aij
+vci
 aaJ
 aaJ
 aaJ
@@ -84827,17 +85675,17 @@ asL
 aoZ
 aoZ
 aJp
-kCr
-tyN
-sqV
-mTn
-sqV
-vlm
-sqV
-rXQ
+ukv
+pCU
+xSM
+uoC
+xSM
+iwh
+xSM
+ebm
 auD
-sqV
-wgx
+xSM
+liO
 ami
 bgk
 ayT
@@ -84857,7 +85705,7 @@ aMJ
 aMH
 acR
 bGb
-acS
+xfy
 acS
 acS
 abZ
@@ -84875,12 +85723,12 @@ buc
 buj
 buC
 arb
-aih
-aih
+jwi
+jwi
 bmz
-aih
-aih
-aih
+jwi
+jwi
+jwi
 bnA
 bkZ
 bob
@@ -84894,13 +85742,13 @@ bkZ
 ciL
 ljw
 bqG
-aih
+jwi
 azX
 aCi
 aYy
 aYC
 aYH
-aij
+vci
 aaJ
 aaJ
 aaJ
@@ -85084,17 +85932,17 @@ asL
 asL
 aoZ
 aJp
-kCr
-wzZ
-sqV
-jup
-sqV
-ckJ
-rjx
+ukv
+tgc
+xSM
+qCx
+xSM
+pMv
+xcN
 aMI
 auD
-sqV
-kga
+xSM
+wKb
 ami
 aqF
 bbR
@@ -85132,8 +85980,8 @@ aqM
 bzC
 aqT
 arc
-aih
-aim
+jwi
+khS
 blp
 bzD
 bkZ
@@ -85149,15 +85997,15 @@ apV
 apV
 bzE
 apV
-aij
+vci
 glh
-aih
-aih
+jwi
+jwi
 aPw
 bzG
-aij
-aij
-aij
+vci
+vci
+vci
 aaJ
 aaJ
 aaJ
@@ -85341,17 +86189,17 @@ aaJ
 asL
 aoZ
 aJp
-kCr
-uZp
-sqV
-qRm
-sqV
-imp
-sqV
-txB
+ukv
+gQy
+xSM
+jgp
+xSM
+hMl
+xSM
+soc
 auD
-sqV
-lJl
+xSM
+csH
 ami
 aqH
 arv
@@ -85381,18 +86229,18 @@ aVt
 bue
 aVt
 bfT
-wjY
+bPc
 bjq
-wjY
-wjY
-wjY
-wjY
-aih
-aih
-aih
-aim
-aij
-aij
+bPc
+bPc
+bPc
+bPc
+jwi
+jwi
+jwi
+khS
+vci
+vci
 apV
 apV
 apV
@@ -85401,18 +86249,18 @@ uIA
 apV
 qEi
 apV
-aCo
 bJJ
+aCo
 aWb
 aWb
 aWb
-aij
+vci
 glh
-aih
-aim
+jwi
+khS
 aVK
-aim
-aij
+khS
+vci
 aaJ
 aaJ
 aaJ
@@ -85596,19 +86444,19 @@ aaJ
 aaJ
 aaJ
 asL
-gqT
+mLr
 aJp
-kCr
-eKP
-sqV
-jcZ
-sqV
-dCx
+ukv
+ctk
+xSM
+mwl
+xSM
+wen
 bAK
 aYW
-tWY
-niU
-vdf
+oRC
+eaw
+owZ
 ami
 ami
 ami
@@ -85638,17 +86486,17 @@ bbP
 buy
 aVu
 bgg
-wjY
+bPc
 bjz
 amY
 aVE
 aVH
 aVJ
-aih
+jwi
 uDe
-aih
-aim
-aij
+jwi
+khS
+vci
 bFj
 azC
 azP
@@ -85663,13 +86511,13 @@ apV
 apV
 apV
 aWa
-aij
+vci
 glh
-aih
+jwi
 aAa
 aVW
 aYz
-aij
+vci
 aaJ
 aaJ
 aaJ
@@ -85855,14 +86703,14 @@ aaJ
 asL
 aoZ
 aJp
-kCr
-kCr
-kCr
-kCr
-kCr
+ukv
+ukv
+ukv
+ukv
+ukv
 aJN
-kCr
-kCr
+ukv
+ukv
 auE
 auM
 aRF
@@ -85895,17 +86743,17 @@ bdp
 bzB
 bdp
 bgo
-wjY
+bPc
 bjG
 bkF
 bkY
 bkY
 fXQ
 blz
-blj
-aih
-aim
-aij
+mDl
+jwi
+khS
+vci
 aWb
 azO
 azR
@@ -85920,13 +86768,13 @@ aDU
 aVY
 aVZ
 aWb
-aij
+vci
 bqH
-aih
-aih
-aih
-aih
-aij
+jwi
+jwi
+jwi
+jwi
+vci
 aaJ
 aaJ
 aaJ
@@ -86114,15 +86962,15 @@ aoZ
 aYN
 aYK
 aYM
-kCr
+ukv
 aJL
 aLs
-xNv
-sqV
-kCr
+loN
+xSM
+ukv
 auF
 auD
-pZt
+sBu
 ami
 ami
 ami
@@ -86152,7 +87000,7 @@ aVv
 bkg
 aVv
 aVz
-wjY
+bPc
 amP
 qxl
 aMA
@@ -86161,8 +87009,8 @@ aMA
 air
 blL
 ais
-aim
-aij
+khS
+vci
 aWb
 azO
 azS
@@ -86177,13 +87025,13 @@ apV
 apV
 apV
 aWa
-aij
+vci
 glh
 bHw
-aim
+khS
 bHx
 bHx
-aYI
+qNG
 aaJ
 aaJ
 aaJ
@@ -86368,16 +87216,16 @@ aaJ
 aaJ
 asL
 asL
-eYp
+wwO
 asL
 aJp
-kCr
-oAc
+ukv
+cuz
 aul
-xiH
+uEa
 auo
-kCr
-klv
+ukv
+uWp
 auD
 auD
 ami
@@ -86409,17 +87257,17 @@ aeL
 aeL
 aeL
 aeL
-wjY
+bPc
 arz
 aVD
 aVG
 aVI
 bln
-aih
+jwi
 blL
-aih
-aih
-aij
+jwi
+jwi
+vci
 aWb
 azO
 azT
@@ -86429,18 +87277,18 @@ aBx
 apV
 qEi
 apV
-aCo
 bJJ
+aCo
 aWb
 aWb
 aWb
-aij
+vci
 glh
-aih
-aim
-aim
-aim
-aYI
+jwi
+khS
+khS
+khS
+qNG
 aaJ
 aaJ
 aaJ
@@ -86628,15 +87476,15 @@ aaJ
 aAy
 asL
 aJp
-kCr
-sBm
-kuE
+ukv
+gbT
+vqH
 bhH
-cWx
-kCr
-kCr
-xIM
-kCr
+lcZ
+ukv
+ukv
+fUW
+ukv
 aqC
 aqC
 aqC
@@ -86660,44 +87508,44 @@ btd
 btf
 byt
 byt
-byt
+dwf
 bAy
 aXr
 bkh
+pBG
 aPp
-aPp
-aih
-aih
+jwi
+jwi
 bzG
-aih
-aih
+jwi
+jwi
 blo
-aih
+jwi
 blL
 ait
 aix
-aij
-aij
-aij
-aij
-aij
+vci
+vci
+vci
+vci
+vci
 aiE
-aij
-aij
+vci
+vci
 mwO
-aij
-aij
-aij
-aij
-aij
-aij
-aij
+vci
+vci
+vci
+vci
+vci
+vci
+vci
 glh
-aij
-aij
-aYI
-aYI
-aYI
+vci
+vci
+qNG
+qNG
+qNG
 aaJ
 aaJ
 aaJ
@@ -86885,15 +87733,15 @@ aaJ
 aAy
 asL
 aJp
-kCr
-tZM
-sRo
-hCK
-sCm
-kCr
-juD
-qiZ
-urK
+ukv
+qHd
+mbh
+oQo
+jBf
+ukv
+pqM
+nhj
+rqu
 anp
 aSn
 aqi
@@ -86927,17 +87775,17 @@ aii
 bjI
 bkG
 bkZ
-blj
+mDl
 blp
-blj
+mDl
 blL
 aiu
 aiy
-aim
-aim
-aim
-aim
-aim
+khS
+khS
+khS
+khS
+khS
 aiI
 aiL
 aiL
@@ -86950,7 +87798,7 @@ ljw
 pFX
 ljw
 vpr
-aij
+vci
 aaJ
 aaJ
 aaJ
@@ -87142,15 +87990,15 @@ aaJ
 aAy
 asL
 aJp
-kCr
-qav
-xYl
-sqV
-sqV
-kCr
-kIZ
-uif
-tjX
+ukv
+gqR
+try
+xSM
+xSM
+ukv
+fps
+dOP
+tdV
 anp
 aoa
 azq
@@ -87180,8 +88028,8 @@ aBJ
 aBJ
 aBJ
 aBJ
-aih
-atf
+jwi
+pMQ
 aiW
 ail
 blk
@@ -87203,11 +88051,11 @@ bkZ
 bkZ
 boN
 bpp
-aim
-aij
-atf
-aim
-aij
+khS
+vci
+pMQ
+khS
+vci
 aaJ
 aaJ
 aaJ
@@ -87399,12 +88247,12 @@ aaJ
 aAy
 asL
 aJp
-kCr
-kCr
-kCr
-dmM
-kCr
-uyq
+ukv
+ukv
+ukv
+fzg
+ukv
+tDI
 anp
 anp
 anp
@@ -87424,11 +88272,11 @@ aBg
 aey
 arW
 arW
-arW
+nfu
 afk
 aPz
 aNd
-arW
+nTO
 arW
 arW
 aPt
@@ -87437,34 +88285,34 @@ bGo
 bGo
 byq
 aPt
-aij
-aij
-aij
-aij
-aij
+vci
+vci
+vci
+vci
+vci
 blr
-aij
-aij
+vci
+vci
 aiw
 aiA
-aij
-aij
-aij
-aij
+vci
+vci
+vci
+vci
 aiD
-aij
-aij
-aij
+vci
+vci
+vci
 amt
-aij
-aij
-aij
+vci
+vci
+vci
 avo
-aij
-aij
-aij
-aij
-aij
+vci
+vci
+vci
+vci
+vci
 aaJ
 aaJ
 aaJ
@@ -88169,9 +89017,9 @@ aaJ
 aaJ
 anb
 anb
-pPg
-hWr
-vYw
+hzD
+ykt
+tUg
 aoZ
 aJp
 aoZ
@@ -88180,7 +89028,7 @@ apP
 agC
 ayS
 aSl
-aSp
+hTx
 anp
 awj
 ayO
@@ -88694,7 +89542,7 @@ apU
 aqe
 ayU
 aqe
-aSp
+opr
 anp
 anQ
 aQE
@@ -89717,7 +90565,7 @@ aHJ
 asL
 aJp
 aoZ
-pus
+cfS
 asL
 anW
 anZ
@@ -89974,7 +90822,7 @@ asL
 asL
 bhn
 aoZ
-xOj
+gsn
 asL
 aqb
 aAU
@@ -91520,7 +92368,7 @@ anO
 anQ
 anZ
 bkp
-ane
+tNr
 aBb
 bhv
 aHy
@@ -92804,7 +93652,7 @@ anm
 aoX
 aQl
 aQs
-btn
+sBW
 anj
 aaJ
 aRc
@@ -93318,7 +94166,7 @@ anm
 anM
 apX
 aQq
-anm
+ydV
 anj
 aaJ
 aRc
@@ -93832,7 +94680,7 @@ anm
 aoX
 aQl
 aQs
-anm
+oKJ
 anj
 aaJ
 aey

--- a/_maps/map_files/Enterprise/Enterprise2.dmm
+++ b/_maps/map_files/Enterprise/Enterprise2.dmm
@@ -40158,16 +40158,17 @@
 /obj/machinery/light,
 /turf/open/floor/monotile,
 /area/security/brig)
+"bPL" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
 "bRy" = (
 /obj/item/beacon,
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"bXZ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
 "cgt" = (
 /obj/machinery/holopad,
 /turf/open/floor/carpet/ship,
@@ -40189,6 +40190,17 @@
 /obj/machinery/light,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
+"ckJ" = (
+/obj/structure/bookcase/random/religion,
+/turf/open/floor/wood,
+/area/library)
+"cqG" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/storage/toolbox/emergency,
+/obj/item/clothing/gloves/color/fyellow,
+/turf/open/floor/plating,
+/area/nsv/briefingroom)
 "cuG" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -40199,12 +40211,6 @@
 /obj/machinery/mineral/equipment_vendor,
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
-"cHC" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood,
-/area/library)
 "cJz" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 8
@@ -40222,13 +40228,16 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"cVe" = (
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
-/obj/structure/cable{
-	icon_state = "4-8"
+"cWx" = (
+/obj/structure/chair/office/light{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/open/floor/wood,
+/area/library)
 "cXV" = (
 /obj/machinery/light/small,
 /obj/structure/bed,
@@ -40239,6 +40248,31 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/security/prison)
+"daY" = (
+/obj/item/reagent_containers/food/drinks/sillycup{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/drinks/sillycup,
+/obj/item/reagent_containers/food/drinks/sillycup{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/drinks/sillycup{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/drinks/sillycup{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/structure/table,
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
+"dmM" = (
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "dnd" = (
 /obj/machinery/gateway{
 	dir = 8
@@ -40246,48 +40280,22 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/monotile,
 /area/gateway)
-"dsf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
-"dtZ" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/open/floor/carpet/ship,
-/area/crew_quarters/dorms)
 "duz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
 /turf/closed/wall/r_wall/ship,
 /area/engine/atmospherics_engine)
-"duJ" = (
-/obj/item/paper_bin,
-/obj/item/pen,
+"dCx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
+	dir = 6
 	},
-/obj/structure/table/wood,
-/turf/open/floor/carpet,
-/area/library)
-"dGM" = (
-/obj/machinery/photocopier{
-	pixel_y = 3
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/wood,
 /area/library)
 "dIo" = (
@@ -40301,9 +40309,17 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"dPW" = (
-/turf/closed/wall/r_wall/ship,
-/area/library)
+"dPL" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "hor_window";
+	name = "privacy shutter"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hor)
 "dSD" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	req_one_access_txt = "2"
@@ -40313,15 +40329,10 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"dYL" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/fitness/recreation)
+"dUE" = (
+/obj/structure/closet/toolcloset,
+/turf/open/floor/plating,
+/area/nsv/briefingroom)
 "ecN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -40349,29 +40360,12 @@
 /area/crew_quarters/cafeteria{
 	name = "Mess hall"
 	})
-"eoK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/wood,
-/area/library)
 "eqA" = (
 /obj/structure/table,
 /obj/item/clothing/suit/hazardvest,
 /obj/item/clothing/mask/breath,
 /turf/open/floor/monotile/dark,
 /area/gateway)
-"erP" = (
-/obj/machinery/camera/autoname,
-/obj/machinery/vending/games,
-/turf/open/floor/wood,
-/area/library)
 "evj" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -40394,15 +40388,18 @@
 	},
 /turf/open/floor/monotile,
 /area/security/brig)
-"eCL" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
+"ezB" = (
+/obj/structure/punching_bag,
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
+"eBS" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
 	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/punching_bag,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/crew_quarters/fitness/recreation)
@@ -40415,20 +40412,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"eFi" = (
+"eKP" = (
 /obj/machinery/bookbinder,
 /obj/machinery/camera/autoname,
 /turf/open/floor/wood,
 /area/library)
-"eHq" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
 "ePo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -40436,6 +40424,10 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/light,
 /area/medical/virology)
+"eQM" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
 "eQZ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/ship/public/glass{
@@ -40459,6 +40451,10 @@
 /obj/item/stack/cable_coil,
 /turf/open/floor/monotile,
 /area/medical/chemistry)
+"eUj" = (
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall/ship,
+/area/hallway/nsv/deck2/frame2/port)
 "eUK" = (
 /obj/machinery/requests_console{
 	department = "Munitions bay";
@@ -40466,6 +40462,12 @@
 	},
 /turf/closed/wall/r_wall/ship,
 /area/nsv/weapons/fore)
+"eVy" = (
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
 "eXm" = (
 /obj/machinery/light/small,
 /obj/structure/bed,
@@ -40476,17 +40478,14 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/security/prison)
-"faV" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "hor_window";
-	name = "privacy shutter"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
+"eYp" = (
+/obj/structure/lattice,
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/department/engine)
+"fdx" = (
+/obj/structure/closet/firecloset,
 /turf/open/floor/plating,
-/area/crew_quarters/heads/hor)
+/area/maintenance/department/medical)
 "fjB" = (
 /obj/machinery/door/airlock/ship{
 	name = "Exothermic Chamber";
@@ -40505,27 +40504,23 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"fvh" = (
-/obj/machinery/light,
-/turf/open/floor/monotile/dark,
-/area/hallway/secondary/exit)
+"fwk" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/east,
+/obj/structure/punching_bag,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
 "fxX" = (
 /obj/structure/lattice,
 /turf/open/space,
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"fBR" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/library)
 "fEj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/closed/wall/r_wall/ship,
@@ -40539,11 +40534,16 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmospherics_engine)
-"fJS" = (
-/obj/structure/punching_bag,
-/obj/machinery/computer/ship/viewscreen,
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
+"fLW" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/open/floor/plating,
+/area/nsv/briefingroom)
 "fMP" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -40555,13 +40555,6 @@
 /obj/item/beacon,
 /turf/open/floor/monotile,
 /area/hallway/secondary/exit)
-"fOC" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
-"fQZ" = (
-/turf/closed/wall/ship,
-/area/hallway/secondary/service)
 "fVu" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_y = -30
@@ -40578,18 +40571,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/service)
-"fYE" = (
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
-/turf/open/floor/monotile/dark,
-/area/nsv/briefingroom)
-"gaq" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "glh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40615,24 +40596,16 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"gCJ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_large/ship{
-	name = "Gym"
+"gqT" = (
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/carpet/ship,
-/area/crew_quarters/fitness/recreation)
-"gDC" = (
-/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"gDT" = (
-/obj/machinery/door/morgue{
-	name = "Private Study";
-	req_access_txt = "37"
-	},
-/turf/open/floor/wood,
-/area/library)
+"gsk" = (
+/obj/structure/closet/boxinggloves,
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
 "gFl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -40651,10 +40624,6 @@
 /obj/item/hand_labeler,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/kitchen)
-"gHv" = (
-/obj/effect/landmark/nuclear_waste_spawner,
-/turf/open/floor/wood,
-/area/library)
 "gHK" = (
 /obj/machinery/requests_console{
 	department = "Engineering";
@@ -40679,6 +40648,9 @@
 	},
 /turf/closed/wall/ship,
 /area/medical/medbay/central)
+"gRc" = (
+/turf/closed/wall/r_wall/ship,
+/area/crew_quarters/fitness/recreation)
 "gUv" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -40693,16 +40665,28 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/monotile/dark,
 /area/security/brig)
-"hgH" = (
-/obj/effect/turf_decal/tile/yellow{
+"hbf" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
+"hgJ" = (
+/obj/structure/lattice,
+/obj/machinery/camera/motion{
+	c_tag = "Armoury";
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/turf/open/space/basic,
+/area/maintenance/ship_exterior)
+"hhp" = (
+/obj/structure/weightmachine/stacklifter,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/item/radio/intercom{
-	name = "intra ship intercom";
-	pixel_x = -26
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/fitness/recreation)
@@ -40741,34 +40725,10 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"hov" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
 "hrv" = (
 /obj/machinery/newscaster/security_unit,
 /turf/closed/wall/ship,
 /area/security/brig)
-"huY" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood,
-/area/library)
-"hwS" = (
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/carpet/ship,
-/area/crew_quarters/dorms)
 "hwV" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	req_one_access_txt = "13"
@@ -40804,22 +40764,46 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"igr" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Patient Room B"
+"hCK" = (
+/obj/item/storage/crayons,
+/obj/structure/table/wood,
+/turf/open/floor/carpet,
+/area/library)
+"hVt" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+/turf/open/floor/wood,
+/area/library)
+"hWr" = (
+/obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/monotile,
-/area/medical/medbay/central)
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
+"iaE" = (
+/obj/machinery/status_display/evac,
+/turf/closed/wall/ship,
+/area/crew_quarters/cafeteria{
+	name = "Mess hall"
+	})
+"imp" = (
+/obj/structure/bookcase/random/reference,
+/turf/open/floor/wood,
+/area/library)
 "ini" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"ioY" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "irj" = (
 /obj/structure/window/reinforced/fulltile/ship,
 /obj/structure/grille,
@@ -40837,6 +40821,13 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
+"iwB" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
 "iyx" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /obj/machinery/camera/autoname,
@@ -40844,21 +40835,6 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"iBb" = (
-/obj/structure/bookcase/manuals/engineering,
-/turf/open/floor/wood,
-/area/library)
-"iDp" = (
-/obj/structure/closet/boxinggloves,
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
-"iKQ" = (
-/obj/structure/bookcase/manuals/medical,
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/library)
 "iMe" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -40890,40 +40866,16 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/monotile/dark,
 /area/gateway)
-"iTn" = (
-/obj/effect/spawner/lootdrop/maintenance,
+"jbX" = (
+/obj/structure/closet/firecloset,
 /turf/open/floor/plating,
-/area/maintenance/central)
-"iUL" = (
-/obj/structure/bookcase/random/religion,
+/area/maintenance/department/engine)
+"jcZ" = (
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/library)
-"iWi" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 26
-	},
-/obj/item/radio/intercom{
-	name = "intra ship intercom";
-	pixel_x = 26
-	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
-"jaP" = (
-/obj/structure/bookcase/random/nonfiction,
-/turf/open/floor/wood,
-/area/library)
-"jbx" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/carpet/ship,
-/area/crew_quarters/heads/hor)
 "jku" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
@@ -40942,35 +40894,19 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"jlD" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
-"jmF" = (
-/obj/structure/closet/lasertag/blue,
-/obj/machinery/light,
-/turf/open/floor/monotile,
+"jns" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/fitness/recreation)
-"jov" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/library)
 "jtt" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"jyY" = (
+"jup" = (
+/obj/structure/bookcase/random/nonfiction,
+/turf/open/floor/wood,
+/area/library)
+"juD" = (
 /obj/structure/destructible/cult/tome,
 /obj/item/book/codex_gigas,
 /obj/machinery/newscaster{
@@ -40992,18 +40928,23 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/break_room)
-"jHo" = (
-/obj/structure/bookcase/random/fiction,
-/turf/open/floor/wood,
-/area/library)
-"jII" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+"jCa" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "hor_window";
+	name = "privacy shutter"
 	},
-/obj/structure/punching_bag,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hor)
+"jGN" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/monotile,
 /area/crew_quarters/fitness/recreation)
@@ -41038,10 +40979,18 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"jQP" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+"jVl" = (
+/obj/docking_port/stationary/turbolift{
+	dir = 2;
+	dwidth = 7;
+	height = 6;
+	id = "turbolift_primary";
+	name = "aircraft hangar";
+	roundstart_template = /datum/map_template/shuttle/turbolift/nsv/enterprise;
+	width = 15
+	},
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/central)
 "jYW" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -41054,9 +41003,6 @@
 	},
 /turf/open/floor/monotile,
 /area/crew_quarters/dorms)
-"kah" = (
-/turf/closed/wall/r_wall/ship,
-/area/crew_quarters/fitness/recreation)
 "kdb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -41069,12 +41015,27 @@
 	},
 /turf/open/floor/monotile,
 /area/gateway)
-"kfa" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+"kdP" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship,
-/area/crew_quarters/dorms)
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/fitness/recreation)
+"kga" = (
+/obj/structure/bookcase/manuals/medical,
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/library)
+"klv" = (
+/obj/machinery/computer/libraryconsole/bookmanagement,
+/obj/structure/table/wood,
+/turf/open/floor/carpet,
+/area/library)
 "knh" = (
 /obj/machinery/button/door{
 	dir = 8;
@@ -41085,10 +41046,11 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/security/execution/transfer)
-"kuF" = (
-/obj/structure/lattice,
-/turf/closed/wall/r_wall/ship,
-/area/maintenance/department/engine)
+"kuE" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/carpet,
+/area/library)
 "kyA" = (
 /obj/structure/table,
 /obj/item/disk/design_disk,
@@ -41100,6 +41062,9 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/science/research)
+"kCr" = (
+/turf/closed/wall/ship,
+/area/library)
 "kFm" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -41112,22 +41077,18 @@
 	},
 /turf/open/floor/monotile,
 /area/medical/chemistry)
-"kHa" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+"kIZ" = (
+/obj/structure/bookcase{
+	name = "Forbidden Knowledge"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/turf/open/floor/wood,
+/area/library)
+"kNj" = (
+/obj/machinery/newscaster{
+	pixel_x = -28
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
+/turf/open/floor/wood,
+/area/library)
 "kOA" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light/small{
@@ -41135,11 +41096,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"kOC" = (
-/obj/structure/displaycase/trophy,
-/obj/structure/sign/solgov_flag/right,
-/turf/open/floor/wood,
-/area/library)
 "kSX" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -41173,24 +41129,12 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/engine/atmospherics_engine)
-"lgQ" = (
-/obj/machinery/newscaster{
-	pixel_x = -28
-	},
-/turf/open/floor/wood,
-/area/library)
 "ljw" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"lkg" = (
-/obj/structure/table/wood,
-/obj/item/camera,
-/obj/item/taperecorder,
-/turf/open/floor/wood,
-/area/library)
 "lwJ" = (
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_interior,
 /obj/effect/mapping_helpers/airlock/locked,
@@ -41218,24 +41162,26 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/closed/wall/r_wall/ship,
 /area/science/xenobiology)
-"lNg" = (
-/obj/docking_port/stationary/turbolift{
-	dir = 2;
-	dwidth = 7;
-	height = 6;
-	id = "turbolift_primary";
-	name = "aircraft hangar";
-	roundstart_template = /datum/map_template/shuttle/turbolift/nsv/enterprise;
-	width = 15
+"lHm" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
 	},
-/turf/closed/wall/r_wall/ship,
-/area/maintenance/central)
-"lPH" = (
-/obj/structure/chair/comfy/brown{
-	dir = 4
-	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
+"lJl" = (
+/obj/machinery/airalarm/directional/south,
+/obj/structure/bookcase/manuals/research_and_development,
 /turf/open/floor/wood,
 /area/library)
+"lNi" = (
+/obj/structure/lattice,
+/obj/machinery/camera/motion{
+	c_tag = "Armoury";
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/maintenance/ship_exterior)
 "lRd" = (
 /obj/structure/sink{
 	dir = 8;
@@ -41244,13 +41190,19 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/science/xenobiology)
-"lSS" = (
-/obj/machinery/door/airlock/ship/external/glass{
-	req_one_access_txt = "13"
+"lRC" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/fitness/recreation)
+"lSg" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "lTI" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -41258,25 +41210,19 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"lUc" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/port)
-"lUl" = (
-/obj/item/radio/intercom{
-	dir = 4;
-	pixel_x = 27
-	},
-/turf/open/floor/wood,
-/area/library)
-"lUK" = (
-/obj/structure/lattice,
-/obj/machinery/camera/motion{
-	c_tag = "Armoury";
+"lUm" = (
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/turf/open/space/basic,
-/area/maintenance/ship_exterior)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_x = -26
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/fitness/recreation)
 "lVV" = (
 /obj/structure/chair{
 	dir = 8
@@ -41287,19 +41233,6 @@
 	},
 /turf/open/floor/monotile/light,
 /area/medical/medbay/lobby)
-"lWM" = (
-/obj/structure/weightmachine/stacklifter,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/fitness/recreation)
 "mbD" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -41314,17 +41247,33 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
+"mgd" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
 "mlk" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
 /area/maintenance/ship_exterior)
-"mpo" = (
-/obj/machinery/computer/libraryconsole/bookmanagement,
-/obj/structure/table/wood,
-/turf/open/floor/carpet,
-/area/library)
+"moP" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
 "mrY" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	req_one_access_txt = "8;13"
@@ -41365,15 +41314,6 @@
 	},
 /turf/closed/wall/r_wall/ship,
 /area/engine/atmospherics_engine)
-"mLc" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
-"mLH" = (
-/obj/item/storage/crayons,
-/obj/structure/table/wood,
-/turf/open/floor/carpet,
-/area/library)
 "mMv" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -41385,21 +41325,20 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port)
-"mNO" = (
+"mTn" = (
+/obj/structure/bookcase/random/fiction,
+/turf/open/floor/wood,
+/area/library)
+"mWo" = (
+/obj/structure/weightmachine/weightlifter,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
-	dir = 6
+	dir = 4
 	},
-/turf/open/floor/carpet/ship,
-/area/crew_quarters/dorms)
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/fitness/recreation)
 "ndL" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
@@ -41415,11 +41354,10 @@
 	},
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
-"nkS" = (
-/obj/machinery/light_switch{
-	pixel_x = -28
+"niU" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/library)
 "nqx" = (
@@ -41439,68 +41377,21 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"nqR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
 "nvJ" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/monotile/light,
 /area/security/prison)
-"nyB" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "hor_window";
-	name = "privacy shutter"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hor)
 "nzF" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/port)
+"nGX" = (
+/obj/structure/closet/lasertag/blue,
+/obj/machinery/light,
 /turf/open/floor/monotile,
 /area/crew_quarters/fitness/recreation)
-"nCb" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/ship,
-/area/crew_quarters/cafeteria{
-	name = "Mess hall"
-	})
-"nCW" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/east,
-/obj/structure/punching_bag,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
-"nEC" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/library)
 "nHC" = (
 /obj/structure/table,
 /obj/item/stock_parts/micro_laser,
@@ -41520,36 +41411,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/science/xenobiology)
-"nQG" = (
-/obj/structure/displaycase/trophy,
-/obj/structure/sign/solgov_flag,
-/turf/open/floor/wood,
-/area/library)
-"ocY" = (
-/obj/machinery/vending/coffee,
-/obj/machinery/computer/ship/viewscreen,
-/turf/open/floor/wood,
-/area/library)
-"ojM" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/iron/fifty{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/turf/open/floor/plating,
-/area/nsv/briefingroom)
-"ong" = (
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/monotile,
-/area/crew_quarters/bar)
-"ooD" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/library)
 "oqq" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
@@ -41559,10 +41420,6 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"orn" = (
-/obj/machinery/vending/wardrobe/curator_wardrobe,
-/turf/open/floor/wood,
-/area/library)
 "oun" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	req_one_access_txt = "8;13"
@@ -41572,10 +41429,6 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"oxc" = (
-/obj/structure/bookcase/random/adult,
-/turf/open/floor/wood,
-/area/library)
 "oyf" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -41588,6 +41441,16 @@
 	},
 /turf/open/floor/monotile,
 /area/hallway/secondary/exit)
+"oAc" = (
+/obj/machinery/airalarm/directional/north,
+/obj/structure/table/wood,
+/obj/item/toy/cards/deck/cas,
+/obj/item/toy/cards/deck/cas/black{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/open/floor/wood,
+/area/library)
 "oDq" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
@@ -41606,14 +41469,28 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"oKT" = (
-/obj/machinery/newscaster{
-	pixel_y = -32
+"oGv" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/turf/open/floor/carpet,
-/area/library)
-"oWU" = (
-/obj/structure/punching_bag,
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
+"pam" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
+"pgD" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/monotile,
 /area/crew_quarters/fitness/recreation)
 "poV" = (
@@ -41622,10 +41499,25 @@
 	},
 /turf/open/floor/monotile,
 /area/science/xenobiology)
+"pus" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "pxy" = (
 /obj/machinery/newscaster,
 /turf/closed/wall/ship,
 /area/quartermaster/qm)
+"pxK" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/status_display/ai{
+	pixel_x = -32
+	},
+/turf/open/floor/monotile/dark,
+/area/nsv/briefingroom)
+"pCp" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "pFX" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess,
@@ -41633,28 +41525,78 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"pGG" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/heads/hor)
+"pPg" = (
+/obj/machinery/door/airlock/ship/external/glass{
+	req_one_access_txt = "13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "pSV" = (
 /obj/machinery/newscaster,
 /turf/closed/wall/ship,
 /area/medical/genetics)
+"pWv" = (
+/obj/structure/displaycase/trophy,
+/obj/structure/sign/solgov_flag,
+/turf/open/floor/wood,
+/area/library)
+"pZt" = (
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/turf/open/floor/carpet,
+/area/library)
+"qav" = (
+/obj/machinery/vending/coffee,
+/obj/machinery/computer/ship/viewscreen,
+/turf/open/floor/wood,
+/area/library)
 "qbw" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"qmK" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+"qfQ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
 	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
 	},
 /turf/open/floor/monotile,
 /area/crew_quarters/fitness/recreation)
+"qgD" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
+"qiZ" = (
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/library)
 "qmY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -41679,14 +41621,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/service)
-"qAR" = (
-/obj/structure/lattice,
-/obj/machinery/camera/motion{
-	c_tag = "Armoury";
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/maintenance/ship_exterior)
 "qEi" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
@@ -41700,16 +41634,6 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/monotile,
 /area/gateway)
-"qGS" = (
-/obj/machinery/airalarm/directional/north,
-/obj/structure/table/wood,
-/obj/item/toy/cards/deck/cas,
-/obj/item/toy/cards/deck/cas/black{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/turf/open/floor/wood,
-/area/library)
 "qLh" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -41754,31 +41678,27 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/gateway)
-"qYq" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/storage/toolbox/emergency,
-/obj/item/clothing/gloves/color/fyellow,
-/turf/open/floor/plating,
-/area/nsv/briefingroom)
+"qRm" = (
+/obj/structure/bookcase,
+/turf/open/floor/wood,
+/area/library)
 "qZd" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"rbT" = (
-/obj/machinery/power/apc/auto_name/south,
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/library)
-"rcf" = (
-/obj/machinery/door/airlock/ship/external/glass{
-	req_one_access_txt = "13"
+"reN" = (
+/obj/machinery/status_display/evac,
+/turf/closed/wall/ship,
+/area/medical/genetics)
+"rgA" = (
+/obj/structure/punching_bag,
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
 "riT" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -41789,68 +41709,60 @@
 	},
 /turf/open/floor/monotile,
 /area/science/xenobiology)
-"rjr" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
-	},
-/obj/machinery/light,
+"rjx" = (
+/obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/wood,
 /area/library)
+"rlQ" = (
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Patient Room B"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/monotile,
+/area/medical/medbay/central)
 "rnf" = (
 /obj/machinery/igniter/incinerator_toxmix,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"rsF" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
+"rqk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/obj/structure/window/reinforced,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
 /turf/open/floor/monotile,
 /area/crew_quarters/fitness/recreation)
-"rwx" = (
-/obj/machinery/light/small{
-	dir = 8
+"rqy" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/ship,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/crew_quarters/fitness/recreation)
+"rsw" = (
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"rwZ" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/status_display/ai{
-	pixel_x = -32
-	},
-/turf/open/floor/monotile/dark,
-/area/nsv/briefingroom)
-"rBE" = (
-/obj/structure/punching_bag,
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
 "rCB" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"rCZ" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/libraryconsole,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/library)
 "rFe" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -41885,26 +41797,30 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"rMx" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
+"rIm" = (
+/obj/machinery/light,
+/turf/open/floor/monotile/dark,
+/area/hallway/secondary/exit)
 "rMN" = (
 /obj/machinery/newscaster{
 	pixel_y = -30
 	},
 /turf/open/floor/monotile/dark,
 /area/science/nanite)
-"rNP" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
+"rXQ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/structure/table/wood,
-/obj/item/paicard,
-/turf/open/floor/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/carpet,
 /area/library)
 "sax" = (
 /obj/machinery/newscaster{
@@ -41912,27 +41828,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit/departure_lounge)
-"scJ" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/door/window/eastright{
-	name = "Fitness Ring"
-	},
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/fitness/recreation)
-"sey" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
 "sfx" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -41956,6 +41851,15 @@
 	},
 /turf/open/floor/monotile,
 /area/medical/chemistry)
+"sjw" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
+"sqV" = (
+/turf/open/floor/wood,
+/area/library)
 "srs" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/structure/cable{
@@ -41994,55 +41898,57 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"sAl" = (
-/obj/item/reagent_containers/food/drinks/sillycup{
-	pixel_x = -5;
-	pixel_y = 3
+"szq" = (
+/obj/structure/closet/lasertag/red,
+/obj/machinery/newscaster{
+	pixel_y = -30
 	},
-/obj/item/reagent_containers/food/drinks/sillycup,
-/obj/item/reagent_containers/food/drinks/sillycup{
-	pixel_x = 5;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/food/drinks/sillycup{
-	pixel_x = 5;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/food/drinks/sillycup{
-	pixel_x = 5;
-	pixel_y = 3
-	},
-/obj/structure/table,
 /turf/open/floor/monotile,
 /area/crew_quarters/fitness/recreation)
-"sKO" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
+"sBm" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
 	},
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
-"sMP" = (
+/obj/structure/table/wood,
+/obj/item/paicard,
+/turf/open/floor/wood,
+/area/library)
+"sBA" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/monotile,
 /area/crew_quarters/fitness/recreation)
-"sUQ" = (
+"sCm" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/library)
+"sHQ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 4;
+	sortType = 16
 	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/fitness/recreation)
+/area/hallway/nsv/deck2/frame2/port)
+"sRo" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/carpet,
+/area/library)
 "tiu" = (
 /obj/machinery/requests_console{
 	department = "Genetics";
@@ -42060,36 +41966,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"tlj" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 4;
-	sortType = 16
-	},
-/turf/open/floor/monotile/dark,
-/area/hallway/nsv/deck2/frame2/port)
-"tlR" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/ship,
-/area/medical/genetics)
-"tmG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
+"tjX" = (
+/obj/structure/table/wood,
+/obj/item/camera,
+/obj/item/taperecorder,
 /turf/open/floor/wood,
 /area/library)
+"tmG" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "tnm" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -42102,19 +41990,14 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/break_room)
-"tqY" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/monotile,
+"twJ" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_large/ship{
+	name = "Gym"
+	},
+/turf/open/floor/carpet/ship,
 /area/crew_quarters/fitness/recreation)
-"txH" = (
-/obj/machinery/holopad,
-/turf/open/floor/carpet/blue,
-/area/crew_quarters/heads/cmo)
-"tzl" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/department/science)
-"tKd" = (
+"txB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
@@ -42129,13 +42012,37 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
-"tMz" = (
-/obj/structure/closet/lasertag/red,
-/obj/machinery/newscaster{
-	pixel_y = -30
+"txH" = (
+/obj/machinery/holopad,
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/heads/cmo)
+"tyN" = (
+/obj/structure/displaycase/trophy,
+/obj/structure/sign/solgov_flag/right,
+/turf/open/floor/wood,
+/area/library)
+"tBs" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
+"tCn" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "tUT" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -42156,6 +42063,15 @@
 /obj/machinery/status_display/supply,
 /turf/closed/wall/ship,
 /area/quartermaster/storage)
+"tWY" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood,
+/area/library)
 "tXO" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -42169,10 +42085,43 @@
 	},
 /turf/open/floor/monotile,
 /area/science/xenobiology)
+"tYd" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/door/window/eastright{
+	name = "Fitness Ring"
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/fitness/recreation)
+"tZM" = (
+/obj/machinery/camera/autoname,
+/obj/machinery/vending/games,
+/turf/open/floor/wood,
+/area/library)
+"tZW" = (
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/monotile,
+/area/crew_quarters/bar)
 "udH" = (
 /obj/machinery/gateway/centerstation,
 /turf/open/floor/monotile/dark,
 /area/gateway)
+"uif" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/library)
+"urK" = (
+/obj/machinery/vending/wardrobe/curator_wardrobe,
+/turf/open/floor/wood,
+/area/library)
 "uts" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -42200,19 +42149,8 @@
 	},
 /turf/open/floor/monotile,
 /area/security/brig)
-"uwy" = (
-/obj/structure/weightmachine/weightlifter,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/fitness/recreation)
-"uAX" = (
-/obj/structure/bookcase/random/reference,
-/turf/open/floor/wood,
+"uyq" = (
+/turf/closed/wall/r_wall/ship,
 /area/library)
 "uDe" = (
 /obj/effect/spawner/lootdrop/maintenance,
@@ -42232,9 +42170,6 @@
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/monotile/dark,
 /area/engine/atmospherics_engine)
-"uLo" = (
-/turf/closed/wall/ship,
-/area/library)
 "uNi" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -42248,13 +42183,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"uPv" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
 "uTe" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -42263,10 +42191,30 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"vdV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/carpet,
+"uXW" = (
+/obj/machinery/status_display/evac{
+	pixel_x = -32
+	},
+/turf/open/floor/monotile/dark,
+/area/nsv/briefingroom)
+"uZp" = (
+/obj/machinery/photocopier{
+	pixel_y = 3
+	},
+/obj/machinery/computer/ship/viewscreen,
+/turf/open/floor/wood,
+/area/library)
+"vcn" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
+"vdf" = (
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
+/turf/open/floor/wood,
 /area/library)
 "vii" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -42278,6 +42226,10 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
+"vlm" = (
+/obj/structure/bookcase/random/adult,
+/turf/open/floor/wood,
+/area/library)
 "vlL" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/stripes/line{
@@ -42299,35 +42251,30 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"vtc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/turf/open/floor/monotile,
-/area/crew_quarters/fitness/recreation)
 "vtl" = (
 /obj/machinery/light,
 /turf/open/floor/monotile,
 /area/engine/engineering/hangar)
-"vuO" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/dorms)
-"vNw" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/dorms)
+"vzE" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
+"vKU" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "vPd" = (
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_exterior,
 /obj/effect/mapping_helpers/airlock/locked,
@@ -42346,10 +42293,17 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"wcf" = (
-/obj/structure/bookcase{
-	name = "Forbidden Knowledge"
+"vYw" = (
+/obj/machinery/door/airlock/ship/external/glass{
+	req_one_access_txt = "13"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
+"wgx" = (
+/obj/structure/bookcase/manuals/engineering,
 /turf/open/floor/wood,
 /area/library)
 "wgS" = (
@@ -42365,10 +42319,9 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"woD" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/fitness/recreation)
+"wjY" = (
+/turf/closed/wall/ship,
+/area/hallway/secondary/service)
 "wqR" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/incinerator_input{
 	dir = 1
@@ -42383,16 +42336,31 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"wvW" = (
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+"wsS" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 26
+	},
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_x = 26
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
 "wyO" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/science/xenobiology)
+"wzZ" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/libraryconsole,
+/obj/machinery/computer/lore_terminal,
+/turf/open/floor/wood,
+/area/library)
 "wEq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
@@ -42401,10 +42369,6 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"wGg" = (
-/obj/structure/closet/toolcloset,
-/turf/open/floor/plating,
-/area/nsv/briefingroom)
 "wId" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
@@ -42418,11 +42382,20 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"wOe" = (
+"wNN" = (
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
+"wOm" = (
 /obj/effect/turf_decal/tile/neutral{
-	dir = 4
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/monotile,
 /area/crew_quarters/fitness/recreation)
 "wUv" = (
@@ -42434,22 +42407,12 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/gateway)
-"wWp" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "wZp" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/nsv/observation)
-"xdI" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/ship,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/crew_quarters/fitness/recreation)
 "xdR" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -42480,6 +42443,26 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/science/research)
+"xiH" = (
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/table/wood,
+/turf/open/floor/carpet,
+/area/library)
+"xjX" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
 "xqR" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -42499,13 +42482,11 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/briefingroom)
-"xxj" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+"xwk" = (
+/obj/structure/punching_bag,
+/obj/machinery/computer/ship/viewscreen,
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
 "xDQ" = (
 /obj/machinery/door/poddoor/incinerator_toxmix,
 /turf/open/floor/plating/airless,
@@ -42516,14 +42497,29 @@
 /obj/machinery/holopad,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms)
-"xFD" = (
-/obj/structure/bookcase,
+"xIM" = (
+/obj/machinery/door/morgue{
+	name = "Private Study";
+	req_access_txt = "37"
+	},
 /turf/open/floor/wood,
 /area/library)
-"xIx" = (
-/obj/structure/disposalpipe/segment,
-/turf/closed/wall/ship,
-/area/hallway/nsv/deck2/frame2/port)
+"xNv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/wood,
+/area/library)
+"xOj" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "xOP" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -42542,15 +42538,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/security/prison)
-"xRi" = (
-/obj/machinery/airalarm/directional/south,
-/obj/structure/bookcase/manuals/research_and_development,
-/turf/open/floor/wood,
-/area/library)
-"xRv" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/carpet,
-/area/library)
 "xWe" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -42564,6 +42551,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/closed/wall/r_wall/ship,
 /area/engine/atmospherics_engine)
+"xYl" = (
+/obj/item/radio/intercom{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/wood,
+/area/library)
 "xYC" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -42574,7 +42568,23 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/science)
-"ydt" = (
+"ybZ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/fitness/recreation)
+"yjB" = (
+/obj/machinery/light_switch{
+	pixel_x = -28
+	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/library)
 
@@ -59910,7 +59920,7 @@ anb
 anb
 anb
 anb
-qAR
+lNi
 anb
 anb
 anb
@@ -60211,11 +60221,11 @@ bzA
 aKr
 aLb
 abB
-faV
-faV
-faV
-faV
-faV
+jCa
+jCa
+jCa
+jCa
+jCa
 aXi
 alK
 lRd
@@ -61243,7 +61253,7 @@ bjU
 bqK
 aLc
 aLc
-jbx
+pGG
 aaC
 bxf
 aKS
@@ -61448,7 +61458,7 @@ aaJ
 aaJ
 aaJ
 aaJ
-lUK
+hgJ
 aac
 adT
 aDB
@@ -61754,10 +61764,10 @@ aKY
 bpG
 abB
 bdx
-nyB
-nyB
-nyB
-nyB
+dPL
+dPL
+dPL
+dPL
 aXi
 bgr
 aKS
@@ -63775,7 +63785,7 @@ anb
 aaJ
 aZa
 akL
-mLc
+fdx
 aZa
 bgu
 bei
@@ -64032,7 +64042,7 @@ anb
 anb
 aZa
 akL
-fOC
+hbf
 aZa
 ayX
 bCZ
@@ -64289,7 +64299,7 @@ anb
 aaJ
 aZa
 baD
-wWp
+ioY
 aZa
 aEL
 bEc
@@ -65587,10 +65597,10 @@ agX
 agX
 agX
 agX
-fOC
+hbf
 bhN
 agX
-mLc
+fdx
 afw
 bmo
 bmC
@@ -65617,7 +65627,7 @@ bbv
 lTI
 acs
 bbv
-tzl
+vKU
 bIF
 aMc
 bHP
@@ -66591,7 +66601,7 @@ afw
 ahm
 ahK
 ahm
-igr
+rlQ
 ahm
 ahm
 bfw
@@ -66602,7 +66612,7 @@ aic
 aUx
 afw
 aXN
-sKO
+vcn
 agP
 agW
 aki
@@ -68443,7 +68453,7 @@ brA
 bre
 bre
 bre
-lUc
+nzF
 bst
 bsy
 bsy
@@ -69181,7 +69191,7 @@ ahc
 ahc
 pSV
 akP
-tlR
+reN
 ahc
 ahc
 alr
@@ -71212,7 +71222,7 @@ aYT
 aYT
 aae
 apu
-iTn
+pCp
 aae
 amK
 amM
@@ -71457,7 +71467,7 @@ aaJ
 aaJ
 aaJ
 aAv
-iTn
+pCp
 aAs
 aAk
 aYR
@@ -72520,11 +72530,11 @@ bcy
 aMv
 aaj
 bfi
-fYE
+uXW
 bFX
 bji
 biZ
-rwZ
+pxK
 blf
 aaj
 aSC
@@ -72740,7 +72750,7 @@ aiH
 aAl
 aAp
 aae
-iTn
+pCp
 aae
 bhm
 aZO
@@ -73337,7 +73347,7 @@ aNX
 acc
 aOe
 acc
-fvh
+rIm
 aOe
 aaJ
 aaJ
@@ -74283,7 +74293,7 @@ bIp
 bIp
 bIp
 aae
-iTn
+pCp
 aZO
 aAv
 bip
@@ -75393,7 +75403,7 @@ aNX
 acc
 aOe
 acc
-fvh
+rIm
 aOe
 aaJ
 aaJ
@@ -75570,7 +75580,7 @@ ini
 aae
 bFQ
 aZO
-lNg
+jVl
 bip
 bip
 bip
@@ -78688,9 +78698,9 @@ bcy
 aMv
 aaj
 acI
-ojM
+fLW
 abJ
-qYq
+cqG
 aaj
 buQ
 ada
@@ -79715,7 +79725,7 @@ ahz
 bcy
 aMv
 abf
-wGg
+dUE
 abs
 aaf
 acm
@@ -80194,8 +80204,8 @@ asL
 asL
 anP
 aoZ
-xxj
-jlD
+lHm
+jbX
 aJp
 amr
 aYX
@@ -80701,11 +80711,11 @@ aaJ
 aaJ
 aaJ
 aaJ
-kah
-kah
-cVe
-kah
-kah
+gRc
+gRc
+rsw
+gRc
+gRc
 anN
 anN
 anN
@@ -80958,12 +80968,12 @@ aaJ
 aaJ
 aaJ
 aaJ
-kah
-nzF
-eHq
+gRc
+xjX
+jGN
 auA
 auG
-hgH
+lUm
 aRH
 anN
 bqZ
@@ -81002,7 +81012,7 @@ bde
 bbI
 aVl
 bde
-nCb
+iaE
 abZ
 aaY
 aaY
@@ -81215,9 +81225,9 @@ aaJ
 aaJ
 aaJ
 aaJ
-xdI
-sAl
-sey
+rqy
+daY
+moP
 auB
 auH
 aAA
@@ -81249,7 +81259,7 @@ aMJ
 aMH
 abd
 abR
-ong
+tZW
 ajS
 baI
 abZ
@@ -81472,9 +81482,9 @@ aaJ
 aaJ
 bJe
 aaJ
-xdI
-tqY
-sey
+rqy
+eQM
+moP
 auz
 auH
 auJ
@@ -81729,10 +81739,10 @@ aaJ
 aaJ
 aaJ
 aaJ
-xdI
+rqy
 aup
-sey
-rsF
+moP
+qgD
 auI
 aRE
 aRJ
@@ -81986,12 +81996,12 @@ aaJ
 aaJ
 aaJ
 aaJ
-kah
+gRc
 auk
-sey
-hov
-eCL
-scJ
+moP
+pam
+qfQ
+tYd
 aRG
 anN
 aQw
@@ -82243,9 +82253,9 @@ aaJ
 aaJ
 aaJ
 aaJ
-kah
-fJS
-sey
+gRc
+xwk
+moP
 aqI
 aqI
 aqI
@@ -82500,13 +82510,13 @@ aaJ
 aaJ
 aaJ
 aaJ
-kah
-rBE
-kHa
-uPv
-wOe
-bXZ
-iDp
+gRc
+rgA
+vzE
+oGv
+iwB
+pgD
+gsk
 anN
 auZ
 aeY
@@ -82757,13 +82767,13 @@ aaJ
 aaJ
 aaJ
 aaJ
-xdI
-rMx
-sUQ
+rqy
+bPL
+kdP
 auJ
 auJ
-nqR
-jmF
+ybZ
+nGX
 anN
 auh
 agd
@@ -83014,13 +83024,13 @@ aaJ
 aaJ
 aaJ
 aaJ
-xdI
-rMx
-uwy
+rqy
+bPL
+mWo
 auJ
 auK
-dsf
-tMz
+mgd
+szq
 anN
 ams
 agA
@@ -83271,19 +83281,19 @@ aaJ
 aaJ
 aaJ
 aaJ
-xdI
-rMx
-sUQ
+rqy
+bPL
+kdP
 auJ
 auJ
-dsf
-aqI
+mgd
+eVy
 anN
 bfr
 atz
 bhD
-dtZ
-hwS
+tCn
+wNN
 atz
 aoe
 ami
@@ -83528,20 +83538,20 @@ aaJ
 aaJ
 aaJ
 aaJ
-xdI
-rMx
-lWM
+rqy
+bPL
+hhp
 auJ
 auL
-vtc
+rqk
 aqI
-gCJ
+twJ
 aqy
 atz
-kfa
+tmG
 xEa
 aqy
-mNO
+tBs
 ahe
 aip
 aiJ
@@ -83785,11 +83795,11 @@ aaJ
 aaJ
 aaJ
 aaJ
-xdI
-rMx
-dYL
-woD
-woD
+rqy
+bPL
+lRC
+jns
+jns
 bFP
 auV
 aqB
@@ -83810,12 +83820,12 @@ aZo
 aZw
 bhF
 btF
-vuO
-vNw
+sjw
+lSg
 bhA
-xIx
+eUj
 bGj
-tlj
+sHQ
 bkj
 acR
 afc
@@ -84042,13 +84052,13 @@ aaJ
 aaJ
 aaJ
 aaJ
-kah
-iWi
-sMP
-qmK
-nCW
-jII
-oWU
+gRc
+wsS
+wOm
+sBA
+fwk
+eBS
+ezB
 anN
 bIx
 aqy
@@ -84299,21 +84309,21 @@ aaJ
 aaJ
 aaJ
 aaJ
-kah
+gRc
 anN
-cVe
+rsw
 anN
-uLo
-uLo
-uLo
-uLo
-uLo
-uLo
+kCr
+kCr
+kCr
+kCr
+kCr
+kCr
 bAI
 aZm
 aum
-uLo
-uLo
+kCr
+kCr
 ami
 aqE
 aro
@@ -84560,17 +84570,17 @@ asL
 aHP
 aYN
 aYM
-uLo
-nQG
-ydt
-lgQ
-ydt
+kCr
+pWv
+sqV
+kNj
+sqV
 afx
 bAJ
 aZr
 bhE
-nkS
-fBR
+yjB
+hVt
 ami
 aqF
 art
@@ -84817,17 +84827,17 @@ asL
 aoZ
 aoZ
 aJp
-uLo
-kOC
-ydt
-jHo
-ydt
-oxc
-ydt
-jov
+kCr
+tyN
+sqV
+mTn
+sqV
+vlm
+sqV
+rXQ
 auD
-ydt
-iBb
+sqV
+wgx
 ami
 bgk
 ayT
@@ -85074,17 +85084,17 @@ asL
 asL
 aoZ
 aJp
-uLo
-rCZ
-ydt
-jaP
-ydt
-iUL
-gHv
+kCr
+wzZ
+sqV
+jup
+sqV
+ckJ
+rjx
 aMI
 auD
-ydt
-iKQ
+sqV
+kga
 ami
 aqF
 bbR
@@ -85331,17 +85341,17 @@ aaJ
 asL
 aoZ
 aJp
-uLo
-dGM
-ydt
-xFD
-ydt
-uAX
-ydt
-tKd
+kCr
+uZp
+sqV
+qRm
+sqV
+imp
+sqV
+txB
 auD
-ydt
-xRi
+sqV
+lJl
 ami
 aqH
 arv
@@ -85371,12 +85381,12 @@ aVt
 bue
 aVt
 bfT
-fQZ
+wjY
 bjq
-fQZ
-fQZ
-fQZ
-fQZ
+wjY
+wjY
+wjY
+wjY
 aih
 aih
 aih
@@ -85586,19 +85596,19 @@ aaJ
 aaJ
 aaJ
 asL
-gaq
+gqT
 aJp
-uLo
-eFi
-ydt
-ydt
-ydt
-eoK
+kCr
+eKP
+sqV
+jcZ
+sqV
+dCx
 bAK
 aYW
-huY
-cHC
-rbT
+tWY
+niU
+vdf
 ami
 ami
 ami
@@ -85628,7 +85638,7 @@ bbP
 buy
 aVu
 bgg
-fQZ
+wjY
 bjz
 amY
 aVE
@@ -85845,14 +85855,14 @@ aaJ
 asL
 aoZ
 aJp
-uLo
-uLo
-uLo
-uLo
-uLo
+kCr
+kCr
+kCr
+kCr
+kCr
 aJN
-uLo
-uLo
+kCr
+kCr
 auE
 auM
 aRF
@@ -85885,7 +85895,7 @@ bdp
 bzB
 bdp
 bgo
-fQZ
+wjY
 bjG
 bkF
 bkY
@@ -86104,15 +86114,15 @@ aoZ
 aYN
 aYK
 aYM
-uLo
+kCr
 aJL
 aLs
-tmG
-ydt
-uLo
+xNv
+sqV
+kCr
 auF
 auD
-oKT
+pZt
 ami
 ami
 ami
@@ -86142,7 +86152,7 @@ aVv
 bkg
 aVv
 aVz
-fQZ
+wjY
 amP
 qxl
 aMA
@@ -86358,16 +86368,16 @@ aaJ
 aaJ
 asL
 asL
-kuF
+eYp
 asL
 aJp
-uLo
-qGS
+kCr
+oAc
 aul
-duJ
+xiH
 auo
-uLo
-mpo
+kCr
+klv
 auD
 auD
 ami
@@ -86399,7 +86409,7 @@ aeL
 aeL
 aeL
 aeL
-fQZ
+wjY
 arz
 aVD
 aVG
@@ -86618,15 +86628,15 @@ aaJ
 aAy
 asL
 aJp
-uLo
-rNP
-vdV
+kCr
+sBm
+kuE
 bhH
-rjr
-uLo
-uLo
-gDT
-uLo
+cWx
+kCr
+kCr
+xIM
+kCr
 aqC
 aqC
 aqC
@@ -86875,15 +86885,15 @@ aaJ
 aAy
 asL
 aJp
-uLo
-erP
-xRv
-mLH
-ooD
-uLo
-jyY
-lPH
-orn
+kCr
+tZM
+sRo
+hCK
+sCm
+kCr
+juD
+qiZ
+urK
 anp
 aSn
 aqi
@@ -87132,15 +87142,15 @@ aaJ
 aAy
 asL
 aJp
-uLo
-ocY
-lUl
-ydt
-ydt
-uLo
-wcf
-nEC
-lkg
+kCr
+qav
+xYl
+sqV
+sqV
+kCr
+kIZ
+uif
+tjX
 anp
 aoa
 azq
@@ -87389,12 +87399,12 @@ aaJ
 aAy
 asL
 aJp
-uLo
-uLo
-uLo
-wvW
-uLo
-dPW
+kCr
+kCr
+kCr
+dmM
+kCr
+uyq
 anp
 anp
 anp
@@ -88159,9 +88169,9 @@ aaJ
 aaJ
 anb
 anb
-lSS
-rwx
-rcf
+pPg
+hWr
+vYw
 aoZ
 aJp
 aoZ
@@ -89707,7 +89717,7 @@ aHJ
 asL
 aJp
 aoZ
-jQP
+pus
 asL
 anW
 anZ
@@ -89964,7 +89974,7 @@ asL
 asL
 bhn
 aoZ
-gDC
+xOj
 asL
 aqb
 aAU


### PR DESCRIPTION
- Adds intercoms and fire alarms to areas that didn't have them
- Fire extinguishers EVERYWHERE.
- Adds missing pilot RC console
- AI/Evac displays around the map.
- Maintenance uses the correct area types (starboard and port types)
- Pilots no longer have to pass through maintenance to reach the flight deck ladder.

![image](https://user-images.githubusercontent.com/31044876/75627250-84547080-5bc6-11ea-98fc-662a4fe44580.png)

- Fixes xenobio shield generators so that monsters can't smash them within the secure containment room
- Fixes xenobiology disposals leading to cargo instead of space
- Medbay+brig entrance firelocks
- Fixed a few instances of cameras on light tubes
- Air alarms in areas that needed them, such as the engine room and the engineering hangar.
- Renamed bridge RC to CIC RC.