### PR TITLE
Removes nostromo from the name choices for the main ship

### DIFF
--- a/strings/station_names.txt
+++ b/strings/station_names.txt
@@ -12,7 +12,6 @@ Syria planum
 Recurve
 Feliciana
 Vishari
-Nostromo
 Prometheus
 Sephora
 Vespira


### PR DESCRIPTION
Stares at KMC

:cl: Central naming convention committee
fix: The main vessel is no longer possibly named the same as its support mining vessel.
/:cl: