### PR TITLE
[PORT] Beestation #1344 (Unban panel fix)

### DIFF
--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -556,7 +556,7 @@
 			if(roles_to_ban[1] == "Server" && (!is_admin || (is_admin && applies_to_admins)))
 				qdel(i)
 
-/datum/admins/proc/unban_panel(player_key, admin_key, player_ip, player_cid, global_ban, page = 0)
+/datum/admins/proc/unban_panel(player_key, admin_key, player_ip, player_cid, page = 0)
 	if(!check_rights(R_BAN))
 		return
 	if(!SSdbcore.Connect())
@@ -576,7 +576,7 @@
 	</div>
 	<div class='main'>
 	"}
-	if(player_key || admin_key || player_ip || player_cid || global_ban)
+	if(player_key || admin_key || player_ip || player_cid)
 		var/list/searchlist = list()
 		if(player_key)
 			searchlist += "ckey = '[sanitizeSQL(ckey(player_key))]'"
@@ -602,7 +602,7 @@
 			var/pagecount = 1
 			var/list/pagelist = list()
 			while(bancount > 0)
-				pagelist += "<a href='?_src_=holder;[HrefToken()];unbanpagecount=[pagecount - 1];unbankey=[player_key];unbanadminkey=[admin_key];unbanip=[player_ip];unbancid=[player_cid]'>[pagecount == page ? "<b>\[[pagecount]\]</b>" : "\[[pagecount]\]"]</a>"
+				pagelist += "<a href='?_src_=holder;[HrefToken()];unbanpagecount=[pagecount - 1];unbankey=[player_key];unbanadminkey=[admin_key];unbanip=[player_ip];unbancid=[player_cid]'>[pagecount == (page + 1) ? "<b>\[[pagecount]\]</b>" : "\[[pagecount]\]"]</a>"
 				bancount -= bansperpage
 				pagecount++
 			output += pagelist.Join(" | ")


### PR DESCRIPTION
The `global_ban` variable was a remnant of some experimental changes being made to the unbanning panel when cross-server bans was first implemented. The result, however, is that pages no longer work. Removing the fragment resolves this.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
> Copied from upstream PR

Fixes an error added in https://github.com/BeeStation/BeeStation-Hornet/pull/489 which prevents admins from changing pages on the unban panel.

A parameter was introduced during our rushed implementation of cross-server banning. This item was originally going to be used to help filter searches, but, when that feature was removed the parameter was left in. Preventing admins from viewing more than one page of bans when attempting to edit/remove bans using the unban panel.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Crossedfall
admin: Admins can view more than one page on the unban panel again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
