### PR TITLE
Aetherwhisp followup and map fixes

### DIFF
--- a/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
@@ -8537,6 +8537,9 @@
 /obj/machinery/recharger{
 	pixel_x = -7
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/warden)
 "fTW" = (
@@ -18502,6 +18505,12 @@
 /obj/item/clothing/ears/earmuffs,
 /turf/open/floor/plating,
 /area/maintenance/department/security)
+"mYV" = (
+/obj/machinery/chem_dispenser/mutagensaltpetersmall,
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#99FF99"
+	},
+/area/hydroponics)
 "mYX" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 8;
@@ -32611,6 +32620,9 @@
 /area/security/brig)
 "xuy" = (
 /obj/machinery/seed_extractor,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#99FF99"
 	},
@@ -33310,12 +33322,6 @@
 	},
 /turf/open/floor/carpet/ship/blue,
 /area/medical/apothecary)
-"xSI" = (
-/obj/machinery/chem_dispenser/mutagensaltpetersmall,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
-/area/hydroponics)
 "xSX" = (
 /obj/structure/closet/wardrobe/white/medical,
 /obj/machinery/airalarm/directional/north,
@@ -64628,7 +64634,7 @@ bfy
 hPx
 hPx
 jDv
-xSI
+mYV
 nfK
 kbE
 fUj

--- a/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
@@ -4865,16 +4865,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"dqP" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	dir = 4;
-	id = "ceshutter"
-	},
-/turf/open/floor/plating,
-/area/engine/engine_room/external{
-	name = "Stormdrive Interior"
-	})
 "drc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
@@ -6215,6 +6205,10 @@
 /area/security/main{
 	name = "Security War Room"
 	})
+"ekq" = (
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/carpet/ship/blue,
+/area/medical/patients_rooms/room_d)
 "ekt" = (
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/carpet/ship/red_carpet,
@@ -7323,6 +7317,10 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/shuttle/turbolift/secondary)
+"eZY" = (
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/department/security)
 "faJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -7457,6 +7455,13 @@
 	},
 /turf/open/floor/engine/n2,
 /area/engine/atmos)
+"fey" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "chapel_shutters_space"
+	},
+/turf/open/floor/plating,
+/area/chapel/main)
 "feG" = (
 /obj/structure/closet/radiation,
 /obj/item/clothing/mask/gas,
@@ -7474,6 +7479,10 @@
 "ffF" = (
 /obj/structure/table/wood,
 /obj/machinery/light,
+/obj/item/reagent_containers/food/snacks/grown/poppy{
+	pixel_x = 3;
+	pixel_y = 3
+	},
 /obj/item/reagent_containers/food/snacks/grown/poppy,
 /turf/open/floor/carpet/royalblack,
 /area/chapel/main)
@@ -10040,6 +10049,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/checkpoint/escape)
 "hbR" = (
@@ -10485,6 +10495,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/patients_rooms/room_c)
 "hvY" = (
@@ -11358,7 +11369,6 @@
 	dir = 4;
 	name = "starmap console"
 	},
-/obj/item/reagent_containers/food/snacks/grown/poppy/lily,
 /turf/open/floor/carpet/royalblack,
 /area/chapel/main)
 "iep" = (
@@ -12315,6 +12325,17 @@
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
+"iMP" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/machinery/button/door{
+	id = "chapel_shutters_space";
+	name = "chapel shutters control";
+	pixel_x = -6;
+	pixel_y = -25
+	},
+/turf/open/floor/wood,
+/area/chapel/main)
 "iMR" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -14523,6 +14544,11 @@
 	},
 /turf/open/floor/carpet/ship/red_carpet,
 /area/crew_quarters/heads/hos)
+"kpS" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/grown/poppy/lily,
+/turf/open/floor/carpet/royalblack,
+/area/chapel/main)
 "kqi" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 4
@@ -18920,6 +18946,7 @@
 /obj/item/instrument/eguitar,
 /obj/item/paper/guides/jobs/security/range,
 /obj/machinery/firealarm/directional/west,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/carpet/ship/red_carpet,
 /area/ai_monitored/security/armory/lockup)
 "nmC" = (
@@ -21288,6 +21315,14 @@
 	},
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/department/medical)
+"pbZ" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "chapel_shutters_space"
+	},
+/turf/open/floor/plating,
+/area/chapel/main)
 "pcq" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -23138,6 +23173,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/patients_rooms/room_a)
 "qrE" = (
@@ -25411,6 +25447,16 @@
 /obj/item/cartridge/medical,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/storage)
+"saz" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "ceshutter"
+	},
+/turf/open/floor/plating,
+/area/engine/engine_room/external{
+	name = "Stormdrive Interior"
+	})
 "saD" = (
 /obj/structure/table/glass,
 /obj/item/storage/fancy/donut_box,
@@ -25706,6 +25752,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/patients_rooms/room_c)
 "skM" = (
@@ -26113,6 +26160,9 @@
 /area/engine/engine_smes)
 "sGU" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "chapel_shutters_space"
+	},
 /turf/open/floor/plating,
 /area/chapel/office)
 "sHv" = (
@@ -27517,6 +27567,7 @@
 "tLz" = (
 /obj/machinery/iv_drip,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/patients_rooms/room_a)
 "tLE" = (
@@ -30061,6 +30112,7 @@
 /area/engine/atmos)
 "vDE" = (
 /obj/machinery/computer/crew,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/checkpoint/medical)
 "vDM" = (
@@ -33967,6 +34019,10 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/plating,
 /area/security/prison)
+"yjQ" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/carpet/ship/blue,
+/area/medical/patients_rooms/room_b)
 "yjR" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -54677,8 +54733,8 @@ fZX
 dch
 cxG
 fZX
-dqP
-dqP
+saz
+saz
 acZ
 acZ
 bTh
@@ -61664,7 +61720,7 @@ wnw
 mVk
 tJL
 lYW
-eoO
+iMP
 jBW
 aIO
 drp
@@ -61922,7 +61978,7 @@ mVk
 mVk
 iEN
 mVk
-fMV
+fey
 icn
 drp
 drp
@@ -62179,7 +62235,7 @@ eoO
 mVk
 iEN
 ojk
-fMV
+fey
 icn
 drp
 drp
@@ -62436,7 +62492,7 @@ mVk
 lNi
 uQl
 lNi
-fMV
+fey
 icn
 aIO
 drp
@@ -63207,7 +63263,7 @@ wEc
 jhM
 foC
 fKi
-fMV
+fey
 icn
 drp
 drp
@@ -63464,7 +63520,7 @@ mVk
 lNi
 uQl
 lNi
-fMV
+fey
 icn
 drp
 drp
@@ -63721,7 +63777,7 @@ wEc
 jhM
 foC
 fKi
-fMV
+fey
 icn
 drp
 drp
@@ -64237,8 +64293,8 @@ foC
 fKi
 jBW
 jBW
-fMV
-fMV
+pbZ
+pbZ
 jBW
 uzR
 jBW
@@ -65006,7 +65062,7 @@ mVk
 lNi
 uQl
 ieg
-gdT
+kpS
 gdT
 gdT
 bAp
@@ -71656,7 +71712,7 @@ oZp
 xSb
 jGf
 eaE
-eaE
+eZY
 oZp
 lGF
 dCv
@@ -73471,7 +73527,7 @@ nGw
 nGw
 mLU
 ksS
-hIk
+yjQ
 ikd
 ybo
 uDi
@@ -73483,7 +73539,7 @@ rxk
 tYt
 xzn
 kCK
-onY
+ekq
 pQv
 qzL
 pvR

--- a/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
@@ -1206,7 +1206,7 @@
 	height = 15;
 	id = "arrivals_stationary";
 	name = "Deck 2 Arrivals Port";
-	roundstart_template = /datum/map_template/shuttle/arrival/kilo;
+	roundstart_template = /datum/map_template/shuttle/arrival/box;
 	width = 7
 	},
 /turf/open/space/basic,
@@ -4865,6 +4865,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"dqP" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "ceshutter"
+	},
+/turf/open/floor/plating,
+/area/engine/engine_room/external{
+	name = "Stormdrive Interior"
+	})
 "drc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
@@ -7794,16 +7804,6 @@
 /obj/machinery/chem_master,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/chemistry)
-"fsj" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	dir = 4;
-	id = "ceshutter"
-	},
-/turf/open/floor/plating,
-/area/engine/engine_room/external{
-	name = "Stormdrive Interior"
-	})
 "fsv" = (
 /turf/closed/wall/ship,
 /area/security/checkpoint/engineering)
@@ -54677,8 +54677,8 @@ fZX
 dch
 cxG
 fZX
-fsj
-fsj
+dqP
+dqP
 acZ
 acZ
 bTh

--- a/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
@@ -1207,7 +1207,7 @@
 	height = 15;
 	id = "arrivals_stationary";
 	name = "Deck 2 Arrivals Port";
-	roundstart_template = /datum/map_template/shuttle/arrival/box;
+	roundstart_template = /datum/map_template/shuttle/arrival/aetherwhisp;
 	width = 7
 	},
 /turf/open/space/basic,

--- a/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
@@ -24433,7 +24433,7 @@
 	},
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "0-8"
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
@@ -24963,16 +24963,6 @@
 	color = "#99FF99"
 	},
 /area/medical/virology)
-"rJe" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	dir = 4;
-	id = "ceshutter"
-	},
-/turf/open/floor/plating,
-/area/engine/engine_room/external{
-	name = "Stormdrive Interior"
-	})
 "rJi" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/machinery/camera/autoname{
@@ -33807,6 +33797,16 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"yeT" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "ceshutter"
+	},
+/turf/open/floor/plating,
+/area/engine/engine_room/external{
+	name = "Stormdrive Interior"
+	})
 "yfp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -54677,8 +54677,8 @@ fZX
 dch
 cxG
 fZX
-rJe
-rJe
+yeT
+yeT
 acZ
 acZ
 bTh

--- a/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
@@ -646,6 +646,10 @@
 /obj/machinery/door/window/eastleft{
 	req_one_access_txt = "3"
 	},
+/obj/machinery/door/poddoor/ship/preopen{
+	dir = 4;
+	id = "briglockdown"
+	},
 /turf/open/floor/plating,
 /area/security/warden)
 "auT" = (
@@ -738,6 +742,9 @@
 	icon_state = "2-4"
 	},
 /obj/effect/landmark/nuclear_waste_spawner,
+/obj/machinery/door/poddoor/ship/preopen{
+	id = "brig shutters"
+	},
 /turf/open/floor/plating,
 /area/security/brig)
 "ayO" = (
@@ -2373,6 +2380,16 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/wood,
 /area/security/execution/education)
+"byz" = (
+/obj/machinery/conveyor{
+	dir = 10;
+	id = "arrivals_baggage_claim";
+	operating = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry{
+	name = "Arrivals"
+	})
 "byA" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
@@ -5020,6 +5037,7 @@
 "dxz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
 	id = "ceshutter"
 	},
 /turf/open/floor/plating,
@@ -5544,10 +5562,11 @@
 /area/maintenance/department/medical)
 "dPE" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
 	id = "cmoshutter"
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/cmo)
 "dQg" = (
@@ -11558,9 +11577,6 @@
 /area/engine/engine_room)
 "imh" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	id = "cmoshutter"
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
@@ -11569,6 +11585,10 @@
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "cmoshutter"
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/cmo)
@@ -12734,7 +12754,7 @@
 /area/crew_quarters/bar)
 "jda" = (
 /obj/machinery/conveyor{
-	dir = 4;
+	dir = 5;
 	id = "arrivals_baggage_claim";
 	operating = 1
 	},
@@ -14318,6 +14338,37 @@
 /obj/structure/table,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/button/door{
+	desc = "A remote control switch for the medbay foyer.";
+	id = "pw_fd_outer";
+	name = "Brig Exterior Doors Control";
+	normaldoorcontrol = 1;
+	pixel_x = -5;
+	pixel_y = 8;
+	req_access_txt = "63"
+	},
+/obj/machinery/button/door{
+	desc = "A remote control switch for the medbay foyer.";
+	id = "pw_fd_inner";
+	name = "Brig Interior Doors Control";
+	normaldoorcontrol = 1;
+	pixel_x = -5;
+	pixel_y = -2;
+	req_access_txt = "63"
+	},
+/obj/machinery/button/door{
+	id = "briglockdown";
+	name = "Brig Lockdown Control";
+	pixel_x = 5;
+	pixel_y = 8
+	},
+/obj/machinery/button/door{
+	id = "brig shutters";
+	name = "Cell Window Control";
+	pixel_x = 5;
+	pixel_y = -2;
+	specialfunctions = 4
 	},
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/warden)
@@ -16817,6 +16868,9 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/machinery/door/poddoor/ship/preopen{
+	id = "briglockdown"
+	},
 /turf/open/floor/plating,
 /area/security/warden)
 "lTm" = (
@@ -17177,7 +17231,8 @@
 	pixel_x = 6;
 	pixel_y = 6
 	},
-/obj/machinery/conveyor/inverted{
+/obj/machinery/conveyor{
+	dir = 9;
 	id = "arrivals_baggage_claim";
 	operating = 1
 	},
@@ -17774,6 +17829,9 @@
 	},
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/ship/preopen{
+	id = "briglockdown"
+	},
 /turf/open/floor/plating,
 /area/security/warden)
 "mBQ" = (
@@ -18370,11 +18428,12 @@
 /area/crew_quarters/toilet/restrooms)
 "mUs" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	id = "cmoshutter"
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "cmoshutter"
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/cmo)
@@ -19163,6 +19222,9 @@
 	req_one_access_txt = "3"
 	},
 /obj/machinery/door/window/southleft,
+/obj/machinery/door/poddoor/ship/preopen{
+	id = "briglockdown"
+	},
 /turf/open/floor/plating,
 /area/security/warden)
 "nwm" = (
@@ -22031,6 +22093,9 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/door/poddoor/ship/preopen{
+	id = "brig shutters"
+	},
 /turf/open/floor/plating,
 /area/security/brig)
 "pJD" = (
@@ -23775,6 +23840,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/poddoor/ship/preopen{
+	id = "brig shutters"
+	},
 /turf/open/floor/plating,
 /area/security/brig)
 "qOb" = (
@@ -24895,6 +24963,16 @@
 	color = "#99FF99"
 	},
 /area/medical/virology)
+"rJe" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "ceshutter"
+	},
+/turf/open/floor/plating,
+/area/engine/engine_room/external{
+	name = "Stormdrive Interior"
+	})
 "rJi" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/machinery/camera/autoname{
@@ -26211,6 +26289,7 @@
 "sOv" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
 	id = "cmoshutter"
 	},
 /obj/structure/cable{
@@ -26250,6 +26329,9 @@
 /obj/effect/spawner/structure/window/reinforced/ship,
 /obj/structure/cable{
 	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/ship/preopen{
+	id = "brig shutters"
 	},
 /turf/open/floor/plating,
 /area/security/brig)
@@ -26597,6 +26679,7 @@
 /area/medical/medbay/central)
 "tdK" = (
 /obj/machinery/conveyor{
+	dir = 6;
 	id = "arrivals_baggage_claim";
 	operating = 1
 	},
@@ -27312,7 +27395,7 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/airlock/ship/security{
-	id_tag = "pw_fd_outer";
+	id_tag = "pw_fd_inner";
 	req_one_access_txt = "3;4;38;63"
 	},
 /turf/open/floor/carpet/ship,
@@ -28568,13 +28651,14 @@
 /area/medical/morgue)
 "uHC" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	id = "cmoshutter"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "cmoshutter"
+	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/cmo)
 "uHK" = (
@@ -30059,6 +30143,10 @@
 "vFY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
+/obj/machinery/door/poddoor/ship/preopen{
+	dir = 4;
+	id = "briglockdown"
+	},
 /turf/open/floor/plating,
 /area/security/warden)
 "vGe" = (
@@ -30691,6 +30779,10 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/machinery/door/poddoor/ship/preopen{
+	dir = 4;
+	id = "briglockdown"
+	},
 /turf/open/floor/plating,
 /area/security/warden)
 "wgR" = (
@@ -30749,7 +30841,7 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/airlock/ship/security{
-	id_tag = "pw_fd_outer";
+	id_tag = "pw_fd_inner";
 	req_one_access_txt = "3;4;38;63"
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
@@ -31804,6 +31896,10 @@
 	},
 /obj/item/paper{
 	info = "<p>Reminder that squad equipment vendors are located in the council chamber, tool storage, and that 4-way junction at the primary hallway, Deck 1</p>"
+	},
+/obj/machinery/door/poddoor/ship/preopen{
+	dir = 4;
+	id = "briglockdown"
 	},
 /turf/open/floor/plating,
 /area/security/warden)
@@ -54581,8 +54677,8 @@ fZX
 dch
 cxG
 fZX
-rKq
-rKq
+rJe
+rJe
 acZ
 acZ
 bTh
@@ -66145,7 +66241,7 @@ col
 lSq
 tdK
 kMh
-pzC
+byz
 vll
 qIM
 jex

--- a/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
@@ -691,10 +691,10 @@
 /turf/open/floor/carpet/ship/blue,
 /area/medical/patients_rooms/room_c)
 "awN" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/turf/open/space/basic,
+/obj/structure/hull_plate/end{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "awV" = (
 /obj/structure/chair/stool/bar,
@@ -1198,8 +1198,8 @@
 	dwidth = 3;
 	height = 15;
 	id = "arrivals_stationary";
-	name = "Deck 1 Arrivals Port";
-	roundstart_template = /datum/map_template/shuttle/arrival/box;
+	name = "Deck 2 Arrivals Port";
+	roundstart_template = /datum/map_template/shuttle/arrival/kilo;
 	width = 7
 	},
 /turf/open/space/basic,
@@ -2373,13 +2373,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/wood,
 /area/security/execution/education)
-"byz" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/space/basic,
-/area/space/nearstation)
 "byA" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
@@ -6415,7 +6408,7 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/airlock/ship/external/glass{
-	name = "External Access Deck 1 Starboard";
+	name = "External Access Deck 2 Starboard";
 	req_one_access_txt = "13"
 	},
 /turf/open/floor/plating,
@@ -8118,11 +8111,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /obj/machinery/door/airlock/ship/external/glass{
-	name = "External Access Deck 1 Starboard";
+	name = "External Access Deck 2 Starboard";
 	req_one_access_txt = "13"
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "fDK" = (
@@ -9464,7 +9457,7 @@
 /area/medical/surgery)
 "gKb" = (
 /obj/machinery/door/airlock/ship/command{
-	name = "Deck 1 Generator";
+	name = "Gravity Generator Room";
 	req_one_access_txt = "10"
 	},
 /obj/machinery/door/firedoor/border_only/directional/west,
@@ -9555,7 +9548,7 @@
 "gOq" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/machinery/door/airlock/ship/external/glass{
-	name = "External Access Deck 1 Port";
+	name = "External Access Deck 2 Port";
 	req_one_access_txt = "13"
 	},
 /turf/open/floor/plating,
@@ -16055,7 +16048,7 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/airlock/ship/external/glass{
-	name = "External Access Deck 1 Port";
+	name = "External Access Deck 2 Port";
 	req_one_access_txt = "13"
 	},
 /turf/open/floor/plating,
@@ -18915,8 +18908,7 @@
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "noN" = (
-/obj/structure/hull_plate,
-/obj/structure/hull_plate,
+/obj/structure/hull_plate/end,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "npd" = (
@@ -20664,7 +20656,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/ship/external/glass{
-	name = "External Access Deck 1 Arch";
+	name = "External Access Deck 2 Arch";
 	req_one_access_txt = "13"
 	},
 /turf/open/floor/plating,
@@ -22760,7 +22752,7 @@
 /area/chapel/main)
 "qia" = (
 /obj/machinery/door/airlock/ship/external/glass{
-	name = "External Access Deck 1 Starboard";
+	name = "External Access Deck 2 Starboard";
 	req_one_access_txt = "13"
 	},
 /turf/open/floor/plating,
@@ -25377,7 +25369,7 @@
 "saQ" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/machinery/door/airlock/ship/external/glass{
-	name = "External Access Deck 1 Fore Port";
+	name = "External Access Deck 2 Fore Port";
 	req_one_access_txt = "2"
 	},
 /turf/open/floor/plating,
@@ -25759,11 +25751,11 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/kitchen)
 "sqk" = (
-/obj/machinery/computer/prisoner{
-	dir = 8
-	},
 /obj/machinery/camera/autoname{
 	dir = 9
+	},
+/obj/machinery/computer/prisoner/management{
+	dir = 8
 	},
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/warden)
@@ -26202,7 +26194,7 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/airlock/ship/external/glass{
-	name = "External Access Deck 1 Starboard";
+	name = "External Access Deck 2 Starboard";
 	req_one_access_txt = "13"
 	},
 /turf/open/floor/plating,
@@ -27598,7 +27590,7 @@
 "tQJ" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/machinery/door/airlock/ship/external/glass{
-	name = "External Access Deck 1 Starboard";
+	name = "External Access Deck 2 Starboard";
 	req_one_access_txt = "13"
 	},
 /turf/open/floor/plating,
@@ -27737,7 +27729,7 @@
 "tWo" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/machinery/door/airlock/ship/external/glass{
-	name = "External Access Deck 1 Fore Starboard";
+	name = "External Access Deck 2 Fore Starboard";
 	req_one_access_txt = "13"
 	},
 /turf/open/floor/plating,
@@ -28011,7 +28003,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/ship/external/glass{
-	name = "External Access Deck 1 Arch";
+	name = "External Access Deck 2 Arch";
 	req_one_access_txt = "13"
 	},
 /obj/structure/cable/white{
@@ -28881,7 +28873,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/door/airlock/ship/external/glass{
-	name = "External Access Deck 1 Fore Starboard";
+	name = "External Access Deck 2 Fore Starboard";
 	req_one_access_txt = "13"
 	},
 /turf/open/floor/plating,
@@ -31872,7 +31864,7 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/airlock/ship/external/glass{
-	name = "External Access Deck 1 Fore Port";
+	name = "External Access Deck 2 Fore Port";
 	req_one_access_txt = "2"
 	},
 /turf/open/floor/plating,
@@ -32380,7 +32372,7 @@
 /area/ai_monitored/security/armory/lockup)
 "xkN" = (
 /obj/machinery/door/airlock/ship/external/glass{
-	name = "External Access Deck 1 Starboard";
+	name = "External Access Deck 2 Starboard";
 	req_one_access_txt = "13"
 	},
 /turf/open/floor/plating,
@@ -48928,7 +48920,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 aIO
 fZX
@@ -48992,7 +48984,7 @@ mBS
 fcp
 aIO
 atr
-atr
+noN
 drp
 drp
 drp
@@ -49185,7 +49177,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 mjO
 aae
@@ -49249,7 +49241,7 @@ uPR
 xxr
 cxm
 atr
-atr
+noN
 drp
 drp
 drp
@@ -49442,7 +49434,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 icn
 oeJ
@@ -49506,7 +49498,7 @@ azc
 eOj
 aIO
 atr
-atr
+noN
 drp
 drp
 drp
@@ -49699,7 +49691,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 mjO
 aae
@@ -49763,7 +49755,7 @@ uPR
 xxr
 cxm
 atr
-atr
+noN
 drp
 drp
 drp
@@ -49956,7 +49948,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 icn
 oeJ
@@ -50020,7 +50012,7 @@ azc
 eOj
 aIO
 atr
-atr
+noN
 drp
 drp
 drp
@@ -50213,7 +50205,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 mjO
 aae
@@ -50277,7 +50269,7 @@ uPR
 xxr
 cxm
 atr
-atr
+noN
 drp
 drp
 drp
@@ -50470,7 +50462,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 aIO
 fZX
@@ -50534,7 +50526,7 @@ azc
 fcp
 aIO
 atr
-atr
+noN
 drp
 drp
 drp
@@ -50727,7 +50719,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 atr
 fZX
@@ -50791,7 +50783,7 @@ azc
 fcp
 atr
 atr
-atr
+noN
 drp
 drp
 drp
@@ -50984,7 +50976,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 atr
 fZX
@@ -51048,7 +51040,7 @@ azc
 fcp
 atr
 atr
-atr
+noN
 drp
 drp
 drp
@@ -51241,7 +51233,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 atr
 fZX
@@ -51305,7 +51297,7 @@ azc
 fcp
 atr
 atr
-atr
+noN
 drp
 drp
 drp
@@ -51498,7 +51490,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 atr
 fZX
@@ -51562,7 +51554,7 @@ azc
 fcp
 atr
 atr
-atr
+noN
 drp
 drp
 drp
@@ -51755,7 +51747,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 atr
 fZX
@@ -51819,7 +51811,7 @@ btl
 fcp
 atr
 atr
-atr
+noN
 drp
 drp
 drp
@@ -52012,7 +52004,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 atr
 fZX
@@ -52076,7 +52068,7 @@ azc
 fcp
 atr
 atr
-atr
+noN
 drp
 drp
 drp
@@ -52269,7 +52261,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 atr
 fZX
@@ -52333,7 +52325,7 @@ azc
 fcp
 atr
 atr
-atr
+noN
 drp
 drp
 drp
@@ -52526,7 +52518,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 atr
 fZX
@@ -52590,7 +52582,7 @@ tOt
 fcp
 atr
 atr
-atr
+noN
 drp
 drp
 drp
@@ -52783,7 +52775,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 atr
 fZX
@@ -52847,7 +52839,7 @@ llX
 fcp
 atr
 atr
-atr
+noN
 drp
 drp
 drp
@@ -53040,7 +53032,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 atr
 fZX
@@ -53104,7 +53096,7 @@ qMe
 fcp
 atr
 atr
-atr
+noN
 drp
 drp
 drp
@@ -53297,7 +53289,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 atr
 fZX
@@ -53361,7 +53353,7 @@ llX
 fcp
 atr
 atr
-atr
+noN
 drp
 drp
 drp
@@ -53554,7 +53546,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 atr
 fZX
@@ -53618,7 +53610,7 @@ llX
 eav
 atr
 atr
-atr
+noN
 drp
 drp
 drp
@@ -53811,7 +53803,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 atr
 fZX
@@ -53875,7 +53867,7 @@ llX
 fcp
 atr
 atr
-atr
+noN
 drp
 drp
 drp
@@ -54068,7 +54060,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 atr
 fZX
@@ -54132,7 +54124,7 @@ fsy
 fcp
 atr
 atr
-atr
+noN
 drp
 drp
 drp
@@ -54325,7 +54317,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 atr
 fZX
@@ -54389,7 +54381,7 @@ llX
 fcp
 atr
 atr
-atr
+noN
 drp
 drp
 drp
@@ -54583,7 +54575,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 fZX
 dch
@@ -54645,7 +54637,7 @@ vWz
 sLc
 fcp
 atr
-atr
+noN
 drp
 drp
 drp
@@ -54840,7 +54832,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 fZX
 vcT
@@ -54902,7 +54894,7 @@ llX
 dac
 fcp
 atr
-atr
+noN
 drp
 drp
 drp
@@ -55097,7 +55089,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 fZX
 vcT
@@ -55159,7 +55151,7 @@ rdx
 xWq
 fcp
 atr
-atr
+noN
 drp
 drp
 drp
@@ -55354,7 +55346,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 fZX
 aLW
@@ -55416,7 +55408,7 @@ llX
 qJx
 fcp
 atr
-atr
+noN
 drp
 drp
 drp
@@ -55611,7 +55603,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 fZX
 dmx
@@ -55673,7 +55665,7 @@ llX
 xWq
 fcp
 atr
-atr
+noN
 drp
 drp
 drp
@@ -55868,7 +55860,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 fZX
 yca
@@ -55930,7 +55922,7 @@ kGP
 kSa
 fcp
 atr
-atr
+noN
 drp
 drp
 drp
@@ -56125,7 +56117,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 fZX
 qDt
@@ -56187,7 +56179,7 @@ akq
 xWq
 fcp
 atr
-atr
+noN
 drp
 drp
 drp
@@ -56382,7 +56374,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 cvp
 fZX
 isN
@@ -56444,7 +56436,7 @@ bvN
 xWq
 fcp
 atr
-atr
+noN
 drp
 drp
 drp
@@ -56639,7 +56631,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 fZX
 elW
@@ -56701,7 +56693,7 @@ xWq
 qJx
 fcp
 atr
-atr
+noN
 drp
 drp
 drp
@@ -56896,7 +56888,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 fZX
 yca
@@ -56958,7 +56950,7 @@ xWq
 iKc
 fcp
 atr
-atr
+noN
 drp
 drp
 drp
@@ -64084,7 +64076,7 @@ drp
 drp
 drp
 drp
-aIO
+drp
 drp
 drp
 drp
@@ -64341,7 +64333,7 @@ drp
 drp
 drp
 drp
-awN
+drp
 drp
 drp
 drp
@@ -64598,14 +64590,14 @@ drp
 drp
 drp
 drp
-byz
-rnP
-rnP
-rnP
-rnP
-rnP
-rnP
-rnP
+drp
+drp
+drp
+drp
+drp
+drp
+drp
+drp
 jGa
 qIn
 kEW
@@ -64855,11 +64847,11 @@ drp
 drp
 drp
 drp
-awN
 drp
 drp
 drp
-rnP
+drp
+drp
 drp
 drp
 drp
@@ -65112,11 +65104,11 @@ drp
 drp
 drp
 drp
-aIO
 drp
 drp
 drp
-rnP
+drp
+drp
 drp
 drp
 drp
@@ -65369,11 +65361,11 @@ drp
 drp
 drp
 drp
-aIO
 drp
 drp
 drp
-rnP
+drp
+drp
 drp
 drp
 drp
@@ -65626,11 +65618,11 @@ drp
 drp
 drp
 drp
-aIO
 drp
 drp
 drp
-rnP
+drp
+drp
 drp
 drp
 drp
@@ -65883,11 +65875,11 @@ drp
 drp
 drp
 drp
-aIO
 drp
 drp
 drp
-rnP
+drp
+drp
 drp
 drp
 drp
@@ -66140,11 +66132,11 @@ drp
 drp
 drp
 drp
-awN
 drp
 drp
 drp
-rnP
+drp
+drp
 drp
 drp
 drp
@@ -66397,14 +66389,14 @@ drp
 drp
 drp
 drp
-byz
-rnP
-rnP
-rnP
-rnP
-rnP
-rnP
-rnP
+drp
+drp
+drp
+drp
+drp
+drp
+drp
+drp
 jGa
 ctT
 kEW
@@ -66654,7 +66646,7 @@ drp
 drp
 drp
 drp
-awN
+drp
 drp
 drp
 drp
@@ -66911,7 +66903,7 @@ drp
 drp
 drp
 drp
-aIO
+drp
 drp
 drp
 drp
@@ -67433,7 +67425,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 eXv
 bWv
@@ -67690,7 +67682,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 fyD
 eXv
 fTT
@@ -67752,7 +67744,7 @@ bmf
 vqt
 iLN
 atr
-atr
+noN
 drp
 drp
 drp
@@ -67947,7 +67939,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 fyD
 eXv
 vzU
@@ -68009,7 +68001,7 @@ vsf
 pQv
 trj
 atr
-atr
+noN
 drp
 drp
 drp
@@ -68204,7 +68196,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 fyD
 eXv
 sRt
@@ -68461,7 +68453,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 eXv
 eXv
@@ -68718,7 +68710,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 icn
 pJt
@@ -68975,7 +68967,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 icn
 qNy
@@ -69232,7 +69224,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 icn
 sQH
@@ -69489,7 +69481,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 mjO
 snG
@@ -69746,7 +69738,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 icn
 ayN
@@ -70003,7 +69995,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 icn
 qNy
@@ -70260,7 +70252,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 icn
 sQH
@@ -70517,7 +70509,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 mjO
 snG
@@ -70774,7 +70766,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 icn
 pJt
@@ -71031,7 +71023,7 @@ drp
 drp
 eLi
 drp
-atr
+awN
 atr
 icn
 qNy
@@ -71288,7 +71280,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 icn
 sQH
@@ -71545,7 +71537,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 mjO
 snG
@@ -71802,7 +71794,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 icn
 pJt
@@ -72059,7 +72051,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 icn
 qNy
@@ -72316,7 +72308,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 icn
 sQH
@@ -72573,7 +72565,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 wLO
 wLO
@@ -72830,7 +72822,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 wLO
 bBq
@@ -73087,7 +73079,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 fyD
 wLO
 cZt
@@ -73344,7 +73336,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 fyD
 wLO
 ehh
@@ -73601,7 +73593,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 fyD
 wLO
 eoz
@@ -73858,7 +73850,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 bWG
 wLO
 fbW
@@ -74115,7 +74107,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 fyD
 wLO
 ffw
@@ -74372,7 +74364,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 fyD
 wLO
 foi
@@ -74629,7 +74621,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 fyD
 wLO
 fFJ
@@ -74886,7 +74878,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 atr
 uhH
 uhH
@@ -74948,7 +74940,7 @@ vNp
 wYY
 mvd
 fyD
-atr
+noN
 drp
 drp
 drp
@@ -75143,7 +75135,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 fyD
 uhH
 fGx
@@ -75205,7 +75197,7 @@ vNp
 wYY
 mvd
 fyD
-atr
+noN
 drp
 drp
 drp
@@ -75400,7 +75392,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 fyD
 uhH
 fGx
@@ -75462,7 +75454,7 @@ vNp
 wYY
 mvd
 fyD
-atr
+noN
 drp
 drp
 drp
@@ -75657,7 +75649,7 @@ drp
 drp
 drp
 drp
-atr
+awN
 fyD
 uhH
 fGx

--- a/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
@@ -318,7 +318,7 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/airlock/ship/security/glass{
-	name = "Lawyer Office";
+	name = "Law Office";
 	req_one_access_txt = "38"
 	},
 /obj/structure/disposalpipe/segment,
@@ -11802,14 +11802,14 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/break_room)
 "iuT" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/wood,
 /area/lawoffice)
 "ivA" = (
@@ -22865,10 +22865,6 @@
 /turf/open/floor/plating,
 /area/security/prison)
 "qlM" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc/auto_name/north,
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/camera/autoname{
 	dir = 5
@@ -24365,6 +24361,10 @@
 "rnj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
@@ -33310,6 +33310,12 @@
 	},
 /turf/open/floor/carpet/ship/blue,
 /area/medical/apothecary)
+"xSI" = (
+/obj/machinery/chem_dispenser/mutagensaltpetersmall,
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#99FF99"
+	},
+/area/hydroponics)
 "xSX" = (
 /obj/structure/closet/wardrobe/white/medical,
 /obj/machinery/airalarm/directional/north,
@@ -64622,7 +64628,7 @@ bfy
 hPx
 hPx
 jDv
-jDv
+xSI
 nfK
 kbE
 fUj

--- a/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
@@ -7794,6 +7794,16 @@
 /obj/machinery/chem_master,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/chemistry)
+"fsj" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "ceshutter"
+	},
+/turf/open/floor/plating,
+/area/engine/engine_room/external{
+	name = "Stormdrive Interior"
+	})
 "fsv" = (
 /turf/closed/wall/ship,
 /area/security/checkpoint/engineering)
@@ -14025,7 +14035,7 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/airlock/ship/medical{
-	name = "Plumbing";
+	name = "Chemistry Manufacturing";
 	req_access_txt = "6;33"
 	},
 /obj/structure/disposalpipe/segment{
@@ -33797,16 +33807,6 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"yeT" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	dir = 4;
-	id = "ceshutter"
-	},
-/turf/open/floor/plating,
-/area/engine/engine_room/external{
-	name = "Stormdrive Interior"
-	})
 "yfp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -54677,8 +54677,8 @@ fZX
 dch
 cxG
 fZX
-yeT
-yeT
+fsj
+fsj
 acZ
 acZ
 bTh

--- a/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
@@ -4305,6 +4305,10 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"cVO" = (
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/department/security)
 "cWq" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5004,6 +5008,10 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
+"dwp" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/carpet/ship/blue,
+/area/medical/patients_rooms/room_b)
 "dws" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/open/floor/plating,
@@ -6205,10 +6213,6 @@
 /area/security/main{
 	name = "Security War Room"
 	})
-"ekq" = (
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/carpet/ship/blue,
-/area/medical/patients_rooms/room_d)
 "ekt" = (
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/carpet/ship/red_carpet,
@@ -7317,10 +7321,6 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/shuttle/turbolift/secondary)
-"eZY" = (
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/plating,
-/area/maintenance/department/security)
 "faJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -7455,13 +7455,6 @@
 	},
 /turf/open/floor/engine/n2,
 /area/engine/atmos)
-"fey" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	id = "chapel_shutters_space"
-	},
-/turf/open/floor/plating,
-/area/chapel/main)
 "feG" = (
 /obj/structure/closet/radiation,
 /obj/item/clothing/mask/gas,
@@ -10546,6 +10539,16 @@
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
+"hxA" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "ceshutter"
+	},
+/turf/open/floor/plating,
+/area/engine/engine_room/external{
+	name = "Stormdrive Interior"
+	})
 "hxC" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable{
@@ -12325,17 +12328,6 @@
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
-"iMP" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/machinery/button/door{
-	id = "chapel_shutters_space";
-	name = "chapel shutters control";
-	pixel_x = -6;
-	pixel_y = -25
-	},
-/turf/open/floor/wood,
-/area/chapel/main)
 "iMR" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -12663,6 +12655,17 @@
 /obj/item/surgical_drapes,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/surgery)
+"jbz" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/machinery/button/door{
+	id = "chapel_shutters_space";
+	name = "chapel shutters control";
+	pixel_x = -6;
+	pixel_y = -25
+	},
+/turf/open/floor/wood,
+/area/chapel/main)
 "jbE" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -14544,11 +14547,6 @@
 	},
 /turf/open/floor/carpet/ship/red_carpet,
 /area/crew_quarters/heads/hos)
-"kpS" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/grown/poppy/lily,
-/turf/open/floor/carpet/royalblack,
-/area/chapel/main)
 "kqi" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 4
@@ -18857,6 +18855,11 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
 /area/security/execution/education)
+"niq" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/grown/poppy/lily,
+/turf/open/floor/carpet/royalblack,
+/area/chapel/main)
 "niT" = (
 /obj/structure/table/glass,
 /obj/structure/cable{
@@ -20056,6 +20059,13 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"oeB" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "chapel_shutters_space"
+	},
+/turf/open/floor/plating,
+/area/chapel/main)
 "oeJ" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
 /turf/open/floor/plating,
@@ -21315,14 +21325,6 @@
 	},
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/department/medical)
-"pbZ" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	dir = 4;
-	id = "chapel_shutters_space"
-	},
-/turf/open/floor/plating,
-/area/chapel/main)
 "pcq" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -22171,6 +22173,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"pJY" = (
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/carpet/ship/blue,
+/area/medical/patients_rooms/room_d)
 "pKs" = (
 /obj/machinery/computer/warrant{
 	dir = 1
@@ -23467,6 +23473,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/item/extrapolator,
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#99FF99"
 	},
@@ -25447,16 +25454,6 @@
 /obj/item/cartridge/medical,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/storage)
-"saz" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	dir = 4;
-	id = "ceshutter"
-	},
-/turf/open/floor/plating,
-/area/engine/engine_room/external{
-	name = "Stormdrive Interior"
-	})
 "saD" = (
 /obj/structure/table/glass,
 /obj/item/storage/fancy/donut_box,
@@ -29013,6 +29010,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"uTi" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/engine,
+/area/gateway)
 "uTl" = (
 /obj/machinery/vending/wallmed{
 	pixel_x = 32
@@ -30303,6 +30304,14 @@
 /obj/machinery/holopad,
 /turf/open/floor/wood,
 /area/lawoffice)
+"vIF" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "chapel_shutters_space"
+	},
+/turf/open/floor/plating,
+/area/chapel/main)
 "vJq" = (
 /turf/closed/wall/ship,
 /area/storage/tech)
@@ -34019,10 +34028,6 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/plating,
 /area/security/prison)
-"yjQ" = (
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/carpet/ship/blue,
-/area/medical/patients_rooms/room_b)
 "yjR" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -54733,8 +54738,8 @@ fZX
 dch
 cxG
 fZX
-saz
-saz
+hxA
+hxA
 acZ
 acZ
 bTh
@@ -59114,7 +59119,7 @@ gUq
 hIl
 ckj
 fZX
-wLi
+uTi
 wLi
 biy
 tvH
@@ -61720,7 +61725,7 @@ wnw
 mVk
 tJL
 lYW
-iMP
+jbz
 jBW
 aIO
 drp
@@ -61978,7 +61983,7 @@ mVk
 mVk
 iEN
 mVk
-fey
+oeB
 icn
 drp
 drp
@@ -62235,7 +62240,7 @@ eoO
 mVk
 iEN
 ojk
-fey
+oeB
 icn
 drp
 drp
@@ -62492,7 +62497,7 @@ mVk
 lNi
 uQl
 lNi
-fey
+oeB
 icn
 aIO
 drp
@@ -63263,7 +63268,7 @@ wEc
 jhM
 foC
 fKi
-fey
+oeB
 icn
 drp
 drp
@@ -63520,7 +63525,7 @@ mVk
 lNi
 uQl
 lNi
-fey
+oeB
 icn
 drp
 drp
@@ -63777,7 +63782,7 @@ wEc
 jhM
 foC
 fKi
-fey
+oeB
 icn
 drp
 drp
@@ -64293,8 +64298,8 @@ foC
 fKi
 jBW
 jBW
-pbZ
-pbZ
+vIF
+vIF
 jBW
 uzR
 jBW
@@ -65062,7 +65067,7 @@ mVk
 lNi
 uQl
 ieg
-kpS
+niq
 gdT
 gdT
 bAp
@@ -71712,7 +71717,7 @@ oZp
 xSb
 jGf
 eaE
-eZY
+cVO
 oZp
 lGF
 dCv
@@ -73527,7 +73532,7 @@ nGw
 nGw
 mLU
 ksS
-yjQ
+dwp
 ikd
 ybo
 uDi
@@ -73539,7 +73544,7 @@ rxk
 tYt
 xzn
 kCK
-ekq
+pJY
 pQv
 qzL
 pvR

--- a/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
@@ -993,6 +993,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/restrooms)
 "aIO" = (
@@ -1583,6 +1584,12 @@
 /area/security/prison)
 "bdj" = (
 /obj/structure/table/glass,
+/obj/machinery/requests_console{
+	department = "Medbay";
+	departmentType = 1;
+	name = "Medbay RC";
+	pixel_y = -32
+	},
 /turf/open/floor/carpet/ship/blue,
 /area/medical/medbay/lobby)
 "bdF" = (
@@ -3332,6 +3339,10 @@
 	req_one_access_txt = "33"
 	},
 /obj/machinery/door/window/southleft,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "chemistry_shutters";
+	name = "chemistry shutters"
+	},
 /turf/open/floor/plating,
 /area/medical/chemistry)
 "chS" = (
@@ -5802,7 +5813,7 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/airlock/ship/maintenance{
-	name = "Maintenance Access Medbay and Plumbing";
+	name = "Maintenance Access Infirmary and Plumbing";
 	req_one_access_txt = "5;33"
 	},
 /obj/structure/sign/departments/minsky/medical/chemistry/chemical2{
@@ -6536,6 +6547,11 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "chemistry_shutters";
+	name = "chemistry shutters"
+	},
 /turf/open/floor/plating,
 /area/medical/chemistry)
 "eye" = (
@@ -6641,6 +6657,13 @@
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/break_room)
+"eCo" = (
+/obj/structure/table,
+/obj/item/paicard,
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/lounge{
+	name = "Cafeteria"
+	})
 "eEn" = (
 /obj/machinery/camera/motion{
 	c_tag = "External Viewport Prison Wing";
@@ -7325,6 +7348,11 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
 	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "chemistry_shutters";
+	name = "chemistry shutters"
 	},
 /turf/open/floor/plating,
 /area/medical/chemistry)
@@ -8118,7 +8146,7 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/airlock/ship/maintenance{
-	name = "Maintenance Access Medbay Lobby";
+	name = "Maintenance Access Infirmary Lobby";
 	req_one_access_txt = "5"
 	},
 /turf/open/floor/plating,
@@ -8411,6 +8439,11 @@
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "chemistry_shutters";
+	name = "chemistry shutters"
 	},
 /turf/open/floor/plating,
 /area/medical/chemistry)
@@ -9311,6 +9344,9 @@
 	req_one_access_txt = "6;39;68"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/carpet/ship/blue,
 /area/medical/genetics/cloning)
 "gCF" = (
@@ -9999,12 +10035,13 @@
 /turf/open/floor/engine/plasma,
 /area/engine/atmos)
 "haC" = (
-/obj/machinery/requests_console{
-	department = "Medbay";
-	departmentType = 1;
-	name = "Medbay RC"
-	},
 /obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	desc = "A remote control switch for the medbay foyer.";
+	id = "MedbayFoyer";
+	name = "Medbay Doors Control";
+	normaldoorcontrol = 1
+	},
 /turf/open/floor/carpet/blue,
 /area/medical/medbay/lobby)
 "hba" = (
@@ -10550,11 +10587,8 @@
 	name = "Stormdrive Interior"
 	})
 "hxC" = (
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/clonepod,
+/obj/machinery/clonepod/prefilled,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/genetics/cloning)
 "hyv" = (
@@ -11403,6 +11437,9 @@
 	req_one_access_txt = "5;6;39;68"
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
 	},
 /turf/open/floor/carpet/ship/blue,
@@ -13977,6 +14014,8 @@
 	dir = 4;
 	icon_state = "rwindow"
 	},
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/genetics/cloning)
 "jSP" = (
@@ -15455,7 +15494,7 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/airlock/ship/medical{
-	name = "Medbay Lobby";
+	name = "Infirmary Reception";
 	req_one_access_txt = "5"
 	},
 /obj/structure/disposalpipe/segment,
@@ -18451,6 +18490,9 @@
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen,
+/obj/machinery/vending/wallmed{
+	pixel_y = -32
+	},
 /turf/open/floor/carpet/ship/blue,
 /area/medical/medbay/central)
 "mUq" = (
@@ -19910,7 +19952,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/ship/medical{
-	name = "Medbay Lobby"
+	name = "Infirmary Lobby"
 	},
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue,
@@ -21478,9 +21520,6 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/vending/wallmed{
-	pixel_x = 32
-	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -22923,6 +22962,9 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/carpet/blue,
 /area/medical/genetics/cloning)
 "qkh" = (
@@ -23135,10 +23177,10 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/airlock/ship/medical{
-	name = "Medbay Lobby"
-	},
 /obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/airlock/ship/medical{
+	name = "Infirmary Lobby"
+	},
 /turf/open/floor/carpet/ship/blue,
 /area/medical/medbay/lobby)
 "qqj" = (
@@ -23949,6 +23991,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/carpet/ship/blue,
 /area/medical/genetics/cloning)
 "qPX" = (
@@ -24725,8 +24770,11 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/ship/medical{
-	name = "Medbay";
+	id_tag = "MedbayFoyer";
 	req_one_access_txt = "5;6;33;39;68"
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
 	},
 /turf/open/floor/carpet/ship/blue,
 /area/medical/medbay/lobby)
@@ -25581,12 +25629,15 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/airlock/ship/medical{
-	name = "Medbay";
-	req_one_access_txt = "5;6;33;39;68"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/medical{
+	id_tag = "MedbayFoyer";
+	req_one_access_txt = "5;6;33;39;68"
 	},
 /turf/open/floor/carpet/ship/blue,
 /area/medical/medbay/lobby)
@@ -27965,7 +28016,7 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/airlock/ship/maintenance{
-	name = "Maintenance Access Medbay";
+	name = "Maintenance Access Infirmary";
 	req_one_access_txt = "5"
 	},
 /turf/open/floor/carpet/ship/blue,
@@ -28236,6 +28287,7 @@
 "upa" = (
 /obj/machinery/recharge_station,
 /obj/effect/landmark/start/cyborg,
+/obj/machinery/light,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/storage)
 "upb" = (
@@ -29308,9 +29360,6 @@
 /area/crew_quarters/kitchen)
 "vei" = (
 /obj/machinery/vending/cola/random,
-/obj/machinery/vending/wallmed{
-	pixel_x = 32
-	},
 /turf/open/floor/carpet/ship/blue,
 /area/medical/medbay/lobby)
 "vez" = (
@@ -32543,15 +32592,9 @@
 /area/engine/atmos)
 "xmb" = (
 /obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet/ship/blue,
+/turf/open/floor/carpet/blue,
 /area/medical/genetics/cloning)
 "xmt" = (
 /obj/structure/cable/yellow{
@@ -33060,6 +33103,11 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "chemistry_shutters";
+	name = "chemistry shutters"
+	},
 /turf/open/floor/plating,
 /area/medical/chemistry)
 "xDq" = (
@@ -33473,7 +33521,6 @@
 /area/medical/apothecary)
 "xSX" = (
 /obj/structure/closet/wardrobe/white/medical,
-/obj/machinery/airalarm/directional/north,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -60428,7 +60475,7 @@ xAn
 gkd
 olz
 olz
-rSl
+eCo
 tdz
 xWq
 tdz
@@ -76103,7 +76150,7 @@ tgQ
 fvs
 xSX
 wut
-wut
+xmb
 qPW
 jSp
 gAd
@@ -76358,7 +76405,7 @@ mpb
 jDn
 fZN
 hbv
-xmb
+aqr
 lqv
 qjc
 dZB

--- a/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
@@ -685,6 +685,9 @@
 "awG" = (
 /obj/machinery/stasis,
 /obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/open/floor/carpet/ship/blue,
 /area/medical/patients_rooms/room_c)
 "awN" = (
@@ -1439,6 +1442,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
 	id = "interrogatorshutter"
 	},
 /turf/open/floor/plating,
@@ -3405,6 +3409,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
 	id = "interrogatorshutter"
 	},
 /turf/open/floor/plating,
@@ -7615,6 +7620,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
 	id = "hosshutter"
 	},
 /turf/open/floor/plating,
@@ -9401,6 +9407,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
 	id = "hosshutter"
 	},
 /turf/open/floor/plating,
@@ -17570,6 +17577,7 @@
 	dir = 8
 	},
 /obj/machinery/door/poddoor/shutters/ship{
+	dir = 4;
 	id = "cell1_ld"
 	},
 /obj/structure/cable{
@@ -22067,6 +22075,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
 	id = "interrogatorshutter"
 	},
 /turf/open/floor/plating,
@@ -32859,6 +32868,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
 	id = "hosshutter"
 	},
 /turf/open/floor/plating,
@@ -33248,6 +33258,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
 	id = "interrogatorshutter"
 	},
 /turf/open/floor/plating,

--- a/_maps/map_files/Aetherwhisp/Aetherwhisp2.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp2.dmm
@@ -3672,6 +3672,22 @@
 	},
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/science/xenobiology)
+"cFY" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/carpet/ship/blue{
+	color = "#9999DD";
+	name = "nanoweave carpet (bluer)"
+	},
+/area/teleporter)
 "cGt" = (
 /obj/effect/turf_decal/arrows{
 	dir = 8;
@@ -5917,6 +5933,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/auxiliary)
 "eDn" = (
@@ -6279,6 +6296,7 @@
 "eQL" = (
 /obj/structure/rack,
 /obj/structure/window/reinforced,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "eQT" = (
@@ -7767,6 +7785,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/engine,
 /area/engine/engineering/hangar{
 	name = "Bridge Gravity Generator"
@@ -7820,6 +7839,14 @@
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
+"fZG" = (
+/obj/effect/turf_decal/delivery/white,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
+/area/nsv/weapons/fore)
 "gag" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/engine,
@@ -9199,6 +9226,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "hlr" = (
@@ -10742,6 +10770,12 @@
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
+"iIQ" = (
+/obj/structure/closet/secure_closet/personal{
+	anchored = 1
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/dorms)
 "iIV" = (
 /obj/structure/bed,
 /obj/item/bedsheet/hop,
@@ -11089,17 +11123,6 @@
 /obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/carpet/ship/beige_carpet,
 /area/quartermaster/storage)
-"jcL" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	dir = 4;
-	id = "tcommsatshutter"
-	},
-/turf/open/floor/plating,
-/area/science/server)
 "jcR" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable/yellow{
@@ -13182,12 +13205,6 @@
 	name = "nanoweave carpet (bluer)"
 	},
 /area/bridge/showroom/corporate)
-"kNm" = (
-/obj/structure/closet/secure_closet/personal{
-	anchored = 1
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/dorms)
 "kNU" = (
 /obj/structure/chair,
 /turf/open/floor/carpet/ship,
@@ -15341,6 +15358,17 @@
 /area/science{
 	name = "Science Lobby"
 	})
+"mCq" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "tcommsatshutter"
+	},
+/turf/open/floor/plating,
+/area/science/server)
 "mCr" = (
 /obj/effect/turf_decal/delivery/white,
 /obj/machinery/status_display/evac/south,
@@ -15634,6 +15662,11 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
+"mOx" = (
+/obj/structure/closet/secure_closet/miner,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/carpet/ship/beige_carpet,
+/area/quartermaster/miningoffice)
 "mPz" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -22665,6 +22698,7 @@
 "syA" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/firealarm/directional/east,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
 "syB" = (
@@ -24558,6 +24592,14 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
+"ucr" = (
+/obj/structure/curtain,
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/toilet/locker)
 "udo" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -26607,6 +26649,12 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"vKS" = (
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/carpet/ship,
+/area/bridge/showroom{
+	name = "Battle Bridge"
+	})
 "vKW" = (
 /obj/structure/chair/office/light,
 /obj/effect/landmark/start/roboticist,
@@ -27685,6 +27733,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/start/depsec/supply,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/checkpoint/supply)
 "wGl" = (
@@ -49274,7 +49323,7 @@ nEh
 qgI
 xWZ
 xpP
-qYU
+ucr
 qYU
 qYU
 kJw
@@ -51334,8 +51383,8 @@ aJr
 mrH
 vPv
 duZ
-kNm
-kNm
+iIQ
+iIQ
 mrH
 aJr
 nfD
@@ -56212,7 +56261,7 @@ lww
 oOV
 lrc
 jzk
-uTr
+mOx
 ejO
 uTr
 qld
@@ -56994,7 +57043,7 @@ bfR
 aTn
 joF
 gDN
-gDN
+vKS
 nsQ
 pFt
 xai
@@ -57775,7 +57824,7 @@ nsQ
 nsQ
 wEX
 nsQ
-jcL
+mCq
 nsQ
 sLN
 lIB
@@ -69081,7 +69130,7 @@ pOI
 lDz
 lDz
 nzZ
-nzZ
+cFY
 snp
 bXh
 maU
@@ -71104,7 +71153,7 @@ hbT
 fMJ
 rNy
 fMJ
-wqr
+fZG
 sRk
 hOv
 gDg

--- a/_maps/map_files/Aetherwhisp/Aetherwhisp2.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp2.dmm
@@ -150,7 +150,7 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/airlock/ship/public{
 	id_tag = "cabin1";
-	name = "Cabin Room"
+	name = "Cabin 1"
 	},
 /obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/wood,
@@ -1444,7 +1444,7 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/airlock/ship/public{
 	id_tag = "cabin3";
-	name = "Cabin Room"
+	name = "Cabin 3"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
@@ -5072,6 +5072,12 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/captain)
+"dNM" = (
+/obj/structure/hull_plate/end{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "dOf" = (
 /turf/closed/wall/r_wall/ship,
 /area/quartermaster/storage)
@@ -5965,7 +5971,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/ship/external/glass{
-	name = "External Access Deck 2 Arch";
+	name = "External Access Deck 1 Arch";
 	req_one_access_txt = "46"
 	},
 /turf/open/floor/plating,
@@ -7279,7 +7285,7 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/airlock/ship/public{
 	id_tag = "cabin2";
-	name = "Cabin Room"
+	name = "Cabin 2"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
@@ -7456,11 +7462,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /obj/machinery/door/airlock/ship/external/glass{
-	name = "External Access Deck 2 Aft";
+	name = "External Access Deck 1 Aft";
 	req_one_access_txt = "13"
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "fLO" = (
@@ -7638,7 +7644,7 @@
 "fTx" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/machinery/door/airlock/ship/external/glass{
-	name = "External Access Deck 2 Fore Starboard";
+	name = "External Access Deck 1 Fore Starboard";
 	req_one_access_txt = "13"
 	},
 /turf/open/floor/plating,
@@ -8880,14 +8886,15 @@
 /area/bridge/meeting_room/council)
 "haP" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	id = "rndshutter"
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "rndshutter"
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
@@ -9131,6 +9138,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
+"hjm" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "tcommsatshutter"
+	},
+/turf/open/floor/plating,
+/area/science/server)
 "hjD" = (
 /obj/structure/chair{
 	dir = 8
@@ -9395,10 +9413,11 @@
 /area/quartermaster/warehouse)
 "hwX" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
 	id = "rndshutter"
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
 "hxk" = (
@@ -10122,6 +10141,13 @@
 	name = "nanoweave carpet (puce)"
 	},
 /area/nsv/weapons/fore)
+"icT" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "cabin2_privacy"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/dorms)
 "idc" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10202,7 +10228,7 @@
 "ijt" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/machinery/door/airlock/ship/external/glass{
-	name = "External Access Deck 2 Starboard";
+	name = "External Access Deck 1 Starboard";
 	req_one_access_txt = "13;7"
 	},
 /turf/open/floor/plating,
@@ -11040,9 +11066,16 @@
 	name = "Cabin Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = -25;
+	pixel_y = -8;
 	specialfunctions = 4
 	},
 /obj/item/lipstick/random,
+/obj/machinery/button/door{
+	id = "cabin2_privacy";
+	name = "Privacy Shutters";
+	pixel_x = -25;
+	pixel_y = 8
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "jaE" = (
@@ -11602,7 +11635,7 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/airlock/ship/public{
 	id_tag = "cabin4";
-	name = "Cabin Room"
+	name = "Cabin 4"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
@@ -12863,7 +12896,7 @@
 /area/science/explab)
 "kxO" = (
 /obj/machinery/door/airlock/ship/external/glass{
-	name = "External Access Deck 2 Aft";
+	name = "External Access Deck 1 Aft";
 	req_one_access_txt = "13"
 	},
 /turf/open/floor/plating,
@@ -14922,10 +14955,7 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "mpX" = (
-/obj/machinery/camera{
-	c_tag = "External Viewport Toxins"
-	},
-/obj/structure/hull_plate,
+/obj/structure/hull_plate/end,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "mpY" = (
@@ -16183,7 +16213,7 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/airlock/ship/external/glass{
-	name = "External Access Deck 2 Arch";
+	name = "External Access Deck 1 Arch";
 	req_one_access_txt = "46"
 	},
 /turf/open/floor/plating,
@@ -17037,7 +17067,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/ship/external/glass{
-	name = "External Access Deck 2 Arch";
+	name = "External Access Deck 1 Arch";
 	req_one_access_txt = "46"
 	},
 /turf/open/floor/plating,
@@ -17168,6 +17198,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"oih" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "cabin1_privacy"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/dorms)
 "oij" = (
 /obj/machinery/door/poddoor/shutters/ship{
 	id = "cargo_exterior"
@@ -17947,7 +17984,7 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/airlock/ship/external/glass{
-	name = "External Access Deck 2 Fore Starboard";
+	name = "External Access Deck 1 Fore Starboard";
 	req_one_access_txt = "13"
 	},
 /turf/open/floor/plating,
@@ -18185,7 +18222,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/ship/external/glass{
-	name = "External Access Deck 2 Arch";
+	name = "External Access Deck 1 Arch";
 	req_one_access_txt = "46"
 	},
 /turf/open/floor/plating,
@@ -18620,13 +18657,14 @@
 /area/science/mixing)
 "pts" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	id = "rndshutter"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "rndshutter"
+	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
 "ptx" = (
@@ -18779,7 +18817,7 @@
 /area/quartermaster/storage)
 "pwR" = (
 /obj/machinery/door/airlock/ship/external/glass{
-	name = "External Access Deck 2 Fore";
+	name = "External Access Deck 1 Fore";
 	req_one_access_txt = "19"
 	},
 /turf/open/floor/plating,
@@ -19324,7 +19362,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/door/airlock/ship/external/glass{
-	name = "External Access Deck 2 Starboard";
+	name = "External Access Deck 1 Starboard";
 	req_one_access_txt = "13;7"
 	},
 /turf/open/floor/plating,
@@ -20790,7 +20828,9 @@
 	c_tag = "External Viewport Hangar";
 	dir = 1
 	},
-/obj/structure/hull_plate,
+/obj/structure/hull_plate/end{
+	dir = 1
+	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "rfB" = (
@@ -23703,7 +23743,7 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/airlock/ship/public{
 	id_tag = "cabin8";
-	name = "Cabin Room"
+	name = "Cabin 8"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
@@ -24301,7 +24341,7 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/airlock/ship/public{
 	id_tag = "cabin7";
-	name = "Cabin Room"
+	name = "Cabin 7"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -24510,11 +24550,12 @@
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	id = "rndshutter"
-	},
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "rndshutter"
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
@@ -24715,9 +24756,16 @@
 	name = "Cabin Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = 25;
+	pixel_y = -8;
 	specialfunctions = 4
 	},
 /obj/item/lipstick/random,
+/obj/machinery/button/door{
+	id = "cabin1_privacy";
+	name = "Privacy Shutters";
+	pixel_x = 25;
+	pixel_y = 8
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "ulz" = (
@@ -25066,7 +25114,7 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/airlock/ship/external/glass{
-	name = "External Access Deck 2 Fore";
+	name = "External Access Deck 1 Fore";
 	req_one_access_txt = "19"
 	},
 /turf/open/floor/plating,
@@ -26288,7 +26336,7 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/airlock/ship/public{
 	id_tag = "cabin5";
-	name = "Cabin Room"
+	name = "Cabin 5"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
@@ -28256,6 +28304,7 @@
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
 	id = "rndshutter"
 	},
 /turf/open/floor/plating,
@@ -28327,7 +28376,7 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/airlock/ship/public{
 	id_tag = "cabin6";
-	name = "Cabin Room"
+	name = "Cabin 6"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
@@ -29342,7 +29391,9 @@
 	c_tag = "External Viewport Munitions 1";
 	dir = 8
 	},
-/obj/structure/hull_plate,
+/obj/structure/hull_plate/end{
+	dir = 1
+	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "ycm" = (
@@ -44570,7 +44621,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 sdP
 iMh
@@ -44634,7 +44685,7 @@ twh
 iMh
 sdP
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -44827,7 +44878,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 hvg
 axG
@@ -44891,7 +44942,7 @@ sgT
 fCZ
 fMW
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -45084,7 +45135,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 hbT
 ptx
@@ -45148,7 +45199,7 @@ lqv
 ptx
 hbT
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -45341,7 +45392,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 hvg
 axG
@@ -45405,7 +45456,7 @@ qmb
 fCZ
 fMW
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -45598,7 +45649,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 hbT
 ptx
@@ -45662,7 +45713,7 @@ xKo
 ptx
 hbT
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -45855,7 +45906,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 hvg
 axG
@@ -45919,7 +45970,7 @@ xXS
 fCZ
 fMW
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -46112,7 +46163,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 aee
 iMh
@@ -46176,7 +46227,7 @@ xKo
 iMh
 sdP
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -46369,7 +46420,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 aee
 iMh
@@ -46433,7 +46484,7 @@ xKo
 iMh
 aee
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -46626,7 +46677,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 aee
 iMh
@@ -46690,7 +46741,7 @@ xKo
 iMh
 aee
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -46883,7 +46934,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 aee
 iMh
@@ -46947,7 +46998,7 @@ xKo
 iMh
 aee
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -47140,7 +47191,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 aee
 iMh
@@ -47204,7 +47255,7 @@ xKo
 iMh
 aee
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -47397,7 +47448,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 aee
 iMh
@@ -47461,7 +47512,7 @@ xKo
 iMh
 aee
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -47654,7 +47705,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 aee
 fyO
@@ -47718,7 +47769,7 @@ xKo
 iMh
 aee
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -47911,7 +47962,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 owl
 gqs
@@ -47975,7 +48026,7 @@ pjX
 iMh
 aee
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -48168,7 +48219,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 owl
 gqs
@@ -48232,7 +48283,7 @@ tZs
 iMh
 aee
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -48425,7 +48476,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 owl
 gqs
@@ -48489,7 +48540,7 @@ tZs
 iMh
 aee
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -48682,7 +48733,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 aee
 fyO
@@ -48746,7 +48797,7 @@ tZs
 iMh
 aee
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -48939,7 +48990,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 aee
 kJw
@@ -49003,7 +49054,7 @@ tZs
 iMh
 aee
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -49196,7 +49247,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 aee
 kJw
@@ -49260,7 +49311,7 @@ tZs
 oXb
 aee
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -49453,10 +49504,10 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 owl
-cTw
+oih
 lvL
 wwn
 bzb
@@ -49517,7 +49568,7 @@ tZs
 iMh
 aee
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -49710,10 +49761,10 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 owl
-cTw
+oih
 cQA
 cal
 nOF
@@ -49774,7 +49825,7 @@ tZs
 iMh
 aee
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -49967,7 +50018,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 aee
 kJw
@@ -50031,7 +50082,7 @@ tZs
 iMh
 aee
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -50225,7 +50276,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 kJw
 duZ
@@ -50287,7 +50338,7 @@ iMh
 tZs
 iMh
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -50482,7 +50533,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 owl
 cTw
 frO
@@ -50544,7 +50595,7 @@ iMh
 udo
 iMh
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -50739,7 +50790,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 owl
 cTw
 xQl
@@ -50801,7 +50852,7 @@ uEh
 lNh
 fgg
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -50996,7 +51047,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 kJw
 duZ
@@ -51058,7 +51109,7 @@ tRF
 fgg
 fgg
 fgg
-aee
+mpX
 nZT
 nZT
 nZT
@@ -51253,7 +51304,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 kJw
 jag
@@ -51315,7 +51366,7 @@ aIu
 cSK
 uIO
 pLt
-aee
+mpX
 nZT
 nZT
 nZT
@@ -51510,9 +51561,9 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 owl
-cTw
+icT
 aJr
 ggo
 nOF
@@ -51767,9 +51818,9 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 owl
-cTw
+icT
 cQA
 vOI
 hqe
@@ -51829,7 +51880,7 @@ aIu
 qAw
 fgg
 uDg
-aee
+mpX
 nZT
 nZT
 nZT
@@ -52024,7 +52075,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 dDt
 kJw
 hJG
@@ -52086,7 +52137,7 @@ esn
 lGW
 gnA
 oma
-aee
+mpX
 nZT
 nZT
 nZT
@@ -52281,7 +52332,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 hla
 hlc
@@ -52343,7 +52394,7 @@ aIu
 nRe
 cBF
 owl
-aee
+mpX
 nZT
 nZT
 nZT
@@ -52538,7 +52589,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 hla
 nRP
@@ -52600,7 +52651,7 @@ aIu
 cfH
 fgg
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -57719,7 +57770,7 @@ nsQ
 nsQ
 wEX
 nsQ
-jOK
+hjm
 nsQ
 sLN
 lIB
@@ -63075,7 +63126,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 owl
 jQc
 vpq
@@ -63332,7 +63383,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 owl
 jQc
 ePh
@@ -63394,7 +63445,7 @@ rlD
 bTI
 qhB
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -63589,7 +63640,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 mgr
 mgr
 mgr
@@ -63651,7 +63702,7 @@ rlD
 bTI
 qhB
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -63846,7 +63897,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 mDy
 mzQ
 vDc
@@ -63908,7 +63959,7 @@ rlD
 frq
 qhB
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -64103,7 +64154,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 mDy
 lDE
 rjk
@@ -64165,7 +64216,7 @@ nhj
 bTI
 qhB
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -64360,7 +64411,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 mDy
 sBq
 nIK
@@ -64422,7 +64473,7 @@ gBZ
 xpf
 qhB
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -64679,7 +64730,7 @@ nhj
 nhj
 qhB
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -64874,7 +64925,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 jXx
 mzQ
 vDc
@@ -64936,7 +64987,7 @@ rlD
 rlD
 qhB
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -65131,7 +65182,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 jXx
 lDE
 rjk
@@ -65193,7 +65244,7 @@ oVJ
 jxE
 xMP
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -65388,7 +65439,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 jXx
 sBq
 eSC
@@ -65450,7 +65501,7 @@ nUQ
 oVJ
 xMP
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -65645,7 +65696,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 mgr
 mgr
 mgr
@@ -65707,7 +65758,7 @@ oVJ
 oVJ
 xMP
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -65902,7 +65953,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 xnd
 iUH
@@ -65964,7 +66015,7 @@ oVJ
 oVJ
 xMP
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -66159,7 +66210,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 owl
 wNh
 qzq
@@ -66221,7 +66272,7 @@ oVJ
 oVJ
 xMP
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -66416,7 +66467,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 owl
 mYb
 iEl
@@ -66478,7 +66529,7 @@ iOt
 iOt
 xMP
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -66673,7 +66724,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 owl
 mYb
 tdz
@@ -66735,7 +66786,7 @@ sdz
 nps
 xMP
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -66930,7 +66981,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 wNh
 ycv
@@ -66992,7 +67043,7 @@ uvI
 uvI
 xMP
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -67187,7 +67238,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 wNh
 mav
@@ -67249,7 +67300,7 @@ msR
 hys
 xMP
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -67444,7 +67495,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 wNh
 wjT
@@ -67506,7 +67557,7 @@ wSw
 xMP
 xMP
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -67701,7 +67752,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 hbT
 wjT
@@ -67763,7 +67814,7 @@ iOt
 xMP
 hbT
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -67958,7 +68009,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 hbT
 wjT
@@ -68020,7 +68071,7 @@ gSZ
 uxC
 hbT
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -68215,7 +68266,7 @@ nZT
 aEe
 nZT
 nZT
-aee
+dNM
 aee
 hbT
 wjT
@@ -68277,7 +68328,7 @@ nCR
 uxC
 hbT
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -68472,7 +68523,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 hvg
 hWj
@@ -68534,7 +68585,7 @@ oIn
 tlN
 fMW
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -68729,7 +68780,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 hbT
 wjT
@@ -68791,7 +68842,7 @@ gSZ
 uxC
 hbT
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -68986,7 +69037,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 hbT
 wjT
@@ -69048,7 +69099,7 @@ knK
 uxC
 hbT
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -69243,7 +69294,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 hbT
 wjT
@@ -69305,7 +69356,7 @@ iUx
 uxC
 hbT
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -69500,7 +69551,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 hvg
 hWj
@@ -69562,7 +69613,7 @@ oIn
 tlN
 fMW
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -69757,7 +69808,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 hbT
 fMJ
@@ -69819,7 +69870,7 @@ knK
 uxC
 hbT
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -70014,7 +70065,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 hbT
 fMJ
@@ -70076,7 +70127,7 @@ cAg
 uxC
 hbT
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -70271,7 +70322,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 hbT
 fMJ
@@ -70333,7 +70384,7 @@ gSZ
 uxC
 hbT
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -70528,7 +70579,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 hvg
 tWA
@@ -70590,7 +70641,7 @@ tay
 tlN
 fMW
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -70785,7 +70836,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 hbT
 fMJ
@@ -70847,7 +70898,7 @@ knK
 uxC
 hbT
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -71042,7 +71093,7 @@ nZT
 nZT
 nZT
 nZT
-aee
+dNM
 aee
 hbT
 fMJ
@@ -71104,7 +71155,7 @@ mvk
 uxC
 hbT
 aee
-aee
+mpX
 nZT
 nZT
 nZT
@@ -71361,7 +71412,7 @@ xMP
 xMP
 hbT
 aee
-aee
+mpX
 nZT
 nZT
 nZT

--- a/_maps/map_files/Aetherwhisp/Aetherwhisp2.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp2.dmm
@@ -436,12 +436,6 @@
 	},
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/medical/genetics)
-"aqf" = (
-/obj/structure/hull_plate/end{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "aqk" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3960,9 +3954,6 @@
 /area/crew_quarters/dorms)
 "cQJ" = (
 /obj/machinery/recharge_station,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/landmark/start/cyborg,
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable{
@@ -11098,6 +11089,17 @@
 /obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/carpet/ship/beige_carpet,
 /area/quartermaster/storage)
+"jcL" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "tcommsatshutter"
+	},
+/turf/open/floor/plating,
+/area/science/server)
 "jcR" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable/yellow{
@@ -12589,12 +12591,6 @@
 /area/ai_monitored/storage/eva)
 "kjZ" = (
 /obj/machinery/mech_bay_recharge_port,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/robotics/lab)
 "kkg" = (
@@ -13186,12 +13182,11 @@
 	name = "nanoweave carpet (bluer)"
 	},
 /area/bridge/showroom/corporate)
-"kMq" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	id = "cabin2_privacy"
+"kNm" = (
+/obj/structure/closet/secure_closet/personal{
+	anchored = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "kNU" = (
 /obj/structure/chair,
@@ -15160,17 +15155,6 @@
 	name = "nanoweave carpet (bluer)"
 	},
 /area/ai_monitored/storage/eva)
-"mvU" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	dir = 4;
-	id = "tcommsatshutter"
-	},
-/turf/open/floor/plating,
-/area/science/server)
 "mwE" = (
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -17605,11 +17589,11 @@
 /turf/open/floor/engine,
 /area/nsv/weapons/fore)
 "oAO" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/hull_plate/end{
+	dir = 1
 	},
-/turf/closed/wall/ship,
-/area/ai_monitored/turret_protected/aisat_interior)
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "oCi" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 8;
@@ -19318,18 +19302,12 @@
 /turf/open/floor/carpet/ship,
 /area/janitor)
 "pSb" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "cabin1_privacy"
 	},
-/obj/machinery/power/apc/auto_name/west,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/carpet/ship/blue{
-	color = "#9999DD";
-	name = "nanoweave carpet (bluer)"
-	},
-/area/ai_monitored/turret_protected/aisat_interior)
+/turf/open/floor/plating,
+/area/crew_quarters/dorms)
 "pSg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -24686,13 +24664,6 @@
 	},
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/lab)
-"uhB" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	id = "cabin1_privacy"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/dorms)
 "uhN" = (
 /obj/structure/rack,
 /obj/item/shovel{
@@ -25806,14 +25777,12 @@
 	name = "Launch tubes 1 and 2"
 	})
 "veo" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "cabin2_privacy"
 	},
-/turf/open/floor/carpet/ship/blue{
-	color = "#9999DD";
-	name = "nanoweave carpet (bluer)"
-	},
-/area/ai_monitored/turret_protected/aisat_interior)
+/turf/open/floor/plating,
+/area/crew_quarters/dorms)
 "veC" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -44657,7 +44626,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 sdP
 iMh
@@ -44914,7 +44883,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 hvg
 axG
@@ -45171,7 +45140,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 hbT
 ptx
@@ -45428,7 +45397,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 hvg
 axG
@@ -45685,7 +45654,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 hbT
 ptx
@@ -45942,7 +45911,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 hvg
 axG
@@ -46199,7 +46168,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 aee
 iMh
@@ -46456,7 +46425,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 aee
 iMh
@@ -46713,7 +46682,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 aee
 iMh
@@ -46970,7 +46939,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 aee
 iMh
@@ -47227,7 +47196,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 aee
 iMh
@@ -47484,7 +47453,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 aee
 iMh
@@ -47741,7 +47710,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 aee
 fyO
@@ -47998,7 +47967,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 owl
 gqs
@@ -48255,7 +48224,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 owl
 gqs
@@ -48512,7 +48481,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 owl
 gqs
@@ -48769,7 +48738,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 aee
 fyO
@@ -49026,7 +48995,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 aee
 kJw
@@ -49283,7 +49252,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 aee
 kJw
@@ -49540,10 +49509,10 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 owl
-uhB
+pSb
 lvL
 wwn
 bzb
@@ -49797,10 +49766,10 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 owl
-uhB
+pSb
 cQA
 cal
 nOF
@@ -50054,7 +50023,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 aee
 kJw
@@ -50312,7 +50281,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 kJw
 duZ
@@ -50569,7 +50538,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 owl
 cTw
 frO
@@ -50826,7 +50795,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 owl
 cTw
 xQl
@@ -51083,7 +51052,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 kJw
 duZ
@@ -51340,7 +51309,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 kJw
 jag
@@ -51365,8 +51334,8 @@ aJr
 mrH
 vPv
 duZ
-gym
-gym
+kNm
+kNm
 mrH
 aJr
 nfD
@@ -51597,9 +51566,9 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 owl
-kMq
+veo
 aJr
 ggo
 nOF
@@ -51854,9 +51823,9 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 owl
-kMq
+veo
 cQA
 vOI
 hqe
@@ -52111,7 +52080,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 dDt
 kJw
 hJG
@@ -52368,7 +52337,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 hla
 hlc
@@ -52625,7 +52594,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 hla
 nRP
@@ -57806,7 +57775,7 @@ nsQ
 nsQ
 wEX
 nsQ
-mvU
+jcL
 nsQ
 sLN
 lIB
@@ -61660,9 +61629,9 @@ nFo
 nFo
 ecO
 qbZ
-pSb
-veo
-oAO
+oWJ
+nVb
+dOP
 kjZ
 cQJ
 mPU
@@ -63162,7 +63131,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 owl
 jQc
 vpq
@@ -63419,7 +63388,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 owl
 jQc
 ePh
@@ -63676,7 +63645,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 mgr
 mgr
 mgr
@@ -63933,7 +63902,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 mDy
 mzQ
 vDc
@@ -64190,7 +64159,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 mDy
 lDE
 rjk
@@ -64447,7 +64416,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 mDy
 sBq
 nIK
@@ -64961,7 +64930,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 jXx
 mzQ
 vDc
@@ -65218,7 +65187,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 jXx
 lDE
 rjk
@@ -65475,7 +65444,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 jXx
 sBq
 eSC
@@ -65732,7 +65701,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 mgr
 mgr
 mgr
@@ -65989,7 +65958,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 xnd
 iUH
@@ -66246,7 +66215,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 owl
 wNh
 qzq
@@ -66503,7 +66472,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 owl
 mYb
 iEl
@@ -66760,7 +66729,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 owl
 mYb
 tdz
@@ -67017,7 +66986,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 wNh
 ycv
@@ -67274,7 +67243,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 wNh
 mav
@@ -67531,7 +67500,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 wNh
 wjT
@@ -67788,7 +67757,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 hbT
 wjT
@@ -68045,7 +68014,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 hbT
 wjT
@@ -68302,7 +68271,7 @@ nZT
 aEe
 nZT
 nZT
-aqf
+oAO
 aee
 hbT
 wjT
@@ -68559,7 +68528,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 hvg
 hWj
@@ -68816,7 +68785,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 hbT
 wjT
@@ -69073,7 +69042,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 hbT
 wjT
@@ -69330,7 +69299,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 hbT
 wjT
@@ -69587,7 +69556,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 hvg
 hWj
@@ -69844,7 +69813,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 hbT
 fMJ
@@ -70101,7 +70070,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 hbT
 fMJ
@@ -70358,7 +70327,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 hbT
 fMJ
@@ -70615,7 +70584,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 hvg
 tWA
@@ -70872,7 +70841,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 hbT
 fMJ
@@ -71129,7 +71098,7 @@ nZT
 nZT
 nZT
 nZT
-aqf
+oAO
 aee
 hbT
 fMJ

--- a/_maps/map_files/Aetherwhisp/Aetherwhisp2.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp2.dmm
@@ -564,7 +564,7 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/airlock/ship/command{
-	name = "Captain Bedroom";
+	name = "Captain Quarters";
 	req_access_txt = "20"
 	},
 /obj/structure/disposalpipe/segment{
@@ -2757,6 +2757,7 @@
 /obj/structure/bed,
 /obj/machinery/newscaster/security_unit/north,
 /obj/effect/landmark/start/captain,
+/obj/item/bedsheet/captain,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "bWC" = (
@@ -2809,7 +2810,7 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/airlock/ship/maintenance{
-	name = "Maintenance Access Captain Bedroom";
+	name = "Maintenance Access Captain Quarters";
 	req_one_access_txt = "20"
 	},
 /turf/open/floor/plating,
@@ -3913,12 +3914,12 @@
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/crew_quarters/heads/hor)
 "cOm" = (
-/obj/machinery/computer/ship/viewscreen{
-	desc = "It's falling apart!";
-	name = "broken viewscreen"
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/turf/closed/wall/r_wall/ship,
-/area/bridge)
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/toilet/locker)
 "cOE" = (
 /obj/machinery/cryopod,
 /turf/open/floor/carpet/ship/beige_carpet,
@@ -4427,7 +4428,7 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/airlock/ship/command{
-	name = "Deck 2 Generator";
+	name = "Deck 1 Generator";
 	req_one_access_txt = "10"
 	},
 /turf/open/floor/carpet/ship/blue{
@@ -4978,6 +4979,7 @@
 "dJc" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
 /obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
 	id = "captainoffice"
 	},
 /turf/open/floor/plating,
@@ -5662,6 +5664,7 @@
 /area/maintenance/fore)
 "euE" = (
 /obj/machinery/door/poddoor/ship{
+	dir = 4;
 	id = "bridgewindows"
 	},
 /obj/effect/spawner/structure/window/reinforced/ship,
@@ -5741,6 +5744,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/item/reagent_containers/food/drinks/flask/gold,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "ewJ" = (
@@ -8093,6 +8097,7 @@
 /area/quartermaster/qm)
 "gmy" = (
 /obj/structure/closet/firecloset/full,
+/obj/machinery/light,
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/lab)
 "gmR" = (
@@ -9249,9 +9254,16 @@
 /obj/structure/closet/crate,
 /obj/item/beacon,
 /obj/item/beacon,
-/obj/item/hand_tele,
+/obj/item/hand_tele{
+	req_access_txt = "17;19"
+	},
 /obj/item/beacon,
 /obj/item/beacon,
+/obj/machinery/button/door{
+	id = "teleporter_shutters";
+	name = "teleporter shutter control";
+	pixel_x = -24
+	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -14684,6 +14696,7 @@
 /obj/machinery/shower{
 	dir = 4
 	},
+/obj/item/bikehorn/rubberducky,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/heads/captain)
 "mhv" = (
@@ -15489,9 +15502,7 @@
 	icon_state = "0-2"
 	},
 /obj/item/storage/box/pinpointer_pairs,
-/obj/item/pinpointer/nuke,
 /obj/item/hand_tele,
-/obj/item/disk/nuclear,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "mIw" = (
@@ -16230,6 +16241,8 @@
 /area/maintenance/department/science/xenobiology)
 "nsd" = (
 /obj/structure/table/glass,
+/obj/item/pinpointer/nuke,
+/obj/item/disk/nuclear,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "nsy" = (
@@ -16263,6 +16276,10 @@
 /area/medical/genetics)
 "ntF" = (
 /obj/structure/table/glass,
+/obj/item/ship_weapon/parts/torpedo/warhead/probe,
+/obj/item/ship_weapon/parts/torpedo/warhead/probe{
+	pixel_y = 6
+	},
 /turf/open/floor/carpet/purple,
 /area/science/lab)
 "nuj" = (
@@ -19176,8 +19193,6 @@
 /obj/structure/table/glass,
 /obj/machinery/smartfridge/disks,
 /obj/item/storage/box/disks_nanite,
-/obj/item/ship_weapon/parts/torpedo/warhead/probe,
-/obj/item/ship_weapon/parts/torpedo/warhead/probe,
 /turf/open/floor/carpet/purple,
 /area/science/lab)
 "pLo" = (
@@ -20580,9 +20595,15 @@
 	},
 /area/bridge)
 "qVC" = (
-/obj/machinery/door/poddoor/shutters,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
+/obj/machinery/door/poddoor/shutters/ship{
+	id = "teleporter_shutters";
+	name = "teleporter shutters"
+	},
+/turf/open/floor/carpet/ship/blue{
+	color = "#9999DD";
+	name = "nanoweave carpet (bluer)"
+	},
 /area/teleporter)
 "qWr" = (
 /obj/machinery/power/apc/auto_name/east,
@@ -21119,7 +21140,6 @@
 	name = "Science Lobby"
 	})
 "rqS" = (
-/obj/item/reagent_containers/food/drinks/flask/gold,
 /obj/item/storage/fancy/donut_box,
 /obj/structure/table/glass,
 /turf/open/floor/carpet,
@@ -48551,7 +48571,7 @@ xWZ
 xpN
 wFc
 xXp
-cqW
+cOm
 xWZ
 xWZ
 jvn
@@ -73748,7 +73768,7 @@ bVG
 euE
 euE
 euE
-cOm
+bVG
 euE
 euE
 euE

--- a/_maps/map_files/Aetherwhisp/Aetherwhisp2.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp2.dmm
@@ -436,6 +436,12 @@
 	},
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/medical/genetics)
+"aqf" = (
+/obj/structure/hull_plate/end{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "aqk" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2130,6 +2136,10 @@
 /obj/machinery/door/window/westleft,
 /obj/machinery/door/window/eastright{
 	req_one_access_txt = "29"
+	},
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "robotics_shutters"
 	},
 /turf/open/floor/plating,
 /area/science/robotics/lab)
@@ -3950,11 +3960,14 @@
 /area/crew_quarters/dorms)
 "cQJ" = (
 /obj/machinery/recharge_station,
-/obj/structure/extinguisher_cabinet/west,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/start/cyborg,
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/robotics/lab)
 "cRy" = (
@@ -5072,12 +5085,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/captain)
-"dNM" = (
-/obj/structure/hull_plate/end{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "dOf" = (
 /turf/closed/wall/r_wall/ship,
 /area/quartermaster/storage)
@@ -7028,7 +7035,7 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/airlock/ship/station/research{
-	name = "Robotics";
+	name = "Robotics Lab";
 	req_one_access_txt = "29"
 	},
 /obj/structure/disposalpipe/segment,
@@ -7197,6 +7204,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/button/door{
+	id = "robotics_shutters";
+	name = "robotics shutters control";
+	pixel_x = -26;
+	pixel_y = 26;
+	req_access_txt = "29"
+	},
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/robotics/lab)
 "fyA" = (
@@ -7237,6 +7251,7 @@
 /obj/item/hemostat,
 /obj/item/retractor,
 /obj/item/cautery,
+/obj/structure/extinguisher_cabinet/south,
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/robotics/lab)
 "fBc" = (
@@ -7613,7 +7628,6 @@
 /obj/item/folder/white{
 	pixel_x = 4
 	},
-/obj/structure/cable,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -9138,17 +9152,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
-"hjm" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	dir = 4;
-	id = "tcommsatshutter"
-	},
-/turf/open/floor/plating,
-/area/science/server)
 "hjD" = (
 /obj/structure/chair{
 	dir = 8
@@ -10141,13 +10144,6 @@
 	name = "nanoweave carpet (puce)"
 	},
 /area/nsv/weapons/fore)
-"icT" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	id = "cabin2_privacy"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/dorms)
 "idc" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -11113,6 +11109,10 @@
 /obj/machinery/door/window/eastright,
 /obj/item/paper{
 	info = "<p>Reminder that squad equipment vendors are located in the council chamber, tool storage, and that 4-way junction at the primary hallway, Deck 1</p>"
+	},
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "research_shutters"
 	},
 /turf/open/floor/plating,
 /area/science/lab)
@@ -12612,9 +12612,6 @@
 /obj/structure/chair/office/light{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
@@ -13189,6 +13186,13 @@
 	name = "nanoweave carpet (bluer)"
 	},
 /area/bridge/showroom/corporate)
+"kMq" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "cabin2_privacy"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/dorms)
 "kNU" = (
 /obj/structure/chair,
 /turf/open/floor/carpet/ship,
@@ -14231,6 +14235,10 @@
 /obj/machinery/door/window/eastleft{
 	req_one_access_txt = "29"
 	},
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "robotics_shutters"
+	},
 /turf/open/floor/plating,
 /area/science/robotics/lab)
 "lJb" = (
@@ -15152,6 +15160,17 @@
 	name = "nanoweave carpet (bluer)"
 	},
 /area/ai_monitored/storage/eva)
+"mvU" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "tcommsatshutter"
+	},
+/turf/open/floor/plating,
+/area/science/server)
 "mwE" = (
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -15654,12 +15673,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
 	},
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/robotics/lab)
@@ -17198,13 +17213,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"oih" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	id = "cabin1_privacy"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/dorms)
 "oij" = (
 /obj/machinery/door/poddoor/shutters/ship{
 	id = "cargo_exterior"
@@ -18082,6 +18090,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
 	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 1;
+	id = "robotics_shutters"
 	},
 /turf/open/floor/plating,
 /area/science/robotics/lab)
@@ -21537,6 +21549,10 @@
 	req_one_access_txt = "7;9;47"
 	},
 /obj/machinery/door/window/eastleft,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "research_shutters"
+	},
 /turf/open/floor/plating,
 /area/science/lab)
 "rKr" = (
@@ -24242,7 +24258,8 @@
 	id = "toxgun_interior";
 	name = "Toxins Interior Blast Door";
 	pixel_x = 6;
-	pixel_y = -26
+	pixel_y = -26;
+	req_one_access_txt = "7"
 	},
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/mixing)
@@ -24308,6 +24325,10 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 1;
+	id = "robotics_shutters"
 	},
 /turf/open/floor/plating,
 /area/science/robotics/lab)
@@ -24665,6 +24686,13 @@
 	},
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/lab)
+"uhB" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "cabin1_privacy"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/dorms)
 "uhN" = (
 /obj/structure/rack,
 /obj/item/shovel{
@@ -26002,6 +26030,10 @@
 "vru" = (
 /obj/structure/closet/emcloset,
 /obj/item/storage/toolbox/emergency,
+/obj/machinery/button/door{
+	id = "research_shutters";
+	pixel_y = -30
+	},
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/lab)
 "vrD" = (
@@ -26411,6 +26443,10 @@
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 1;
+	id = "robotics_shutters"
 	},
 /turf/open/floor/plating,
 /area/science/robotics/lab)
@@ -44621,7 +44657,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 sdP
 iMh
@@ -44878,7 +44914,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 hvg
 axG
@@ -45135,7 +45171,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 hbT
 ptx
@@ -45392,7 +45428,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 hvg
 axG
@@ -45649,7 +45685,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 hbT
 ptx
@@ -45906,7 +45942,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 hvg
 axG
@@ -46163,7 +46199,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 aee
 iMh
@@ -46420,7 +46456,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 aee
 iMh
@@ -46677,7 +46713,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 aee
 iMh
@@ -46934,7 +46970,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 aee
 iMh
@@ -47191,7 +47227,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 aee
 iMh
@@ -47448,7 +47484,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 aee
 iMh
@@ -47705,7 +47741,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 aee
 fyO
@@ -47962,7 +47998,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 owl
 gqs
@@ -48219,7 +48255,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 owl
 gqs
@@ -48476,7 +48512,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 owl
 gqs
@@ -48733,7 +48769,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 aee
 fyO
@@ -48990,7 +49026,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 aee
 kJw
@@ -49247,7 +49283,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 aee
 kJw
@@ -49504,10 +49540,10 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 owl
-oih
+uhB
 lvL
 wwn
 bzb
@@ -49761,10 +49797,10 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 owl
-oih
+uhB
 cQA
 cal
 nOF
@@ -50018,7 +50054,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 aee
 kJw
@@ -50276,7 +50312,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 kJw
 duZ
@@ -50533,7 +50569,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 owl
 cTw
 frO
@@ -50790,7 +50826,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 owl
 cTw
 xQl
@@ -51047,7 +51083,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 kJw
 duZ
@@ -51304,7 +51340,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 kJw
 jag
@@ -51561,9 +51597,9 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 owl
-icT
+kMq
 aJr
 ggo
 nOF
@@ -51818,9 +51854,9 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 owl
-icT
+kMq
 cQA
 vOI
 hqe
@@ -52075,7 +52111,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 dDt
 kJw
 hJG
@@ -52332,7 +52368,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 hla
 hlc
@@ -52589,7 +52625,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 hla
 nRP
@@ -57770,7 +57806,7 @@ nsQ
 nsQ
 wEX
 nsQ
-hjm
+mvU
 nsQ
 sLN
 lIB
@@ -63126,7 +63162,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 owl
 jQc
 vpq
@@ -63383,7 +63419,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 owl
 jQc
 ePh
@@ -63640,7 +63676,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 mgr
 mgr
 mgr
@@ -63897,7 +63933,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 mDy
 mzQ
 vDc
@@ -64154,7 +64190,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 mDy
 lDE
 rjk
@@ -64411,7 +64447,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 mDy
 sBq
 nIK
@@ -64925,7 +64961,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 jXx
 mzQ
 vDc
@@ -65182,7 +65218,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 jXx
 lDE
 rjk
@@ -65439,7 +65475,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 jXx
 sBq
 eSC
@@ -65696,7 +65732,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 mgr
 mgr
 mgr
@@ -65953,7 +65989,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 xnd
 iUH
@@ -66210,7 +66246,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 owl
 wNh
 qzq
@@ -66467,7 +66503,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 owl
 mYb
 iEl
@@ -66724,7 +66760,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 owl
 mYb
 tdz
@@ -66981,7 +67017,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 wNh
 ycv
@@ -67238,7 +67274,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 wNh
 mav
@@ -67495,7 +67531,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 wNh
 wjT
@@ -67752,7 +67788,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 hbT
 wjT
@@ -68009,7 +68045,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 hbT
 wjT
@@ -68266,7 +68302,7 @@ nZT
 aEe
 nZT
 nZT
-dNM
+aqf
 aee
 hbT
 wjT
@@ -68523,7 +68559,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 hvg
 hWj
@@ -68780,7 +68816,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 hbT
 wjT
@@ -69037,7 +69073,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 hbT
 wjT
@@ -69294,7 +69330,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 hbT
 wjT
@@ -69551,7 +69587,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 hvg
 hWj
@@ -69808,7 +69844,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 hbT
 fMJ
@@ -70065,7 +70101,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 hbT
 fMJ
@@ -70322,7 +70358,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 hbT
 fMJ
@@ -70579,7 +70615,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 hvg
 tWA
@@ -70836,7 +70872,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 hbT
 fMJ
@@ -71093,7 +71129,7 @@ nZT
 nZT
 nZT
 nZT
-dNM
+aqf
 aee
 hbT
 fMJ

--- a/_maps/map_files/Aetherwhisp/Aetherwhisp2.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp2.dmm
@@ -1722,10 +1722,11 @@
 /turf/open/floor/carpet/blue,
 /area/bridge)
 "bjW" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/structure/reagent_dispensers/watertank,
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/open/floor/carpet/ship,
 /area/janitor)
 "bjX" = (
@@ -19385,10 +19386,6 @@
 /turf/open/floor/carpet/ship,
 /area/bridge/meeting_room/council)
 "pWf" = (
-/obj/machinery/power/apc/auto_name/west,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
 /obj/machinery/vending/wardrobe/jani_wardrobe,
 /turf/open/floor/carpet/ship,
 /area/janitor)

--- a/_maps/shuttles/arrival_aetherwhisp.dmm
+++ b/_maps/shuttles/arrival_aetherwhisp.dmm
@@ -1,0 +1,294 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/template_noop,
+/area/template_noop)
+"b" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/arrival)
+"c" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Arrivals Shuttle Airlock"
+	},
+/turf/open/floor/plating,
+/area/shuttle/arrival)
+"d" = (
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/shuttle/arrival)
+"e" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/carpet/ship/blue,
+/area/shuttle/arrival)
+"f" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/carpet/ship/blue,
+/area/shuttle/arrival)
+"g" = (
+/obj/structure/closet/wardrobe/white,
+/obj/structure/sign/solgov_seal,
+/turf/open/floor/carpet/ship/blue,
+/area/shuttle/arrival)
+"h" = (
+/obj/structure/closet/wardrobe/green,
+/turf/open/floor/carpet/ship/blue,
+/area/shuttle/arrival)
+"i" = (
+/obj/structure/closet/wardrobe/black,
+/turf/open/floor/carpet/ship/blue,
+/area/shuttle/arrival)
+"j" = (
+/obj/structure/closet/wardrobe/mixed,
+/turf/open/floor/carpet/ship/blue,
+/area/shuttle/arrival)
+"k" = (
+/obj/structure/closet/wardrobe/grey,
+/turf/open/floor/carpet/ship/blue,
+/area/shuttle/arrival)
+"l" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
+/obj/structure/sign/solgov_seal,
+/turf/open/floor/carpet/ship/blue,
+/area/shuttle/arrival)
+"m" = (
+/obj/structure/shuttle/engine/heater{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/arrival)
+"n" = (
+/obj/structure/shuttle/engine/propulsion/burst/right{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/arrival)
+"o" = (
+/obj/machinery/requests_console{
+	department = "Arrival shuttle";
+	name = "Arrivals Shuttle console";
+	pixel_y = 30
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/carpet/ship/blue,
+/area/shuttle/arrival)
+"p" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/carpet/ship/blue,
+/area/shuttle/arrival)
+"q" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/carpet/ship/blue,
+/area/shuttle/arrival)
+"r" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/open/floor/carpet/ship/blue,
+/area/shuttle/arrival)
+"s" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/arrival)
+"t" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Arrivals Shuttle Airlock"
+	},
+/turf/open/floor/carpet/ship/blue,
+/area/shuttle/arrival)
+"u" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 4
+	},
+/obj/docking_port/mobile/arrivals,
+/turf/open/floor/plating/airless,
+/area/shuttle/arrival)
+"v" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/carpet/ship/blue,
+/area/shuttle/arrival)
+"w" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/carpet/ship/blue,
+/area/shuttle/arrival)
+"x" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/carpet/ship/blue,
+/area/shuttle/arrival)
+"y" = (
+/obj/machinery/light,
+/turf/open/floor/carpet/ship/blue,
+/area/shuttle/arrival)
+"z" = (
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -29
+	},
+/obj/machinery/light,
+/turf/open/floor/carpet/ship/blue,
+/area/shuttle/arrival)
+"A" = (
+/obj/structure/shuttle/engine/propulsion/burst/left{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/arrival)
+"S" = (
+/turf/open/floor/carpet/ship/blue,
+/area/shuttle/arrival)
+
+(1,1,1) = {"
+a
+b
+d
+d
+d
+b
+a
+"}
+(2,1,1) = {"
+a
+b
+p
+S
+v
+b
+a
+"}
+(3,1,1) = {"
+a
+b
+q
+S
+w
+b
+a
+"}
+(4,1,1) = {"
+b
+b
+b
+t
+b
+b
+b
+"}
+(5,1,1) = {"
+b
+e
+S
+S
+S
+x
+b
+"}
+(6,1,1) = {"
+b
+f
+r
+r
+r
+S
+c
+"}
+(7,1,1) = {"
+b
+g
+S
+S
+S
+y
+b
+"}
+(8,1,1) = {"
+d
+h
+r
+r
+r
+S
+d
+"}
+(9,1,1) = {"
+d
+i
+S
+S
+S
+S
+d
+"}
+(10,1,1) = {"
+d
+j
+r
+r
+r
+S
+d
+"}
+(11,1,1) = {"
+d
+k
+S
+S
+S
+S
+d
+"}
+(12,1,1) = {"
+b
+l
+r
+r
+r
+z
+b
+"}
+(13,1,1) = {"
+b
+o
+S
+S
+S
+S
+c
+"}
+(14,1,1) = {"
+b
+m
+m
+m
+m
+m
+b
+"}
+(15,1,1) = {"
+b
+n
+s
+u
+s
+A
+b
+"}

--- a/_maps/shuttles/arrival_box.dmm
+++ b/_maps/shuttles/arrival_box.dmm
@@ -153,6 +153,13 @@
 "S" = (
 /turf/open/floor/mineral/titanium,
 /area/shuttle/arrival)
+"X" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Arrivals Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/arrival)
 
 (1,1,1) = {"
 a
@@ -200,7 +207,7 @@ x
 b
 "}
 (6,1,1) = {"
-c
+X
 f
 r
 r
@@ -263,7 +270,7 @@ z
 b
 "}
 (13,1,1) = {"
-c
+X
 f
 S
 S

--- a/_maps/shuttles/arrival_box.dmm
+++ b/_maps/shuttles/arrival_box.dmm
@@ -153,13 +153,6 @@
 "S" = (
 /turf/open/floor/mineral/titanium,
 /area/shuttle/arrival)
-"X" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Arrivals Shuttle Airlock"
-	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plating,
-/area/shuttle/arrival)
 
 (1,1,1) = {"
 a
@@ -207,7 +200,7 @@ x
 b
 "}
 (6,1,1) = {"
-X
+c
 f
 r
 r
@@ -270,7 +263,7 @@ z
 b
 "}
 (13,1,1) = {"
-X
+c
 f
 S
 S

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -555,6 +555,10 @@
 /datum/map_template/shuttle/arrival/omega
 	suffix = "omega"
 	name = "arrival shuttle (Omega)"
+	
+/datum/map_template/shuttle/arrival/aetherwhisp //NSV13 - Aetherwhisp Arrivals
+	suffix = "aetherwhisp"
+	name = "arrival shuttle (Aetherwhisp)"
 
 /datum/map_template/shuttle/aux_base/default
 	suffix = "default"


### PR DESCRIPTION
Aetherwhisp follow up PR #1, contains a bunch of important fixes such as missing air alarms. Adds shutters to places like the chapel, brig, and dorms.

## Why it's good for the game

makes Aetherwhisp more enjoyable

## Changelog

:cl:
fix: Fixed some bugs with the SGV Aetherwhisp
/:cl: