### PR TITLE
Fixes directional Extinguisher cabinets

### DIFF
--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -61,3 +61,15 @@
 		return
 	if(!(stat & (BROKEN|NOPOWER)))
 		power_change()
+
+/obj/machinery/light_switch/north //NSV13 Start
+	pixel_y = 24
+
+/obj/machinery/light_switch/south
+	pixel_y = -24
+
+/obj/machinery/light_switch/east
+	pixel_x = 24
+
+/obj/machinery/light_switch/west
+	pixel_x = -24 //NSV13 End

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -163,8 +163,8 @@
 	
 /obj/structure/extinguisher_cabinet/west
 	dir = WEST
-	pixel_x = 27
+	pixel_x = -27
 	
 /obj/structure/extinguisher_cabinet/east
 	dir = EAST
-	pixel_x = -27 //NSV13 End
+	pixel_x = 27 //NSV13 End


### PR DESCRIPTION
## About The Pull Request

fixes the east extinguisher cabinet being west and vice-versa.

Adds directional light switches

## Why It's Good For The Game

correct directional typepaths are good...

## Changelog

:cl:
add: Adds directional light switches for mapmakers.
/:cl:
