### PR TITLE
Makes the AI no longer able to connect to the CTF and syndicate radio channels with the intercoms

### DIFF
--- a/code/__DEFINES/radio.dm
+++ b/code/__DEFINES/radio.dm
@@ -58,8 +58,9 @@
 #define RADIO_CHANNEL_CTF_BLUE "Blue Team"
 
 
-#define MIN_FREE_FREQ 1201 // -------------------------------------------------
+#define MIN_FREE_FREQ 1221 // -------------------------------------------------
 // Frequencies are always odd numbers and range from 1201 to 1599.
+//(NSV13) Free frequency minimum was increased to 1221 to avoid the AI using comms to access syndicate and CTF channels
 
 #define FREQ_SYNDICATE 1213  //!  Nuke op comms frequency, dark brown
 #define FREQ_CTF_RED 1215  //!  CTF red team comms frequency, red

--- a/code/game/machinery/telecomms/broadcasting.dm
+++ b/code/game/machinery/telecomms/broadcasting.dm
@@ -161,9 +161,9 @@
 					radios += R
 
 		if (TRANSMISSION_SUPERSPACE)
-			// Only radios which are independent
+			// Only radios which are independent //NSV13 - or atc radios
 			for(var/obj/item/radio/R in GLOB.all_radios["[frequency]"])
-				if(R.independent && R.can_receive(frequency, levels))
+				if(R.independent && R.can_receive(frequency, levels) || R.atc && R.can_receive(frequency, levels))
 					radios += R
 
 	// From the list of radios, find all mobs who can hear those.

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -7,6 +7,7 @@
 	var/translate_binary = FALSE
 	var/syndie = FALSE
 	var/independent = FALSE
+	var/atc = FALSE
 	var/list/channels = list()
 
 /obj/item/encryptionkey/Initialize()
@@ -82,7 +83,7 @@
 /obj/item/encryptionkey/heads/captain //NSV13 - added ATC & Munitions
 	name = "\proper the captain's encryption key"
 	icon_state = "cap_cypherkey"
-	independent = TRUE
+	atc = TRUE //For allowing atc radio to ignore z-levels
 	channels = list(RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_SECURITY = 1, RADIO_CHANNEL_ENGINEERING = 0, RADIO_CHANNEL_SCIENCE = 0, RADIO_CHANNEL_MEDICAL = 0, RADIO_CHANNEL_SUPPLY = 0, RADIO_CHANNEL_SERVICE = 0, RADIO_CHANNEL_MUNITIONS = 0, RADIO_CHANNEL_ATC = 0)
 
 /obj/item/encryptionkey/heads/rd
@@ -132,7 +133,7 @@
 	channels = list(RADIO_CHANNEL_CENTCOM = 1)
 
 /obj/item/encryptionkey/ai //ported from NT, this goes 'inside' the AI. NSV13 - added munitions & ATC
-	independent = TRUE
+	atc = TRUE //For allowing atc radio to ignore z-levels
 	channels = list(RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_SECURITY = 1, RADIO_CHANNEL_ENGINEERING = 1, RADIO_CHANNEL_SCIENCE = 1, RADIO_CHANNEL_MEDICAL = 1, RADIO_CHANNEL_SUPPLY = 1, RADIO_CHANNEL_SERVICE = 1, RADIO_CHANNEL_AI_PRIVATE = 1, RADIO_CHANNEL_MUNITIONS = 1, RADIO_CHANNEL_ATC = 1)
 
 /obj/item/encryptionkey/secbot

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -338,6 +338,8 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 			syndie = TRUE
 		if (keyslot2.independent)
 			independent = TRUE
+		if (keyslot2.atc)
+			atc = TRUE
 
 	for(var/ch_name in channels)
 		secure_radio_connections[ch_name] = add_radio(src, GLOB.radiochannels[ch_name])

--- a/nsv13/code/game/objects/items/munitions_items.dm
+++ b/nsv13/code/game/objects/items/munitions_items.dm
@@ -20,25 +20,25 @@
 	name = "air traffic control radio encryption key"
 	icon_state = "sec_cypherkey"
 	channels = list(RADIO_CHANNEL_ATC = 1, RADIO_CHANNEL_MUNITIONS = 1, RADIO_CHANNEL_COMMAND = 1)
-	independent = TRUE
+	atc = TRUE
 
 /obj/item/encryptionkey/pilot
 	name = "fighter pilot radio encryption key"
 	icon_state = "sec_cypherkey"
 	channels = list(RADIO_CHANNEL_ATC = 1, RADIO_CHANNEL_MUNITIONS = 1)
-	independent = TRUE
+	atc = TRUE
 
 /obj/item/encryptionkey/heads/master_at_arms
 	name = "master at arms radio encryption key"
 	icon_state = "sec_cypherkey"
 	channels = list(RADIO_CHANNEL_MUNITIONS = 1, RADIO_CHANNEL_SUPPLY = 1, RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_ATC = 1)
-	independent = TRUE
+	atc = TRUE
 
 /obj/item/encryptionkey/munitions_tech
 	name = "munitions department encryption key"
 	icon_state = "sec_cypherkey"
 	channels = list(RADIO_CHANNEL_MUNITIONS = 1, RADIO_CHANNEL_SUPPLY = 1)
-	independent = TRUE
+	atc = TRUE
 
 ///////RADIO HEADSETS//////
 
@@ -63,7 +63,7 @@
 /obj/item/radio/headset/heads/master_at_arms/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/wearertargeting/earprotection, list(SLOT_EARS))
-	
+
 /obj/item/radio/headset/headset_sec/alt/munitions_tech
 	name = "munitions technician radio headset"
 	desc = "Use :w to access the department frequency. Use :u to access the supply frequency."
@@ -79,7 +79,7 @@
 	item_state = "g_suit"
 	item_color = "camogreen"
 	can_adjust = FALSE
-	
+
 /obj/item/clothing/under/rank/master_at_arms
 	name = "master at arms' jumpsuit"
 	desc = "It's a jumpsuit worn by those with the experience to be \"Master At Arms\". It provides minor fire protection."


### PR DESCRIPTION
## About The Pull Request

Changes the minimum allowed frequency devices with 'freerange' can tune to as to avoid the AI (and the clock cult) tuning in to syndicate and CTF channels. Fixes #253, it does not stop the AI from tuning in to central command's radio. If that needs to be fixed aswell yell at me in the comments.
Also changes the atc radios to use a seperate superspace channel than the 'independent' one used by central command and CTF radio's.

## Why It's Good For The Game

Stops the AI from talking to people who are enjoying a friendly game of capture the flag which is highly illegal under space law.

## Changelog
:cl:
fix: the AI intercoms can now no longer change their frequency below 122.1 KHz
refactor: atc radio now uses a seperate superspace channel.
/:cl: