### PR TITLE
Increase nicotine OD threshold

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -41,7 +41,7 @@
 	addiction_threshold = 10
 	taste_description = "smoke"
 	trippy = FALSE
-	overdose_threshold=15
+	overdose_threshold=50 // usual cigarette leaves you with 5u of nicotine after smoking, Havanian cigs contain 15u, premium - 25u, cohiba robusto contain 40u, usual cigs contain 15-20u
 	metabolization_rate = 0.125 * REAGENTS_METABOLISM
 
 /datum/reagent/drug/nicotine/on_mob_life(mob/living/carbon/M)

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -41,7 +41,7 @@
 	addiction_threshold = 10
 	taste_description = "smoke"
 	trippy = FALSE
-	overdose_threshold=50 // usual cigarette leaves you with 5u of nicotine after smoking, Havanian cigs contain 15u, premium - 25u, cohiba robusto contain 40u, usual cigs contain 15-20u
+	overdose_threshold=35 //NSV13: usual cigarette leaves you with 5u of nicotine after smoking, Havanian cigs contain 15u, premium - 25u, cohiba robusto contains 40u, usual cigs contain 15-20u
 	metabolization_rate = 0.125 * REAGENTS_METABOLISM
 
 /datum/reagent/drug/nicotine/on_mob_life(mob/living/carbon/M)

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -41,7 +41,7 @@
 	addiction_threshold = 10
 	taste_description = "smoke"
 	trippy = FALSE
-	overdose_threshold=35 //NSV13: usual cigarette leaves you with 5u of nicotine after smoking, Havanian cigs contain 15u, premium - 25u, cohiba robusto contains 40u, usual cigs contain 15-20u
+	overdose_threshold=35 //NSV13
 	metabolization_rate = 0.125 * REAGENTS_METABOLISM
 
 /datum/reagent/drug/nicotine/on_mob_life(mob/living/carbon/M)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Current nicotine OD threshold is 15, usual cigarette leaves you with 5u nicotine in system after smoking it, smoking premium or robusto cigars straight OD you. I raised OD level to ~~50~~ 35 units, smoking whole pack of cigs isn't dangerous now, but cigars can still OD you

## Why It's Good For The Game

muh smoker trait

## Changelog
:cl:
tweak: Raised nicotine OD threshold.
/:cl: