### PR TITLE
Makes bar bottles more consistent with other food items

### DIFF
--- a/nsv13/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/nsv13/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -1,5 +1,5 @@
 // Blocks gulp_size changing proc and makes the empty glass bottles renamable
 /obj/item/reagent_containers/food/drinks/bottle/on_reagent_change(changetype)
-..()
+
 /obj/item/reagent_containers/food/drinks/bottle/blank
 	obj_flags = UNIQUE_RENAME

--- a/nsv13/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/nsv13/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -1,0 +1,5 @@
+// Blocks gulp_size changing proc and makes the empty glass bottles renamable
+/obj/item/reagent_containers/food/drinks/bottle/on_reagent_change(changetype)
+..()
+/obj/item/reagent_containers/food/drinks/bottle/blank
+	obj_flags = UNIQUE_RENAME


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so that drinking out of liquid food containers (booze, juices, sodacans etc) excluding drinking and shot glasses doesn't change the amount you drink everytime you take a sip.
Also the glass bottle and small glass bottle become renamable, consistent with drinking glasses and chef food
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Consistency makes drinking out of bottles less confusing and painful when you want to use them without glasses, and being able to rename them allows for more creative freedom using custom drinks, similar to custom food
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Makes drinking out of bar bottles more consistent with other liquid containers
tweak: Glass bottles and small glass bottles renamable and customizable descriptions
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
