### PR TITLE
Aetherwhisp 6, more map fixes 

### DIFF
--- a/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
@@ -9126,6 +9126,8 @@
 	pixel_x = -4
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/open/floor/wood,
 /area/chapel/office)
 "grw" = (
@@ -11808,6 +11810,8 @@
 /obj/item/storage/book/bible{
 	pixel_y = -1
 	},
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/open/floor/carpet/ship,
 /area/chapel/office)
 "irN" = (

--- a/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
@@ -17227,6 +17227,7 @@
 	},
 /obj/machinery/recharger,
 /obj/machinery/computer/security/telescreen{
+	network = list("ss13");
 	pixel_x = -30
 	},
 /turf/open/floor/carpet/ship/red_carpet,
@@ -27230,7 +27231,7 @@
 	name = "Cafeteria"
 	})
 "sjo" = (
-/obj/structure/beebox/premade,
+/obj/structure/beebox,
 /turf/open/floor/grass,
 /area/hydroponics)
 "sjs" = (
@@ -30922,7 +30923,7 @@
 /area/engine/atmospherics_engine)
 "uZq" = (
 /obj/machinery/disposal/deliveryChute{
-	desc = "A chute for big and small packages alike!\n(While holding an item, click the chute to insert it inside for delivery)";
+	desc = "A chute for big and small packages alike! (While holding an item, click the chute to insert it inside for delivery)";
 	dir = 1;
 	name = "Laundromat Output (click to insert)"
 	},

--- a/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
@@ -15,9 +15,9 @@
 /turf/open/floor/carpet/ship/blue,
 /area/medical/medbay/lobby)
 "aaK" = (
-/obj/structure/lattice,
+/obj/effect/landmark/carpspawn,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "aaL" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
 /obj/effect/landmark/nuclear_waste_spawner,
@@ -35,6 +35,21 @@
 	})
 "abs" = (
 /turf/closed/wall/r_wall/ship,
+/area/security/prison)
+"abH" = (
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_y = 10
+	},
+/obj/structure/mirror{
+	pixel_x = -27;
+	pixel_y = -2
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -11
+	},
+/turf/open/floor/plasteel/freezer,
 /area/security/prison)
 "acn" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -123,6 +138,12 @@
 "aeg" = (
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
+"aek" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/closed/wall/ship,
+/area/security/brig)
 "aex" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -149,6 +170,9 @@
 	},
 /obj/structure/closet/emcloset,
 /obj/item/storage/toolbox/emergency,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "afg" = (
@@ -207,15 +231,10 @@
 /turf/open/floor/wood,
 /area/security/detectives_office)
 "ahF" = (
-/obj/structure/bed,
-/obj/item/bedsheet/nanotrasen,
-/obj/structure/sign/poster/random{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
-	},
-/turf/open/floor/carpet/ship,
+/obj/machinery/airalarm/directional/north,
+/obj/structure/closet/secure_closet/security/sec,
+/obj/item/gun/energy/laser,
+/turf/open/floor/carpet/ship/red_carpet,
 /area/security/prison)
 "ahJ" = (
 /obj/structure/table,
@@ -801,6 +820,14 @@
 /area/security/main{
 	name = "Security War Room"
 	})
+"azx" = (
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "azy" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -837,10 +864,24 @@
 	},
 /turf/open/floor/carpet/ship/blue,
 /area/medical/genetics/cloning)
+"azV" = (
+/obj/structure/reflector/box/anchored{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "aAj" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"aAF" = (
+/obj/structure/rack,
+/obj/item/paint/white,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "aAG" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -895,6 +936,17 @@
 /obj/machinery/atmospherics/pipe/manifold4w/purple/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
+"aCm" = (
+/obj/machinery/seed_extractor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/obj/machinery/light_switch/east,
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "aCs" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -984,8 +1036,15 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/atmospheric_technician,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/break_room)
+"aJB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engine_room)
 "aJG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -1034,12 +1093,36 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"aMj" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "aMR" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 8
 	},
 /turf/open/floor/engine,
 /area/gateway)
+"aNh" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/department/medical)
+"aNs" = (
+/obj/structure/sign/warning/enginesafety,
+/turf/closed/wall/ship,
+/area/maintenance/department/medical)
 "aNz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -1088,6 +1171,23 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
+"aPA" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/computer/secure_data{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/carpet/red,
+/area/security/prison)
+"aQf" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/checkpoint/medical)
 "aQl" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
@@ -1125,6 +1225,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/holopad,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_room)
 "aQM" = (
@@ -1180,7 +1281,7 @@
 	width = 7
 	},
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "aTh" = (
 /obj/machinery/status_display/evac,
 /turf/closed/wall/ship,
@@ -1422,6 +1523,21 @@
 	},
 /turf/open/floor/plating,
 /area/security/detectives_office)
+"aZm" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "aZG" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
@@ -1522,9 +1638,15 @@
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/brig)
 "bcj" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/docking_port/stationary{
+	dwidth = 11;
+	height = 22;
+	id = "unused_3";
+	name = "Deck 1 Fore Port";
+	width = 35
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "bck" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -1543,13 +1665,13 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
 "bcT" = (
-/obj/structure/sink/kitchen{
-	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
-	name = "old sink";
-	pixel_y = 28
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/turf/open/floor/carpet/ship,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/turf/open/floor/carpet/ship/red_carpet,
 /area/security/prison)
 "bdj" = (
 /obj/structure/table/glass,
@@ -1695,8 +1817,27 @@
 /turf/open/floor/carpet/royalblack,
 /area/chapel/main)
 "bgz" = (
-/obj/structure/sign/warning/vacuum,
-/turf/closed/wall/ship,
+/obj/machinery/firealarm{
+	pixel_x = -26;
+	pixel_y = 25
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/window/brigdoor/security/cell/southright{
+	req_one_access_txt = "2"
+	},
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/deliveryChute{
+	name = "Baggage Delivery Input"
+	},
+/turf/open/floor/carpet/ship/red_carpet,
 /area/security/prison)
 "bgN" = (
 /turf/open/floor/engine/n2o,
@@ -1710,7 +1851,7 @@
 	width = 35
 	},
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "bha" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/bottle/toxin{
@@ -1724,6 +1865,13 @@
 /obj/item/reagent_containers/glass/bottle/epinephrine,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/chemistry)
+"bhc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/holopad,
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "bhd" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -2279,6 +2427,10 @@
 /area/engine/supermatter{
 	name = "Supermatter Core"
 	})
+"bwU" = (
+/obj/machinery/atmospherics/pipe/manifold4w/purple/hidden,
+/turf/template_noop,
+/area/maintenance/department/medical)
 "bwW" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -2323,6 +2475,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/carpet/ship/red_carpet,
 /area/ai_monitored/security/armory/security)
 "bxy" = (
@@ -2402,6 +2557,13 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_room)
+"byQ" = (
+/obj/machinery/newscaster/directional/north,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "byW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -2409,17 +2571,17 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/engine/engine_room)
+"bzb" = (
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
 "bzI" = (
-/obj/docking_port/stationary{
-	dir = 2;
-	dwidth = 11;
-	height = 22;
-	id = "unused_2";
-	name = "Deck 1 Fore Starboard";
-	width = 35
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/door/airlock/ship/external/glass{
+	name = "External Access Deck 2 Fore Port";
+	req_one_access_txt = "2"
 	},
-/turf/open/space/basic,
-/area/space)
+/turf/open/floor/plating,
+/area/security/prison)
 "bzL" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/engine/co2,
@@ -2463,6 +2625,9 @@
 	icon_state = "4-8"
 	},
 /obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
@@ -2540,11 +2705,12 @@
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/checkpoint/engineering)
 "bFt" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+/obj/machinery/camera/motion{
+	c_tag = "External Viewport Prison Wing";
 	dir = 4
 	},
-/turf/closed/wall/r_wall/ship,
-/area/security/prison)
+/turf/open/space/basic,
+/area/space/nearstation)
 "bGX" = (
 /obj/machinery/vending/wallmed{
 	pixel_x = -32
@@ -2642,6 +2808,15 @@
 /area/crew_quarters/lounge{
 	name = "Cafeteria"
 	})
+"bKu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "bKK" = (
 /obj/machinery/power/port_gen,
 /turf/open/floor/plating,
@@ -2666,6 +2841,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/grass,
 /area/hydroponics)
+"bMg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "bNg" = (
 /obj/machinery/field/generator,
 /turf/open/floor/plating,
@@ -2841,6 +3025,12 @@
 /obj/structure/sign/departments/minsky/medical/chemistry/chemical2,
 /turf/closed/wall/r_wall/ship,
 /area/medical/chemistry)
+"bRo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/closed/wall/ship,
+/area/security/warden)
 "bRU" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/carpet/ship/orange_carpet,
@@ -2922,18 +3112,24 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "bTz" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 8
+/obj/structure/disposaloutlet{
+	dir = 4;
+	eject_range = 6
 	},
-/obj/machinery/light/small{
+/obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
-/area/maintenance/department/medical)
+/area/space/nearstation)
 "bTA" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/turf/open/floor/carpet/ship,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor/ship/preopen{
+	id = "permabrigshutter"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/security/prison)
 "bTS" = (
 /obj/machinery/airalarm/directional/north,
@@ -3059,6 +3255,12 @@
 	},
 /turf/open/floor/grass,
 /area/hydroponics)
+"bZu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/department/medical)
 "bZv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -3413,12 +3615,13 @@
 /turf/open/floor/engine/n2,
 /area/engine/atmos)
 "cla" = (
-/obj/machinery/vending/hydroseeds,
-/obj/item/stack/spacecash/c50,
-/obj/machinery/camera/autoname{
-	dir = 8
+/obj/structure/table,
+/obj/item/storage/box/handcuffs,
+/obj/item/storage/box/flashbangs{
+	pixel_x = -2;
+	pixel_y = -2
 	},
-/turf/open/floor/carpet/ship,
+/turf/open/floor/carpet/ship/red_carpet,
 /area/security/prison)
 "cle" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -3653,6 +3856,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
 "ctT" = (
@@ -3859,11 +4063,12 @@
 /turf/open/floor/circuit,
 /area/tcommsat/server)
 "cCI" = (
-/obj/structure/shuttle/engine/large{
-	dir = 4
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 3";
+	name = "Cell 3 Locker"
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/carpet/ship/red_carpet,
+/area/security/prison)
 "cCR" = (
 /obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall/ship,
@@ -3909,17 +4114,10 @@
 	name = "Cafeteria"
 	})
 "cFr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/flasher{
-	id = "PCell 4";
-	pixel_x = -24
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/turf/open/floor/carpet/ship,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/carpet/red,
 /area/security/prison)
 "cGN" = (
 /obj/structure/table/wood,
@@ -3940,6 +4138,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/medbay/central)
+"cHk" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/turf/closed/wall/ship,
+/area/maintenance/department/medical)
 "cHT" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -4097,6 +4301,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security)
+"cPW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/carpet/ship,
+/area/security/brig)
 "cPY" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -4210,6 +4420,19 @@
 	},
 /turf/open/floor/carpet/ship/blue,
 /area/medical/chemistry)
+"cSM" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/pen,
+/obj/machinery/flasher{
+	id = "PCell 1";
+	pixel_x = -28
+	},
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "cSZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -4313,6 +4536,12 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/department/security)
+"cWa" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 5
+	},
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "cWq" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4335,6 +4564,18 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"cXV" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/purple/hidden{
+	dir = 4
+	},
+/obj/machinery/modular_computer/console/preset/civilian{
+	dir = 8
+	},
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "cYh" = (
 /obj/structure/closet/emcloset,
 /obj/item/storage/toolbox/emergency,
@@ -4363,6 +4604,13 @@
 /area/engine/engine_room/external{
 	name = "Stormdrive Interior"
 	})
+"cZl" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/obj/effect/spawner/room/fivexfour,
+/turf/template_noop,
+/area/maintenance/department/medical)
 "cZt" = (
 /obj/structure/rack,
 /obj/machinery/airalarm/directional/north,
@@ -4377,15 +4625,8 @@
 /turf/open/floor/carpet/ship/red_carpet,
 /area/ai_monitored/security/armory/security)
 "cZI" = (
-/obj/docking_port/stationary{
-	dwidth = 11;
-	height = 22;
-	id = "unused_3";
-	name = "Deck 1 Fore Port";
-	width = 35
-	},
-/turf/open/space/basic,
-/area/space)
+/turf/open/floor/plating,
+/area/security/prison)
 "cZX" = (
 /obj/structure/rack,
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
@@ -4408,6 +4649,11 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
+"cZY" = (
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "dac" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
@@ -4703,6 +4949,11 @@
 /obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/engine,
 /area/engine/engine_room)
+"dlK" = (
+/obj/structure/table/wood,
+/obj/structure/extinguisher_cabinet/west,
+/turf/open/floor/wood,
+/area/chapel/main)
 "dmn" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4806,6 +5057,14 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"dpk" = (
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "dpq" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/engine/n2,
@@ -4969,6 +5228,11 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/patients_rooms/room_a)
+"duc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "dug" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5030,6 +5294,9 @@
 "dwk" = (
 /obj/structure/closet/radiation,
 /obj/item/clothing/mask/gas,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "dwp" = (
@@ -5067,10 +5334,19 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/tcommsat/server)
 "dxw" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 5
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/closed/wall/r_wall/ship,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "2;5;12"
+	},
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/plating,
 /area/maintenance/department/medical)
 "dxz" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -5289,10 +5565,11 @@
 /turf/open/floor/carpet/ship/blue,
 /area/medical/storage)
 "dDn" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/table,
+/obj/structure/bedsheetbin{
+	anchored = 0
 	},
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/carpet/ship,
 /area/security/prison)
 "dDq" = (
 /obj/structure/rack,
@@ -5398,6 +5675,15 @@
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
+"dFz" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/pen,
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "dFD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -5419,6 +5705,10 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/medical/morgue)
+"dGm" = (
+/obj/item/rollingpaper,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "dHs" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -5478,6 +5768,14 @@
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
+"dJv" = (
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/airlock/ship/public{
+	name = "Bathroom Cell"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
 "dJw" = (
 /obj/machinery/computer/crew{
 	dir = 4
@@ -5556,6 +5854,12 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
+/area/security/prison)
+"dNA" = (
+/obj/machinery/washing_machine,
+/obj/item/clothing/under/color/random,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/carpet/ship,
 /area/security/prison)
 "dNK" = (
 /obj/structure/cable{
@@ -5675,11 +5979,10 @@
 "dRo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/turf/open/floor/carpet/ship,
+/turf/open/floor/carpet/red,
 /area/security/prison)
 "dSB" = (
 /obj/item/twohanded/required/kirbyplants/random,
@@ -5975,12 +6278,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/break_room)
-"ebT" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 6
-	},
-/turf/closed/wall/ship,
-/area/security/prison)
 "ech" = (
 /obj/structure/closet/emcloset,
 /obj/item/storage/toolbox/emergency,
@@ -6088,6 +6385,11 @@
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/carpet/ship/red_carpet,
 /area/ai_monitored/security/armory/security)
+"ehL" = (
+/obj/effect/spawner/lootdrop/maintenance/seven,
+/obj/structure/closet/crate,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "ehU" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6220,7 +6522,23 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/obj/item/banner/engineering,
+/obj/machinery/disposal/deliveryChute{
+	dir = 4;
+	pixel_x = -5
+	},
+/obj/machinery/door/window/eastright{
+	req_one_access_txt = "10;11;24"
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/break_room)
 "elw" = (
@@ -6251,6 +6569,10 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"emc" = (
+/obj/structure/reflector/box/anchored,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "enb" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -6324,10 +6646,8 @@
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "epp" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/carpet/ship,
+/obj/machinery/status_display/ai,
+/turf/closed/wall/r_wall/ship,
 /area/security/prison)
 "epv" = (
 /obj/structure/table,
@@ -6423,6 +6743,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/ship,
 /area/maintenance/department/security)
+"erG" = (
+/obj/machinery/computer/lore_terminal,
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "est" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -6444,20 +6768,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "etF" = (
-/obj/structure/chair{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/turf/open/floor/carpet/ship,
+/turf/open/floor/carpet/ship/red_carpet,
 /area/security/prison)
 "etK" = (
 /obj/structure/sink{
@@ -6476,6 +6792,24 @@
 	color = "#99FF99"
 	},
 /area/medical/virology)
+"etQ" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/brigdoor/security/cell/northleft,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/disposaloutlet{
+	dir = 1;
+	name = "Laundromat Input"
+	},
+/turf/open/floor/carpet/ship,
+/area/maintenance/department/medical)
 "etU" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -6486,16 +6820,7 @@
 	width = 35
 	},
 /turf/open/space/basic,
-/area/space)
-"eub" = (
-/obj/structure/table,
-/obj/effect/holodeck_effect/cards,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/turf/open/floor/carpet/ship,
-/area/security/prison)
+/area/space/nearstation)
 "euw" = (
 /obj/machinery/disposal/bin,
 /obj/item/trash/candle{
@@ -6637,11 +6962,11 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "eAc" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 1";
+	name = "Cell 1 Locker"
 	},
-/obj/machinery/cryopod,
-/turf/open/floor/carpet/ship,
+/turf/open/floor/carpet/ship/red_carpet,
 /area/security/prison)
 "eAP" = (
 /obj/structure/cable/yellow{
@@ -6655,6 +6980,22 @@
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/break_room)
+"eAY" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/door/poddoor/ship/preopen{
+	id = "permabrigshutter"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "eCo" = (
 /obj/structure/table,
 /obj/item/paicard,
@@ -6663,12 +7004,21 @@
 	name = "Cafeteria"
 	})
 "eEn" = (
-/obj/machinery/camera/motion{
-	c_tag = "External Viewport Prison Wing";
+/obj/machinery/suit_storage_unit,
+/obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/advanced_airlock_controller/directional/north,
+/obj/machinery/camera{
+	c_tag = "External Access Prison Wing";
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 10
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "eEp" = (
 /obj/machinery/status_display/ai,
 /turf/closed/wall/r_wall/ship,
@@ -6844,10 +7194,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
 /area/chapel/main)
@@ -7063,6 +7410,14 @@
 	},
 /turf/open/floor/plating,
 /area/chapel/main)
+"eQW" = (
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 6
+	},
+/obj/machinery/computer/libraryconsole,
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "eRp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -7166,6 +7521,11 @@
 	},
 /turf/open/floor/carpet/ship/blue,
 /area/medical/medbay/lobby)
+"eTZ" = (
+/obj/machinery/advanced_airlock_controller/directional/north,
+/obj/machinery/suit_storage_unit/standard_unit,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "eUy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/structure/cable/white{
@@ -7199,6 +7559,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "eUT" = (
@@ -7262,6 +7623,12 @@
 	mood_message = "<span class='nicegreen'>This area is pretty serious!\n</span>";
 	name = "Interrogation Room"
 	})
+"eXp" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 8
+	},
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/department/medical)
 "eXv" = (
 /turf/closed/wall/r_wall/ship,
 /area/security/warden)
@@ -7288,6 +7655,20 @@
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
+"eXW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/atmospherics/components/binary/pump/layer1{
+	on = 1;
+	target_pressure = 2000
+	},
+/obj/machinery/door/airlock/ship/external/glass{
+	name = "External Access Deck 2 Fore Starboard";
+	req_one_access_txt = "13"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "eYd" = (
 /obj/structure/filingcabinet/chestdrawer/wheeled,
 /obj/structure/cable{
@@ -7387,6 +7768,9 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "fbW" = (
@@ -7420,7 +7804,10 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "fcH" = (
-/turf/open/floor/carpet/blue,
+/obj/structure/chair/office{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
 /area/security/prison)
 "fde" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -7521,6 +7908,26 @@
 	dir = 8;
 	name = "emergency shower"
 	},
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = 2
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = 2
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -10
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -10
+	},
 /turf/open/floor/plating,
 /area/engine/break_room)
 "fgE" = (
@@ -7551,6 +7958,12 @@
 	pixel_y = 32
 	},
 /obj/structure/closet/secure_closet/engineering_chief,
+/obj/item/clothing/accessory/medal/silver{
+	color = "#ffcc00";
+	desc = "A high quality and decorated medal to show you are appreciated!";
+	name = "custom medal"
+	},
+/obj/item/twohanded/rcl/pre_loaded,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/crew_quarters/heads/chief)
 "fhC" = (
@@ -7584,12 +7997,11 @@
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "fhR" = (
-/obj/machinery/biogenerator,
-/obj/item/reagent_containers/glass/beaker,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/ship/preopen{
+	id = "permabrigshutter"
 	},
-/turf/open/floor/carpet/ship,
+/turf/open/floor/plating,
 /area/security/prison)
 "fhS" = (
 /obj/structure/bed/dogbed/runtime,
@@ -7597,14 +8009,19 @@
 /turf/open/floor/carpet/ship/blue,
 /area/crew_quarters/heads/cmo)
 "fiU" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "1-4"
 	},
-/obj/machinery/light{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/obj/machinery/vending/snack/random,
-/turf/open/floor/carpet/ship,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/ship/preopen{
+	id = "permabrigshutter"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
 /area/security/prison)
 "fjb" = (
 /obj/structure/closet/l3closet/security,
@@ -7680,12 +8097,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"flN" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "fmb" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -7789,6 +8200,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_room)
 "fqZ" = (
@@ -7935,11 +8347,8 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
 "fuA" = (
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
 /obj/machinery/light{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/science/misc_lab{
@@ -7994,12 +8403,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/patients_rooms/room_c)
-"fwS" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/floor/carpet/orange,
-/area/engine/break_room)
 "fxa" = (
 /obj/machinery/meter/atmos/distro_loop{
 	pixel_x = -6;
@@ -8124,6 +8527,12 @@
 /obj/effect/landmark/start/lawyer,
 /turf/open/floor/wood,
 /area/lawoffice)
+"fCr" = (
+/obj/structure/reflector/box/anchored{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "fCJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -8386,6 +8795,32 @@
 	},
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/department/engine)
+"fKE" = (
+/obj/item/twohanded/required/kirbyplants/random{
+	block_sound = 'sound/items/bikehorn.ogg';
+	desc = "A little bit of nature contained in a pot. This one is softer than the other potted plants on this ship.";
+	force = 0;
+	force_wielded = 0;
+	hitsound = 'sound/items/bikehorn.ogg';
+	name = "plush potted plant";
+	throwforce = 0;
+	wieldsound = 'sound/items/bikehorn.ogg'
+	},
+/obj/structure/railing/corner{
+	pixel_y = 1
+	},
+/turf/open/floor/carpet/ship,
+/area/security/prison)
+"fKT" = (
+/obj/structure/chair/wood,
+/turf/open/floor/wood,
+/area/maintenance/department/medical)
+"fLs" = (
+/obj/machinery/light_switch/west,
+/turf/open/floor/carpet/ship/red_carpet,
+/area/security/main{
+	name = "Security War Room"
+	})
 "fLB" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
@@ -8405,6 +8840,13 @@
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmospherics_engine)
+"fMc" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "fMP" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank Oxygen";
@@ -8433,7 +8875,10 @@
 /turf/open/floor/plating,
 /area/chapel/main)
 "fNu" = (
-/obj/structure/extinguisher_cabinet/west,
+/obj/machinery/computer/ship/viewscreen{
+	pixel_x = -32;
+	pixel_y = -6
+	},
 /turf/open/floor/carpet/royalblack,
 /area/chapel/main)
 "fNy" = (
@@ -8617,6 +9062,22 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/security/brig)
+"fTX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/deck_relay,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "fUq" = (
 /obj/structure/chair{
 	dir = 4
@@ -8871,6 +9332,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/patients_rooms/room_d)
+"gfZ" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/carpet/royalblack,
+/area/chapel/main)
 "ggs" = (
 /turf/closed/wall/ship,
 /area/security/detectives_office/private_investigators_office{
@@ -8986,6 +9454,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"glz" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "2;5;12;33"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "glB" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -9047,15 +9523,9 @@
 /turf/open/floor/carpet/ship/blue,
 /area/medical/medbay/central)
 "gnC" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/structure/sign/warning/vacuum,
+/turf/closed/wall/r_wall/ship,
+/area/security/prison)
 "gpg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -9071,7 +9541,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment{
-	dir = 9
+	dir = 5
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/break_room)
@@ -9131,10 +9601,14 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "grf" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
-/turf/open/floor/carpet/ship,
+/obj/machinery/door/poddoor/ship/preopen{
+	id = "permabrigshutter"
+	},
+/turf/open/floor/plating,
 /area/security/prison)
 "grg" = (
 /obj/structure/table/wood,
@@ -9289,16 +9763,20 @@
 /turf/open/floor/circuit,
 /area/tcommsat/server)
 "gyD" = (
-/obj/structure/chair{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/blue,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/computer/prisoner/management{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/carpet/ship/red_carpet,
 /area/security/prison)
 "gyM" = (
 /obj/machinery/status_display/ai,
@@ -9425,14 +9903,13 @@
 /turf/template_noop,
 /area/maintenance/department/engine)
 "gEq" = (
-/obj/machinery/computer/station_alert{
-	dir = 4
-	},
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/structure/cable/white,
+/obj/machinery/computer/monitor{
+	dir = 4;
+	name = "stormdrive power monitoring console"
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/break_room)
@@ -9496,6 +9973,12 @@
 	dir = 4
 	},
 /obj/item/radio/intercom/directional/west,
+/turf/open/floor/carpet/ship/orange_carpet,
+/area/engine/engine_smes)
+"gHn" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
 "gIm" = (
@@ -9580,6 +10063,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
+"gMR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "gMV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plating,
@@ -9588,6 +10080,11 @@
 /obj/machinery/power/port_gen/pacman,
 /mob/living/simple_animal/mouse,
 /turf/open/floor/plating,
+/area/maintenance/department/medical)
+"gNM" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/seven,
+/turf/open/floor/wood,
 /area/maintenance/department/medical)
 "gNY" = (
 /obj/structure/rack,
@@ -9626,6 +10123,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"gOt" = (
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/airlock/ship/public/glass{
+	id_tag = "permabolt1"
+	},
+/obj/machinery/door/poddoor/shutters/ship{
+	id = "permacell1"
+	},
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "gOx" = (
 /obj/structure/chair/office,
 /obj/structure/cable{
@@ -9678,20 +10186,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
-"gRH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/meter/atmos/distro_loop{
-	pixel_x = -6;
-	pixel_y = -6;
-	target_layer = 1
-	},
-/obj/machinery/camera{
-	c_tag = "External Access Prison Wing";
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "gRN" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -9802,6 +10296,10 @@
 	},
 /turf/open/floor/carpet/red,
 /area/ai_monitored/security/armory/lockup)
+"gTp" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "gTz" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -10015,12 +10513,15 @@
 /turf/open/floor/carpet/ship,
 /area/medical/virology)
 "gZC" = (
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/airlock/ship/public{
-	name = "Bathroom Cell"
+/obj/machinery/camera/autoname{
+	dir = 9
 	},
-/turf/open/floor/plasteel/freezer,
+/obj/machinery/firealarm/directional/east,
+/obj/structure/railing/corner{
+	dir = 8;
+	pixel_y = 1
+	},
+/turf/open/floor/carpet/ship,
 /area/security/prison)
 "gZO" = (
 /obj/structure/cable/yellow{
@@ -10029,6 +10530,20 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
+"gZS" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor/ship/preopen{
+	id = "permabrigshutter"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
+"gZT" = (
+/obj/structure/table_frame,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "had" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
@@ -10153,29 +10668,22 @@
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/checkpoint/engineering)
 "heC" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/manifold/purple/hidden{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "heL" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/soda_cans/thirteenloko{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/analyzer,
-/obj/item/clothing/ears/earmuffs,
-/obj/item/clothing/glasses/meson/engine/tray,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/orange,
 /area/engine/break_room)
 "hfs" = (
@@ -10232,8 +10740,14 @@
 	},
 /obj/item/clothing/gloves/color/black,
 /obj/item/cartridge/engineering,
+/obj/item/holosign_creator/atmos,
 /turf/open/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
+"hhz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "hid" = (
 /turf/open/floor/carpet/ship,
 /area/storage/tools)
@@ -10474,6 +10988,9 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
 "htD" = (
@@ -10511,6 +11028,12 @@
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/storage/tech)
+"huy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/closed/wall/r_wall/ship,
+/area/ai_monitored/security/armory/lockup)
 "huD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/carpet/ship,
@@ -10634,6 +11157,11 @@
 	},
 /turf/template_noop,
 /area/maintenance/department/medical)
+"hzF" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/railing,
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "hAb" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -10769,6 +11297,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
 "hGG" = (
@@ -10793,13 +11324,15 @@
 /turf/open/floor/plating,
 /area/crew_quarters/kitchen)
 "hHd" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/cultivator,
-/obj/item/shovel/spade{
-	pixel_x = 4;
-	pixel_y = -1
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/plating,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/conveyor/inverted{
+	id = "permabrig_labor_belt";
+	operating = 1
+	},
+/turf/open/floor/carpet/ship/red_carpet,
 /area/security/prison)
 "hHy" = (
 /obj/machinery/power/apc/auto_name/north,
@@ -10978,6 +11511,11 @@
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
+"hKX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "hLi" = (
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
@@ -10988,21 +11526,39 @@
 /turf/open/floor/carpet/ship,
 /area/security/execution/education)
 "hLp" = (
-/obj/machinery/disposal/bin,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
 /obj/structure/sign/solgov_seal,
 /obj/machinery/firealarm/directional/west,
+/obj/machinery/computer/ship/reactor_control_computer{
+	dir = 4
+	},
+/obj/item/paper{
+	info = "<p>Reminder to add control rods to the Stormdrive engine BEFORE turning it on! Adding control rods requires the engine to be in maintenance mode, and it won't work if the reactor is powered!<br><br>Control rods are located in crate behind particle accelerator</p>";
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/paper{
+	info = "<p>Engineering notice: There are three wire colors used on the Aetherwhisp 6 ship model. White cable is wired to the Stormdrive MK-4 and the supermatter crystal near atmospherics. These lead to their own SMES located nearby. Yellow wires are department distribution wires, which deliver power from the engines SMES to deparment SMES. Red wires deliver power from department SMES to department APCs.</p>"
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/break_room)
 "hLS" = (
 /obj/structure/sign/departments/minsky/medical/virology/virology2,
 /turf/closed/wall/ship,
 /area/medical/virology)
+"hLZ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/ship/orange_carpet,
+/area/engine/break_room)
 "hMd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/machinery/hydroponics/constructable,
@@ -11030,6 +11586,9 @@
 /obj/structure/cable,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/warden)
@@ -11119,9 +11678,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 10
 	},
@@ -11178,12 +11734,20 @@
 /turf/closed/wall/ship,
 /area/maintenance/department/medical)
 "hSc" = (
-/obj/machinery/camera{
-	c_tag = "External Access Medbay";
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/components/binary/pump/layer1{
+	dir = 1;
+	on = 1;
+	target_pressure = 2000
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/airlock/ship/external/glass{
+	name = "External Access Deck 2 Fore Port";
+	req_one_access_txt = "2"
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/medical)
+/area/security/prison)
 "hSh" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -11198,6 +11762,13 @@
 	},
 /turf/open/floor/carpet/ship/red_carpet,
 /area/crew_quarters/heads/hos)
+"hSn" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
+/obj/item/reagent_containers/food/snacks/grown/ambrosia,
+/obj/item/reagent_containers/food/snacks/grown/ambrosia,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "hSE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -11243,6 +11814,10 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/chapel/office)
+"hUM" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/department/medical)
 "hVc" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/wood,
@@ -11250,6 +11825,9 @@
 "hVC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/closed/wall/r_wall/ship,
 /area/science/misc_lab{
@@ -11322,6 +11900,14 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
+"hZf" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/machinery/computer/ship/navigation/public{
+	dir = 8;
+	name = "starmap console"
+	},
+/turf/open/floor/carpet/blue,
+/area/security/prison)
 "iai" = (
 /obj/machinery/atmospherics/pipe/manifold/purple/hidden,
 /turf/closed/wall/ship,
@@ -11517,21 +12103,21 @@
 /turf/open/floor/carpet/ship/blue,
 /area/medical/storage)
 "ifC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/purple/hidden,
-/turf/open/floor/carpet/ship,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/carpet/ship/red_carpet,
 /area/security/prison)
 "ifG" = (
 /obj/structure/cable{
@@ -11678,6 +12264,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/patients_rooms/room_a)
+"ikp" = (
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "ikq" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12190,11 +12780,6 @@
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "iCe" = (
-/obj/machinery/computer/apc_control{
-	dir = 8;
-	req_access = null;
-	req_one_access_txt = "10;11"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -12203,6 +12788,10 @@
 	pixel_x = 30;
 	pixel_y = 25
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/break_room)
 "iCy" = (
@@ -12240,14 +12829,8 @@
 /turf/open/floor/wood,
 /area/chapel/main)
 "iEU" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 10
-	},
-/turf/open/floor/plasteel/freezer,
+/obj/machinery/camera/autoname,
+/turf/open/floor/carpet/ship/red_carpet,
 /area/security/prison)
 "iEZ" = (
 /obj/structure/cable{
@@ -12478,14 +13061,12 @@
 /turf/open/floor/engine,
 /area/engine/atmos)
 "iNo" = (
-/obj/structure/disposaloutlet{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/maintenance/department/medical)
+/turf/open/floor/carpet/ship/red_carpet,
+/area/security/prison)
 "iNr" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12497,6 +13078,12 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
+"iNN" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "iOU" = (
@@ -12621,6 +13208,7 @@
 	name = "Stormdrive Engine";
 	req_one_access_txt = "10"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_room)
 "iVi" = (
@@ -12668,9 +13256,35 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "iVV" = (
-/obj/structure/sign/warning/vacuum,
-/turf/closed/wall/ship,
-/area/maintenance/department/medical)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/button/door{
+	id = "permabolt3";
+	name = "Cell Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 26;
+	pixel_y = 6;
+	specialfunctions = 4
+	},
+/obj/machinery/button/door{
+	id = "permabolt3";
+	name = "Cell Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 38;
+	pixel_y = 6;
+	specialfunctions = 4
+	},
+/obj/machinery/button/flasher{
+	id = "PCell 3";
+	pixel_x = 26;
+	pixel_y = -6
+	},
+/obj/machinery/light_switch{
+	pixel_x = 26;
+	pixel_y = 26
+	},
+/turf/open/floor/carpet/ship/red_carpet,
+/area/security/prison)
 "iVW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable/yellow{
@@ -12749,6 +13363,7 @@
 	pixel_x = -6;
 	pixel_y = -25
 	},
+/obj/structure/extinguisher_cabinet/west,
 /turf/open/floor/wood,
 /area/chapel/main)
 "jbE" = (
@@ -12799,6 +13414,29 @@
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
+"jbX" = (
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = 2
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -10
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = 2
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -10
+	},
+/turf/open/floor/carpet/ship/orange_carpet,
+/area/engine/storage)
 "jce" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -12806,21 +13444,8 @@
 /turf/closed/wall/ship,
 /area/medical/medbay/lobby)
 "jcm" = (
-/obj/structure/table,
-/obj/item/storage/box/donkpockets{
-	pixel_x = 2;
-	pixel_y = 1
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 3
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
+/obj/item/chair,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/ship,
 /area/security/prison)
 "jcr" = (
@@ -12886,11 +13511,30 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "jde" = (
-/obj/machinery/computer/ship/navigation/public{
-	dir = 1;
-	name = "starmap console"
+/obj/machinery/button/door{
+	id = "permabrigwork";
+	name = "Laundromat Lockdown";
+	normaldoorcontrol = 1;
+	pixel_x = 6;
+	pixel_y = -26;
+	specialfunctions = 4
 	},
-/turf/open/floor/carpet/blue,
+/obj/machinery/button/door{
+	id = "permabrigshutter";
+	name = "Permabrig Window Shutters";
+	normaldoorcontrol = 1;
+	pixel_x = -6;
+	pixel_y = -26;
+	specialfunctions = 4
+	},
+/obj/structure/table,
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/item/storage/box/prisoner,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/carpet/ship/red_carpet,
 /area/security/prison)
 "jdF" = (
 /obj/structure/cable{
@@ -12963,10 +13607,6 @@
 	},
 /turf/open/floor/carpet/ship/blue,
 /area/medical/genetics/cloning)
-"jgr" = (
-/obj/machinery/seed_extractor,
-/turf/open/floor/carpet/ship,
-/area/security/prison)
 "jgs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -12974,6 +13614,17 @@
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/carpet/blue,
 /area/medical/genetics/cloning)
+"jgw" = (
+/obj/structure/table,
+/turf/open/floor/carpet/ship,
+/area/security/prison)
+"jgG" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engine_room)
 "jgK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -13014,6 +13665,9 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/engine,
 /area/science/misc_lab{
 	name = "Shield Generator"
@@ -13052,6 +13706,10 @@
 /obj/machinery/vending/wardrobe/atmos_wardrobe,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
+"jio" = (
+/obj/structure/closet/secure_closet/bar,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "jip" = (
 /obj/structure/table/wood,
 /obj/item/trash/plate,
@@ -13116,6 +13774,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"jkv" = (
+/obj/structure/table_frame,
+/obj/item/reagent_containers/pill/floorpill{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/pill/floorpill,
+/obj/item/stack/sheet/iron/ten,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "jkX" = (
 /obj/machinery/computer/pandemic,
 /obj/machinery/power/apc/auto_name/north,
@@ -13233,8 +13901,21 @@
 /turf/open/floor/plating,
 /area/engine/engine_smes)
 "jnG" = (
-/obj/machinery/advanced_airlock_controller/directional/north,
-/turf/open/floor/plating,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_y = 10
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 6
+	},
+/obj/machinery/camera/autoname,
+/obj/machinery/flasher{
+	id = "PCell 3";
+	pixel_x = -26;
+	pixel_y = -6
+	},
+/turf/open/floor/carpet/ship,
 /area/security/prison)
 "joQ" = (
 /obj/structure/table,
@@ -13298,19 +13979,32 @@
 	})
 "jre" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "jrr" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/purple/hidden{
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/ship/preopen{
+	id = "permabrigshutter"
+	},
+/turf/open/floor/plating,
 /area/security/prison)
 "jrV" = (
 /obj/machinery/smartfridge/food,
@@ -13420,12 +14114,19 @@
 /turf/open/floor/plating,
 /area/engine/atmospherics_engine)
 "jwx" = (
-/obj/structure/table,
-/obj/machinery/computer/lore_terminal,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 6
+/obj/machinery/firealarm{
+	pixel_x = 26;
+	pixel_y = 25
 	},
-/obj/machinery/computer/libraryconsole,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/pen,
 /turf/open/floor/carpet/ship,
 /area/security/prison)
 "jxg" = (
@@ -13439,6 +14140,7 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
 "jxK" = (
@@ -13849,6 +14551,12 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/grass,
 /area/hydroponics)
+"jMs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "jMJ" = (
 /obj/machinery/door_timer{
 	id = "pw_2";
@@ -13918,10 +14626,11 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "jPf" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 8
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 2";
+	name = "Cell 2 Locker"
 	},
-/turf/closed/wall/r_wall/ship,
+/turf/open/floor/carpet/ship/red_carpet,
 /area/security/prison)
 "jPo" = (
 /obj/machinery/chem_master,
@@ -13954,11 +14663,12 @@
 /area/tcommsat/server)
 "jPX" = (
 /obj/structure/table/wood,
+/obj/item/folder/white,
+/obj/item/holosign_creator/atmos,
 /obj/item/folder/blue{
 	pixel_x = 4;
 	pixel_y = 4
 	},
-/obj/item/folder/white,
 /obj/item/assembly/timer{
 	desc = "Oh my will you look at the time! Why don't we schedule an appointment for next week?"
 	},
@@ -14003,9 +14713,7 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /turf/open/floor/plating,
-/area/security/main{
-	name = "Security War Room"
-	})
+/area/maintenance/department/medical)
 "jQT" = (
 /obj/structure/spirit_board,
 /obj/structure/disposalpipe/segment{
@@ -14046,6 +14754,10 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/genetics/cloning)
+"jSD" = (
+/obj/structure/sign/warning/vacuum,
+/turf/closed/wall/ship,
+/area/maintenance/department/medical)
 "jSP" = (
 /obj/machinery/holopad,
 /obj/machinery/computer/cryopod{
@@ -14079,6 +14791,19 @@
 /area/science/storage{
 	name = "Atmospherics Canister Storage"
 	})
+"jTz" = (
+/obj/machinery/door/airlock/ship/public{
+	id_tag = "permabrigwork";
+	name = "Laundromat"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "jTY" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/carpet/ship/orange_carpet,
@@ -14137,22 +14862,6 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/medical/apothecary)
-"jVL" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
-	},
-/turf/open/floor/carpet/ship,
-/area/security/prison)
 "jWu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -14169,6 +14878,14 @@
 /obj/machinery/status_display/ai/west,
 /turf/open/floor/carpet/royalblack,
 /area/chapel/main)
+"jXi" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/reagent_containers/food/snacks/grown/pumpkin{
+	pixel_x = 3;
+	pixel_y = 11
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "jXk" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -14211,6 +14928,9 @@
 /obj/item/clothing/glasses/welding,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
@@ -14287,13 +15007,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
 /obj/structure/cable/white{
 	icon_state = "0-4"
 	},
 /obj/machinery/modular_computer/console/preset/engineering{
+	dir = 4
+	},
+/obj/machinery/camera/autoname{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -14346,8 +15066,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "1-8"
 	},
 /turf/open/floor/carpet/orange,
 /area/engine/break_room)
@@ -14431,6 +15152,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
 "kji" = (
@@ -14482,15 +15206,11 @@
 /turf/closed/wall/r_wall/ship,
 /area/engine/gravity_generator)
 "kjT" = (
-/obj/item/soap/nanotrasen,
-/obj/item/bikehorn/rubberducky,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel/freezer,
+/obj/structure/table,
+/obj/item/clothing/under/suit/black,
+/obj/item/clothing/under/suit/sl,
+/obj/machinery/light_switch/west,
+/turf/open/floor/carpet/ship,
 /area/security/prison)
 "kkw" = (
 /obj/structure/flora/ausbushes/fullgrass,
@@ -14619,6 +15339,11 @@
 	},
 /turf/open/floor/carpet/ship/red_carpet,
 /area/crew_quarters/heads/hos)
+"kpY" = (
+/obj/structure/lattice,
+/obj/machinery/power/rad_collector,
+/turf/open/space/basic,
+/area/space/nearstation)
 "kqi" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 4
@@ -14669,12 +15394,24 @@
 "kru" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
+/obj/machinery/disposal/deliveryChute{
+	dir = 4;
+	pixel_x = -5
+	},
+/obj/machinery/door/window/eastright{
+	req_one_access_txt = "10;11;24"
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk,
 /turf/open/floor/carpet/orange,
 /area/science/misc_lab{
 	name = "Shield Generator"
@@ -14809,6 +15546,10 @@
 /obj/machinery/holopad,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/patients_rooms/room_a)
+"kvS" = (
+/obj/structure/ladder,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "kvV" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/carpet/ship/orange_carpet,
@@ -14822,6 +15563,7 @@
 "kwv" = (
 /obj/item/reagent_containers/glass/beaker,
 /obj/effect/landmark/blobstart,
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "kwB" = (
@@ -14865,12 +15607,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
-"kxe" = (
-/obj/machinery/door/window{
-	dir = 4
-	},
-/turf/open/floor/plasteel/freezer,
-/area/security/prison)
 "kxj" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -15084,11 +15820,11 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "kEI" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/turf/closed/wall/r_wall/ship,
+/area/security/prison)
 "kEM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -15286,9 +16022,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/storage)
-"kLl" = (
-/turf/open/floor/plating,
-/area/security/prison)
 "kLT" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -15375,10 +16108,6 @@
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
-/obj/machinery/computer/ship/viewscreen{
-	pixel_x = -32;
-	pixel_y = -6
-	},
 /turf/open/floor/wood,
 /area/chapel/main)
 "kPO" = (
@@ -15413,21 +16142,11 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/tcommsat/server)
 "kQp" = (
-/obj/structure/easel,
-/obj/item/canvas/twentythreeXtwentythree,
-/obj/item/canvas/twentythreeXtwentythree,
-/obj/item/canvas/twentythreeXtwentythree,
-/obj/machinery/camera/autoname{
-	dir = 8
+/obj/structure/shuttle/engine/large{
+	dir = 4
 	},
-/obj/structure/sign/poster/random{
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/pipe/manifold/purple/hidden{
-	dir = 8
-	},
-/turf/open/floor/carpet/ship,
-/area/security/prison)
+/turf/open/space/basic,
+/area/space/nearstation)
 "kQC" = (
 /obj/structure/cable/white{
 	icon_state = "2-8"
@@ -15574,9 +16293,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "kUj" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/holopad,
 /turf/open/floor/carpet/orange,
 /area/science/misc_lab{
 	name = "Shield Generator"
@@ -15722,15 +16439,10 @@
 /turf/open/floor/carpet/ship/blue,
 /area/medical/patients_rooms/room_a)
 "kZI" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/chair/wood{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/manifold/purple/hidden{
-	dir = 8
-	},
-/turf/open/floor/plating,
+/turf/open/floor/wood,
 /area/maintenance/department/medical)
 "laf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
@@ -15752,6 +16464,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"lbw" = (
+/obj/structure/curtain,
+/obj/machinery/shower{
+	dir = 8;
+	layer = 3.5
+	},
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
 "lbB" = (
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/carpet/ship/blue,
@@ -15772,6 +16492,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "lch" = (
@@ -15783,14 +16504,33 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
 "lcF" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/machinery/button/door{
+	id = "permabolt1";
+	name = "Cell Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 6;
+	pixel_y = -38;
+	specialfunctions = 4
+	},
+/obj/machinery/button/door{
+	id = "permacell1";
+	name = "Cell 1 Lockdown";
+	pixel_x = 6;
+	pixel_y = -26;
+	req_access_txt = "2"
+	},
+/obj/machinery/button/flasher{
+	id = "PCell 1";
+	pixel_x = -6;
+	pixel_y = -26
+	},
+/turf/open/floor/carpet/ship/red_carpet,
 /area/security/prison)
 "lcT" = (
 /obj/structure/table,
@@ -15914,11 +16654,13 @@
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/brig)
 "lfF" = (
-/obj/machinery/suit_storage_unit,
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
 	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/carpet/ship/red_carpet,
 /area/security/prison)
 "lfG" = (
 /obj/structure/disposalpipe/segment{
@@ -15968,9 +16710,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
 /area/chapel/main)
@@ -16149,10 +16889,10 @@
 "lmO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/holopad,
 /obj/structure/cable/white{
 	icon_state = "0-8"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/orange,
 /area/science/misc_lab{
 	name = "Shield Generator"
@@ -16188,6 +16928,12 @@
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
+"lno" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/closed/wall/r_wall/ship,
+/area/security/prison)
 "lnJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/ship/preopen{
@@ -16222,6 +16968,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/blue,
 /area/medical/genetics/cloning)
+"lqL" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/turf/template_noop,
+/area/maintenance/department/medical)
 "lrk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -16526,14 +17276,18 @@
 /turf/open/floor/carpet/ship,
 /area/storage/tools)
 "lBq" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/rack,
+/obj/item/storage/toolbox/emergency{
+	pixel_x = -2
 	},
-/obj/machinery/computer/cryopod{
-	pixel_y = 32
+/obj/item/storage/toolbox/emergency{
+	pixel_x = 2;
+	pixel_y = -3
 	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/carpet/ship,
+/obj/item/wirecutters{
+	pixel_y = 2
+	},
+/turf/open/floor/carpet/ship/red_carpet,
 /area/security/prison)
 "lBt" = (
 /obj/structure/closet/l3closet/virology,
@@ -16569,9 +17323,6 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "lBK" = (
@@ -16603,6 +17354,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/computer/lore_terminal,
+/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/break_room)
 "lDU" = (
@@ -16924,6 +17679,12 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmospherics_engine)
+"lOl" = (
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/gloves/color/latex,
+/obj/structure/closet/l3closet/virology,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "lOU" = (
 /obj/machinery/dna_scannernew,
 /obj/structure/sign/poster/official/random{
@@ -16969,6 +17730,16 @@
 /obj/item/surgical_drapes,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/surgery/aux)
+"lRg" = (
+/obj/structure/curtain,
+/obj/machinery/shower{
+	dir = 8;
+	layer = 3.5
+	},
+/obj/item/soap/nanotrasen,
+/obj/item/bikehorn/rubberducky,
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
 "lRy" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=loc7";
@@ -17144,9 +17915,6 @@
 /obj/machinery/camera/autoname{
 	dir = 9
 	},
-/obj/structure/sign/poster/random{
-	pixel_x = 32
-	},
 /turf/open/floor/carpet/ship/blue,
 /area/medical/apothecary)
 "lWF" = (
@@ -17192,14 +17960,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/machinery/atmospherics/components/binary/valve/digital{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -17250,6 +18018,14 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/security/brig)
+"mbq" = (
+/obj/structure/table_frame/wood,
+/obj/item/stack/sheet/mineral/wood{
+	amount = 10
+	},
+/obj/item/storage/fancy/candle_box,
+/turf/open/floor/wood,
+/area/maintenance/department/medical)
 "mbt" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -17304,9 +18080,23 @@
 /obj/structure/table,
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/brig)
+"mex" = (
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "meB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/carpet/blue,
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/pen,
+/obj/item/folder/red{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/turf/open/floor/carpet/ship/red_carpet,
 /area/security/prison)
 "meI" = (
 /obj/structure/table/glass,
@@ -17347,11 +18137,12 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
 "mgd" = (
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/gloves/color/latex,
-/obj/structure/closet/l3closet/virology,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/turf/open/floor/carpet/ship/red_carpet,
+/area/security/prison)
 "mgi" = (
 /obj/machinery/light{
 	dir = 4
@@ -17399,12 +18190,6 @@
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
-"mhq" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
-	},
-/turf/open/floor/carpet/ship,
-/area/security/prison)
 "mhI" = (
 /obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall/ship,
@@ -17648,9 +18433,8 @@
 /turf/open/floor/carpet/ship,
 /area/medical/morgue)
 "mqP" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/structure/cable,
-/turf/open/floor/plating,
+/obj/structure/closet/crate/trashcart,
+/turf/open/floor/carpet/ship,
 /area/security/prison)
 "mqW" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater{
@@ -17760,33 +18544,6 @@
 	},
 /turf/closed/wall/r_wall/ship,
 /area/engine/atmos)
-"mtQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Long-Term Confinement"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/shutters/ship{
-	dir = 4;
-	id = "cell1_ld"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
-	},
-/turf/open/floor/carpet/ship,
-/area/security/prison)
 "mtS" = (
 /obj/item/clothing/mask/surgical,
 /obj/item/clothing/gloves/color/latex,
@@ -17941,13 +18698,9 @@
 "mAf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "2;5;12"
 	},
@@ -18050,6 +18803,10 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/obj/effect/landmark/start/station_engineer,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/break_room)
 "mDr" = (
@@ -18218,12 +18975,37 @@
 /obj/machinery/lazylift_button,
 /turf/closed/wall/ship,
 /area/shuttle/turbolift/primary)
-"mJr" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
+"mIC" = (
+/obj/structure/chair{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/turf/open/floor/carpet/ship,
+/area/security/prison)
+"mJr" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/machinery/button/door{
+	id = "permacell2";
+	name = "Cell 2 Lockdown";
+	pixel_x = 6;
+	pixel_y = -26;
+	req_access_txt = "2"
+	},
+/obj/machinery/button/door{
+	id = "permabolt2";
+	name = "Cell Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 6;
+	pixel_y = -38;
+	specialfunctions = 4
+	},
+/obj/machinery/button/flasher{
+	id = "PCell 2";
+	pixel_x = -6;
+	pixel_y = -26
+	},
+/turf/open/floor/carpet/ship/red_carpet,
+/area/security/prison)
 "mKm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/camera/autoname{
@@ -18329,11 +19111,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "mLZ" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/structure/cable{
-	icon_state = "0-2"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/open/floor/carpet/ship/red_carpet,
 /area/security/prison)
 "mMe" = (
 /obj/structure/cable{
@@ -18411,6 +19196,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"mQs" = (
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_y = 10
+	},
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
 "mQJ" = (
 /obj/structure/sign/warning/radiation,
 /turf/closed/wall/r_wall/ship,
@@ -18432,9 +19227,6 @@
 /turf/open/floor/carpet/royalblack,
 /area/chapel/main)
 "mRb" = (
-/obj/structure/chair/office/light{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -18444,7 +19236,15 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
-/obj/effect/landmark/start/station_engineer,
+/obj/structure/disposalpipe/segment,
+/obj/structure/table,
+/obj/item/analyzer,
+/obj/item/reagent_containers/food/drinks/soda_cans/thirteenloko{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/glasses/meson/engine/tray,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/break_room)
 "mRi" = (
@@ -18471,7 +19271,6 @@
 	name = "Supermatter Core"
 	})
 "mRI" = (
-/obj/structure/table,
 /obj/machinery/camera/autoname{
 	dir = 9
 	},
@@ -18481,10 +19280,9 @@
 	name = "Engineering RC";
 	pixel_x = 30
 	},
-/obj/item/airlock_painter,
-/obj/item/cartridge/atmos,
-/obj/item/cartridge/engineering,
-/obj/item/holosign_creator/engineering,
+/obj/machinery/computer/station_alert{
+	dir = 8
+	},
 /turf/open/floor/carpet/orange,
 /area/engine/break_room)
 "mSr" = (
@@ -18630,17 +19428,42 @@
 /turf/open/floor/carpet/ship/blue,
 /area/crew_quarters/heads/cmo)
 "mWX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/airlock/ship/security/glass{
+	req_one_access_txt = "Permabrig Cell 3"
+	},
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "mXf" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = 2
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = 2
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -10
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -10
 	},
 /turf/open/floor/carpet/ship/blue,
 /area/medical/medbay/central)
@@ -18937,6 +19760,7 @@
 /obj/item/cartridge/engineering{
 	pixel_x = 3
 	},
+/obj/item/reagent_containers/pill/patch/silver_sulf,
 /obj/item/computer_hardware/card_slot,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/crew_quarters/heads/chief)
@@ -18966,6 +19790,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/surgery)
+"nif" = (
+/obj/structure/reagent_dispensers/foamtank/hull_repair_juice,
+/obj/item/extinguisher/advanced/hull_repair_juice,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "nil" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -19130,13 +19959,7 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "npd" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/carpet/ship,
 /area/security/prison)
 "npk" = (
 /obj/structure/table/glass,
@@ -19167,6 +19990,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"npu" = (
+/obj/machinery/vending/hydroseeds,
+/obj/item/stack/spacecash/c50,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "npJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19199,9 +20033,9 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
 "nrL" = (
-/obj/item/skub,
 /obj/item/coin/iron,
 /obj/item/storage/toolbox/emergency/old,
+/obj/effect/spawner/lootdrop/maintenance/four,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "nrM" = (
@@ -19212,6 +20046,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/landmark/start/security_officer,
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/carpet/ship,
 /area/security/brig)
 "nsi" = (
@@ -19395,6 +20232,26 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = 2
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = 2
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -10
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -10
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmospherics_engine)
 "nwt" = (
@@ -19406,6 +20263,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
@@ -19450,6 +20310,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"nya" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/turf/open/floor/wood,
+/area/maintenance/department/medical)
 "nyC" = (
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/firedoor/border_only/directional/north,
@@ -19488,22 +20357,26 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "nBw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
-"nBP" = (
-/obj/machinery/shower{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/structure/curtain,
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/carpet/ship,
+/area/security/prison)
+"nBP" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/gloves,
+/obj/effect/spawner/lootdrop/gloves,
+/turf/open/floor/carpet/ship,
 /area/security/prison)
 "nBT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/department/medical)
 "nCf" = (
@@ -19536,6 +20409,17 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/kitchen)
+"nCX" = (
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 11;
+	height = 22;
+	id = "unused_2";
+	name = "Deck 1 Fore Starboard";
+	width = 35
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "nDg" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 8
@@ -19650,11 +20534,11 @@
 	name = "Long-Term Confinement";
 	req_one_access_txt = "2"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/prison)
@@ -19695,9 +20579,6 @@
 /turf/open/floor/carpet/ship/blue,
 /area/medical/storage)
 "nJk" = (
-/obj/structure/chair/office/light{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/white{
 	icon_state = "1-4"
@@ -19716,6 +20597,13 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"nKC" = (
+/obj/structure/table,
+/obj/item/storage/crayons,
+/obj/item/instrument/harmonica,
+/obj/effect/holodeck_effect/cards,
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "nLr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -19881,6 +20769,14 @@
 /area/science/storage{
 	name = "Atmospherics Canister Storage"
 	})
+"nQT" = (
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/airlock/ship/public{
+	name = "Permabrig Bathroom"
+	},
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "nRc" = (
 /obj/structure/sink/puddle,
 /turf/open/floor/grass,
@@ -20006,6 +20902,17 @@
 /obj/machinery/power/terminal,
 /turf/open/floor/carpet/ship/red_carpet,
 /area/ai_monitored/security/armory/security)
+"nUx" = (
+/obj/machinery/biogenerator,
+/obj/item/reagent_containers/glass/beaker,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "nUQ" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/camera/autoname{
@@ -20073,6 +20980,12 @@
 	},
 /turf/open/floor/plating,
 /area/chapel/main)
+"nXR" = (
+/obj/structure/frame/computer{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "nYd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -20226,8 +21139,14 @@
 /turf/open/floor/carpet/ship,
 /area/chapel/office)
 "ofM" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/r_wall/ship,
+/obj/structure/bed,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/open/floor/carpet/ship,
 /area/security/prison)
 "ogg" = (
 /obj/structure/cable{
@@ -20309,6 +21228,16 @@
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/shuttle/turbolift/secondary)
+"okE" = (
+/obj/structure/chair,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "okK" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/carbon_input,
 /turf/open/floor/engine/co2,
@@ -20368,6 +21297,16 @@
 	},
 /turf/open/floor/carpet/ship/red_carpet,
 /area/crew_quarters/heads/hos)
+"omY" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/shovel/spade{
+	pixel_x = 4;
+	pixel_y = -1
+	},
+/obj/item/cultivator,
+/turf/open/floor/plating,
+/area/security/prison)
 "onb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -20406,6 +21345,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/tcommsat/server)
 "ooA" = (
@@ -20423,6 +21365,15 @@
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
+"opC" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "opS" = (
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo)
@@ -20485,6 +21436,9 @@
 	dir = 1
 	},
 /obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
 "orZ" = (
@@ -20523,6 +21477,9 @@
 	id = "tcommsatshutter2";
 	pixel_x = -26;
 	pixel_y = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/tcommsat/server)
@@ -20563,11 +21520,7 @@
 /turf/open/floor/carpet/ship/blue,
 /area/medical/medbay/central)
 "ouK" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/ship,
 /area/security/prison)
 "ovc" = (
@@ -20580,6 +21533,10 @@
 	},
 /turf/open/floor/plating,
 /area/security/checkpoint/escape)
+"ovd" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "ovK" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -20628,6 +21585,7 @@
 /obj/item/gps/engineering,
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/orange,
 /area/science/misc_lab{
 	name = "Shield Generator"
@@ -20651,6 +21609,16 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
 /area/security/detectives_office)
+"oyd" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/grass,
+/area/chapel/main)
 "oyG" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -20696,6 +21664,14 @@
 	},
 /turf/open/floor/carpet,
 /area/maintenance/department/medical)
+"oAG" = (
+/obj/structure/table,
+/obj/machinery/airalarm/directional/west,
+/obj/item/clothing/under/color/grey,
+/obj/item/clothing/under/color/grey,
+/obj/item/clothing/under/color/random,
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "oAN" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
 	dir = 8
@@ -20767,6 +21743,10 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/engine,
 /area/engine/engine_room)
+"oEQ" = (
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/department/medical)
 "oFw" = (
 /obj/structure/closet/secure_closet/courtroom,
 /turf/open/floor/wood,
@@ -20796,11 +21776,15 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/tcommsat/server)
 "oGp" = (
-/obj/item/clothing/mask/surgical,
-/obj/structure/closet/l3closet/security,
-/obj/item/clothing/gloves/color/latex,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/airlock/ship/security/glass{
+	req_one_access_txt = "Permabrig Cell 1"
+	},
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "oGt" = (
 /turf/closed/wall/ship,
 /area/crew_quarters/kitchen)
@@ -20882,11 +21866,15 @@
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/checkpoint/escape)
 "oKs" = (
-/obj/structure/closet/secure_closet/brig,
-/turf/open/floor/carpet/ship/red_carpet,
-/area/security/main{
-	name = "Security War Room"
-	})
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/airlock/ship/security/glass{
+	req_one_access_txt = "Permabrig Cell 2"
+	},
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "oKF" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
@@ -20904,6 +21892,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
+/obj/structure/sign/poster/random{
+	pixel_x = 32
+	},
 /turf/open/floor/carpet/ship/blue,
 /area/medical/apothecary)
 "oKL" = (
@@ -20925,6 +21916,15 @@
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
+"oLb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "oLf" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -20951,6 +21951,11 @@
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/tcommsat/server)
+"oLD" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "oLX" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -20994,10 +21999,15 @@
 /turf/open/floor/plating,
 /area/crew_quarters/kitchen)
 "oMJ" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/purple/hidden{
 	dir = 8
 	},
-/turf/closed/wall/r_wall/ship,
+/turf/open/floor/wood,
 /area/maintenance/department/medical)
 "oMT" = (
 /obj/machinery/vending/engineering,
@@ -21040,11 +22050,8 @@
 	name = "Maintenance Access Security War Room";
 	req_one_access_txt = "2"
 	},
-/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
-/area/security/main{
-	name = "Security War Room"
-	})
+/area/maintenance/department/security)
 "oOV" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -21158,11 +22165,19 @@
 /turf/open/floor/carpet/ship/blue,
 /area/medical/medbay/lobby)
 "oSx" = (
-/obj/machinery/atmospherics/pipe/manifold/purple/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/airlock/ship/public/glass{
+	id_tag = "permabolt3"
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/machinery/door/poddoor/shutters/ship{
+	id = "permacell3"
+	},
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "oSO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -21229,6 +22244,9 @@
 /area/chapel/office)
 "oUL" = (
 /obj/effect/landmark/start/warden,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/warden)
 "oVl" = (
@@ -21435,6 +22453,26 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/airalarm/directional/north,
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = 2
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = 2
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -10
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -10
+	},
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/brig)
 "pad" = (
@@ -21469,7 +22507,7 @@
 	name = "Cafeteria"
 	})
 "pbN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /turf/closed/wall/r_wall/ship,
@@ -21486,7 +22524,10 @@
 	pixel_x = -12;
 	pixel_y = 2
 	},
-/obj/machinery/light_switch/west,
+/obj/structure/mirror{
+	pixel_x = -27;
+	pixel_y = -2
+	},
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/brig)
 "pct" = (
@@ -21664,8 +22705,24 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "pjK" = (
-/obj/structure/closet/crate/trashcart,
-/turf/open/floor/plating,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/disposaloutlet{
+	dir = 1;
+	name = "Laundromat Output"
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/carpet/ship/red_carpet,
 /area/security/prison)
 "plo" = (
 /obj/item/twohanded/required/kirbyplants/random,
@@ -21701,6 +22758,16 @@
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
+"pmR" = (
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_y = 6
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "pne" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -22004,12 +23071,15 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "pvX" = (
-/obj/machinery/power/deck_relay,
-/obj/structure/cable/white{
-	icon_state = "0-2"
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_x = -7
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/machinery/recharger{
+	pixel_x = 7
+	},
+/turf/open/floor/carpet/ship/red_carpet,
+/area/security/prison)
 "pwr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -22223,6 +23293,29 @@
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/tcommsat/server)
+"pFp" = (
+/obj/machinery/newscaster/directional/west,
+/obj/machinery/disposal/deliveryChute{
+	desc = "A chute for big and small packages alike! Please don't smuggle stuff into the laudromat. Yes, you.";
+	dir = 4;
+	name = "Laundromat Input";
+	pixel_x = -5
+	},
+/obj/machinery/door/window/brigdoor/security/cell/eastleft{
+	req_one_access_txt = "2"
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/carpet/ship/red_carpet,
+/area/security/prison)
 "pFQ" = (
 /obj/structure/table,
 /obj/item/toy/cards/deck{
@@ -22263,11 +23356,25 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/ship,
 /area/storage/tools)
+"pHg" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "pIL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "pIZ" = (
@@ -22421,8 +23528,9 @@
 /turf/open/floor/plating,
 /area/security/checkpoint/medical)
 "pLX" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
+/obj/structure/reagent_dispensers/foamtank/hull_repair_juice,
+/obj/item/extinguisher/advanced/hull_repair_juice,
+/turf/open/floor/wood,
 /area/maintenance/department/medical)
 "pMn" = (
 /obj/structure/sign/directions/command{
@@ -22503,6 +23611,14 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /turf/open/floor/carpet/ship,
 /area/security/brig)
+"pOp" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/ship/preopen{
+	id = "permabrigshutter"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "pOq" = (
 /obj/machinery/vending/security,
 /turf/open/floor/carpet/ship/red_carpet,
@@ -22535,7 +23651,7 @@
 	dir = 8
 	},
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "pQq" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
 	dir = 1
@@ -22600,11 +23716,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "pRp" = (
-/obj/structure/bookcase/random,
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/computer/shuttle/labor{
+	dir = 8
 	},
-/turf/open/floor/carpet/ship,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/carpet/ship/red_carpet,
 /area/security/prison)
 "pSe" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -22719,16 +23837,16 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
-	},
-/turf/open/floor/carpet/ship,
+/turf/open/floor/carpet/ship/red_carpet,
 /area/security/prison)
 "pXC" = (
 /obj/item/twohanded/required/kirbyplants/random,
@@ -22753,6 +23871,9 @@
 /obj/machinery/airalarm/directional/west,
 /obj/structure/table,
 /obj/item/twohanded/rcl/pre_loaded,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/carpet/orange,
 /area/science/misc_lab{
 	name = "Shield Generator"
@@ -23145,6 +24266,12 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/medical/genetics/cloning)
+"qjY" = (
+/obj/structure/closet/l3closet/security,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/gloves/color/latex,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "qkh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall/ship,
@@ -23189,17 +24316,13 @@
 	name = "Hallway"
 	})
 "qlC" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating,
+/turf/open/floor/carpet/ship,
 /area/security/prison)
 "qlM" = (
 /obj/machinery/firealarm/directional/west,
@@ -23229,6 +24352,17 @@
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
+"qmy" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/carpet/ship/orange_carpet,
+/area/engine/break_room)
 "qmK" = (
 /turf/closed/wall/ship,
 /area/medical/apothecary)
@@ -23245,14 +24379,13 @@
 /turf/open/floor/carpet/ship/red_carpet,
 /area/ai_monitored/security/armory/lockup)
 "qnx" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/structure/mirror{
-	pixel_x = 27;
-	pixel_y = -2
+/obj/structure/chair{
+	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/ship,
 /area/security/prison)
 "qnU" = (
@@ -23261,6 +24394,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"qoe" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/department/medical)
 "qog" = (
 /obj/structure/sign/departments/minsky/engineering/telecommmunications,
 /turf/closed/wall/r_wall/ship,
@@ -23272,6 +24411,10 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/kitchen)
+"qom" = (
+/obj/structure/frame/machine,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "qor" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -23330,6 +24473,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/tcommsat/server)
 "qpA" = (
@@ -23378,6 +24524,12 @@
 	},
 /turf/template_noop,
 /area/maintenance/department/engine/atmos)
+"qqz" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/turf/template_noop,
+/area/maintenance/department/medical)
 "qqD" = (
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/carpet/ship/red_carpet,
@@ -23485,6 +24637,9 @@
 	icon_state = "0-4"
 	},
 /obj/item/twohanded/required/kirbyplants/random,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/carpet/orange,
 /area/science/misc_lab{
 	name = "Shield Generator"
@@ -23492,6 +24647,9 @@
 "qvo" = (
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/closed/wall/r_wall/ship,
 /area/engine/engine_smes)
@@ -23636,6 +24794,9 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
 "qyL" = (
@@ -23728,12 +24889,7 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
 "qAi" = (
-/obj/machinery/modular_computer/console/preset/engineering{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
+/obj/item/banner/engineering,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/break_room)
 "qAS" = (
@@ -23803,6 +24959,25 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"qCZ" = (
+/obj/structure/table,
+/obj/item/storage/box/donkpockets{
+	pixel_x = 2;
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3
+	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "qDd" = (
 /obj/machinery/computer/atmos_control/tank/oxygen_tank{
 	dir = 1
@@ -24035,6 +25210,18 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/chapel/office)
+"qMb" = (
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "qMe" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -24118,6 +25305,12 @@
 /area/security/main{
 	name = "Security War Room"
 	})
+"qPd" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 6
+	},
+/turf/closed/wall/ship,
+/area/maintenance/department/medical)
 "qPp" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/item/clothing/suit/hooded/wintercoat/engineering,
@@ -24186,6 +25379,16 @@
 /area/crew_quarters/lounge{
 	name = "Cafeteria"
 	})
+"qQJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engine_room)
 "qQP" = (
 /obj/structure/chair{
 	dir = 4
@@ -24367,12 +25570,22 @@
 /obj/item/reagent_containers/food/drinks/shaker,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"qXb" = (
+/obj/machinery/vending/snack/random,
+/turf/open/floor/plating,
+/area/security/prison)
 "qXI" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/carpet/ship,
 /area/shuttle/turbolift/quaternary)
+"qXL" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/closed/wall/r_wall/ship,
+/area/ai_monitored/security/armory/security)
 "qYb" = (
 /obj/machinery/light,
 /obj/machinery/button/door{
@@ -24562,6 +25775,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/carpet/ship/red_carpet,
 /area/ai_monitored/security/armory/security)
@@ -24828,6 +26044,21 @@
 /turf/open/floor/circuit,
 /area/tcommsat/server)
 "rrO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/carpet/ship/red_carpet,
+/area/security/prison)
+"rsl" = (
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/carpet/ship,
 /area/security/prison)
 "rsq" = (
@@ -25206,6 +26437,20 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/bar)
+"rGS" = (
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "rHe" = (
 /obj/structure/frame/computer{
 	dir = 4
@@ -25348,12 +26593,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "rMK" = (
-/obj/structure/table,
-/obj/item/stack/spacecash/c20,
-/obj/item/storage/pill_bottle/dice,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/carpet/ship,
+/turf/open/floor/carpet/ship/red_carpet,
 /area/security/prison)
 "rMN" = (
 /obj/machinery/portable_atmospherics/canister/air,
@@ -25487,6 +26727,12 @@
 /area/crew_quarters/lounge{
 	name = "Cafeteria"
 	})
+"rSD" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "rTu" = (
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
@@ -25537,6 +26783,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
+"rWc" = (
+/obj/machinery/hydroponics/constructable,
+/obj/item/seeds/ambrosia,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "rWp" = (
 /obj/structure/sign/poster/random{
 	pixel_x = 32
@@ -25669,27 +26920,27 @@
 /obj/machinery/camera/autoname{
 	dir = 9
 	},
-/obj/machinery/computer/ship/viewscreen{
-	pixel_x = 32;
-	pixel_y = -6
-	},
 /turf/open/floor/wood,
 /area/chapel/main)
 "rZb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/structure/bed,
+/obj/machinery/firealarm{
+	pixel_x = -26;
+	pixel_y = 25
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_y = 10
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
-	},
-/obj/structure/cable/white{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/machinery/camera/autoname,
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "rZt" = (
 /obj/structure/chair{
 	dir = 4
@@ -25699,6 +26950,21 @@
 	},
 /turf/open/floor/carpet/ship/blue,
 /area/medical/medbay/lobby)
+"rZC" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/turf/open/floor/carpet/orange,
+/area/engine/break_room)
+"sab" = (
+/obj/structure/table,
+/obj/item/stack/spacecash/c20,
+/obj/item/storage/pill_bottle/dice,
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "sag" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/structure/cable/yellow{
@@ -25746,12 +27012,11 @@
 /turf/open/floor/engine,
 /area/engine/atmos)
 "saQ" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/machinery/door/airlock/ship/external/glass{
-	name = "External Access Deck 2 Fore Port";
-	req_one_access_txt = "2"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
 	},
-/turf/open/floor/plating,
+/turf/open/floor/carpet/ship,
 /area/security/prison)
 "saS" = (
 /obj/structure/cable/yellow{
@@ -25775,11 +27040,19 @@
 	name = "Interrogation Room"
 	})
 "sca" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_y = 10
 	},
-/turf/closed/wall/r_wall/ship,
-/area/maintenance/department/medical)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "scE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -26015,15 +27288,17 @@
 	initial_gas_mix = "o2=500000;TEMP=293.15"
 	},
 /area/engine/atmos)
+"slv" = (
+/obj/machinery/atmospherics/pipe/manifold/purple/hidden,
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/department/medical)
 "sly" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/department/engine/atmos)
 "slU" = (
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/turf/open/floor/carpet/ship,
+/obj/machinery/light_switch/west,
+/turf/open/floor/carpet/ship/red_carpet,
 /area/security/prison)
 "smb" = (
 /obj/structure/chair/office,
@@ -26040,6 +27315,12 @@
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/break_room)
+"smF" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "smK" = (
 /obj/structure/closet/radiation,
 /obj/item/clothing/mask/gas,
@@ -26085,6 +27366,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/status_display/ai,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/closed/wall/ship,
 /area/tcommsat/server)
 "sol" = (
@@ -26155,8 +27439,17 @@
 /obj/machinery/computer/prisoner/management{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/warden)
+"sqE" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall/ship,
+/area/security/prison)
 "sqV" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -26164,6 +27457,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/white{
 	icon_state = "1-2"
+	},
+/obj/structure/chair/office/light{
+	dir = 8
 	},
 /turf/open/floor/carpet/orange,
 /area/engine/break_room)
@@ -26332,8 +27628,18 @@
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo)
 "sAE" = (
-/obj/machinery/modular_computer/console/preset/civilian,
-/turf/open/floor/carpet/ship,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/computer/security{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/carpet/red,
 /area/security/prison)
 "sAK" = (
 /turf/open/floor/light/colour_cycle/dancefloor_b,
@@ -26367,15 +27673,15 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
 "sCS" = (
-/obj/machinery/washing_machine,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/computer/ship/viewscreen{
-	pixel_x = -32;
-	pixel_y = -6
-	},
-/turf/open/floor/carpet/ship,
+/obj/structure/chair/office,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/carpet/ship/red_carpet,
 /area/security/prison)
 "sCZ" = (
 /obj/structure/table,
@@ -26492,9 +27798,6 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmospherics_engine)
 "sIA" = (
-/obj/structure/chair/office/light{
-	dir = 4
-	},
 /turf/open/floor/carpet/orange,
 /area/engine/break_room)
 "sIF" = (
@@ -26685,6 +27988,29 @@
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
+"sPr" = (
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = 2
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = 2
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -10
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -10
+	},
+/turf/open/floor/wood,
+/area/chapel/main)
 "sQH" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
 /obj/structure/cable{
@@ -26705,6 +28031,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/carpet/ship,
 /area/security/brig)
+"sQX" = (
+/turf/open/floor/carpet/red,
+/area/security/prison)
 "sRb" = (
 /turf/open/floor/carpet/ship,
 /area/security/detectives_office/private_investigators_office{
@@ -26771,15 +28100,17 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/break_room)
 "sTO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/meter/atmos/distro_loop{
-	pixel_x = -6;
-	pixel_y = -6;
-	target_layer = 1
+/obj/structure/bed,
+/obj/machinery/firealarm{
+	pixel_x = 26;
+	pixel_y = 25
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/obj/machinery/camera/autoname,
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "sUe" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -26812,21 +28143,8 @@
 /turf/open/floor/carpet/ship/red_carpet,
 /area/hydroponics)
 "sUV" = (
-/obj/structure/bed,
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/obj/machinery/flasher{
-	id = "PCell 4";
-	pixel_y = 24
-	},
-/obj/machinery/firealarm{
-	pixel_x = 26;
-	pixel_y = 25
-	},
-/turf/open/floor/carpet/ship,
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/carpet/ship/red_carpet,
 /area/security/prison)
 "sVp" = (
 /obj/machinery/vending/assist,
@@ -26862,9 +28180,10 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/crew_quarters/heads/chief)
 "sVP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/carpet/ship,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/turf/open/floor/carpet/ship/red_carpet,
 /area/security/prison)
 "sWw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -26938,6 +28257,11 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/security/brig)
+"sZs" = (
+/obj/structure/frame/machine,
+/obj/item/vending_refill/hydroseeds,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "sZK" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -26962,8 +28286,8 @@
 /turf/open/floor/grass,
 /area/hydroponics)
 "taE" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/carpet/ship,
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall/r_wall/ship,
 /area/security/prison)
 "taT" = (
 /obj/structure/peacekeeper_barricade/metal/plasteel/deployable,
@@ -27028,6 +28352,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/carpet/ship/red_carpet,
 /area/ai_monitored/security/armory/security)
 "tdz" = (
@@ -27091,7 +28418,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/window/reinforced,
+/obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
 /area/chapel/main)
@@ -27260,10 +28587,11 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmospherics_engine)
 "tjB" = (
-/obj/structure/cable/white,
-/obj/machinery/computer/monitor{
-	dir = 4;
-	name = "stormdrive power monitoring console"
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/modular_computer/console/preset/engineering{
+	dir = 4
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/break_room)
@@ -27290,16 +28618,16 @@
 	width = 29
 	},
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "tkg" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/structure/cable/white{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
 	},
 /turf/open/floor/carpet/ship,
-/area/hallway/primary/central{
-	name = "Hallway"
-	})
+/area/security/prison)
 "tky" = (
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/firedoor/border_only/directional/north,
@@ -27346,6 +28674,12 @@
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
+"tmg" = (
+/obj/structure/reflector/box/anchored{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "tmT" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/carpet/ship/blue,
@@ -27359,6 +28693,13 @@
 	color = "#99FF99"
 	},
 /area/medical/virology)
+"tnx" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/department/engine/atmos)
+"tnA" = (
+/turf/open/floor/carpet/blue,
+/area/security/prison)
 "toc" = (
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
@@ -27420,19 +28761,7 @@
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/checkpoint/engineering)
 "tqn" = (
-/obj/machinery/button/flasher{
-	id = "PCell 4";
-	pixel_x = 26;
-	pixel_y = -6
-	},
-/obj/machinery/button/door{
-	dir = 1;
-	id = "cell1_ld";
-	name = "Cell Lockdown Control";
-	pixel_x = 26;
-	pixel_y = 6;
-	req_one_access_txt = "2"
-	},
+/obj/machinery/light_switch/east,
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/brig)
 "tqr" = (
@@ -27521,6 +28850,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"tto" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/closed/wall/r_wall/ship,
+/area/security/warden)
 "ttt" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -27534,6 +28869,15 @@
 "ttB" = (
 /turf/closed/wall/ship,
 /area/chapel/office)
+"ttV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "tun" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -27637,6 +28981,14 @@
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
+"txB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/carpet/orange,
+/area/science/misc_lab{
+	name = "Shield Generator"
+	})
 "txN" = (
 /obj/structure/sign/directions/command{
 	pixel_y = 4
@@ -27700,7 +29052,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/newscaster/directional/east,
 /turf/open/floor/wood,
 /area/chapel/main)
 "tBq" = (
@@ -27731,6 +29082,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/engine,
 /area/engine/engine_room)
+"tBA" = (
+/obj/item/reagent_containers/glass/waterbottle,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "tCh" = (
 /turf/closed/wall/ship,
 /area/medical/surgery)
@@ -27785,10 +29141,10 @@
 /turf/closed/wall/ship,
 /area/maintenance/department/engine/atmos)
 "tHQ" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/item/storage/box/prisoner,
-/turf/open/floor/carpet/ship/red_carpet,
-/area/security/brig)
+/obj/structure/bookcase/random,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "tHT" = (
 /turf/closed/wall/ship,
 /area/crew_quarters/kitchen/coldroom)
@@ -27950,6 +29306,11 @@
 /obj/structure/extinguisher_cabinet/west,
 /turf/open/floor/engine,
 /area/engine/engine_room)
+"tNz" = (
+/obj/machinery/light,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "tNC" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -27958,6 +29319,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/carpet/ship,
 /area/security/brig)
+"tNT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/carpet/ship/red_carpet,
+/area/security/warden)
 "tOn" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/peppermill{
@@ -28113,12 +29482,17 @@
 	name = "Stormdrive Interior"
 	})
 "tSn" = (
-/obj/structure/ladder,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 5
+/obj/structure/chair{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/carpet/ship,
+/area/hallway/secondary/entry{
+	name = "Arrivals"
+	})
 "tSr" = (
 /obj/item/storage/firstaid/regular{
 	pixel_x = 6;
@@ -28179,6 +29553,12 @@
 	},
 /turf/template_noop,
 /area/maintenance/department/medical)
+"tVd" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "tVf" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -28191,15 +29571,16 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_room)
 "tWo" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/machinery/door/airlock/ship/external/glass{
-	name = "External Access Deck 2 Fore Starboard";
-	req_one_access_txt = "13"
+/obj/structure/chair{
+	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/carpet/ship,
+/area/hallway/secondary/entry{
+	name = "Arrivals"
+	})
 "tWJ" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/closed/wall/r_wall/ship,
@@ -28317,9 +29698,7 @@
 	},
 /area/medical/virology)
 "uaO" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 5
-	},
+/obj/machinery/washing_machine,
 /turf/open/floor/carpet/ship,
 /area/security/prison)
 "uaQ" = (
@@ -28338,6 +29717,9 @@
 /obj/item/pen,
 /obj/item/folder/white{
 	pixel_x = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/carpet/orange,
 /area/science/misc_lab{
@@ -28431,6 +29813,16 @@
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/patients_rooms/room_a)
+"ugA" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor/ship/preopen{
+	id = "permabrigshutter"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "ugZ" = (
 /obj/machinery/atmospherics/pipe/manifold4w/general/visible,
 /obj/structure/cable{
@@ -28577,6 +29969,19 @@
 /obj/machinery/reagentgrinder,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"unB" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/purple/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "uod" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -28711,6 +30116,12 @@
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
+"usA" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "usN" = (
 /obj/structure/chair{
 	dir = 8
@@ -28828,12 +30239,12 @@
 /turf/open/floor/plating,
 /area/crew_quarters/cryopods)
 "uwN" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/reagent_containers/food/snacks/grown/pumpkin{
-	pixel_x = 3;
-	pixel_y = 11
+/obj/structure/disposalpipe/segment,
+/obj/machinery/conveyor/inverted{
+	id = "permabrig_labor_belt";
+	operating = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/carpet/ship/red_carpet,
 /area/security/prison)
 "uxk" = (
 /obj/machinery/lazylift_button,
@@ -29073,11 +30484,17 @@
 	},
 /obj/item/twohanded/rcl/pre_loaded,
 /obj/item/storage/toolbox/mechanical,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
 "uIx" = (
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
@@ -29131,6 +30548,9 @@
 /area/lawoffice)
 "uKi" = (
 /obj/machinery/vending/cigarette,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
@@ -29330,6 +30750,16 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/wood,
 /area/security/detectives_office)
+"uQE" = (
+/obj/machinery/computer/cryopod{
+	pixel_y = 32
+	},
+/obj/structure/easel,
+/obj/item/canvas/twentythreeXtwentythree,
+/obj/item/canvas/twentythreeXtwentythree,
+/obj/item/canvas/twentythreeXtwentythree,
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "uQV" = (
 /obj/machinery/suit_storage_unit/atmos,
 /obj/structure/extinguisher_cabinet/west,
@@ -29345,19 +30775,14 @@
 /turf/closed/wall/ship,
 /area/crew_quarters/heads/cmo)
 "uSU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/atmospherics/components/binary/pump/layer1{
-	on = 1;
-	target_pressure = 2000
+/obj/structure/table/wood,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/door/airlock/ship/external/glass{
-	name = "External Access Deck 2 Fore Starboard";
-	req_one_access_txt = "13"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/turf/open/floor/carpet,
+/area/hallway/secondary/entry{
+	name = "Arrivals"
+	})
 "uTi" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/engine,
@@ -29374,8 +30799,6 @@
 /area/medical/patients_rooms/room_c)
 "uTR" = (
 /obj/structure/table,
-/obj/item/twohanded/rcl/pre_loaded,
-/obj/item/reagent_containers/pill/patch/silver_sulf,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -29385,7 +30808,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
-/obj/item/holosign_creator/atmos,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/crew_quarters/heads/chief)
 "uUw" = (
@@ -29498,6 +30920,20 @@
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmospherics_engine)
+"uZq" = (
+/obj/machinery/disposal/deliveryChute{
+	desc = "A chute for big and small packages alike!\n(While holding an item, click the chute to insert it inside for delivery)";
+	dir = 1;
+	name = "Laundromat Output (click to insert)"
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/carpet/ship,
+/area/maintenance/department/medical)
 "uZt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -29522,6 +30958,16 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/security/brig)
+"vaG" = (
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/door/airlock/ship/external/glass{
+	name = "External Access Deck 2 Fore Starboard";
+	req_one_access_txt = "13"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "vbb" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 9
@@ -29535,9 +30981,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/break_room)
 "vbB" = (
@@ -29928,10 +31371,17 @@
 	name = "Cafeteria"
 	})
 "vmk" = (
-/obj/machinery/advanced_airlock_controller/directional/north,
-/obj/machinery/suit_storage_unit/standard_unit,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/landmark/start/assistant,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/hallway/secondary/entry{
+	name = "Arrivals"
+	})
 "vnm" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -30000,6 +31450,16 @@
 	},
 /turf/open/floor/plating,
 /area/hydroponics)
+"vpt" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/meter/atmos/distro_loop{
+	pixel_x = -6;
+	pixel_y = -6;
+	target_layer = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "vpH" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -30109,24 +31569,21 @@
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/checkpoint/escape)
 "vsq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/blue,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/turf/open/floor/carpet/ship/red_carpet,
 /area/security/prison)
 "vte" = (
-/obj/structure/chair,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/turf/open/floor/carpet/ship,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/carpet/ship/red_carpet,
 /area/security/prison)
 "vth" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -30150,14 +31607,10 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/break_room)
 "vuF" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/turf/open/floor/carpet/ship,
+/turf/open/floor/carpet/ship/red_carpet,
 /area/security/prison)
 "vuG" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -30376,9 +31829,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "vBx" = (
-/obj/structure/table/wood,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/obj/structure/table/wood,
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
@@ -30586,7 +32041,6 @@
 /obj/structure/cable/white{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/rad_collector,
 /turf/open/space/basic,
 /area/space/nearstation)
 "vHj" = (
@@ -30991,6 +32445,10 @@
 /obj/item/clothing/gloves/color/black,
 /obj/item/gps/engineering,
 /obj/item/clothing/ears/earmuffs,
+/obj/machinery/light,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/carpet/orange,
 /area/science/misc_lab{
 	name = "Shield Generator"
@@ -31022,6 +32480,7 @@
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "vXG" = (
@@ -31040,11 +32499,12 @@
 /turf/open/floor/carpet/ship,
 /area/security/brig)
 "vYd" = (
-/obj/structure/table,
-/obj/item/storage/crayons,
-/obj/item/instrument/harmonica,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/turf/open/floor/carpet/ship,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/ship/preopen{
+	id = "permabrigshutter"
+	},
+/turf/open/floor/plating,
 /area/security/prison)
 "vZt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -31221,7 +32681,7 @@
 /turf/open/floor/plating,
 /area/security/warden)
 "wgR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/closed/wall/r_wall/ship,
@@ -31341,6 +32801,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"wlM" = (
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/airlock/ship/public/glass{
+	id_tag = "permabolt2"
+	},
+/obj/machinery/door/poddoor/shutters/ship{
+	id = "permacell2"
+	},
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "wmm" = (
 /obj/machinery/holopad,
 /obj/structure/cable{
@@ -31402,6 +32873,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
 "wom" = (
@@ -31447,7 +32919,6 @@
 /area/engine/break_room)
 "wpv" = (
 /obj/machinery/airalarm/directional/north,
-/obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
 "wpN" = (
@@ -31687,6 +33158,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"wxA" = (
+/obj/machinery/light,
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "wyc" = (
 /obj/structure/chair{
 	dir = 1
@@ -31701,6 +33176,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/carpet/ship/red_carpet,
 /area/ai_monitored/security/armory/security)
@@ -31734,6 +33212,10 @@
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
+"wyw" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "wyR" = (
 /obj/machinery/button/door{
 	id = "custom_tank_1_doors";
@@ -31874,10 +33356,11 @@
 /turf/open/floor/plating,
 /area/chapel/main)
 "wDk" = (
-/obj/structure/chair,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/carpet/ship,
+/obj/machinery/conveyor_switch{
+	id = "permabrig_labor_belt";
+	pixel_x = -6
+	},
+/turf/open/floor/carpet/ship/red_carpet,
 /area/security/prison)
 "wDm" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/layer3{
@@ -31914,6 +33397,9 @@
 /obj/machinery/computer/ship/viewscreen{
 	pixel_x = -32;
 	pixel_y = -6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/carpet/ship,
 /area/security/brig)
@@ -32192,6 +33678,9 @@
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/carpet/ship/red_carpet,
 /area/ai_monitored/security/armory/security)
 "wMg" = (
@@ -32333,6 +33822,13 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/cryopods)
+"wQb" = (
+/obj/machinery/camera{
+	c_tag = "External Access Medbay";
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "wQr" = (
 /obj/machinery/door/firedoor/window,
 /obj/structure/grille,
@@ -32354,9 +33850,15 @@
 	name = "Cafeteria"
 	})
 "wRp" = (
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/carpet/ship,
+/area/hallway/secondary/entry{
+	name = "Arrivals"
+	})
 "wRt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -32378,19 +33880,27 @@
 /turf/open/floor/carpet/ship,
 /area/storage/tools)
 "wSy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/atmospherics/components/binary/pump/layer1{
-	dir = 1;
-	on = 1;
-	target_pressure = 2000
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
+	pixel_y = 8
 	},
-/obj/machinery/door/airlock/ship/external/glass{
-	name = "External Access Deck 2 Fore Port";
-	req_one_access_txt = "2"
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
+	pixel_y = 8
 	},
-/turf/open/floor/plating,
+/obj/item/clothing/head/cone{
+	pixel_x = 2
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = 2
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -10
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -10
+	},
+/turf/open/floor/carpet/ship/red_carpet,
 /area/security/prison)
 "wSz" = (
 /obj/machinery/camera/autoname,
@@ -32441,6 +33951,21 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/security/brig)
+"wTj" = (
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/purple/hidden{
+	dir = 8
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/nanotrasen,
+/obj/machinery/computer/ship/viewscreen{
+	pixel_x = 32;
+	pixel_y = -6
+	},
+/turf/open/floor/carpet/blue,
+/area/security/prison)
 "wTV" = (
 /obj/structure/table,
 /obj/item/chair,
@@ -32468,6 +33993,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/closed/wall/ship,
 /area/engine/storage)
 "wVB" = (
@@ -32569,7 +34095,6 @@
 /turf/open/floor/wood,
 /area/security/detectives_office)
 "xaq" = (
-/obj/structure/closet/secure_closet/brig,
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
@@ -32615,6 +34140,9 @@
 /obj/item/clothing/head/helmet/alt,
 /obj/item/clothing/head/helmet/alt,
 /obj/item/clothing/head/helmet/alt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/carpet/ship/red_carpet,
 /area/ai_monitored/security/armory/security)
 "xbF" = (
@@ -32627,6 +34155,9 @@
 /obj/item/clothing/head/helmet/riot,
 /obj/item/clothing/head/helmet/riot,
 /obj/item/clothing/head/helmet/riot,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/carpet/ship/red_carpet,
 /area/ai_monitored/security/armory/security)
 "xbQ" = (
@@ -32732,10 +34263,6 @@
 /turf/open/floor/wood,
 /area/chapel/main)
 "xfo" = (
-/obj/machinery/computer/ship/reactor_control_computer{
-	dir = 8;
-	reactor_id = 1
-	},
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -32743,20 +34270,20 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/item/paper{
-	info = "<p>Reminder to add control rods to the Stormdrive engine BEFORE turning it on! Adding control rods requires the engine to be in maintenance mode, and it won't work if the reactor is powered!<br><br>Control rods are located in crate behind particle accelerator</p>";
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/paper{
-	info = "<p>Engineering notice: There are three wire colors used on the Aetherwhisp 6 ship model. White cable is wired to the Stormdrive MK-4 and the supermatter crystal near atmospherics. These lead to their own SMES located nearby. Yellow wires are department distribution wires, which deliver power from the engines SMES to deparment SMES. Red wires deliver power from department SMES to department APCs.</p>"
-	},
+/obj/structure/table,
+/obj/item/cartridge/engineering,
+/obj/item/airlock_painter,
+/obj/item/cartridge/atmos,
+/obj/item/holosign_creator/engineering,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/break_room)
 "xfp" = (
 /obj/structure/rack,
 /obj/item/storage/lockbox/clusterbang,
 /obj/structure/extinguisher_cabinet/east,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/carpet/ship/red_carpet,
 /area/ai_monitored/security/armory/security)
 "xfM" = (
@@ -32795,6 +34322,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/landmark/start/security_officer,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/carpet/ship,
 /area/security/brig)
 "xhi" = (
@@ -32842,12 +34372,8 @@
 /turf/open/floor/wood,
 /area/security/execution/education)
 "xie" = (
-/obj/structure/rack,
-/obj/item/paint/white,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
-	},
-/turf/open/floor/carpet/ship,
+/obj/machinery/status_display/evac,
+/turf/closed/wall/r_wall/ship,
 /area/security/prison)
 "xiG" = (
 /obj/machinery/status_display/evac,
@@ -32893,6 +34419,9 @@
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet/west,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/carpet/ship/red_carpet,
 /area/ai_monitored/security/armory/lockup)
 "xkN" = (
@@ -32979,12 +34508,24 @@
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
+"xpm" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "xpp" = (
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
 /turf/open/floor/carpet/ship/blue,
 /area/medical/storage)
+"xpG" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "xqr" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -33008,11 +34549,8 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "xrv" = (
-/obj/structure/table,
-/obj/structure/bedsheetbin{
-	anchored = 0
-	},
-/turf/open/floor/carpet/ship,
+/obj/machinery/light,
+/turf/open/floor/carpet/ship/red_carpet,
 /area/security/prison)
 "xrB" = (
 /obj/structure/cable{
@@ -33129,18 +34667,31 @@
 /obj/machinery/seed_extractor,
 /turf/open/floor/grass,
 /area/hydroponics)
+"xuT" = (
+/obj/machinery/hydroponics/soil,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/plating,
+/area/security/prison)
 "xvn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /turf/template_noop,
 /area/maintenance/department/engine)
+"xvt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/carpet/blue,
+/area/security/prison)
 "xvG" = (
 /obj/machinery/modular_computer/console/preset/engineering{
 	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/tcommsat/server)
@@ -33365,6 +34916,9 @@
 /obj/item/clothing/suit/armor/laserproof,
 /obj/item/gun/ballistic/automatic/sniper_rifle,
 /obj/item/gun/energy/ionrifle,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/carpet/red,
 /area/ai_monitored/security/armory/lockup)
 "xCq" = (
@@ -33684,8 +35238,6 @@
 	name = "Hallway"
 	})
 "xLR" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/item/storage/box/prisoner,
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
@@ -33835,6 +35387,26 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = 2
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = 2
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -10
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -10
+	},
 /turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
@@ -33945,6 +35517,10 @@
 "xWq" = (
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
+"xWz" = (
+/obj/effect/spawner/room/fivexfour,
+/turf/template_noop,
+/area/maintenance/department/medical)
 "xWD" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 8
@@ -34010,7 +35586,11 @@
 	name = "Supermatter Core"
 	})
 "xXO" = (
-/turf/closed/wall/ship,
+/obj/machinery/door/poddoor/ship/preopen{
+	id = "permabrigshutter"
+	},
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
 /area/security/prison)
 "xXW" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -34070,6 +35650,14 @@
 /obj/machinery/light,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/genetics/cloning)
+"ybm" = (
+/obj/structure/sink/kitchen{
+	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
+	name = "old sink";
+	pixel_y = 28
+	},
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "ybo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -34148,6 +35736,9 @@
 /obj/item/ammo_box/magazine/sniper_rounds/soporific{
 	pixel_x = -4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/carpet/red,
 /area/ai_monitored/security/armory/lockup)
 "ycq" = (
@@ -34187,6 +35778,16 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"ydc" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/obj/machinery/flasher{
+	id = "PCell 2";
+	pixel_x = -28
+	},
+/turf/open/floor/carpet/ship,
+/area/security/prison)
 "yde" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -34403,10 +36004,16 @@
 	name = "Stormdrive Interior"
 	})
 "yjC" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/reagent_containers/glass/bucket,
-/obj/machinery/newscaster/directional/west,
-/turf/open/floor/plating,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/conveyor/inverted{
+	id = "permabrig_labor_belt";
+	operating = 1
+	},
+/obj/machinery/camera/autoname{
+	dir = 5
+	},
+/obj/item/storage/briefcase,
+/turf/open/floor/carpet/ship/red_carpet,
 /area/security/prison)
 "yjR" = (
 /obj/structure/cable{
@@ -44563,95 +46170,95 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -44820,95 +46427,95 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -45077,95 +46684,95 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -45334,95 +46941,95 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -45591,95 +47198,95 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -45848,95 +47455,95 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -46105,95 +47712,95 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -46362,95 +47969,95 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -46619,95 +48226,95 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -46876,95 +48483,95 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -47133,95 +48740,95 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -47390,95 +48997,95 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 baX
 baX
 eSP
 baX
 baX
 eSP
-drp
-drp
-drp
-drp
-drp
 baX
 baX
-eSP
 baX
 baX
-eSP
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
 baX
 baX
 eSP
 baX
 baX
 eSP
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 baX
 baX
 eSP
 baX
 baX
 eSP
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+eSP
+baX
+baX
+eSP
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -47647,26 +49254,6 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
 baX
 baX
 baX
@@ -47674,33 +49261,19 @@ baX
 baX
 baX
 baX
-cPb
-drp
-baX
-cPb
 baX
 baX
 baX
 baX
 baX
 baX
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 baX
 baX
 baX
@@ -47709,7 +49282,7 @@ baX
 baX
 baX
 cPb
-drp
+baX
 baX
 cPb
 baX
@@ -47718,24 +49291,58 @@ baX
 baX
 baX
 baX
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+cPb
+baX
+baX
+cPb
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -47904,24 +49511,24 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 baX
 cPb
 baX
@@ -47932,7 +49539,6 @@ baX
 baX
 baX
 baX
-drp
 baX
 baX
 baX
@@ -47941,23 +49547,6 @@ baX
 baX
 baX
 baX
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
 baX
 baX
 baX
@@ -47966,7 +49555,25 @@ baX
 baX
 baX
 baX
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 baX
 baX
 baX
@@ -47977,22 +49584,22 @@ baX
 baX
 baX
 cPb
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -48161,24 +49768,24 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 baX
 baX
 fZX
@@ -48200,19 +49807,19 @@ bdK
 fZX
 fZX
 aIO
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 aIO
 fcp
 fcp
@@ -48234,22 +49841,22 @@ gGg
 fcp
 baX
 baX
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -48418,21 +50025,21 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 baX
 jEV
 fZX
@@ -48457,19 +50064,19 @@ vnm
 wsQ
 xkN
 usX
-drp
+baX
 aIO
-drp
-drp
+baX
+baX
 aIO
-drp
-drp
-drp
+baX
+baX
+baX
 aIO
-drp
-drp
+baX
+baX
 aIO
-drp
+baX
 usX
 qia
 nkJ
@@ -48494,19 +50101,19 @@ gGg
 fcp
 baX
 kKb
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -48675,21 +50282,21 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 baX
 baX
 aae
@@ -48714,19 +50321,19 @@ vBw
 yca
 fZX
 aIO
-drp
+baX
 aIO
 icn
 icn
 aIO
-drp
-drp
-drp
+baX
+baX
+baX
 aIO
 icn
 icn
 aIO
-drp
+baX
 aIO
 fcp
 uLq
@@ -48751,19 +50358,19 @@ jQb
 xxr
 baX
 baX
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -48932,22 +50539,22 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 aIO
 fZX
 qnU
@@ -48977,7 +50584,7 @@ mQk
 mQk
 xrF
 xrF
-xrF
+fMc
 xrF
 xrF
 mQk
@@ -49007,20 +50614,20 @@ kvr
 eTu
 fcp
 aIO
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -49189,22 +50796,22 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 fZX
 fZX
 qnU
@@ -49264,20 +50871,20 @@ mEo
 vSU
 wiL
 fcp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -49446,19 +51053,19 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-aaK
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+aIO
 awN
 atr
 aIO
@@ -49524,17 +51131,17 @@ fcp
 aIO
 atr
 noN
-aaK
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+aIO
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -49703,19 +51310,19 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 atr
 mjO
@@ -49781,17 +51388,17 @@ xxr
 cxm
 atr
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -49960,19 +51567,19 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 atr
 icn
@@ -49981,7 +51588,7 @@ yca
 qnU
 bhq
 aXe
-fuA
+gdi
 gdi
 gdi
 dnt
@@ -50038,17 +51645,17 @@ eOj
 aIO
 atr
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -50217,19 +51824,19 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-aaK
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+aIO
 awN
 atr
 mjO
@@ -50243,10 +51850,10 @@ cBF
 cBF
 cBF
 wpX
-mvU
+kUj
 mvU
 gSp
-mvU
+txB
 xTl
 aEx
 sun
@@ -50295,17 +51902,17 @@ xxr
 cxm
 atr
 noN
-aaK
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+aIO
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -50474,19 +52081,19 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 atr
 icn
@@ -50498,9 +52105,9 @@ fZX
 dFa
 cBF
 cBF
-cBF
+fuA
 wpX
-kUj
+mvU
 uhW
 mSN
 qvl
@@ -50519,7 +52126,7 @@ dpc
 baX
 baX
 baX
-aIO
+kpY
 baX
 baX
 baX
@@ -50552,17 +52159,17 @@ eOj
 aIO
 atr
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -50731,19 +52338,19 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 atr
 mjO
@@ -50809,17 +52416,17 @@ xxr
 cxm
 atr
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -50988,19 +52595,19 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-aaK
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+aIO
 awN
 atr
 aIO
@@ -51066,17 +52673,17 @@ fcp
 aIO
 atr
 noN
-aaK
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+aIO
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -51245,19 +52852,19 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 afP
 atr
@@ -51323,17 +52930,17 @@ fcp
 atr
 afP
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -51502,19 +53109,19 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 atr
 atr
@@ -51580,17 +53187,17 @@ fcp
 atr
 atr
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -51759,19 +53366,19 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-aaK
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+aIO
 awN
 atr
 atr
@@ -51837,17 +53444,17 @@ fcp
 atr
 atr
 noN
-aaK
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+aIO
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -52016,19 +53623,19 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 atr
 atr
@@ -52094,17 +53701,17 @@ fcp
 atr
 atr
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -52273,19 +53880,19 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 atr
 atr
@@ -52351,17 +53958,17 @@ fcp
 atr
 atr
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -52530,19 +54137,19 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-aaK
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+aIO
 awN
 atr
 atr
@@ -52608,17 +54215,17 @@ fcp
 atr
 atr
 noN
-aaK
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+aIO
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -52787,19 +54394,19 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 atr
 atr
@@ -52865,17 +54472,17 @@ fcp
 atr
 atr
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -53044,19 +54651,19 @@ drp
 drp
 drp
 eLi
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 atr
 atr
@@ -53122,17 +54729,17 @@ fcp
 atr
 atr
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -53301,19 +54908,19 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-aaK
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+aIO
 awN
 atr
 atr
@@ -53379,17 +54986,17 @@ fcp
 atr
 atr
 noN
-aaK
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+aIO
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -53558,19 +55165,19 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 atr
 atr
@@ -53636,17 +55243,17 @@ fcp
 atr
 atr
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -53815,19 +55422,19 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 atr
 atr
@@ -53857,13 +55464,13 @@ kdy
 kdy
 kdy
 kdy
-qvK
-qvK
-qvK
 kdy
 qvK
 qvK
 qvK
+qvK
+qvK
+kdy
 kdy
 kdy
 okh
@@ -53893,17 +55500,17 @@ fcp
 atr
 atr
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -54072,19 +55679,19 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-aaK
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+aIO
 awN
 atr
 atr
@@ -54150,17 +55757,17 @@ eav
 atr
 atr
 noN
-aaK
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+aIO
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -54329,19 +55936,19 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 atr
 atr
@@ -54407,17 +56014,17 @@ fcp
 atr
 atr
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -54586,19 +56193,19 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 atr
 atr
@@ -54664,17 +56271,17 @@ fcp
 atr
 atr
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -54843,19 +56450,19 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-aaK
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+aIO
 awN
 atr
 atr
@@ -54872,7 +56479,7 @@ lmT
 jHj
 kWC
 pPF
-iGp
+gHn
 hNN
 pct
 vld
@@ -54921,17 +56528,17 @@ fcp
 atr
 atr
 noN
+aIO
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 aaK
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-eLi
-drp
+baX
 drp
 drp
 drp
@@ -55100,20 +56707,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-aaK
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+aIO
 awN
 atr
 fZX
@@ -55129,7 +56736,7 @@ adS
 bTh
 bTh
 faQ
-faQ
+jgG
 eJn
 bTh
 vWW
@@ -55143,7 +56750,7 @@ wyv
 boO
 smK
 vRQ
-aeg
+jbX
 aeg
 aeg
 dqw
@@ -55177,18 +56784,18 @@ sLc
 fcp
 atr
 noN
-aaK
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+aIO
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -55357,20 +56964,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 atr
 fZX
@@ -55434,18 +57041,18 @@ dac
 fcp
 atr
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -55614,20 +57221,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 atr
 fZX
@@ -55643,7 +57250,7 @@ lkK
 hae
 epn
 eeS
-eeS
+aJB
 rVR
 miK
 jNp
@@ -55691,18 +57298,18 @@ xWq
 fcp
 atr
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -55871,20 +57478,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-aaK
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+aIO
 awN
 atr
 fZX
@@ -55900,7 +57507,7 @@ mdp
 lMR
 bjg
 oEB
-oEB
+qQJ
 umm
 vLT
 eWa
@@ -55948,18 +57555,18 @@ qJx
 fcp
 atr
 noN
-aaK
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+aIO
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -56128,20 +57735,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 atr
 fZX
@@ -56205,18 +57812,18 @@ xWq
 fcp
 atr
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -56385,20 +57992,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 atr
 fZX
@@ -56462,18 +58069,18 @@ kSa
 fcp
 atr
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -56642,20 +58249,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-aaK
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+aIO
 awN
 atr
 fZX
@@ -56671,7 +58278,7 @@ fbf
 kZs
 kZs
 pES
-eeS
+aJB
 rVR
 eKJ
 jNp
@@ -56719,18 +58326,18 @@ xWq
 fcp
 atr
 noN
-aaK
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+aIO
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -56899,20 +58506,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 cvp
 fZX
@@ -56976,18 +58583,18 @@ xWq
 fcp
 atr
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -57156,20 +58763,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 atr
 fZX
@@ -57185,7 +58792,7 @@ eaN
 kZs
 kZs
 pES
-eeS
+aJB
 eeS
 oZs
 jNp
@@ -57200,11 +58807,11 @@ hKU
 fhC
 gpD
 mDm
-kUm
+hLZ
 vbj
 kUm
 uDy
-kUm
+qmy
 wSZ
 jUx
 sWz
@@ -57233,18 +58840,18 @@ qJx
 fcp
 atr
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -57413,20 +59020,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-aaK
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+aIO
 awN
 atr
 fZX
@@ -57458,10 +59065,10 @@ wVk
 lDE
 mRb
 kfH
-fwS
+heL
 heL
 aJm
-vuq
+uRt
 eoP
 aeg
 dXM
@@ -57490,18 +59097,18 @@ iKc
 fcp
 atr
 noN
-aaK
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+aIO
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -57670,20 +59277,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 fZX
 fZX
 fZX
@@ -57714,7 +59321,7 @@ gXp
 tUM
 iCe
 xfo
-ykC
+rZC
 sIA
 mRI
 jGv
@@ -57747,18 +59354,18 @@ tdz
 fcp
 fcp
 fcp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -57927,20 +59534,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 fZX
 bKX
 kDe
@@ -58004,18 +59611,18 @@ tdz
 jvJ
 frw
 fcp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -58184,19 +59791,19 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 bgR
 gOq
 jqn
@@ -58262,17 +59869,17 @@ aRl
 tyT
 tQJ
 etU
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -58441,20 +60048,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 bsA
 fFw
 luJ
@@ -58518,18 +60125,18 @@ qRB
 oIZ
 jQc
 fcp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -58698,20 +60305,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 fZX
 fZX
 fZX
@@ -58775,18 +60382,18 @@ fcp
 fcp
 fcp
 fcp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -58955,23 +60562,23 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 fZX
 vij
 vcT
@@ -59029,21 +60636,21 @@ jfB
 mXO
 nnK
 fcp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -59212,23 +60819,23 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 fZX
 yca
 vcT
@@ -59286,21 +60893,21 @@ klg
 jDR
 mXO
 fcp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -59469,23 +61076,23 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 fZX
 yca
 aLW
@@ -59543,21 +61150,21 @@ qqj
 mXO
 mXO
 fcp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -59726,23 +61333,23 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 fZX
 fZX
 dmx
@@ -59800,21 +61407,21 @@ fJK
 tdz
 fcp
 fcp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -59983,24 +61590,24 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 fZX
 vgz
 dmx
@@ -60056,22 +61663,22 @@ clS
 kxc
 xWq
 fcp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -60240,24 +61847,24 @@ drp
 drp
 drp
 eLi
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 fZX
 fZX
 lWT
@@ -60313,22 +61920,22 @@ xWq
 dac
 fcp
 fcp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -60497,25 +62104,25 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 vpI
 pTY
 hEY
@@ -60569,23 +62176,23 @@ xWq
 xWq
 xWq
 fcp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -60754,25 +62361,25 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 vpI
 vpI
 hgi
@@ -60826,23 +62433,23 @@ tdz
 tdz
 fcp
 eav
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -61011,25 +62618,25 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 icn
 sdV
 qfB
@@ -61083,23 +62690,23 @@ iWe
 ldk
 sGU
 icn
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -61268,25 +62875,25 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 mjO
 iKj
 tQW
@@ -61340,23 +62947,23 @@ cAI
 grg
 xzi
 cxm
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -61525,25 +63132,25 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 icn
 sdV
 qHQ
@@ -61597,23 +63204,23 @@ asE
 ofF
 sGU
 icn
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -61782,25 +63389,25 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 mjO
 iKj
 dYO
@@ -61854,23 +63461,23 @@ oIn
 cDq
 xzi
 cxm
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -62039,26 +63646,26 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 aIO
 vpI
 oMl
@@ -62099,7 +63706,7 @@ fgO
 tdz
 xWq
 tdz
-eoO
+dlK
 mll
 ljR
 iTm
@@ -62110,24 +63717,24 @@ lYW
 jbz
 jBW
 aIO
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -62296,26 +63903,26 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 icn
 sdV
 cfL
@@ -62367,24 +63974,24 @@ iEN
 mVk
 oeB
 icn
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-eLi
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+aaK
+baX
 drp
 drp
 drp
@@ -62553,26 +64160,26 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 icn
 sdV
 chE
@@ -62624,24 +64231,24 @@ iEN
 ojk
 oeB
 icn
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -62810,25 +64417,25 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 baX
 icn
 sdV
@@ -62882,23 +64489,23 @@ lNi
 oeB
 icn
 aIO
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -63067,25 +64674,25 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 baX
 jEV
 fQf
@@ -63139,23 +64746,23 @@ rKz
 keg
 baX
 kKb
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -63324,25 +64931,25 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 baX
 baX
 vpI
@@ -63396,23 +65003,23 @@ auT
 jBW
 baX
 baX
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -63581,25 +65188,25 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 baX
 icn
 sdV
@@ -63626,7 +65233,7 @@ eaL
 eaL
 oGt
 rYe
-tkg
+pdJ
 jKk
 bpE
 tdz
@@ -63652,24 +65259,24 @@ foC
 fKi
 oeB
 icn
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -63838,26 +65445,26 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 icn
 sdV
 irN
@@ -63909,24 +65516,24 @@ uQl
 lNi
 oeB
 icn
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -64095,26 +65702,26 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 aIO
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
 icn
 sdV
 rfA
@@ -64142,8 +65749,8 @@ oGt
 cPY
 pdJ
 pyL
-mDU
-tdz
+dSB
+tnx
 mXO
 mXO
 mXO
@@ -64166,24 +65773,24 @@ foC
 fKi
 oeB
 icn
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -64352,20 +65959,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 col
 col
 lDl
@@ -64381,7 +65988,7 @@ dsL
 neA
 fUz
 uDj
-njS
+jio
 aoe
 vMm
 sjo
@@ -64426,21 +66033,21 @@ aIO
 fBV
 fBV
 aIO
-drp
-drp
+baX
+baX
 aIO
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -64609,20 +66216,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 jGa
 gsI
 ebk
@@ -64686,18 +66293,18 @@ jBW
 uzR
 jBW
 jBW
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -64866,20 +66473,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 jJd
 rmH
 fOk
@@ -64943,18 +66550,18 @@ jWE
 oxS
 nWB
 nFB
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -65123,20 +66730,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 jGa
 qIn
 kEW
@@ -65200,18 +66807,18 @@ hoT
 rWz
 xaC
 fMV
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -65380,20 +66987,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 col
 col
 col
@@ -65457,18 +67064,18 @@ kqz
 lWp
 eQR
 nFB
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -65637,20 +67244,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 icn
 baX
 jJd
@@ -65714,18 +67321,18 @@ lRy
 shu
 jBW
 jBW
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -65894,20 +67501,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 icn
 baX
 aaL
@@ -65915,7 +67522,7 @@ ttt
 vFM
 pzC
 wbo
-tcX
+tSn
 lHi
 tcX
 drJ
@@ -65969,20 +67576,20 @@ gag
 hgM
 cIC
 fMV
-drp
+baX
 icn
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -66151,20 +67758,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 icn
 baX
 jJd
@@ -66172,7 +67779,7 @@ tJZ
 kMh
 pzC
 jex
-fZb
+tWo
 jex
 fZb
 biX
@@ -66219,27 +67826,27 @@ mVk
 mVk
 fUM
 tdY
-rWz
+oyd
 eKy
-rWz
+oyd
 lhb
 kbt
-mVk
+sPr
 fMV
 pQh
 icn
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -66408,20 +68015,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 icn
 jsw
 jJd
@@ -66429,7 +68036,7 @@ ttt
 fOk
 pYe
 jex
-aBN
+uSU
 nRw
 aBN
 bad
@@ -66485,18 +68092,18 @@ cBs
 jBW
 lWF
 jBW
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -66665,20 +68272,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 col
 col
 lSq
@@ -66686,7 +68293,7 @@ tdK
 kMh
 byz
 vll
-qIM
+vmk
 nRw
 qIM
 uLk
@@ -66742,18 +68349,18 @@ jBq
 jBW
 ajW
 jBW
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -66922,20 +68529,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 jGa
 ctT
 kEW
@@ -66943,7 +68550,7 @@ guT
 guT
 fsz
 guT
-guT
+wRp
 hSE
 guT
 qft
@@ -67000,17 +68607,17 @@ lWp
 fxa
 nFB
 tjY
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -67179,20 +68786,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 jJd
 rXV
 fOk
@@ -67200,7 +68807,7 @@ iTi
 jex
 jex
 kVt
-jex
+lKG
 cSg
 dxC
 eZb
@@ -67248,7 +68855,7 @@ tFI
 jdX
 jdX
 jdX
-jdX
+gfZ
 vIk
 ovc
 yfp
@@ -67256,18 +68863,18 @@ rWz
 rWz
 wCT
 jBW
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -67436,20 +69043,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 aTc
-drp
-drp
-drp
+baX
+baX
+baX
 jGa
 gsI
 ebk
@@ -67513,18 +69120,18 @@ ieM
 vIk
 pnE
 owu
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -67693,20 +69300,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 col
 col
 lDl
@@ -67714,7 +69321,7 @@ crs
 wgt
 vFY
 crs
-crs
+bRo
 crs
 wCc
 uGY
@@ -67770,18 +69377,18 @@ jRA
 hNH
 uDv
 iLN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -67950,20 +69557,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 atr
 eXv
@@ -68027,18 +69634,18 @@ oeX
 iLN
 tPa
 iLN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -68207,20 +69814,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 fyD
 eXv
@@ -68284,18 +69891,18 @@ vqt
 iLN
 atr
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -68464,20 +70071,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 fyD
 eXv
@@ -68485,7 +70092,7 @@ vzU
 vLG
 kQK
 qEA
-tXS
+tNT
 tXS
 cer
 kNN
@@ -68541,18 +70148,18 @@ pQv
 trj
 atr
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -68721,20 +70328,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-aaK
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+aIO
 awN
 fyD
 eXv
@@ -68798,18 +70405,18 @@ wYY
 trj
 atr
 noN
-aaK
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+aIO
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -68978,20 +70585,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 atr
 eXv
@@ -68999,7 +70606,7 @@ eXv
 eXv
 eXv
 eXv
-eXv
+tto
 eXv
 pSU
 crs
@@ -69055,18 +70662,18 @@ trj
 trj
 atr
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -69235,20 +70842,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 atr
 icn
@@ -69312,18 +70919,18 @@ mvd
 icn
 atr
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -69492,20 +71099,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-aaK
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+aIO
 awN
 atr
 icn
@@ -69569,18 +71176,18 @@ mvd
 icn
 atr
 noN
-aaK
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+aIO
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -69749,20 +71356,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 atr
 icn
@@ -69770,7 +71377,7 @@ sQH
 azr
 xVG
 kwS
-nlw
+cPW
 deU
 fJu
 xmt
@@ -69826,18 +71433,18 @@ mvd
 icn
 atr
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -70006,20 +71613,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 atr
 mjO
@@ -70027,7 +71634,7 @@ snG
 dQZ
 deU
 deU
-deU
+aek
 iSJ
 wTi
 hOk
@@ -70083,18 +71690,18 @@ cog
 cxm
 atr
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -70263,20 +71870,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-aaK
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+aIO
 awN
 atr
 icn
@@ -70340,18 +71947,18 @@ mvd
 icn
 atr
 noN
-aaK
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+aIO
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -70520,20 +72127,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 atr
 icn
@@ -70597,18 +72204,18 @@ mvd
 icn
 atr
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -70777,20 +72384,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 atr
 icn
@@ -70798,7 +72405,7 @@ sQH
 hDa
 xVG
 kwS
-nlw
+cPW
 deU
 jMJ
 nlw
@@ -70854,18 +72461,18 @@ mvd
 icn
 atr
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -71034,20 +72641,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-aaK
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+aIO
 awN
 atr
 mjO
@@ -71055,7 +72662,7 @@ snG
 iai
 deU
 deU
-deU
+aek
 deU
 wZI
 kji
@@ -71111,18 +72718,18 @@ cog
 cxm
 atr
 noN
-aaK
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+aIO
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -71291,20 +72898,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 atr
 icn
@@ -71368,18 +72975,18 @@ trj
 icn
 atr
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -71548,20 +73155,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 atr
 icn
@@ -71625,18 +73232,18 @@ trj
 icn
 atr
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -71805,20 +73412,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-aaK
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+aIO
 awN
 atr
 icn
@@ -71826,7 +73433,7 @@ sQH
 hDa
 xVG
 dRc
-nlw
+cPW
 deU
 vzr
 sfi
@@ -71882,18 +73489,18 @@ trj
 icn
 atr
 noN
+aIO
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 aaK
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-eLi
-drp
-drp
-drp
+baX
+baX
+baX
 drp
 drp
 drp
@@ -72062,20 +73669,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 atr
 mjO
@@ -72083,7 +73690,7 @@ snG
 mmm
 deU
 deU
-deU
+aek
 csT
 pBU
 wYj
@@ -72139,18 +73746,18 @@ cog
 cxm
 atr
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -72319,20 +73926,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 atr
 icn
@@ -72396,18 +74003,18 @@ mvd
 icn
 atr
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -72576,20 +74183,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-aaK
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+aIO
 awN
 atr
 icn
@@ -72653,18 +74260,18 @@ mvd
 icn
 atr
 noN
-aaK
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+aIO
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -72833,20 +74440,20 @@ drp
 drp
 drp
 drp
-drp
-eLi
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+aaK
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 atr
 icn
@@ -72854,7 +74461,7 @@ sQH
 azr
 xVG
 kwS
-nlw
+cPW
 deU
 rgT
 eSD
@@ -72910,18 +74517,18 @@ mvd
 icn
 atr
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -73090,28 +74697,28 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
-afP
+atr
 wLO
 wLO
 wLO
 wLO
 wLO
-wLO
+qXL
 wLO
 rnU
 rXt
@@ -73123,7 +74730,7 @@ rft
 gXW
 wBi
 bhh
-dmF
+fLs
 wOb
 dmF
 eFQ
@@ -73165,20 +74772,20 @@ vXd
 nRL
 trj
 trj
-afP
+atr
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -73347,20 +74954,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-aaK
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+aIO
 awN
 atr
 wLO
@@ -73424,18 +75031,18 @@ wYY
 trj
 atr
 noN
-aaK
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+aIO
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -73604,20 +75211,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 fyD
 wLO
@@ -73681,18 +75288,18 @@ hjw
 trj
 atr
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -73861,20 +75468,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 fyD
 wLO
@@ -73938,18 +75545,18 @@ dCq
 trj
 atr
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -74118,20 +75725,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-aaK
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+aIO
 awN
 fyD
 wLO
@@ -74195,18 +75802,18 @@ wSE
 trj
 atr
 noN
-aaK
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+aIO
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -74375,20 +75982,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 bWG
 wLO
@@ -74452,18 +76059,18 @@ yaE
 trj
 atr
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -74632,20 +76239,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 fyD
 wLO
@@ -74709,18 +76316,18 @@ kwB
 trj
 atr
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -74889,20 +76496,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-aaK
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+aIO
 awN
 fyD
 wLO
@@ -74934,7 +76541,7 @@ pQv
 pQv
 pQv
 pQv
-pQv
+aNs
 jVJ
 qmK
 qmK
@@ -74966,18 +76573,18 @@ trj
 trj
 atr
 noN
-aaK
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+aIO
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -75146,20 +76753,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 fyD
 wLO
@@ -75197,7 +76804,7 @@ dGd
 tPs
 wME
 rmO
-nvE
+aQf
 kCb
 sIF
 ctX
@@ -75223,18 +76830,18 @@ wYY
 trj
 atr
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -75403,20 +77010,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 atr
 uhH
@@ -75424,7 +77031,7 @@ uhH
 uhH
 uhH
 qgZ
-uhH
+huy
 uhH
 cbk
 xMr
@@ -75478,20 +77085,20 @@ ozT
 vNp
 wYY
 mvd
-fyD
+atr
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -75660,20 +77267,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-aaK
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+aIO
 awN
 fyD
 uhH
@@ -75685,7 +77292,7 @@ xkm
 uhH
 taT
 xBi
-tHQ
+iuh
 wqe
 hbl
 ejW
@@ -75735,20 +77342,20 @@ vAw
 vNp
 wYY
 mvd
-fyD
+atr
 noN
-aaK
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+aIO
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -75917,20 +77524,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 fyD
 uhH
@@ -75992,20 +77599,20 @@ liE
 vNp
 wYY
 mvd
-fyD
+atr
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -76174,20 +77781,20 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 awN
 fyD
 uhH
@@ -76202,8 +77809,8 @@ nHC
 abs
 abs
 xaq
-oKs
-oKs
+dmF
+dmF
 eeK
 tym
 kGu
@@ -76251,18 +77858,18 @@ wYY
 trj
 atr
 noN
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -76431,28 +78038,28 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+aIO
+awN
+atr
 abs
 abs
 abs
+xie
 abs
-abs
-abs
-abs
-abs
+lno
 abs
 lBq
 pVE
@@ -76460,7 +78067,7 @@ slU
 abs
 abs
 abs
-ofM
+abs
 trj
 pQv
 pQv
@@ -76504,22 +78111,22 @@ pQv
 pQv
 nkj
 eHg
+pQv
 trj
-trj
-trj
-trj
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+atr
+noN
+aIO
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -76688,36 +78295,36 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-abs
-jnG
-kLl
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+awN
+fyD
+xXO
 bgz
 hHd
 yjC
 uwN
 pjK
-abs
+pFp
 sUV
-jVL
+pVE
 xrv
 abs
 nBP
 kjT
-nBP
+oAG
 trj
 wYY
 wYY
@@ -76761,22 +78368,22 @@ lzg
 oGX
 saG
 yhM
-pQv
-vmk
-bcj
+wYY
 trj
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+atr
+noN
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -76945,36 +78552,36 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-cZI
-saQ
-dMA
-gRH
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+awN
+fyD
+xXO
 wSy
 sVP
 wDk
 rMK
 vuF
-abs
-abs
-mtQ
-abs
-abs
+vuF
+rMK
+pVE
+rMK
+ugA
 dDn
 npd
-kxe
+npd
 trj
 wYY
 wYY
@@ -77018,22 +78625,22 @@ mtg
 vbW
 vfr
 lYm
-uSU
-sTO
-nBw
-tWo
-bzI
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+wYY
+trj
+atr
+noN
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -77202,27 +78809,27 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-bfr
-lfF
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+aIO
+awN
+fyD
 xXO
-ebT
+rMK
 bcT
 vte
-eub
+vte
 etF
 dRo
 cFr
@@ -77231,8 +78838,8 @@ sCS
 fiU
 ouK
 jcm
-rrO
-trj
+tNz
+bZu
 wYY
 wYY
 wYY
@@ -77275,22 +78882,22 @@ ada
 jLm
 nMK
 cch
-iVV
-amB
-hSc
+wYY
 trj
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+atr
+noN
+aIO
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -77459,38 +79066,38 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-abs
-abs
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+awN
+afP
 abs
 ahF
 rrO
 epp
-rrO
-mhq
-rrO
+pvX
+vuF
+sQX
 fcH
 vsq
 meB
 grf
-rrO
-rrO
-rrO
+uaO
+xpG
+fKE
+wgR
 trj
-pQv
 pQv
 pQv
 pQv
@@ -77534,20 +79141,20 @@ pQv
 dqK
 pQv
 trj
-trj
-trj
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+afP
+noN
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -77716,44 +79323,44 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-eEn
-icn
-abs
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+awN
+fyD
+xXO
 eAc
-jgr
+rrO
 fhR
 cla
 pRp
 sAE
-fcH
+aPA
 gyD
 jde
 taE
-rrO
+dNA
 qnx
-rrO
+hzF
+uZq
 trj
 wYY
-wRp
 dPi
-kEI
 wYY
 wYY
-gPL
+wYY
+fTX
 trj
 jkX
 nTH
@@ -77778,33 +79385,33 @@ pQv
 dji
 pQv
 pQv
-dpD
-pjF
-pjF
-pjF
-pjF
-pjF
+wYY
+wYY
+pQv
+efA
+fKT
+mbq
 kZI
-gnC
-pjF
-pjF
+pQv
+qED
+wYY
 heC
-tSn
+wYY
 trj
-aIO
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+atr
+noN
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -77973,39 +79580,39 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 aIO
-abs
+awN
+fyD
+xXO
 jPf
 mLZ
-lcF
 abs
 abs
-jwx
+abs
+abs
 bTA
 jrr
 vYd
-kQp
-uaO
 abs
+uaO
+bMg
 gZC
+etQ
 trj
-wYY
-wYY
+iNN
 kwv
 dbG
 sWw
@@ -78035,33 +79642,33 @@ wYY
 jWu
 wYY
 wYY
+wYY
+wYY
+pQv
+pLX
+uUw
+gNM
+uUw
+pQv
+qED
+wYY
 aQM
 wYY
-wYY
-pLX
-wYY
-wYY
-mJr
 trj
-trj
-mvd
-mvd
-oMJ
-trj
+atr
+noN
 aIO
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -78230,44 +79837,44 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
 baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+awN
+fyD
+xXO
 cCI
-icn
-icn
-aIO
+lcF
 abs
-jPf
-mLZ
+rZb
+cSM
+abs
+uQE
 qlC
 mqP
-bFt
-xie
 abs
-iEU
+xie
+jTz
+abs
+trj
 trj
 wYY
 wYY
 wYY
 wYY
 wYY
-pvX
-rZb
+cSZ
 trj
 gEx
 sin
@@ -78292,33 +79899,33 @@ pjF
 iNr
 pjF
 rBY
-heC
-oSx
+pjF
+pjF
 dxw
-trj
-mvd
-bZK
+nya
+nya
+nya
 oMJ
+dxw
+pjF
+aMj
+ePR
+wYY
 trj
-aIO
-icn
-icn
+atr
+noN
 baX
-cCI
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -78487,49 +80094,49 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
 baX
 baX
-drp
-drp
-drp
 baX
-cCI
-icn
-icn
-icn
-jPf
-jPf
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+awN
+atr
 abs
-abs
-trj
-trj
-hjw
-dCq
-wSE
+rMK
+lfF
 oGp
+saQ
+tVd
+gOt
+npd
+qlC
+npd
+qMb
+rsl
+gMR
+xuT
+trj
+wYY
+wYY
+wYY
+wYY
+wYY
 amB
 cSZ
 pbN
-qkh
-qkh
-qkh
-qkh
+oEQ
+oEQ
+oEQ
+aNh
 nBT
 qkh
 qkh
@@ -78542,40 +80149,40 @@ pQv
 aQM
 wYY
 wYY
+wSE
+lOl
 hjw
 dCq
-wSE
-mgd
+wYY
+wYY
+wYY
+wYY
+wYY
+pQv
+wYY
+gTp
+wYY
+xpm
+pQv
+wYY
+bKu
+wYY
+wYY
 trj
-trj
-mvd
-mvd
-oMJ
-oMJ
-aIO
-icn
-icn
-baX
-cCI
-drp
-drp
-drp
+atr
+noN
 baX
 baX
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -78744,50 +80351,50 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
 baX
 baX
-drp
-drp
-drp
-flN
-flN
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+aaK
+baX
+baX
+abs
+abs
+abs
+iEU
+rrO
+abs
+abs
+abs
+abs
+ybm
+qlC
+npd
+npd
+npd
+gMR
+omY
 trj
-trj
-mvd
-mvd
-trj
-trj
+pQv
+pQv
+glz
+pQv
+pQv
+pQv
 hQj
 mAf
+pMB
+pMB
+pMB
 pIL
-pIL
-pIL
-pIL
-mWX
+pMB
 pMB
 pMB
 pMB
@@ -78799,40 +80406,40 @@ yeR
 ePR
 wYY
 trj
+pQv
+pQv
+pQv
+pQv
+pQv
+pQv
+pQv
+dpk
+pQv
+pQv
+wYY
+tYw
+wYY
+xpm
+pQv
+wYY
+bKu
+kvS
 trj
-mvd
-mvd
 trj
 trj
-aIO
-icn
-icn
-flN
-flN
-drp
-drp
-drp
+trj
 baX
 baX
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -79001,49 +80608,49 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-aIO
-icn
-icn
-aIO
-trj
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+bfr
+cZI
+gnC
+iNo
+mgd
+oKs
 sca
+ydc
+wlM
+npd
+okE
+sab
+jgw
+npd
+gMR
+jXi
+trj
+qjY
+wSE
+wYY
+hjw
+dCq
+trj
+trj
 wgR
 mvd
 mvd
 mvd
-trj
+qoe
 trj
 mvd
 mvd
@@ -79056,40 +80663,40 @@ bZK
 trj
 trj
 trj
-aIO
-icn
-icn
-aIO
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+qzL
+qzL
+qzL
+xWz
+pQv
+qzL
+qzL
+qzL
+xWz
+pQv
+pQv
+pQv
+dpk
+cHk
+pQv
+pQv
+rGS
+pQv
+pQv
+eTZ
+ovd
+trj
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -79258,95 +80865,95 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-iNo
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+bcj
+bzI
+dMA
+hSc
+iVV
+mJr
+abs
+sTO
+dFz
+abs
+byQ
+okE
+dFz
+nKC
+npd
+npu
+qXb
+trj
+wYY
+wYY
+wyw
+wYY
+wYY
+trj
+aIO
 bTz
 icn
 icn
 icn
-aIO
-aIO
-icn
-icn
-icn
-aIO
+opC
 aIO
 icn
 icn
 icn
 aIO
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+aIO
+icn
+icn
+icn
+aIO
+aIO
+trj
+qzL
+qzL
+qzL
+qzL
+pQv
+qzL
+qzL
+qzL
+qzL
+pQv
+qzL
+qzL
+qzL
+cZl
+pQv
+wYY
+ttV
+hhz
+eXW
+vpt
+hKX
+vaG
+nCX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -79515,95 +81122,95 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+abs
+eEn
+abs
+abs
+mWX
+abs
+abs
+abs
+abs
+erG
+pHg
+npd
+mIC
+npd
+nUx
+abs
+trj
+trj
+sZs
+wYY
+wYY
+qom
+mvd
+icn
+baX
+baX
+usX
+baX
+baX
+baX
+baX
+usX
+baX
+baX
+baX
+baX
+usX
+baX
+baX
+icn
+mvd
+qzL
+qzL
+qzL
+qzL
+azx
+qzL
+qzL
+qzL
+qzL
+azx
+qzL
+qzL
+qzL
+qqz
+pQv
+wYY
+wYY
+wYY
+jSD
+amB
+wQb
+trj
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -79772,95 +81379,95 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+abs
+abs
+abs
+jnG
+nBw
+oSx
+tkg
+oLb
+jMs
+bhc
+unB
+xvt
+xvt
+duc
+aCm
+abs
+mQs
+trj
+jkv
+dGm
+wYY
+nXR
+mvd
+icn
+baX
+baX
+usX
+emc
+emc
+emc
+emc
+tmg
+azV
+azV
+azV
+azV
+usX
+baX
+baX
+icn
+mvd
+qzL
+qzL
+qzL
+qzL
+pQv
+qzL
+qzL
+qzL
+qzL
+pQv
+qzL
+qzL
+qzL
+qqz
+pQv
+wYY
+wYY
+wYY
+pQv
+trj
+trj
+trj
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -80029,95 +81636,95 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+bFt
+baX
+abs
+jwx
+ofM
+abs
+tHQ
+qCZ
+pmR
+usA
+aZm
+tnA
+tnA
+wxA
+abs
+abs
+dJv
+trj
+gZT
+wYY
+wYY
+qom
+trj
+aIO
+baX
+emc
+emc
+fCr
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+fCr
+azV
+azV
+baX
+aIO
+trj
+qzL
+qzL
+qzL
+qzL
+pQv
+qzL
+qzL
+qzL
+qzL
+pQv
+qzL
+qzL
+qzL
+qqz
+pQv
+nif
+nif
+nif
+nif
+trj
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -80286,95 +81893,95 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+abs
+kEI
+abs
+abs
+abs
+abs
+eQW
+cZY
+cXV
+hZf
+wTj
+cWa
+nQT
+abH
+bzb
+trj
+hSn
+wYY
+wYY
+trj
+trj
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+trj
+trj
+pQv
+pQv
+pQv
+pQv
+pQv
+pQv
+dpk
+pQv
+qPd
+lqL
+lqL
+lqL
+bwU
+hUM
+hUM
+oLD
+oLD
+cog
+trj
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -80543,95 +82150,95 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+kQp
+icn
+icn
+aIO
+abs
+kEI
+gZS
+eAY
+pOp
+sqE
+aAF
+abs
+lRg
+lbw
+trj
+rWc
+wYY
+wYY
+mvd
+icn
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+icn
+mvd
+wYY
+ikp
+wYY
+pQv
+wYY
+wYY
+wyw
+smF
+slv
+trj
+mvd
+bZK
+eXp
+trj
+aIO
+icn
+icn
+baX
+kQp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -80800,95 +82407,95 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+kQp
+icn
+icn
+icn
+kEI
+kEI
+abs
+abs
+abs
+trj
+mex
+tBA
+wYY
+mvd
+icn
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+icn
+mvd
+ehL
+wYY
+ehL
+trj
+trj
+mvd
+mvd
+eXp
+eXp
+aIO
+icn
+icn
+baX
+kQp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -81057,95 +82664,95 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-eLi
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+rSD
+rSD
+baX
+baX
+aIO
+trj
+trj
+mvd
+mvd
+trj
+aIO
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+aIO
+trj
+mvd
+mvd
+trj
+trj
+aIO
+icn
+icn
+rSD
+rSD
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -81314,95 +82921,95 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+aIO
+icn
+icn
+aIO
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+aIO
+icn
+icn
+aIO
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -81571,96 +83178,96 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 eLi
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
 drp
 drp
 drp
@@ -81828,95 +83435,95 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -82085,95 +83692,95 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -82342,95 +83949,95 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -82599,95 +84206,95 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-eLi
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-eLi
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -82856,95 +84463,95 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -83113,95 +84720,95 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -83370,95 +84977,95 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -83627,95 +85234,95 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -83884,95 +85491,95 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -84141,95 +85748,95 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -84398,95 +86005,95 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+aaK
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -84655,95 +86262,95 @@ drp
 drp
 drp
 drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
-drp
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
+baX
 drp
 drp
 drp
@@ -86262,7 +87869,7 @@ drp
 drp
 drp
 drp
-drp
+eLi
 drp
 drp
 drp

--- a/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
@@ -15,9 +15,9 @@
 /turf/open/floor/carpet/ship/blue,
 /area/medical/medbay/lobby)
 "aaK" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/carpet/ship/orange_carpet,
-/area/engine/atmos)
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "aaL" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
 /obj/effect/landmark/nuclear_waste_spawner,
@@ -176,12 +176,8 @@
 /turf/open/floor/plating,
 /area/hydroponics)
 "afF" = (
-/obj/machinery/computer/monitor{
-	dir = 8
-	},
-/obj/structure/cable/white{
-	icon_state = "0-2"
-	},
+/obj/machinery/atmospherics/pipe/manifold/purple/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "afP" = (
@@ -257,8 +253,7 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 8;
-	icon_state = "connector_map-2"
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
@@ -267,7 +262,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/carpet/ship,
+/turf/open/floor/carpet,
 /area/crew_quarters/lounge{
 	name = "Cafeteria"
 	})
@@ -377,8 +372,7 @@
 	})
 "alZ" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6;
-	icon_state = "pipe11-2"
+	dir = 6
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
@@ -578,6 +572,9 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/tcommsat/server)
 "asx" = (
@@ -597,7 +594,7 @@
 	pixel_y = 5
 	},
 /obj/machinery/firealarm/directional/east,
-/turf/open/floor/wood,
+/turf/open/floor/carpet/ship,
 /area/chapel/office)
 "asI" = (
 /turf/closed/wall/ship,
@@ -752,17 +749,13 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "ayS" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/machinery/computer/monitor{
-	dir = 4;
-	name = "department distribution monitoring console"
-	},
 /obj/structure/sign/solgov_seal,
+/obj/structure/cable/white{
+	icon_state = "0-8"
+	},
+/obj/machinery/modular_computer/console/preset/engineering{
+	dir = 4
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmospherics_engine)
 "ayV" = (
@@ -845,12 +838,9 @@
 /turf/open/floor/carpet/ship/blue,
 /area/medical/genetics/cloning)
 "aAj" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/carpet/ship/orange_carpet,
-/area/engine/atmos)
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "aAG" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -946,6 +936,9 @@
 /area/engine/gravity_generator)
 "aER" = (
 /obj/machinery/vending/wardrobe/chem_wardrobe,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/carpet/ship/blue,
 /area/medical/chemistry)
 "aFl" = (
@@ -1043,8 +1036,7 @@
 /area/maintenance/department/engine)
 "aMR" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 8;
-	icon_state = "pipe11-2"
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/gateway)
@@ -1311,9 +1303,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
@@ -1500,8 +1489,7 @@
 	},
 /obj/machinery/telecomms/processor/preset_four,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5;
-	icon_state = "pipe11-2"
+	dir = 5
 	},
 /turf/open/floor/circuit,
 /area/tcommsat/server)
@@ -1587,8 +1575,7 @@
 /area/maintenance/department/engine)
 "bdK" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 4;
-	icon_state = "connector_map-2"
+	dir = 4
 	},
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/department/engine)
@@ -1631,6 +1618,12 @@
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
+"bfa" = (
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/hydroponics)
 "bfn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1658,13 +1651,12 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
 "bfy" = (
-/obj/machinery/hydroponics/constructable,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/grass,
 /area/hydroponics)
 "bfE" = (
 /obj/structure/cable{
@@ -1686,19 +1678,18 @@
 /turf/closed/wall/ship,
 /area/crew_quarters/kitchen)
 "bgh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
-/turf/open/floor/carpet/ship/orange_carpet,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plating,
 /area/engine/engine_smes)
 "bgk" = (
 /obj/structure/chair/pew/right{
-	dir = 8;
-	icon_state = "pewend_right"
+	dir = 8
 	},
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet/royalblack,
@@ -1749,10 +1740,18 @@
 	name = "Security War Room"
 	})
 "bhq" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/machinery/meter,
-/turf/open/floor/engine,
-/area/engine/engine_room)
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 8
+	},
+/obj/machinery/computer/monitor{
+	dir = 8;
+	name = "stormdrive power monitoring console"
+	},
+/obj/structure/cable/white{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "bhA" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1852,9 +1851,6 @@
 /area/lawoffice)
 "bjg" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -1865,6 +1861,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
@@ -1915,6 +1914,9 @@
 /obj/structure/cable/white{
 	icon_state = "0-2"
 	},
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
 "blv" = (
@@ -1931,11 +1933,22 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9;
-	icon_state = "pipe11-2"
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
+"blH" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/carpet,
+/area/crew_quarters/lounge{
+	name = "Cafeteria"
+	})
 "bmf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -1976,6 +1989,9 @@
 /area/medical/patients_rooms/room_c)
 "boG" = (
 /obj/effect/landmark/observer_start,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
@@ -2026,9 +2042,7 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet/west,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/turf/open/floor/grass,
 /area/hydroponics)
 "bpE" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/layer1{
@@ -2079,10 +2093,6 @@
 /obj/item/watertank/atmos,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
-"brX" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/turf/open/floor/carpet/orange,
-/area/engine/engine_smes)
 "bsz" = (
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
@@ -2137,13 +2147,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "bts" = (
-/obj/machinery/vending/hydroseeds,
-/obj/machinery/camera/autoname{
-	dir = 8
+/obj/structure/flora/tree/jungle/small{
+	pixel_y = -8
 	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
 /area/hydroponics)
 "btN" = (
 /obj/structure/cable{
@@ -2454,8 +2462,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/structure/chair/office/light{
+	dir = 4
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
@@ -2496,9 +2504,10 @@
 	name = "department power storage unit";
 	output_level = 30000
 	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
+/obj/structure/sign/warning/electricshock{
+	pixel_y = -31
 	},
+/turf/open/floor/grass,
 /area/hydroponics)
 "bDY" = (
 /obj/structure/closet/secure_closet/medical3,
@@ -2651,6 +2660,12 @@
 	mood_message = "<span class='nicegreen'>This area is pretty serious!\n</span>";
 	name = "Interrogation Room"
 	})
+"bLD" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/grass,
+/area/hydroponics)
 "bNg" = (
 /obj/machinery/field/generator,
 /turf/open/floor/plating,
@@ -2710,8 +2725,7 @@
 	on = 1
 	},
 /obj/structure/window/plasma/reinforced{
-	dir = 1;
-	icon_state = "plasmarwindow"
+	dir = 1
 	},
 /obj/structure/sink{
 	dir = 4;
@@ -2724,8 +2738,7 @@
 /area/medical/virology)
 "bOk" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 8;
-	icon_state = "pipe11-2"
+	dir = 8
 	},
 /obj/machinery/light{
 	dir = 1
@@ -3044,9 +3057,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/turf/open/floor/grass,
 /area/hydroponics)
 "bZv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -3064,8 +3075,7 @@
 /obj/structure/cable/white{
 	icon_state = "1-8"
 	},
-/obj/item/analyzer,
-/obj/effect/landmark/event_spawn,
+/obj/machinery/meter,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmospherics_engine)
 "bZK" = (
@@ -3094,6 +3104,14 @@
 	},
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/department/engine)
+"cae" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/open/floor/carpet/ship/blue,
+/area/medical/apothecary)
 "cap" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3146,7 +3164,7 @@
 	departmentType = 2;
 	pixel_y = 30
 	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet/ship,
 /area/chapel/office)
 "cdk" = (
 /obj/structure/table,
@@ -3238,9 +3256,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/botanist,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/turf/open/floor/grass,
 /area/hydroponics)
 "cfY" = (
 /obj/structure/rack,
@@ -3272,7 +3288,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
-/turf/open/floor/carpet/ship,
+/turf/open/floor/carpet,
 /area/crew_quarters/kitchen)
 "chp" = (
 /obj/machinery/camera/autoname{
@@ -3385,6 +3401,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "cks" = (
@@ -3456,10 +3475,10 @@
 /area/maintenance/department/engine/atmos)
 "cnq" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/effect/turf_decal/arrows{
-	pixel_x = 12
-	},
 /obj/machinery/meter,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
 "cnv" = (
@@ -3497,15 +3516,8 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/obj/machinery/computer/atmos_control/tank{
-	input_tag = "extra_1_input";
-	output_tag = "extra_1_output";
-	sensors = list("extra_1_sensor" = "Custom Tank 1")
-	},
-/obj/machinery/button/door{
-	id = "custom_tank_1_doors";
-	pixel_x = 6;
-	pixel_y = 26
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Custom 3 to Mix"
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
@@ -3530,6 +3542,14 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/crew_quarters/heads/chief)
+"cpt" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/lounge{
+	name = "Cafeteria"
+	})
 "cqD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3671,8 +3691,8 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/station_engineer,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/structure/cable/white{
+	icon_state = "2-8"
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
@@ -3705,8 +3725,7 @@
 /area/space/nearstation)
 "cvq" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6;
-	icon_state = "pipe11-2"
+	dir = 6
 	},
 /obj/machinery/telecomms/bus/preset_three,
 /turf/open/floor/circuit,
@@ -3723,6 +3742,13 @@
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
+"cwp" = (
+/obj/structure/sign/warning/radiation,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/closed/wall/r_wall/ship,
+/area/engine/engine_room/external{
+	name = "Stormdrive Interior"
+	})
 "cwU" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3754,8 +3780,7 @@
 /area/maintenance/department/engine)
 "cyr" = (
 /obj/machinery/modular_computer/console/preset/command{
-	dir = 4;
-	icon_state = "console"
+	dir = 4
 	},
 /obj/machinery/computer/security/telescreen/ce{
 	pixel_x = -30
@@ -3765,8 +3790,7 @@
 "cyM" = (
 /obj/machinery/telecomms/server/presets/supply,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6;
-	icon_state = "pipe11-2"
+	dir = 6
 	},
 /turf/open/floor/circuit,
 /area/tcommsat/server)
@@ -3790,9 +3814,6 @@
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/checkpoint/escape)
 "czT" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1,
 /turf/open/floor/carpet/ship/orange_carpet,
@@ -3815,7 +3836,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/turf/open/floor/wood,
+/turf/open/floor/carpet/ship,
 /area/chapel/office)
 "cBs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -3855,16 +3876,14 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /turf/closed/wall/r_wall/ship,
 /area/chapel/office)
-"cDF" = (
-/turf/open/floor/carpet/ship/orange_carpet,
-/area/science/misc_lab{
-	name = "Shield Generator"
-	})
 "cEf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
@@ -3872,8 +3891,7 @@
 "cEq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6;
-	icon_state = "pipe11-2"
+	dir = 6
 	},
 /obj/machinery/telecomms/bus/preset_one,
 /turf/open/floor/circuit,
@@ -3997,9 +4015,6 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 9
-	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
 "cMn" = (
@@ -4062,8 +4077,7 @@
 /area/chapel/main)
 "cPb" = (
 /obj/structure/shuttle/engine/large{
-	dir = 8;
-	icon_state = "large_engine"
+	dir = 8
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -4113,10 +4127,9 @@
 /area/medical/medbay/lobby)
 "cRD" = (
 /obj/machinery/firealarm/directional/west,
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/obj/machinery/smartfridge/drying_rack,
+/obj/item/storage/fancy/rollingpapers,
+/turf/open/floor/grass,
 /area/hydroponics)
 "cRE" = (
 /obj/machinery/status_display/evac,
@@ -4178,8 +4191,19 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
 /turf/open/floor/carpet/ship/blue,
 /area/medical/surgery/aux)
+"cSr" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/visible,
+/obj/machinery/meter/atmos{
+	layer = 2.65
+	},
+/turf/closed/wall/r_wall/ship,
+/area/engine/atmos)
 "cSv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -4248,9 +4272,6 @@
 "cUA" = (
 /obj/structure/cable/white{
 	icon_state = "0-2"
-	},
-/obj/structure/cable/white{
-	icon_state = "2-8"
 	},
 /obj/machinery/power/terminal{
 	dir = 4
@@ -4336,6 +4357,12 @@
 	},
 /turf/open/floor/carpet/ship/blue,
 /area/medical/chemistry)
+"cYP" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/open/floor/engine/vacuum,
+/area/engine/engine_room/external{
+	name = "Stormdrive Interior"
+	})
 "cZt" = (
 /obj/structure/rack,
 /obj/machinery/airalarm/directional/north,
@@ -4523,10 +4550,13 @@
 	pixel_y = 32
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "4-8"
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
@@ -4605,6 +4635,9 @@
 /area/engine/storage)
 "dhZ" = (
 /obj/structure/sign/warning/enginesafety,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/closed/wall/r_wall/ship,
 /area/engine/atmospherics_engine)
 "die" = (
@@ -4695,8 +4728,7 @@
 	})
 "dmQ" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/item/clothing/mask/surgical,
 /obj/item/clothing/gloves/color/latex,
@@ -4729,11 +4761,12 @@
 	name = "Cafeteria"
 	})
 "dnt" = (
-/obj/structure/chair/office/light{
-	dir = 4
-	},
 /obj/structure/cable/white{
 	icon_state = "1-2"
+	},
+/obj/machinery/shield_generator,
+/obj/structure/cable/white{
+	icon_state = "0-2"
 	},
 /turf/open/floor/engine,
 /area/science/misc_lab{
@@ -4746,21 +4779,11 @@
 /area/engine/engine_room)
 "dnU" = (
 /obj/structure/bodycontainer/morgue{
-	dir = 8;
-	icon_state = "morgue1"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/carpet/ship,
 /area/medical/morgue)
-"doa" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
-/area/hydroponics)
 "doo" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos{
 	id = "stormdrive_mix_in"
@@ -4886,16 +4909,10 @@
 /turf/open/space/basic,
 /area/space)
 "drA" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "drJ" = (
@@ -4944,8 +4961,7 @@
 /area/crew_quarters/bar)
 "dti" = (
 /obj/machinery/cryopod{
-	dir = 4;
-	icon_state = "cryopod-open"
+	dir = 4
 	},
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
@@ -4962,9 +4978,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
 /area/hydroponics)
 "dvb" = (
 /obj/structure/table/wood,
@@ -4975,6 +4991,18 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
+"dvs" = (
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/airlock/ship/maintenance{
+	name = "Maintenance Access Stormdrive";
+	req_one_access_txt = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "dwe" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
@@ -5023,7 +5051,7 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/turf/open/floor/wood,
+/turf/open/floor/carpet/ship,
 /area/chapel/office)
 "dxo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -5032,6 +5060,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/tcommsat/server)
@@ -5125,9 +5156,10 @@
 /area/maintenance/department/engine)
 "dzH" = (
 /obj/structure/closet/secure_closet/hydroponics,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/obj/item/clothing/suit/beekeeper_suit,
+/obj/item/clothing/head/beekeeper_head,
+/obj/item/clothing/head/rice_hat,
+/turf/open/floor/grass,
 /area/hydroponics)
 "dzP" = (
 /obj/structure/table,
@@ -5214,6 +5246,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/ship,
 /area/storage/tools)
 "dCB" = (
@@ -5255,8 +5290,7 @@
 /area/medical/storage)
 "dDn" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
@@ -5328,9 +5362,6 @@
 /obj/structure/chair/office/light{
 	dir = 4
 	},
-/obj/structure/cable/white{
-	icon_state = "2-8"
-	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmospherics_engine)
 "dEz" = (
@@ -5354,14 +5385,16 @@
 	name = "Hallway"
 	})
 "dFa" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 1
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 31
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/turf/open/floor/engine,
+/area/science/misc_lab{
+	name = "Shield Generator"
+	})
 "dFl" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
@@ -5447,8 +5480,7 @@
 /area/engine/storage)
 "dJw" = (
 /obj/machinery/computer/crew{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /obj/machinery/light_switch/west,
 /turf/open/floor/carpet/ship/blue,
@@ -5560,8 +5592,7 @@
 /area/maintenance/department/engine)
 "dOS" = (
 /obj/structure/chair/pew{
-	dir = 8;
-	icon_state = "pewmiddle"
+	dir = 8
 	},
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet/royalblack,
@@ -5599,9 +5630,6 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "12"
-	},
-/obj/structure/cable/white{
-	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
@@ -5665,8 +5693,7 @@
 /area/medical/patients_rooms/room_b)
 "dTQ" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4;
-	icon_state = "manifold-2"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5761,10 +5788,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "dWQ" = (
-/obj/item/twohanded/required/kirbyplants/random,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/firealarm/directional/east,
-/turf/open/floor/carpet/ship/orange_carpet,
+/turf/open/floor/plating,
 /area/engine/engine_smes)
 "dXd" = (
 /obj/structure/sign/warning/deathsposal,
@@ -5779,12 +5805,6 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 10
-	},
-/obj/machinery/meter/atmos{
-	layer = 2.65
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
@@ -5839,12 +5859,16 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
 /turf/open/floor/carpet/ship/blue,
 /area/medical/genetics/cloning)
 "dZM" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4;
-	icon_state = "connector_map-2"
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/gateway)
@@ -5859,8 +5883,7 @@
 /area/engine/engine_room)
 "ear" = (
 /obj/machinery/computer/apc_control{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/carpet/ship/orange_carpet,
@@ -5894,11 +5917,7 @@
 /area/crew_quarters/kitchen)
 "eaN" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
-	},
-/obj/machinery/meter{
-	pixel_x = 7
+	dir = 4
 	},
 /turf/open/floor/engine/vacuum,
 /area/engine/engine_room/external{
@@ -5909,9 +5928,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/turf/open/floor/grass,
 /area/hydroponics)
 "ebk" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -5991,21 +6008,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 4
-	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
-"edA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
-/area/hydroponics)
 "eet" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5;
-	icon_state = "pipe11-2"
+	dir = 5
 	},
 /obj/machinery/telecomms/bus/preset_two,
 /turf/open/floor/circuit,
@@ -6062,8 +6069,7 @@
 /area/crew_quarters/bar)
 "egF" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9;
-	icon_state = "pipe11-2"
+	dir = 9
 	},
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
@@ -6153,21 +6159,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/turf/open/floor/grass,
 /area/hydroponics)
 "ejp" = (
 /obj/structure/cable/white{
-	icon_state = "0-2"
-	},
-/obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/machinery/computer/monitor{
-	dir = 8
-	},
-/turf/open/floor/carpet/ship/orange_carpet,
+/turf/open/floor/carpet/orange,
 /area/science/misc_lab{
 	name = "Shield Generator"
 	})
@@ -6271,8 +6269,7 @@
 "enp" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6;
-	icon_state = "pipe11-2"
+	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
 	dir = 6
@@ -6349,6 +6346,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/spawner/lootdrop/maintenance/two,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
 /turf/open/floor/carpet,
 /area/storage/tools)
 "epB" = (
@@ -6370,9 +6370,11 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
@@ -6506,10 +6508,17 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
+/obj/structure/bed,
+/obj/item/bedsheet/ce,
+/obj/effect/landmark/start/chief_engineer,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/crew_quarters/heads/chief)
 "euO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
 /turf/open/floor/carpet/ship/blue,
 /area/medical/surgery)
 "evS" = (
@@ -6520,6 +6529,9 @@
 /area/maintenance/department/medical)
 "ewk" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/crew_quarters/lounge{
 	name = "Cafeteria"
@@ -6726,15 +6738,12 @@
 	name = "Interrogation Room"
 	})
 "eGT" = (
-/obj/structure/cable/white{
-	icon_state = "0-4"
+/obj/machinery/computer/monitor{
+	dir = 4;
+	name = "department distribution monitoring console"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/modular_computer/console/preset/engineering{
-	dir = 4;
-	icon_state = "console"
+	icon_state = "0-8"
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmospherics_engine)
@@ -6764,7 +6773,6 @@
 "eHP" = (
 /obj/structure/sink/kitchen{
 	dir = 4;
-	icon_state = "sink_alt";
 	pixel_x = -11
 	},
 /obj/structure/cable{
@@ -6834,8 +6842,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -6845,11 +6852,6 @@
 /turf/open/floor/grass,
 /area/chapel/main)
 "eKE" = (
-/obj/structure/closet/secure_closet/atmospherics,
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos{
-	id_tag = "extra_1_output";
-	on = 0
-	},
 /turf/open/floor/engine,
 /area/engine/atmos)
 "eKJ" = (
@@ -6860,8 +6862,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -6893,6 +6894,9 @@
 "eLE" = (
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet/ship,
 /area/storage/tools)
@@ -6998,6 +7002,16 @@
 /obj/effect/spawner/structure/window/reinforced/ship,
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
+"ePI" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos{
+	dir = 8;
+	id_tag = "stormdrive_chamber_out";
+	piping_layer = 1
+	},
+/turf/open/floor/engine/vacuum,
+/area/engine/engine_room/external{
+	name = "Stormdrive Interior"
+	})
 "ePM" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank Nitrous Oxide";
@@ -7070,26 +7084,25 @@
 /area/engine/engine_smes)
 "eRM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/structure/cable/yellow,
 /obj/machinery/computer/monitor{
 	dir = 4;
-	name = "stormdrive power monitoring console"
-	},
-/obj/structure/cable/white{
-	icon_state = "0-4"
-	},
-/obj/item/paper{
-	info = "<p>Engineering notice: There are three wire colors used on the Aetherwhisp 6 ship model. White cable is wired to the Stormdrive MK-4 and the supermatter crystal near atmospherics. These lead to their own SMES located nearby. Yellow wires are department distribution wires, which deliver power from the engines SMES to deparment SMES. Red wires deliver power from department SMES to department APCs.</p>"
+	name = "department distribution monitoring console"
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
 "eSo" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
+/turf/open/floor/grass,
+/area/hydroponics)
+"eSr" = (
+/obj/structure/flora/ausbushes/grassybush,
+/turf/open/floor/grass,
 /area/hydroponics)
 "eSw" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -7121,8 +7134,7 @@
 /area/security/brig)
 "eSP" = (
 /obj/structure/shuttle/engine/huge{
-	dir = 8;
-	icon_state = "huge_engine"
+	dir = 8
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -7156,6 +7168,9 @@
 /area/medical/medbay/lobby)
 "eUy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
@@ -7351,9 +7366,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/machinery/meter{
-	pixel_x = -8
-	},
 /turf/open/floor/engine/vacuum,
 /area/engine/engine_room/external{
 	name = "Stormdrive Interior"
@@ -7526,14 +7538,11 @@
 	name = "Cafeteria"
 	})
 "fha" = (
-/obj/structure/bed,
-/obj/item/bedsheet/ce,
 /obj/machinery/light_switch/east,
 /obj/machinery/keycard_auth{
 	pixel_x = 24;
 	pixel_y = 24
 	},
-/obj/effect/landmark/start/chief_engineer,
 /obj/machinery/requests_console{
 	announcementConsole = 1;
 	department = "Chief Engineer's Desk";
@@ -7541,6 +7550,7 @@
 	name = "Chief Engineer RC";
 	pixel_y = 32
 	},
+/obj/structure/closet/secure_closet/engineering_chief,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/crew_quarters/heads/chief)
 "fhC" = (
@@ -7560,6 +7570,9 @@
 /area/engine/storage)
 "fhK" = (
 /obj/item/twohanded/required/kirbyplants/random,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/break_room)
 "fhM" = (
@@ -7612,8 +7625,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/obj/machinery/computer/ship/ftl_computer,
-/turf/open/floor/carpet/ship/orange_carpet,
+/turf/open/floor/plating,
 /area/engine/engine_smes)
 "fko" = (
 /obj/structure/cable{
@@ -7623,8 +7635,7 @@
 /area/maintenance/department/engine/atmos)
 "fkp" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7677,14 +7688,7 @@
 /area/space/nearstation)
 "fmb" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/trinary/mixer/layer1{
 	dir = 1
@@ -7762,8 +7766,7 @@
 /area/ai_monitored/security/armory/security)
 "foC" = (
 /obj/structure/chair/pew{
-	dir = 8;
-	icon_state = "pewmiddle"
+	dir = 8
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -7848,8 +7851,7 @@
 	})
 "ftb" = (
 /obj/machinery/computer/station_alert{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/crew_quarters/heads/chief)
@@ -7875,8 +7877,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/particle_accelerator/particle_emitter/center{
-	dir = 1;
-	icon_state = "emitter_center"
+	dir = 1
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_room)
@@ -7934,12 +7935,22 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
 "fuA" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/science/misc_lab{
+	name = "Shield Generator"
+	})
+"fuU" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
-/area/engine/atmos)
+/area/engine/engine_smes)
 "fvf" = (
 /obj/structure/table/reinforced,
 /obj/item/coin/iron{
@@ -7959,8 +7970,7 @@
 /area/medical/morgue)
 "fvF" = (
 /obj/machinery/cryopod{
-	dir = 4;
-	icon_state = "cryopod-open"
+	dir = 4
 	},
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
@@ -7985,6 +7995,9 @@
 /turf/open/floor/carpet/ship/blue,
 /area/medical/patients_rooms/room_c)
 "fwS" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
 /turf/open/floor/carpet/orange,
 /area/engine/break_room)
 "fxa" = (
@@ -8083,21 +8096,12 @@
 	pixel_x = -26;
 	pixel_y = -6
 	},
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high,
-/turf/open/floor/carpet/ship/orange_carpet,
+/turf/open/floor/plating,
 /area/engine/engine_smes)
 "fBL" = (
-/obj/machinery/firealarm{
-	pixel_x = -26;
-	pixel_y = 25
-	},
-/obj/machinery/computer/ship/viewscreen,
-/turf/open/floor/engine,
-/area/science/misc_lab{
-	name = "Shield Generator"
-	})
+/obj/machinery/status_display/ai,
+/turf/closed/wall/r_wall/ship,
+/area/tcommsat/server)
 "fBT" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
@@ -8230,8 +8234,7 @@
 /area/maintenance/department/medical/central)
 "fGM" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/machinery/status_display/supply/west,
 /turf/open/floor/carpet/ship,
@@ -8282,6 +8285,17 @@
 	},
 /turf/open/floor/carpet/ship/blue,
 /area/medical/medbay/lobby)
+"fIp" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/ship,
+/area/hallway/primary/central{
+	name = "Hallway"
+	})
 "fIH" = (
 /obj/machinery/light{
 	dir = 8
@@ -8289,10 +8303,8 @@
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
 "fIX" = (
-/obj/machinery/vending/hydronutrients,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/obj/machinery/vending/hydroseeds,
+/turf/open/floor/grass,
 /area/hydroponics)
 "fJu" = (
 /obj/machinery/door_timer{
@@ -8364,8 +8376,7 @@
 /area/engine/atmos)
 "fKi" = (
 /obj/structure/chair/pew/right{
-	dir = 8;
-	icon_state = "pewend_right"
+	dir = 8
 	},
 /turf/open/floor/carpet/royalblack,
 /area/chapel/main)
@@ -8466,19 +8477,30 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/wood,
 /area/security/execution/education)
+"fOK" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/squad_vendor{
+	density = 0;
+	pixel_y = -32
+	},
+/turf/open/floor/carpet/ship,
+/area/hallway/primary/central{
+	name = "Hallway"
+	})
 "fPB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
-"fQc" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/computer/ship/dradis,
-/turf/open/floor/carpet/ship/orange_carpet,
-/area/engine/engine_smes)
 "fQf" = (
 /obj/machinery/atmospherics/components/unary/portables_connector,
 /obj/effect/landmark/nuclear_waste_spawner,
@@ -8564,14 +8586,10 @@
 /area/engine/storage)
 "fTA" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -8678,18 +8696,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
-/area/hydroponics)
-"fXf" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/landmark/start/botanist,
-/turf/open/floor/carpet/green,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/grass,
 /area/hydroponics)
 "fXX" = (
 /obj/structure/cable{
@@ -8758,8 +8766,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4;
-	icon_state = "manifold-2"
+	dir = 4
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/tcommsat/server)
@@ -8871,11 +8878,10 @@
 	name = "Interrogation Room"
 	})
 "ggE" = (
-/obj/machinery/newscaster/directional/north,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/carpet/ship/orange_carpet,
+/turf/open/floor/plating,
 /area/engine/engine_smes)
 "gik" = (
 /obj/structure/disposalpipe/trunk{
@@ -9021,9 +9027,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/turf/open/floor/grass,
 /area/hydroponics)
 "gni" = (
 /obj/machinery/airalarm/directional/north,
@@ -9095,15 +9099,35 @@
 	mood_message = "<span class='nicegreen'>This area is pretty serious!\n</span>";
 	name = "Interrogation Room"
 	})
+"gqi" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/carpet/ship,
+/area/hallway/primary/central{
+	name = "Hallway"
+	})
 "gqw" = (
-/obj/machinery/light,
-/turf/open/floor/carpet/ship/orange_carpet,
-/area/engine/engine_smes)
+/obj/machinery/computer/ship/viewscreen,
+/obj/machinery/firealarm{
+	pixel_x = -26;
+	pixel_y = 25
+	},
+/obj/machinery/computer/ship/navigation/public{
+	dir = 4;
+	name = "starmap console"
+	},
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/engine,
+/area/science/misc_lab{
+	name = "Shield Generator"
+	})
 "gqY" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 8
 	},
 /obj/machinery/light_switch/west,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "grf" = (
@@ -9128,7 +9152,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /obj/item/paper_bin,
 /obj/item/pen,
-/turf/open/floor/wood,
+/turf/open/floor/carpet/ship,
 /area/chapel/office)
 "grw" = (
 /obj/structure/cable{
@@ -9148,6 +9172,11 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/bar)
+"grJ" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/grass,
+/area/hydroponics)
 "gsj" = (
 /obj/structure/table/wood,
 /obj/structure/cable/yellow{
@@ -9160,7 +9189,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet/ship,
 /area/chapel/office)
 "gsI" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
@@ -9187,9 +9216,6 @@
 /area/security/checkpoint/medical)
 "gtW" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/structure/extinguisher_cabinet/west,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/carpet/ship/orange_carpet,
@@ -9231,8 +9257,7 @@
 /area/tcommsat/server)
 "gwP" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/open/floor/plating,
@@ -9304,8 +9329,7 @@
 /area/medical/genetics/cloning)
 "gAO" = (
 /obj/structure/disposalpipe/trunk/multiz{
-	dir = 4;
-	icon_state = "pipe-up"
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -9402,8 +9426,7 @@
 /area/maintenance/department/engine)
 "gEq" = (
 /obj/machinery/computer/station_alert{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -9423,6 +9446,9 @@
 	id = "ceshutter"
 	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
 "gEV" = (
@@ -9446,8 +9472,7 @@
 	})
 "gGg" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 4;
-	icon_state = "connector_map-2"
+	dir = 4
 	},
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/department/engine/atmos)
@@ -9473,12 +9498,6 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
-"gGC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
-/area/hydroponics)
 "gIm" = (
 /obj/machinery/atmospherics/pipe/simple/multiz,
 /turf/open/floor/plating,
@@ -9496,8 +9515,7 @@
 /area/medical/virology)
 "gJg" = (
 /obj/structure/bodycontainer/morgue{
-	dir = 8;
-	icon_state = "morgue1"
+	dir = 8
 	},
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
@@ -9546,15 +9564,14 @@
 /turf/open/floor/engine/plasma,
 /area/engine/atmos)
 "gMl" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/landmark/start/station_engineer,
+/obj/structure/chair/office/light{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/engine,
-/area/engine/engine_room)
+/area/science/misc_lab{
+	name = "Shield Generator"
+	})
 "gMs" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9599,9 +9616,7 @@
 	dir = 5
 	},
 /obj/effect/landmark/start/botanist,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/turf/open/floor/grass,
 /area/hydroponics)
 "gOq" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
@@ -9635,6 +9650,21 @@
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
+"gPL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "gPQ" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/light{
@@ -9645,18 +9675,6 @@
 "gQV" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 9
-	},
-/obj/machinery/button/door{
-	id = "supermatter_shutter";
-	name = "Supermatter Core Vent";
-	pixel_x = -26;
-	pixel_y = 38
-	},
-/obj/machinery/button/massdriver{
-	id = "superthrust";
-	name = "Toxins Mass Driver Launch";
-	pixel_x = -40;
-	pixel_y = 38
 	},
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
@@ -9708,7 +9726,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/orange_carpet,
+/turf/open/floor/carpet/orange,
 /area/science/misc_lab{
 	name = "Shield Generator"
 	})
@@ -9788,15 +9806,14 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/engine/vacuum,
 /area/engine/engine_room/external{
 	name = "Stormdrive Interior"
 	})
 "gTJ" = (
 /obj/structure/reagent_dispensers/watertank/high,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/turf/open/floor/grass,
 /area/hydroponics)
 "gTM" = (
 /obj/machinery/disposal/deliveryChute,
@@ -9853,7 +9870,6 @@
 "gUH" = (
 /obj/structure/sink/kitchen{
 	dir = 1;
-	icon_state = "sink_alt";
 	pixel_y = 22
 	},
 /turf/open/floor/carpet/ship,
@@ -9872,6 +9888,13 @@
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
+"gVu" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/closed/wall/r_wall/ship,
+/area/engine/atmos)
 "gWQ" = (
 /obj/machinery/flasher/portable{
 	density = 0;
@@ -9889,6 +9912,12 @@
 /obj/machinery/light_switch/east,
 /turf/open/floor/carpet/ship/red_carpet,
 /area/ai_monitored/security/armory/security)
+"gXp" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/ship/orange_carpet,
+/area/engine/storage)
 "gXx" = (
 /obj/machinery/light_switch/east,
 /obj/machinery/disposal/bin,
@@ -9998,10 +10027,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/event_spawn,
-/obj/machinery/holopad,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
 "had" = (
@@ -10171,6 +10196,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
+/obj/machinery/meter,
 /turf/open/floor/engine/vacuum,
 /area/engine/engine_room/external{
 	name = "Stormdrive Interior"
@@ -10259,8 +10285,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9;
-	icon_state = "pipe11-2"
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
@@ -10304,6 +10329,9 @@
 	dir = 8;
 	name = "Mix to Waste"
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "hol" = (
@@ -10341,6 +10369,9 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
@@ -10438,9 +10469,11 @@
 /area/lawoffice)
 "htu" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
 "htD" = (
@@ -10498,8 +10531,8 @@
 	pixel_x = 6;
 	pixel_y = -26
 	},
-/obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
-	dir = 8
+/obj/machinery/atmospherics/components/trinary/filter/atmos/plasma/flipped{
+	dir = 4
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
@@ -10696,13 +10729,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/template_noop,
 /area/maintenance/department/medical)
-"hDI" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
-	},
-/turf/open/floor/carpet/ship/orange_carpet,
-/area/engine/atmos)
 "hEi" = (
 /obj/structure/closet/emcloset,
 /obj/item/storage/toolbox/mechanical,
@@ -10723,6 +10749,7 @@
 /obj/structure/reagent_dispensers/water_cooler{
 	anchored = 0
 	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/engine/vacuum,
 /area/engine/engine_room/external{
 	name = "Stormdrive Interior"
@@ -10856,10 +10883,9 @@
 /obj/structure/sign/poster/random{
 	pixel_x = -32
 	},
-/obj/machinery/biogenerator,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/obj/machinery/vending/wardrobe/hydro_wardrobe,
+/obj/item/lighter/greyscale,
+/turf/open/floor/grass,
 /area/hydroponics)
 "hIK" = (
 /obj/structure/cable{
@@ -10933,11 +10959,23 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/carpet/ship/orange_carpet,
+/turf/open/floor/plating,
 /area/engine/engine_smes)
 "hJP" = (
 /obj/structure/chair/office/light,
 /obj/effect/landmark/start/station_engineer,
+/turf/open/floor/carpet/ship/orange_carpet,
+/area/engine/storage)
+"hKU" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
 "hLi" = (
@@ -10965,6 +11003,11 @@
 /obj/structure/sign/departments/minsky/medical/virology/virology2,
 /turf/closed/wall/ship,
 /area/medical/virology)
+"hMd" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/grass,
+/area/hydroponics)
 "hMy" = (
 /obj/structure/closet/radiation,
 /obj/item/clothing/mask/gas,
@@ -10998,8 +11041,10 @@
 	dir = 6
 	},
 /obj/machinery/firealarm/directional/west,
-/obj/machinery/light{
-	dir = 8
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
 	},
 /turf/open/floor/carpet/ship/blue,
 /area/medical/chemistry)
@@ -11032,9 +11077,7 @@
 /area/security/brig)
 "hPx" = (
 /obj/machinery/hydroponics/constructable,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/turf/open/floor/grass,
 /area/hydroponics)
 "hPH" = (
 /obj/structure/table,
@@ -11112,15 +11155,24 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/structure/cable/white{
+	icon_state = "0-4"
+	},
 /obj/machinery/computer/monitor{
 	dir = 4;
-	name = "department distribution monitoring console"
+	name = "stormdrive power monitoring console"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
+/obj/item/paper{
+	info = "<p>Engineering notice: There are three wire colors used on the Aetherwhisp 6 ship model. White cable is wired to the Stormdrive MK-4 and the supermatter crystal near atmospherics. These lead to their own SMES located nearby. Yellow wires are department distribution wires, which deliver power from the engines SMES to deparment SMES. Red wires deliver power from department SMES to department APCs.</p>"
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
+"hRi" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/engine,
+/area/engine/atmospherics_engine)
 "hRr" = (
 /obj/structure/sign/warning/pods,
 /turf/closed/wall/ship,
@@ -11163,8 +11215,17 @@
 /area/medical/chemistry)
 "hSN" = (
 /obj/structure/disposalpipe/junction/flip,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/break_room)
+"hTj" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/grass,
+/area/hydroponics)
 "hTm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11190,7 +11251,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/closed/wall/ship,
+/turf/closed/wall/r_wall/ship,
 /area/science/misc_lab{
 	name = "Shield Generator"
 	})
@@ -11226,9 +11287,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security)
 "hXv" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall/ship,
-/area/crew_quarters/kitchen)
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/closed/wall/r_wall/ship,
+/area/tcommsat/server)
 "hYl" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -11283,13 +11346,22 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
-/turf/closed/wall/r_wall/ship,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/window,
+/obj/structure/grille,
+/obj/structure/window/plasma/fulltile,
+/turf/open/floor/plating,
 /area/engine/engine_room/external{
 	name = "Stormdrive Interior"
 	})
 "iaN" = (
 /obj/machinery/airalarm/directional/east,
-/turf/open/floor/carpet/ship/orange_carpet,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/engine/engine_smes)
 "ibz" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -11348,8 +11420,10 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "icC" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible,
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
@@ -11385,6 +11459,10 @@
 "idH" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/landmark/nuclear_waste_spawner,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
 /area/science/misc_lab{
 	name = "Shield Generator"
@@ -11477,7 +11555,7 @@
 	},
 /obj/effect/landmark/start/chaplain,
 /obj/machinery/atmospherics/pipe/manifold4w/purple/hidden,
-/turf/open/floor/wood,
+/turf/open/floor/carpet/ship,
 /area/chapel/office)
 "igj" = (
 /obj/machinery/door/window{
@@ -11498,9 +11576,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
-	},
-/obj/structure/cable/white{
-	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
@@ -11572,8 +11647,7 @@
 /area/security/checkpoint/medical)
 "ijG" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
 	dir = 4
@@ -11653,6 +11727,9 @@
 /area/crew_quarters/heads/cmo)
 "imE" = (
 /obj/item/beacon,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/ship,
 /area/storage/tools)
 "imL" = (
@@ -11699,7 +11776,6 @@
 /area/crew_quarters/bar)
 "inY" = (
 /obj/machinery/atmospherics/components/binary/valve/digital,
-/obj/machinery/firealarm/directional/west,
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "iok" = (
@@ -11769,8 +11845,7 @@
 	})
 "ipD" = (
 /obj/machinery/computer/secure_data{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/checkpoint/engineering)
@@ -11891,6 +11966,15 @@
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
+"ivv" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/item/paper/guides/jobs/hydroponics,
+/turf/open/floor/grass,
+/area/hydroponics)
 "ivA" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -11933,14 +12017,11 @@
 /turf/closed/wall/r_wall/ship,
 /area/engine/engine_room)
 "ixl" = (
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/airlock/ship/maintenance{
-	name = "Maintenance Access Stormdrive";
-	req_one_access_txt = "10"
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/turf/closed/wall/r_wall/ship,
+/area/crew_quarters/heads/chief)
 "ixL" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -11993,9 +12074,6 @@
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 4
-	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
 "iyH" = (
@@ -12010,9 +12088,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
@@ -12083,8 +12158,7 @@
 "iAY" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -12131,26 +12205,15 @@
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/break_room)
-"iCs" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
-/area/hydroponics)
 "iCy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/structure/cable/white{
 	icon_state = "1-4"
 	},
-/turf/open/floor/carpet/ship/orange_carpet,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/turf/open/floor/carpet/orange,
 /area/science/misc_lab{
 	name = "Shield Generator"
 	})
@@ -12162,8 +12225,7 @@
 /area/medical/chemistry)
 "iDk" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -12219,9 +12281,13 @@
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/kitchen)
 "iGh" = (
-/obj/machinery/status_display/evac/east,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos{
+	id = "stormdrive_chamber_in"
+	},
+/turf/open/floor/engine/vacuum,
+/area/engine/engine_room/external{
+	name = "Stormdrive Interior"
+	})
 "iGp" = (
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
@@ -12386,7 +12452,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet/ship,
 /area/chapel/office)
 "iNe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -12398,21 +12464,22 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 6
 	},
+/obj/structure/cable/white{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "iNi" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos{
-	dir = 4;
-	id = "extra_1_input";
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos{
+	id_tag = "extra_1_output";
 	on = 0
 	},
+/obj/structure/closet/secure_closet/atmospherics,
 /turf/open/floor/engine,
 /area/engine/atmos)
 "iNo" = (
 /obj/structure/disposaloutlet{
-	dir = 1;
-	icon_state = "outlet"
+	dir = 1
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -12478,6 +12545,9 @@
 	req_one_access_txt = "2;5;12;33"
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "iTi" = (
@@ -12527,8 +12597,7 @@
 /area/lawoffice)
 "iUM" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 1;
-	icon_state = "freezer"
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
@@ -12581,8 +12650,7 @@
 /area/security/checkpoint/engineering)
 "iVI" = (
 /obj/structure/window/plasma/reinforced{
-	dir = 1;
-	icon_state = "plasmarwindow"
+	dir = 1
 	},
 /obj/machinery/computer/atmos_control/tank/air_tank{
 	input_tag = "viro_in_alt";
@@ -12621,7 +12689,7 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet/west,
-/turf/open/floor/wood,
+/turf/open/floor/carpet/ship,
 /area/chapel/office)
 "iWs" = (
 /obj/effect/landmark/nuclear_waste_spawner,
@@ -12656,6 +12724,7 @@
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "jaY" = (
@@ -12774,9 +12843,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "jcC" = (
@@ -12855,7 +12921,6 @@
 	name = "Kitchen Cold Room";
 	req_one_access_txt = "28"
 	},
-/obj/structure/fans/tiny,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/kitchen/coldroom)
 "jfr" = (
@@ -12916,21 +12981,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/airlock/ship/maintenance{
-	name = "Maintenance Access Shield Generator";
-	req_one_access_txt = "10"
-	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall/ship,
 /area/maintenance/department/engine)
 "jgQ" = (
 /obj/machinery/computer/crew{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /turf/open/floor/carpet/ship/blue,
 /area/medical/medbay/lobby)
@@ -12951,8 +13006,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
-/obj/structure/cable/white{
-	icon_state = "0-8"
+/obj/machinery/computer/ship/dradis{
+	dir = 4
+	},
+/obj/item/radio/intercom/directional/west,
+/obj/item/reagent_containers/food/drinks/coffee{
+	pixel_x = 5;
+	pixel_y = 5
 	},
 /turf/open/floor/engine,
 /area/science/misc_lab{
@@ -12960,6 +13020,9 @@
 	})
 "jhD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
@@ -12981,8 +13044,7 @@
 /area/security/checkpoint/engineering)
 "jhM" = (
 /obj/structure/chair/pew/left{
-	dir = 8;
-	icon_state = "pewend_left"
+	dir = 8
 	},
 /turf/open/floor/carpet/royalblack,
 /area/chapel/main)
@@ -13064,6 +13126,28 @@
 	color = "#99FF99"
 	},
 /area/medical/virology)
+"jkY" = (
+/obj/structure/table/glass,
+/obj/item/storage/box/pillbottles{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/obj/item/storage/box/syringes{
+	pixel_y = 4
+	},
+/obj/item/storage/box/beakers{
+	pixel_x = -4
+	},
+/obj/item/folder/blue{
+	pixel_x = 5;
+	pixel_y = -4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light,
+/turf/open/floor/carpet/ship/blue,
+/area/medical/chemistry)
 "jlz" = (
 /turf/closed/wall/ship,
 /area/engine/engine_smes)
@@ -13074,19 +13158,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/table,
-/obj/item/pen,
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/item/folder/white{
-	pixel_x = 4
-	},
-/obj/item/reagent_containers/food/drinks/coffee,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -13095,15 +13169,13 @@
 "jlR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/air_sensor/atmos{
 	id_tag = "extra_1_sensor"
 	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/engine,
 /area/engine/atmos)
 "jmO" = (
@@ -13112,8 +13184,7 @@
 /area/crew_quarters/heads/chief)
 "jng" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 8;
-	icon_state = "pipe11-2"
+	dir = 8
 	},
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
@@ -13159,7 +13230,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
-/turf/open/floor/carpet/ship/orange_carpet,
+/turf/open/floor/plating,
 /area/engine/engine_smes)
 "jnG" = (
 /obj/machinery/advanced_airlock_controller/directional/north,
@@ -13181,8 +13252,7 @@
 /area/crew_quarters/heads/hos)
 "joU" = (
 /obj/structure/bodycontainer/morgue{
-	dir = 8;
-	icon_state = "morgue1"
+	dir = 8
 	},
 /turf/open/floor/carpet/ship,
 /area/medical/morgue)
@@ -13281,8 +13351,8 @@
 /area/engine/storage)
 "jtk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/obj/structure/cable/white{
-	icon_state = "1-2"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmospherics_engine)
@@ -13362,6 +13432,15 @@
 /obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"jxp" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/ship/orange_carpet,
+/area/engine/storage)
 "jxK" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet/ship,
@@ -13424,10 +13503,14 @@
 /area/crew_quarters/lounge{
 	name = "Cafeteria"
 	})
+"jAo" = (
+/turf/open/floor/carpet,
+/area/crew_quarters/kitchen)
 "jAw" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
+/obj/structure/closet/firecloset/full,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "jBq" = (
@@ -13479,11 +13562,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/execution/education)
-"jDv" = (
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
-/area/hydroponics)
 "jDR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
@@ -13523,12 +13601,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/turf/open/floor/grass,
 /area/hydroponics)
 "jFF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/lounge{
 	name = "Cafeteria"
@@ -13542,6 +13621,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet/ship,
 /area/maintenance/department/medical)
@@ -13603,8 +13685,7 @@
 /area/medical/surgery)
 "jGN" = (
 /obj/structure/bodycontainer/morgue{
-	dir = 8;
-	icon_state = "morgue1"
+	dir = 8
 	},
 /obj/machinery/light{
 	dir = 4
@@ -13641,10 +13722,14 @@
 /area/engine/atmos)
 "jIh" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5;
-	icon_state = "pipe11-2"
+	dir = 5
 	},
 /obj/machinery/ntnet_relay,
+/obj/machinery/button/door{
+	id = "tcommsatshutter2";
+	pixel_x = -26;
+	pixel_y = 6
+	},
 /turf/open/floor/circuit,
 /area/tcommsat/server)
 "jJd" = (
@@ -13661,21 +13746,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/bookcase/random,
-/obj/item/book/manual/wiki/engineering_construction{
-	pixel_y = 3
-	},
-/obj/item/book/manual/random,
-/turf/open/floor/carpet/ship/orange_carpet,
+/turf/open/floor/plating,
 /area/engine/engine_smes)
 "jJN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/components/binary/valve/digital,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
-	},
-/obj/structure/cable/white{
-	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
@@ -13754,9 +13831,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/turf/open/floor/grass,
 /area/hydroponics)
 "jMa" = (
 /obj/structure/cable{
@@ -13772,9 +13847,7 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/north,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/turf/open/floor/grass,
 /area/hydroponics)
 "jMJ" = (
 /obj/machinery/door_timer{
@@ -13840,12 +13913,13 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "jPf" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 8;
-	icon_state = "connector_map-2"
+	dir = 8
 	},
 /turf/closed/wall/r_wall/ship,
 /area/security/prison)
@@ -13966,8 +14040,7 @@
 "jSp" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
@@ -14111,12 +14184,9 @@
 /area/storage/tech)
 "jXw" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4;
-	icon_state = "manifold-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
@@ -14139,6 +14209,9 @@
 /obj/structure/closet/firecloset/full,
 /obj/item/clothing/gloves/color/black,
 /obj/item/clothing/glasses/welding,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 5
+	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "jYY" = (
@@ -14155,7 +14228,6 @@
 /area/medical/surgery)
 "jZw" = (
 /obj/structure/table,
-/obj/item/clothing/gloves/color/black,
 /obj/item/clothing/gloves/color/black,
 /obj/item/analyzer,
 /turf/open/floor/carpet/ship/orange_carpet,
@@ -14194,8 +14266,7 @@
 	})
 "kax" = (
 /obj/structure/chair/pew/left{
-	dir = 8;
-	icon_state = "pewend_left"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /turf/open/floor/carpet/royalblack,
@@ -14216,16 +14287,25 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "0-4"
+	},
+/obj/machinery/modular_computer/console/preset/engineering{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/science/misc_lab{
 	name = "Shield Generator"
 	})
 "kcS" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
 "kdy" = (
@@ -14248,6 +14328,9 @@
 /obj/item/clothing/mask/surgical,
 /obj/item/clothing/gloves/color/latex,
 /obj/item/radio/intercom/directional/north,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "kfG" = (
@@ -14261,17 +14344,16 @@
 /area/security/brig)
 "kfH" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-8"
+	icon_state = "1-4"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
 /turf/open/floor/carpet/orange,
 /area/engine/break_room)
 "kfT" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 8;
-	icon_state = "pipe11-2"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -14410,6 +14492,10 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
+"kkw" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/grass,
+/area/hydroponics)
 "kkE" = (
 /obj/structure/closet/radiation,
 /obj/structure/window/reinforced{
@@ -14425,10 +14511,10 @@
 /turf/open/floor/carpet/ship,
 /area/storage/tools)
 "kkK" = (
-/obj/structure/reagent_dispensers/watertank,
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/closet/secure_closet/atmospherics,
 /turf/open/floor/engine,
 /area/engine/atmos)
 "kle" = (
@@ -14468,7 +14554,8 @@
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 1
 	},
-/obj/machinery/computer/lore_terminal,
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "knu" = (
@@ -14536,7 +14623,6 @@
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 4
 	},
-/obj/machinery/meter,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmospherics_engine)
 "kqz" = (
@@ -14589,7 +14675,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/turf/open/floor/carpet/ship/orange_carpet,
+/turf/open/floor/carpet/orange,
 /area/science/misc_lab{
 	name = "Shield Generator"
 	})
@@ -14631,20 +14717,23 @@
 /area/security/main{
 	name = "Security War Room"
 	})
+"ksc" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/engine_smes)
 "ksS" = (
 /turf/closed/wall/ship,
 /area/medical/patients_rooms/room_b)
 "ktr" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/carpet/ship/orange_carpet,
-/area/engine/break_room)
+/obj/structure/closet/emcloset,
+/obj/item/storage/toolbox/emergency,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "kts" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -14666,6 +14755,20 @@
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/engine,
 /area/engine/engine_room)
+"ktz" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine,
+/area/engine/atmospherics_engine)
+"ktK" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/grass,
+/area/hydroponics)
 "kub" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 1;
@@ -14707,10 +14810,7 @@
 /turf/open/floor/carpet/ship/blue,
 /area/medical/patients_rooms/room_a)
 "kvV" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/disposal/bin,
+/obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
 "kwf" = (
@@ -14904,12 +15004,7 @@
 "kAg" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/firealarm/directional/east,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/turf/open/floor/grass,
 /area/hydroponics)
 "kCb" = (
 /obj/item/folder/red,
@@ -14962,8 +15057,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "kDM" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/cable/white{
+	icon_state = "2-4"
 	},
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
@@ -15054,8 +15149,7 @@
 /area/chapel/main)
 "kFA" = (
 /obj/structure/chair/pew{
-	dir = 8;
-	icon_state = "pewmiddle"
+	dir = 8
 	},
 /turf/open/floor/carpet/royalblack,
 /area/chapel/main)
@@ -15166,8 +15260,7 @@
 "kIR" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
+	dir = 4
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
@@ -15175,6 +15268,10 @@
 /obj/structure/shuttle/engine/large,
 /turf/open/space/basic,
 /area/space/nearstation)
+"kKx" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/turf/open/floor/plating,
+/area/engine/engine_smes)
 "kKE" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -15408,6 +15505,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/disposal/bin,
+/obj/machinery/light_switch/east,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_room)
 "kSY" = (
@@ -15479,8 +15577,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/carpet/ship/orange_carpet,
+/turf/open/floor/carpet/orange,
 /area/science/misc_lab{
 	name = "Shield Generator"
 	})
@@ -15506,9 +15603,6 @@
 	},
 /obj/structure/cable/white{
 	icon_state = "0-8"
-	},
-/obj/structure/cable/white{
-	icon_state = "1-8"
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmospherics_engine)
@@ -15554,9 +15648,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
+/obj/structure/extinguisher_cabinet/east,
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "kXz" = (
@@ -15582,9 +15674,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/turf/open/floor/grass,
 /area/hydroponics)
 "kYz" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/o2{
@@ -15596,6 +15686,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
 /turf/open/floor/carpet/ship,
 /area/storage/tools)
 "kYR" = (
@@ -15677,8 +15770,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
@@ -15715,7 +15807,7 @@
 /area/ai_monitored/security/armory/security)
 "ldk" = (
 /obj/machinery/vending/wardrobe/chap_wardrobe,
-/turf/open/floor/wood,
+/turf/open/floor/carpet/ship,
 /area/chapel/office)
 "ldt" = (
 /obj/structure/fans/tiny,
@@ -15755,8 +15847,7 @@
 	})
 "leq" = (
 /obj/machinery/modular_computer/console/preset/command{
-	dir = 4;
-	icon_state = "console"
+	dir = 4
 	},
 /obj/item/paper{
 	info = "<p>Executive Officer notice: Modular computers are currently experiencing technical difficulties regarding their ID modification hardware. The 'identification card authentication module' supports 2 ID slots, and was previously paired with the 'ID Card Modification' program that also supported 2 IDs. There was recently a software update that removed the need to insert your own ID to authenticate and log in. However, it did not update the hardware, nor does it allow you to remove an ID from the authentication slot anymore.<br><br>To edit IDs with a modular computer without losing your ID, insert the target's ID but NEVER insert your own ID. You will still be able to log in if you are wearing it. Make sure you never put more than 1 ID in the modular computer.<br><br>If you do accidentally lose your own ID and getting a new one without your XO access is borderline impossible, contact Central Command. Politely ask them to remote into the console, then run subroutine '/proc/eject_id'<br><br>Have a secure shift</p>";
@@ -15844,8 +15935,7 @@
 /area/engine/engine_room)
 "lfP" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 8;
-	icon_state = "pipe11-2"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -15854,6 +15944,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
+"lfS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engine_room)
 "lfW" = (
 /obj/machinery/button/door{
 	id = "ceshutter";
@@ -15867,8 +15965,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -15944,6 +16041,14 @@
 /obj/item/ammo_box/foambox,
 /turf/open/floor/plating,
 /area/maintenance/department/security)
+"liO" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/lounge{
+	name = "Cafeteria"
+	})
 "ljR" = (
 /obj/structure/chair{
 	dir = 4
@@ -16044,10 +16149,11 @@
 "lmO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/camera/autoname{
-	dir = 4
+/obj/machinery/holopad,
+/obj/structure/cable/white{
+	icon_state = "0-8"
 	},
-/turf/open/floor/carpet/ship/orange_carpet,
+/turf/open/floor/carpet/orange,
 /area/science/misc_lab{
 	name = "Shield Generator"
 	})
@@ -16077,18 +16183,16 @@
 	name = "Stormdrive Hallway";
 	req_one_access_txt = "10;11;24"
 	},
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
-"lny" = (
-/obj/structure/table,
-/obj/item/clothing/ears/earmuffs,
-/obj/item/clothing/glasses/meson/engine/tray,
-/obj/item/clothing/gloves/color/black,
-/obj/item/gps/engineering,
-/turf/open/floor/carpet/ship/orange_carpet,
-/area/engine/engine_smes)
 "lnJ" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "tcommsatshutter2"
+	},
 /turf/open/floor/plating,
 /area/tcommsat/server)
 "lon" = (
@@ -16192,8 +16296,7 @@
 /area/medical/storage)
 "ltS" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6;
-	icon_state = "pipe11-2"
+	dir = 6
 	},
 /obj/structure/closet/secure_closet/freezer/kitchen/maintenance,
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
@@ -16243,19 +16346,19 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/turf/open/floor/carpet/ship/orange_carpet,
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
+/turf/open/floor/carpet/orange,
 /area/science/misc_lab{
 	name = "Shield Generator"
 	})
 "lwp" = (
-/obj/structure/closet/radiation,
-/obj/item/clothing/mask/gas,
 /obj/structure/sign/poster/random{
 	pixel_x = -32
 	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/obj/machinery/chem_dispenser/mutagensaltpetersmall,
+/turf/open/floor/grass,
 /area/hydroponics)
 "lww" = (
 /obj/structure/cable{
@@ -16311,6 +16414,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"lxp" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/grass,
+/area/hydroponics)
 "lxE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -16373,8 +16483,7 @@
 /area/security/checkpoint/engineering)
 "lAz" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6;
-	icon_state = "pipe11-2"
+	dir = 6
 	},
 /turf/open/floor/carpet/ship,
 /area/medical/morgue)
@@ -16393,7 +16502,9 @@
 /turf/open/floor/carpet/blue,
 /area/security/brig)
 "lBe" = (
-/obj/item/twohanded/required/kirbyplants/random,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -16408,6 +16519,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/structure/cable/white{
+	icon_state = "2-4"
 	},
 /turf/open/floor/carpet/ship,
 /area/storage/tools)
@@ -16455,6 +16569,9 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "lBK" = (
@@ -16491,7 +16608,6 @@
 "lDU" = (
 /obj/structure/sink/kitchen{
 	dir = 1;
-	icon_state = "sink_alt";
 	pixel_y = 22
 	},
 /obj/structure/disposalpipe/segment{
@@ -16550,9 +16666,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/turf/open/floor/grass,
 /area/hydroponics)
 "lGS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -16605,11 +16719,10 @@
 /area/ai_monitored/security/armory/lockup)
 "lHT" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/landmark/start/atmospheric_technician,
+/obj/machinery/meter,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmospherics_engine)
 "lHV" = (
@@ -16806,7 +16919,7 @@
 /area/engine/storage)
 "lOk" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/white{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -16824,10 +16937,7 @@
 	name = "engineering power monitoring console"
 	},
 /obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
+	icon_state = "0-8"
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
@@ -16908,11 +17018,7 @@
 /turf/open/floor/plating,
 /area/security/warden)
 "lTm" = (
-/obj/machinery/vending/snack/random,
 /obj/structure/extinguisher_cabinet/west,
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
 "lTF" = (
@@ -17026,9 +17132,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/turf/open/floor/grass,
 /area/hydroponics)
 "lWr" = (
 /obj/structure/cable{
@@ -17084,13 +17188,6 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/wood,
 /area/security/detectives_office)
-"lXR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/carpet/green,
-/area/hydroponics)
 "lYm" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -17159,6 +17256,16 @@
 	},
 /turf/open/floor/wood,
 /area/chapel/main)
+"mbW" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/hydroponics/constructable,
+/obj/item/clothing/gloves/color/black,
+/obj/item/instrument/banjo,
+/turf/open/floor/grass,
+/area/hydroponics)
 "mcF" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction,
 /obj/machinery/door/poddoor/ship{
@@ -17182,9 +17289,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
 	},
-/obj/item/geiger_counter{
-	scanning = 1
-	},
+/obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "mds" = (
@@ -17301,11 +17406,9 @@
 /turf/open/floor/carpet/ship,
 /area/security/prison)
 "mhI" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/carpet/ship/orange_carpet,
-/area/engine/atmospherics_engine)
+/obj/machinery/status_display/evac,
+/turf/closed/wall/r_wall/ship,
+/area/tcommsat/server)
 "miD" = (
 /obj/item/chair,
 /obj/structure/cable{
@@ -17419,9 +17522,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/turf/open/floor/grass,
 /area/hydroponics)
 "mmN" = (
 /turf/open/floor/carpet/ship,
@@ -17505,9 +17606,12 @@
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/cryopods)
 "mou" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
+	dir = 4
+	},
+/obj/item/geiger_counter{
+	scanning = 1
 	},
 /turf/open/floor/engine/vacuum,
 /area/engine/engine_room/external{
@@ -17515,8 +17619,7 @@
 	})
 "mpb" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 8;
-	icon_state = "pipe11-2"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -17534,8 +17637,7 @@
 /area/security/checkpoint/engineering)
 "mpq" = (
 /obj/structure/bodycontainer/morgue{
-	dir = 8;
-	icon_state = "morgue1"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -17652,10 +17754,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "mtu" = (
-/obj/machinery/meter/atmos{
-	layer = 2.65
-	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/machinery/atmospherics/pipe/layer_manifold/visible{
+	dir = 4
+	},
 /turf/closed/wall/r_wall/ship,
 /area/engine/atmos)
 "mtQ" = (
@@ -17697,8 +17799,10 @@
 /area/maintenance/department/medical)
 "mve" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9;
-	icon_state = "pipe11-2"
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
@@ -17726,9 +17830,17 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
 "mvB" = (
-/obj/structure/table,
-/turf/open/floor/carpet/ship/orange_carpet,
+/obj/machinery/light_switch/west,
+/turf/open/floor/plating,
 /area/engine/engine_smes)
+"mvJ" = (
+/obj/machinery/hydroponics/constructable,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/grass,
+/area/hydroponics)
 "mvM" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -17747,8 +17859,7 @@
 	},
 /area/medical/virology)
 "mvU" = (
-/obj/machinery/holopad,
-/turf/open/floor/carpet/ship/orange_carpet,
+/turf/open/floor/carpet/orange,
 /area/science/misc_lab{
 	name = "Shield Generator"
 	})
@@ -17793,6 +17904,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 9
 	},
+/obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "mxu" = (
@@ -17815,9 +17927,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/nuclear_waste_spawner,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/turf/open/floor/grass,
 /area/hydroponics)
 "mze" = (
 /turf/closed/wall/ship,
@@ -17885,7 +17995,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "mBR" = (
-/obj/structure/extinguisher_cabinet/north,
 /obj/machinery/computer/telecomms/monitor,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/tcommsat/server)
@@ -18006,9 +18115,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/turf/open/floor/grass,
 /area/hydroponics)
 "mFc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrogen_output{
@@ -18086,6 +18193,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"mHk" = (
+/obj/structure/table,
+/turf/open/floor/carpet,
+/area/crew_quarters/lounge{
+	name = "Cafeteria"
+	})
 "mHl" = (
 /obj/structure/table/wood,
 /obj/item/clothing/head/that,
@@ -18093,9 +18206,10 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "mIt" = (
-/obj/machinery/computer/atmos_control{
+/obj/machinery/computer/atmos_control/tank{
 	dir = 8;
-	name = "Stormdrive Core Sensor";
+	input_tag = "stormdrive_chamber_in";
+	output_tag = "stormdrive_chamber_out";
 	sensors = list("stormdrive_chamber_sensor" = "Stormdrive Chamber")
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
@@ -18208,6 +18322,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
@@ -18399,15 +18516,13 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/turf/open/floor/carpet/ship/orange_carpet,
+/turf/open/floor/carpet/orange,
 /area/science/misc_lab{
 	name = "Shield Generator"
 	})
 "mTs" = (
-/obj/machinery/plantgenes,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/obj/machinery/biogenerator,
+/turf/open/floor/grass,
 /area/hydroponics)
 "mTz" = (
 /obj/structure/filingcabinet,
@@ -18434,12 +18549,14 @@
 /obj/structure/table/glass,
 /obj/item/paper_bin,
 /obj/item/pen,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/carpet/ship/blue,
 /area/medical/chemistry)
 "mTW" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8;
-	icon_state = "manifold-2"
+	dir = 8
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -18548,7 +18665,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/turf/open/floor/carpet/ship/orange_carpet,
+/turf/open/floor/plating,
 /area/engine/engine_smes)
 "mXH" = (
 /obj/machinery/holopad,
@@ -18594,15 +18711,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security)
 "mYV" = (
-/obj/machinery/chem_dispenser/mutagensaltpetersmall,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/reagent_dispensers/watertank/high,
+/turf/open/floor/grass,
 /area/hydroponics)
 "mYX" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 8;
-	icon_state = "pipe11-2"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -18610,10 +18726,8 @@
 /turf/open/floor/carpet/ship,
 /area/medical/morgue)
 "mZg" = (
-/obj/machinery/chem_master/condimaster,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/obj/machinery/vending/hydronutrients,
+/turf/open/floor/grass,
 /area/hydroponics)
 "mZl" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -18631,7 +18745,7 @@
 	pixel_x = -4
 	},
 /obj/item/clothing/head/hardhat/cakehat,
-/turf/open/floor/carpet/ship,
+/turf/open/floor/carpet,
 /area/crew_quarters/kitchen)
 "nab" = (
 /obj/structure/disposalpipe/segment{
@@ -18694,6 +18808,11 @@
 	mood_message = "<span class='nicegreen'>This area is pretty serious!\n</span>";
 	name = "Interrogation Room"
 	})
+"ndY" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/machinery/light/floor,
+/turf/open/floor/grass,
+/area/hydroponics)
 "ndZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -18766,8 +18885,7 @@
 /area/hydroponics)
 "nfV" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/structure/disposalpipe/segment{
@@ -18963,6 +19081,11 @@
 /obj/machinery/newscaster/security_unit/east,
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/warden)
+"nnl" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/grass,
+/area/hydroponics)
 "nnB" = (
 /obj/structure/closet/radiation,
 /obj/structure/window/reinforced{
@@ -19008,8 +19131,7 @@
 /area/space/nearstation)
 "npd" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -19045,6 +19167,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"npJ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/ship,
+/area/hallway/primary/central{
+	name = "Hallway"
+	})
 "nrv" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -19253,12 +19388,12 @@
 /turf/open/floor/plating,
 /area/security/warden)
 "nwm" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/structure/extinguisher_cabinet/west,
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmospherics_engine)
@@ -19276,8 +19411,7 @@
 /area/engine/engine_smes)
 "nwN" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 8;
-	icon_state = "pipe11-2"
+	dir = 8
 	},
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable{
@@ -19381,6 +19515,9 @@
 /area/maintenance/department/medical)
 "nCk" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "nCH" = (
@@ -19401,8 +19538,7 @@
 /area/crew_quarters/kitchen)
 "nDg" = (
 /obj/structure/bodycontainer/morgue{
-	dir = 8;
-	icon_state = "morgue1"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/item/paper/guides/jobs/medical/morgue,
@@ -19410,8 +19546,7 @@
 /area/medical/morgue)
 "nDV" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -19464,8 +19599,7 @@
 	on = 1
 	},
 /obj/structure/window/plasma/reinforced{
-	dir = 1;
-	icon_state = "plasmarwindow"
+	dir = 1
 	},
 /obj/machinery/airalarm/directional/west{
 	locked = 0
@@ -19477,10 +19611,12 @@
 /turf/open/floor/plating,
 /area/medical/virology)
 "nGg" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
+/obj/structure/flora/ausbushes/fullgrass,
+/mob/living/simple_animal/chicken{
+	name = "Kentucky";
+	real_name = "Kentucky"
 	},
+/turf/open/floor/grass,
 /area/hydroponics)
 "nGt" = (
 /obj/structure/cable{
@@ -19563,6 +19699,9 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/white{
+	icon_state = "1-4"
+	},
 /turf/open/floor/carpet/orange,
 /area/engine/break_room)
 "nJM" = (
@@ -19593,9 +19732,6 @@
 	},
 /obj/structure/cable/white{
 	icon_state = "0-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmospherics_engine)
@@ -19666,6 +19802,12 @@
 /obj/item/extinguisher/advanced/hull_repair_juice,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
+"nOY" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/ship/orange_carpet,
+/area/engine/break_room)
 "nPo" = (
 /obj/item/control_rod,
 /obj/item/control_rod,
@@ -19693,15 +19835,15 @@
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos)
 "nPH" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	pixel_x = 26;
 	pixel_y = 25
 	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
@@ -19740,10 +19882,8 @@
 	name = "Atmospherics Canister Storage"
 	})
 "nRc" = (
-/obj/machinery/vending/wardrobe/hydro_wardrobe,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/obj/structure/sink/puddle,
+/turf/open/floor/grass,
 /area/hydroponics)
 "nRw" = (
 /turf/open/floor/carpet,
@@ -19785,7 +19925,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
-/turf/closed/wall/r_wall/ship,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "tcommsatshutter2"
+	},
+/turf/open/floor/plating,
 /area/tcommsat/server)
 "nSL" = (
 /obj/machinery/camera/autoname{
@@ -19828,8 +19973,7 @@
 /area/engine/atmospherics_engine)
 "nTq" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4;
-	icon_state = "manifold-2"
+	dir = 4
 	},
 /turf/open/floor/carpet/ship/blue,
 /area/medical/genetics/cloning)
@@ -19975,13 +20119,11 @@
 	})
 "obl" = (
 /obj/machinery/hydroponics/constructable,
-/obj/item/paper/guides/jobs/hydroponics,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/grass,
 /area/hydroponics)
 "obm" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -20011,14 +20153,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
@@ -20070,8 +20209,7 @@
 /area/engine/atmos)
 "oeX" = (
 /obj/machinery/computer/secure_data{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/checkpoint/escape)
@@ -20085,7 +20223,7 @@
 	pixel_x = 4
 	},
 /obj/item/soulstone/anybody/chaplain,
-/turf/open/floor/wood,
+/turf/open/floor/carpet/ship,
 /area/chapel/office)
 "ofM" = (
 /obj/machinery/status_display/evac,
@@ -20187,8 +20325,7 @@
 	})
 "olm" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6;
-	icon_state = "pipe11-2"
+	dir = 6
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -20272,9 +20409,6 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/tcommsat/server)
 "ooA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
@@ -20283,6 +20417,9 @@
 	},
 /obj/structure/cable/white{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
@@ -20337,6 +20474,19 @@
 	},
 /turf/open/floor/carpet/ship/blue,
 /area/medical/medbay/lobby)
+"oqZ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/carpet/ship/orange_carpet,
+/area/engine/engine_smes)
 "orZ" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/carpet/ship/red_carpet,
@@ -20344,7 +20494,6 @@
 	name = "Security War Room"
 	})
 "otb" = (
-/obj/machinery/airalarm/directional/east,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall/ship,
 /area/engine/engine_room)
@@ -20369,6 +20518,11 @@
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "tcommsatshutter2";
+	pixel_x = -26;
+	pixel_y = 6
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/tcommsat/server)
@@ -20471,10 +20625,10 @@
 	dir = 5
 	},
 /obj/structure/table,
-/obj/item/radio/intercom/directional/west,
+/obj/item/gps/engineering,
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high,
-/turf/open/floor/carpet/ship/orange_carpet,
+/turf/open/floor/carpet/orange,
 /area/science/misc_lab{
 	name = "Shield Generator"
 	})
@@ -20531,7 +20685,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/carpet/ship,
 /area/maintenance/department/engine/atmos)
 "ozT" = (
 /obj/structure/chair/comfy/beige{
@@ -20544,8 +20698,7 @@
 /area/maintenance/department/medical)
 "oAN" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 8;
-	icon_state = "pipe11-2"
+	dir = 8
 	},
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
@@ -20563,14 +20716,9 @@
 /area/crew_quarters/lounge{
 	name = "Cafeteria"
 	})
-"oBF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/carpet/green,
-/area/hydroponics)
 "oBL" = (
 /obj/structure/chair/pew/left{
-	dir = 8;
-	icon_state = "pewend_left"
+	dir = 8
 	},
 /obj/machinery/computer/lore_terminal,
 /turf/open/floor/carpet/royalblack,
@@ -20692,8 +20840,7 @@
 	})
 "oHT" = (
 /obj/structure/chair/pew/left{
-	dir = 8;
-	icon_state = "pewend_left"
+	dir = 8
 	},
 /obj/machinery/status_display/evac/north,
 /turf/open/floor/carpet/royalblack,
@@ -20831,6 +20978,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/computer/lore_terminal,
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "oME" = (
@@ -20846,8 +20995,7 @@
 /area/crew_quarters/kitchen)
 "oMJ" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 8;
-	icon_state = "connector_map-2"
+	dir = 8
 	},
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/department/medical)
@@ -20881,8 +21029,7 @@
 	})
 "oOB" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9;
-	icon_state = "pipe11-2"
+	dir = 9
 	},
 /turf/open/floor/carpet/ship/blue,
 /area/medical/genetics/cloning)
@@ -20900,8 +21047,7 @@
 	})
 "oOV" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
+	dir = 4
 	},
 /obj/machinery/door/firedoor/window,
 /obj/structure/grille,
@@ -21035,8 +21181,7 @@
 /area/crew_quarters/heads/cmo)
 "oTN" = (
 /obj/machinery/modular_computer/console/preset/command{
-	dir = 4;
-	icon_state = "console"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -21064,6 +21209,15 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/medbay/central)
+"oUe" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/item/shovel/spade,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/wrench,
+/obj/item/cultivator,
+/obj/item/storage/box/disks_plantgene,
+/turf/open/floor/grass,
+/area/hydroponics)
 "oUK" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -21098,8 +21252,7 @@
 /area/maintenance/department/engine/atmos)
 "oWh" = (
 /obj/structure/chair/pew{
-	dir = 8;
-	icon_state = "pewmiddle"
+	dir = 8
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -21179,9 +21332,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/turf/open/floor/grass,
 /area/hydroponics)
 "oYp" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
@@ -21199,8 +21350,7 @@
 /area/engine/engine_smes)
 "oYB" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
+	dir = 4
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmospherics_engine)
@@ -21211,9 +21361,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/turf/open/floor/grass,
 /area/hydroponics)
 "oYL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -21224,6 +21372,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 9
+	},
+/obj/structure/cable/white{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
@@ -21258,8 +21409,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
@@ -21306,6 +21456,9 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
@@ -21377,13 +21530,28 @@
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
-"pdT" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/structure/cable{
+"pdJ" = (
+/obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/turf/open/floor/engine,
-/area/engine/atmospherics_engine)
+/turf/open/floor/carpet/ship,
+/area/hallway/primary/central{
+	name = "Hallway"
+	})
+"pdT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "tcommsatshutter2"
+	},
+/turf/open/floor/plating,
+/area/tcommsat/server)
 "pee" = (
 /obj/structure/chair/office/light,
 /obj/structure/cable{
@@ -21462,6 +21630,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
+"piI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/grass,
+/area/hydroponics)
 "piL" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/border_only/directional/south,
@@ -21535,9 +21710,7 @@
 /area/medical/patients_rooms/room_c)
 "pnl" = (
 /obj/effect/landmark/start/botanist,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/turf/open/floor/grass,
 /area/hydroponics)
 "pnm" = (
 /obj/structure/rack,
@@ -21589,7 +21762,7 @@
 	dir = 5
 	},
 /obj/effect/landmark/start/atmospheric_technician,
-/turf/open/floor/carpet/ship,
+/turf/open/floor/carpet,
 /area/crew_quarters/lounge{
 	name = "Cafeteria"
 	})
@@ -21678,14 +21851,20 @@
 /obj/structure/closet/radiation,
 /obj/item/clothing/mask/gas,
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
 /turf/open/floor/carpet/ship,
 /area/storage/tools)
+"psX" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/engine/atmospherics_engine)
 "ptb" = (
 /obj/structure/rack,
 /obj/item/multitool{
@@ -21741,12 +21920,11 @@
 	name = "Supermatter Core"
 	})
 "ptB" = (
-/obj/effect/turf_decal/arrows{
-	dir = 1;
-	pixel_x = -12
-	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/meter,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
 "ptD" = (
@@ -21771,8 +21949,7 @@
 "put" = (
 /obj/machinery/gibber,
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 8;
-	icon_state = "pipe11-2"
+	dir = 8
 	},
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
@@ -21826,6 +22003,13 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"pvX" = (
+/obj/machinery/power/deck_relay,
+/obj/structure/cable/white{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "pwr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -21834,6 +22018,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Tool Storage"
+	},
+/obj/structure/cable/white{
+	icon_state = "1-2"
 	},
 /turf/open/floor/carpet/ship,
 /area/storage/tools)
@@ -21855,11 +22042,9 @@
 	},
 /area/engine/atmos)
 "pxn" = (
-/obj/machinery/hydroponics/constructable,
 /obj/structure/window/reinforced,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/grass,
 /area/hydroponics)
 "pxq" = (
 /obj/structure/cable{
@@ -21962,8 +22147,7 @@
 "pCx" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
+	dir = 4
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
@@ -22333,8 +22517,7 @@
 /area/engine/engine_smes)
 "pQb" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
+	dir = 4
 	},
 /obj/machinery/firealarm{
 	pixel_x = -26;
@@ -22427,6 +22610,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
+/obj/item/analyzer,
+/obj/effect/landmark/event_spawn,
+/obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmospherics_engine)
 "pSQ" = (
@@ -22473,7 +22659,7 @@
 	state = 2
 	},
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "0-2"
 	},
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
@@ -22502,8 +22688,7 @@
 	icon_state = "1-8"
 	},
 /obj/structure/particle_accelerator/end_cap{
-	dir = 1;
-	icon_state = "end_cap"
+	dir = 1
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_room)
@@ -22512,18 +22697,17 @@
 	dir = 5
 	},
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "pVA" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable{
-	icon_state = "0-2"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -22553,9 +22737,23 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"pXM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos{
+	id = "extra_1_input";
+	on = 0
+	},
+/turf/open/floor/engine,
+/area/engine/atmos)
 "pXT" = (
+/obj/machinery/airalarm/directional/west,
 /obj/structure/table,
-/turf/open/floor/carpet/ship/orange_carpet,
+/obj/item/twohanded/rcl/pre_loaded,
+/turf/open/floor/carpet/orange,
 /area/science/misc_lab{
 	name = "Shield Generator"
 	})
@@ -22575,8 +22773,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8;
-	icon_state = "manifold-2"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
@@ -22599,6 +22796,9 @@
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
+	},
+/obj/structure/cable/white{
+	icon_state = "1-2"
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/break_room)
@@ -22634,8 +22834,7 @@
 	},
 /obj/effect/landmark/nuclear_waste_spawner,
 /obj/structure/particle_accelerator/fuel_chamber{
-	dir = 1;
-	icon_state = "fuel_chamber"
+	dir = 1
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_room)
@@ -22675,12 +22874,26 @@
 	},
 /obj/item/clothing/glasses/meson/engine/tray,
 /obj/item/t_scanner,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet,
 /area/storage/tools)
 "qck" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/lounge{
+	name = "Cafeteria"
+	})
+"qcC" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/lounge{
 	name = "Cafeteria"
@@ -22715,7 +22928,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet/east,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
@@ -22837,7 +23049,7 @@
 /turf/open/floor/carpet/ship/red_carpet,
 /area/ai_monitored/security/armory/lockup)
 "qhb" = (
-/obj/structure/closet/secure_closet/atmospherics,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/engine,
 /area/engine/atmos)
 "qhd" = (
@@ -22887,8 +23099,7 @@
 /area/maintenance/department/engine)
 "qiX" = (
 /obj/machinery/modular_computer/console/preset/civilian{
-	dir = 8;
-	icon_state = "console"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -22951,16 +23162,13 @@
 	pixel_x = 4;
 	pixel_y = 3
 	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/obj/machinery/light_switch/west,
+/turf/open/floor/grass,
 /area/hydroponics)
 "qkz" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "qlu" = (
@@ -23054,9 +23262,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "qog" = (
-/obj/machinery/squad_vendor,
-/turf/closed/wall/ship,
-/area/shuttle/turbolift/primary)
+/obj/structure/sign/departments/minsky/engineering/telecommmunications,
+/turf/closed/wall/r_wall/ship,
+/area/tcommsat/server)
 "qoj" = (
 /obj/machinery/vending/dinnerware,
 /obj/machinery/light{
@@ -23080,8 +23288,7 @@
 "qoz" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/item/clothing/gloves/color/yellow,
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
@@ -23180,8 +23387,7 @@
 /obj/structure/grille,
 /obj/structure/window/plasma/fulltile,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/engine/atmospherics_engine)
@@ -23217,15 +23423,13 @@
 	icon_state = "1-2"
 	},
 /obj/structure/particle_accelerator/power_box{
-	dir = 1;
-	icon_state = "power_box"
+	dir = 1
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_room)
 "qtQ" = (
 /obj/machinery/computer/med_data{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /turf/open/floor/carpet/ship/blue,
 /area/medical/medbay/lobby)
@@ -23281,7 +23485,7 @@
 	icon_state = "0-4"
 	},
 /obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/carpet/ship/orange_carpet,
+/turf/open/floor/carpet/orange,
 /area/science/misc_lab{
 	name = "Shield Generator"
 	})
@@ -23439,6 +23643,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment,
+/mob/living/carbon/monkey/punpun,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "qyT" = (
@@ -23524,10 +23729,11 @@
 /area/engine/storage)
 "qAi" = (
 /obj/machinery/modular_computer/console/preset/engineering{
-	dir = 4;
-	icon_state = "console"
+	dir = 4
 	},
-/obj/structure/cable/white,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/break_room)
 "qAS" = (
@@ -23587,16 +23793,12 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmospherics_engine)
 "qCx" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/item/radio/intercom/directional{
-	pixel_x = 30;
-	pixel_y = 25
-	},
-/turf/open/floor/wood,
-/area/chapel/office)
+/obj/machinery/vending/snack/random,
+/turf/open/floor/carpet/ship/orange_carpet,
+/area/engine/engine_smes)
 "qCE" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
@@ -23610,13 +23812,6 @@
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
-"qDq" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/turf/open/floor/carpet/orange,
-/area/engine/engine_smes)
 "qDt" = (
 /obj/structure/reagent_dispensers/foamtank/hull_repair_juice,
 /obj/item/extinguisher/advanced/hull_repair_juice,
@@ -23677,8 +23872,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
@@ -23699,7 +23894,7 @@
 	icon_state = "0-4"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmospherics_engine)
@@ -23782,8 +23977,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
+	dir = 4
 	},
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -23862,13 +24056,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "qMz" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
 	},
-/obj/machinery/portable_atmospherics/canister,
-/turf/open/floor/carpet/ship/orange_carpet,
-/area/engine/atmos)
+/obj/structure/closet/radiation,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "qMB" = (
 /obj/structure/closet/crate/solarpanel_small,
 /obj/machinery/power/apc/auto_name/east,
@@ -23928,8 +24122,7 @@
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/item/clothing/suit/hooded/wintercoat/engineering,
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -23950,8 +24143,7 @@
 "qPW" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -24035,6 +24227,9 @@
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "qRm" = (
@@ -24083,8 +24278,7 @@
 /area/medical/medbay/lobby)
 "qSB" = (
 /obj/machinery/computer/crew{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 8
@@ -24112,11 +24306,14 @@
 "qTW" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/extinguisher_cabinet/east,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
 "qVm" = (
@@ -24157,13 +24354,17 @@
 	})
 "qVW" = (
 /obj/structure/table/wood,
-/obj/item/storage/box/cups,
 /obj/item/storage/box/drinkingglasses{
 	pixel_x = 5;
 	pixel_y = 5
 	},
-/obj/item/reagent_containers/food/drinks/shaker,
 /obj/machinery/light,
+/obj/item/storage/box/beakers/variety{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/condimentbottles,
+/obj/item/reagent_containers/food/drinks/shaker,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "qXI" = (
@@ -24179,15 +24380,13 @@
 	pixel_x = 6;
 	pixel_y = -26
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/ship,
 /area/crew_quarters/kitchen)
 "qYI" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/meter,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmospherics_engine)
 "qZd" = (
@@ -24610,9 +24809,16 @@
 /turf/open/floor/plating,
 /area/crew_quarters/kitchen)
 "rqW" = (
-/obj/machinery/squad_vendor,
-/turf/closed/wall/ship,
-/area/shuttle/turbolift/secondary)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/purple/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "rrN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/telecomms/processor/preset_three,
@@ -24652,6 +24858,9 @@
 /obj/structure/ladder,
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
@@ -24700,6 +24909,18 @@
 /area/crew_quarters/heads/chief)
 "ruX" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/button/massdriver{
+	id = "superthrust";
+	name = "Toxins Mass Driver Launch";
+	pixel_x = -40;
+	pixel_y = 10
+	},
+/obj/machinery/button/door{
+	id = "supermatter_shutter";
+	name = "Supermatter Core Vent";
+	pixel_x = -26;
+	pixel_y = 10
+	},
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
 "rwu" = (
@@ -24709,12 +24930,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/table,
-/obj/item/inducer,
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/junction{
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
@@ -24823,18 +25045,25 @@
 "rAa" = (
 /turf/open/floor/wood,
 /area/lawoffice)
+"rAn" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/hydroponics)
 "rAw" = (
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/airlock/ship/engineering{
-	name = "Telecommunications";
-	req_one_access_txt = "61"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/airlock/ship/engineering{
+	name = "Tech Storage";
+	req_one_access_txt = "10;23"
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/storage/tech)
 "rBY" = (
@@ -24879,9 +25108,10 @@
 /area/storage/tech)
 "rDu" = (
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/mob/living/simple_animal/chick,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/machinery/light/floor,
+/turf/open/floor/grass,
 /area/hydroponics)
 "rDB" = (
 /obj/structure/bed,
@@ -25045,25 +25275,13 @@
 	name = "Arrivals"
 	})
 "rJD" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/engine,
-/area/engine/atmospherics_engine)
-"rJM" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
-/area/hydroponics)
+/turf/open/floor/engine,
+/area/engine/atmospherics_engine)
 "rKq" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
 /turf/open/floor/plating,
@@ -25072,8 +25290,7 @@
 	})
 "rKz" = (
 /obj/structure/chair/pew/right{
-	dir = 8;
-	icon_state = "pewend_right"
+	dir = 8
 	},
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -25098,9 +25315,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/turf/open/floor/grass,
 /area/hydroponics)
 "rLG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -25319,9 +25534,7 @@
 	dir = 1;
 	name = "Nitrogen to Mix"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "rWp" = (
@@ -25462,6 +25675,21 @@
 	},
 /turf/open/floor/wood,
 /area/chapel/main)
+"rZb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "rZt" = (
 /obj/structure/chair{
 	dir = 4
@@ -25666,12 +25894,7 @@
 /turf/closed/wall/r_wall/ship,
 /area/chapel/main)
 "shv" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
-	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/turf/open/floor/grass,
 /area/hydroponics)
 "shM" = (
 /obj/structure/cable{
@@ -25705,6 +25928,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/ship,
 /area/maintenance/department/medical)
 "siD" = (
@@ -25731,22 +25957,19 @@
 	name = "Cafeteria"
 	})
 "sjo" = (
-/obj/structure/closet/firecloset/full,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/obj/structure/beebox/premade,
+/turf/open/floor/grass,
 /area/hydroponics)
 "sjs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
 /area/hydroponics)
 "sjQ" = (
 /obj/machinery/status_display/ai,
@@ -25754,8 +25977,7 @@
 /area/medical/virology)
 "sjW" = (
 /obj/machinery/modular_computer/console/preset/civilian{
-	dir = 4;
-	icon_state = "console"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -25813,6 +26035,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/landmark/nuclear_waste_spawner,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/break_room)
 "smK" = (
@@ -25885,10 +26110,10 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
 "sph" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/valve/digital{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -25903,8 +26128,26 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "spS" = (
-/turf/open/floor/carpet,
-/area/crew_quarters/kitchen)
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/airlock/ship/maintenance{
+	name = "Maintenance Access Shield Generator";
+	req_one_access_txt = "10"
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
+"spV" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/closed/wall/r_wall/ship,
+/area/engine/atmospherics_engine)
 "sqk" = (
 /obj/machinery/camera/autoname{
 	dir = 9
@@ -25919,6 +26162,9 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
 /turf/open/floor/carpet/orange,
 /area/engine/break_room)
 "srz" = (
@@ -25937,6 +26183,9 @@
 	dir = 4;
 	name = "Mix to Waste"
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "ssc" = (
@@ -25947,6 +26196,9 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/junction/yjunction,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/ship,
 /area/maintenance/department/medical)
 "ssL" = (
@@ -26045,8 +26297,7 @@
 	pixel_y = 25
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6;
-	icon_state = "pipe11-2"
+	dir = 6
 	},
 /obj/machinery/telecomms/server/presets/command,
 /turf/open/floor/circuit,
@@ -26169,8 +26420,7 @@
 /area/engine/storage)
 "sEN" = (
 /obj/structure/bodycontainer/morgue{
-	dir = 8;
-	icon_state = "morgue1"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -26191,7 +26441,7 @@
 	},
 /obj/machinery/computer/ship/viewscreen,
 /obj/item/radio/intercom/directional/west,
-/turf/open/floor/carpet/ship/orange_carpet,
+/turf/open/floor/plating,
 /area/engine/engine_smes)
 "sGU" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
@@ -26270,6 +26520,18 @@
 /area/crew_quarters/lounge{
 	name = "Cafeteria"
 	})
+"sJf" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/folder/white{
+	pixel_x = 4
+	},
+/obj/item/pen,
+/turf/open/floor/carpet/ship/orange_carpet,
+/area/engine/engine_smes)
 "sJm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
@@ -26406,6 +26668,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmospherics_engine)
 "sPd" = (
@@ -26594,8 +26859,6 @@
 	name = "Cafeteria"
 	})
 "sVK" = (
-/obj/structure/closet/secure_closet/engineering_chief,
-/obj/item/holosign_creator/atmos,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/crew_quarters/heads/chief)
 "sVP" = (
@@ -26614,9 +26877,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
@@ -26641,8 +26901,7 @@
 /area/engine/engine_smes)
 "sXQ" = (
 /obj/machinery/computer/ship/dradis{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/break_room)
@@ -26695,7 +26954,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/carpet/green,
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/landmark/start/botanist,
+/mob/living/simple_animal/chicken/rabbit/normal,
+/turf/open/floor/grass,
 /area/hydroponics)
 "taE" = (
 /obj/effect/landmark/event_spawn,
@@ -26719,6 +26983,10 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmospherics_engine)
+"tcj" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
+/area/hydroponics)
 "tcs" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -26818,8 +27086,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 1
@@ -26867,6 +27134,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
@@ -26990,14 +27260,10 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmospherics_engine)
 "tjB" = (
+/obj/structure/cable/white,
 /obj/machinery/computer/monitor{
-	dir = 4
-	},
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
+	dir = 4;
+	name = "stormdrive power monitoring console"
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/break_room)
@@ -27025,6 +27291,15 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"tkg" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/ship,
+/area/hallway/primary/central{
+	name = "Hallway"
+	})
 "tky" = (
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/firedoor/border_only/directional/north,
@@ -27212,13 +27487,15 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "trJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
 /turf/open/floor/carpet/ship,
 /area/storage/tools)
 "trZ" = (
@@ -27232,8 +27509,8 @@
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/bar)
 "tsa" = (
-/obj/machinery/atmospherics/components/binary/pump,
 /obj/machinery/firealarm/directional/east,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/engine,
 /area/engine/engine_room/external{
 	name = "Stormdrive Interior"
@@ -27261,9 +27538,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/turf/open/floor/grass,
 /area/hydroponics)
 "tuR" = (
 /obj/machinery/door/firedoor/border_only/directional/north,
@@ -27321,6 +27596,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/lounge{
 	name = "Cafeteria"
@@ -27369,13 +27647,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/computer/ship/navigation/public{
-	name = "starmap console"
-	},
-/turf/open/floor/carpet/ship/orange_carpet,
+/obj/structure/frame/computer,
+/turf/open/floor/plating,
 /area/engine/engine_smes)
 "tym" = (
 /obj/machinery/disposal/bin,
@@ -27393,7 +27666,7 @@
 /area/maintenance/department/engine/atmos)
 "tzb" = (
 /obj/machinery/holopad,
-/turf/open/floor/carpet/ship,
+/turf/open/floor/carpet,
 /area/crew_quarters/kitchen)
 "tzi" = (
 /obj/structure/table,
@@ -27406,8 +27679,7 @@
 /area/medical/patients_rooms/room_a)
 "tzl" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 8;
-	icon_state = "pipe11-2"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -27447,9 +27719,8 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
 /area/hydroponics)
 "tBz" = (
 /obj/machinery/atmospherics/components/binary/passive_gate{
@@ -27592,18 +27863,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/turf/open/floor/grass,
 /area/hydroponics)
 "tKX" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/start/botanist,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/obj/machinery/light/floor,
+/turf/open/floor/grass,
 /area/hydroponics)
 "tLu" = (
 /obj/structure/table,
@@ -27613,7 +27881,7 @@
 	pixel_x = 3;
 	pixel_y = 4
 	},
-/turf/open/floor/carpet/ship,
+/turf/open/floor/carpet,
 /area/crew_quarters/lounge{
 	name = "Cafeteria"
 	})
@@ -27639,7 +27907,10 @@
 /turf/open/floor/plating,
 /area/engine/atmospherics_engine)
 "tLG" = (
-/obj/machinery/airalarm/directional/north,
+/obj/machinery/squad_vendor{
+	density = 0;
+	pixel_y = 26
+	},
 /turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
@@ -27694,7 +27965,7 @@
 	pixel_y = 4
 	},
 /obj/item/reagent_containers/food/condiment/saltshaker,
-/turf/open/floor/carpet/ship,
+/turf/open/floor/carpet,
 /area/crew_quarters/lounge{
 	name = "Cafeteria"
 	})
@@ -27794,8 +28065,7 @@
 /area/crew_quarters/bar)
 "tRb" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/carpet/ship/orange_carpet,
@@ -27909,6 +28179,13 @@
 	},
 /turf/template_noop,
 /area/maintenance/department/medical)
+"tVf" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engine_room)
 "tVr" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/carpet/ship/orange_carpet,
@@ -28029,13 +28306,10 @@
 /turf/open/floor/carpet/ship/blue,
 /area/maintenance/department/medical)
 "tZP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/turf/open/floor/grass,
 /area/hydroponics)
 "uaF" = (
 /turf/open/floor/carpet/ship/beige_carpet{
@@ -28055,6 +28329,20 @@
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/plating,
 /area/engine/atmospherics_engine)
+"ube" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/pen,
+/obj/item/folder/white{
+	pixel_x = 4
+	},
+/turf/open/floor/carpet/orange,
+/area/science/misc_lab{
+	name = "Shield Generator"
+	})
 "ubj" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -28169,6 +28457,14 @@
 /obj/machinery/holopad,
 /turf/open/floor/carpet/ship/blue,
 /area/crew_quarters/heads/cmo)
+"uhW" = (
+/obj/machinery/computer/ship/ftl_computer{
+	dir = 4
+	},
+/turf/open/floor/carpet/orange,
+/area/science/misc_lab{
+	name = "Shield Generator"
+	})
 "uij" = (
 /obj/machinery/atmospherics/components/trinary/filter/critical{
 	dir = 8
@@ -28229,6 +28525,9 @@
 /area/engine/storage)
 "ukT" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/engine/break_room)
 "umm" = (
@@ -28345,6 +28644,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
 "upT" = (
@@ -28356,15 +28658,8 @@
 /turf/open/floor/plating,
 /area/medical/genetics/cloning)
 "upW" = (
-/obj/structure/table,
-/obj/structure/sign/solgov_seal,
-/obj/machinery/smartfridge/disks,
-/obj/item/disk/plantgene,
-/obj/item/disk/plantgene,
-/obj/item/paper/guides/jobs/hydroponics,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/obj/machinery/plantgenes,
+/turf/open/floor/grass,
 /area/hydroponics)
 "uqr" = (
 /obj/item/storage/box/gloves{
@@ -28607,8 +28902,7 @@
 "uBe" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer{
-	dir = 1;
-	icon_state = "booze_dispenser"
+	dir = 1
 	},
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -28737,9 +29031,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
 "uGY" = (
@@ -28772,6 +29063,16 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/twohanded/rcl/pre_loaded,
+/obj/item/storage/toolbox/mechanical,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
 "uIx" = (
@@ -28816,9 +29117,7 @@
 	pixel_x = -31;
 	pixel_y = -2
 	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/turf/open/floor/grass,
 /area/hydroponics)
 "uJR" = (
 /obj/effect/turf_decal/stripes/line,
@@ -28840,7 +29139,7 @@
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
-/turf/open/floor/carpet/ship/orange_carpet,
+/turf/open/floor/plating,
 /area/engine/engine_smes)
 "uLk" = (
 /obj/structure/cable{
@@ -28921,6 +29220,9 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/visible{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "uNb" = (
@@ -28963,20 +29265,6 @@
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/break_room)
-"uPn" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/shovel/spade,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/wrench,
-/obj/item/cultivator,
-/obj/item/storage/box/disks_plantgene,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
-/area/hydroponics)
 "uPC" = (
 /obj/structure/table/glass,
 /obj/item/cartridge/chemistry{
@@ -29097,6 +29385,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
+/obj/item/holosign_creator/atmos,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/crew_quarters/heads/chief)
 "uUw" = (
@@ -29124,8 +29413,7 @@
 /area/medical/storage)
 "uVi" = (
 /obj/structure/chair/pew/right{
-	dir = 8;
-	icon_state = "pewend_right"
+	dir = 8
 	},
 /obj/item/newspaper,
 /turf/open/floor/carpet/royalblack,
@@ -29163,13 +29451,18 @@
 /area/engine/atmospherics_engine)
 "uXg" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/lounge{
 	name = "Cafeteria"
 	})
+"uXh" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/orange,
+/area/engine/break_room)
 "uYb" = (
 /obj/machinery/atmospherics/pipe/manifold/green/visible{
 	dir = 8
@@ -29242,6 +29535,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/break_room)
 "vbB" = (
@@ -29251,7 +29547,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/orange_carpet,
+/turf/open/floor/carpet/orange,
 /area/science/misc_lab{
 	name = "Shield Generator"
 	})
@@ -29292,8 +29588,7 @@
 "vcs" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
 	dir = 4
@@ -29458,6 +29753,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/lounge{
 	name = "Cafeteria"
@@ -29499,9 +29797,10 @@
 	icon_state = "1-4"
 	},
 /obj/structure/closet/secure_closet/hydroponics,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/obj/item/clothing/suit/beekeeper_suit,
+/obj/item/clothing/head/beekeeper_head,
+/obj/item/clothing/head/rice_hat,
+/turf/open/floor/grass,
 /area/hydroponics)
 "vjv" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -29618,8 +29917,7 @@
 /area/crew_quarters/bar)
 "vmg" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -29661,9 +29959,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/turf/open/floor/grass,
 /area/hydroponics)
 "vnI" = (
 /obj/machinery/door/firedoor/border_only/directional/north,
@@ -29684,6 +29980,13 @@
 	},
 /turf/open/floor/carpet/ship/blue,
 /area/medical/medbay/lobby)
+"vnP" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/sink/puddle,
+/turf/open/floor/grass,
+/area/hydroponics)
 "voB" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 8
@@ -29722,8 +30025,7 @@
 	dir = 4
 	},
 /obj/structure/bodycontainer/morgue{
-	dir = 8;
-	icon_state = "morgue1"
+	dir = 8
 	},
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/carpet/ship,
@@ -29834,10 +30136,13 @@
 /area/crew_quarters/kitchen)
 "vtl" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "vuk" = (
-/turf/closed/wall/ship,
+/turf/closed/wall/r_wall/ship,
 /area/science/misc_lab{
 	name = "Shield Generator"
 	})
@@ -29892,15 +30197,9 @@
 /area/crew_quarters/cryopods)
 "vvf" = (
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/turf/open/floor/grass,
 /area/hydroponics)
 "vvU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -29986,14 +30285,12 @@
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/warden)
 "vAj" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1
-	},
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/floor/engine,
 /area/engine/engine_room/external{
 	name = "Stormdrive Interior"
@@ -30046,25 +30343,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/table,
-/obj/item/storage/toolbox/electrical{
-	pixel_x = 6;
-	pixel_y = 8
-	},
-/obj/item/storage/toolbox/mechanical,
-/obj/item/twohanded/rcl/pre_loaded,
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
+/obj/machinery/holopad,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
 "vBu" = (
 /obj/structure/sink/kitchen{
 	dir = 4;
-	icon_state = "sink_alt";
 	pixel_x = -11
 	},
 /obj/structure/cable{
@@ -30077,9 +30364,8 @@
 	dir = 6
 	},
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/grass,
 /area/hydroponics)
 "vBw" = (
 /obj/machinery/camera{
@@ -30098,7 +30384,8 @@
 	name = "Arrivals"
 	})
 "vBA" = (
-/turf/open/floor/carpet/green,
+/obj/machinery/light/floor,
+/turf/open/floor/grass,
 /area/hydroponics)
 "vBB" = (
 /obj/structure/sign/warning/nosmoking,
@@ -30117,16 +30404,13 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/storage/tech)
 "vCC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/turf/open/floor/grass,
 /area/hydroponics)
 "vCG" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -30147,9 +30431,6 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"vDo" = (
-/turf/open/floor/carpet/orange,
-/area/engine/engine_smes)
 "vDr" = (
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable{
@@ -30158,9 +30439,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/turf/open/floor/grass,
 /area/hydroponics)
 "vDu" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -30214,9 +30493,6 @@
 	input_tag = "supermatter_fusion_in";
 	output_tag = "supermatter_fusion_out";
 	sensors = list("supermatter_fusion_sensor" = "Supermatter Fusion Chamber")
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /obj/item/radio/intercom/directional/north,
 /obj/structure/extinguisher_cabinet/east,
@@ -30373,6 +30649,15 @@
 	},
 /turf/open/floor/plating,
 /area/chapel/main)
+"vJa" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/closed/wall/r_wall/ship,
+/area/engine/atmos)
 "vJq" = (
 /turf/closed/wall/ship,
 /area/storage/tech)
@@ -30440,14 +30725,10 @@
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "vMm" = (
-/obj/structure/closet/emcloset,
-/obj/item/storage/toolbox/emergency,
 /obj/structure/sign/poster/random{
 	pixel_x = -32
 	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/turf/open/floor/grass,
 /area/hydroponics)
 "vNf" = (
 /obj/machinery/recharge_station,
@@ -30507,6 +30788,9 @@
 	},
 /obj/machinery/camera/autoname{
 	dir = 1
+	},
+/obj/structure/cable/white{
+	icon_state = "1-4"
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
@@ -30574,6 +30858,13 @@
 /obj/item/gps/engineering,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
+"vSI" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/storage/tools)
 "vSU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -30688,15 +30979,19 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "vWT" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical{
 	pixel_x = 6;
 	pixel_y = 8
 	},
 /obj/item/storage/toolbox/mechanical,
-/obj/item/twohanded/rcl/pre_loaded,
+/obj/item/clothing/gloves/color/black,
+/obj/item/gps/engineering,
 /obj/item/clothing/ears/earmuffs,
-/turf/open/floor/carpet/ship/orange_carpet,
+/turf/open/floor/carpet/orange,
 /area/science/misc_lab{
 	name = "Shield Generator"
 	})
@@ -30744,12 +31039,6 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/carpet/ship,
 /area/security/brig)
-"vXM" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/carpet/ship/orange_carpet,
-/area/engine/engine_smes)
 "vYd" = (
 /obj/structure/table,
 /obj/item/storage/crayons,
@@ -30771,7 +31060,6 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
 "vZI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -30781,6 +31069,9 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /obj/machinery/door/airlock/ship/engineering/glass{
 	name = "Atmospherics";
 	req_one_access_txt = "10;24"
@@ -30880,8 +31171,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
@@ -30895,6 +31185,9 @@
 /area/engine/atmospherics_engine)
 "wgb" = (
 /obj/item/beacon,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/lounge{
 	name = "Cafeteria"
@@ -30944,9 +31237,6 @@
 "wis" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/food/snacks/cookie,
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/open/floor/carpet/ship/blue,
 /area/medical/chemistry)
 "wiJ" = (
@@ -31046,6 +31336,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "wmm" = (
@@ -31133,9 +31426,6 @@
 /area/maintenance/department/engine)
 "wpp" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "wpr" = (
@@ -31198,6 +31488,9 @@
 /obj/machinery/door/airlock/ship/engineering/glass{
 	name = "Supermatter Engine Monitoring";
 	req_one_access_txt = "24"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmospherics_engine)
@@ -31363,7 +31656,7 @@
 /obj/item/hand_labeler,
 /obj/item/stack/wrapping_paper,
 /obj/item/hand_labeler_refill,
-/turf/open/floor/carpet/ship,
+/turf/open/floor/carpet,
 /area/crew_quarters/kitchen)
 "wvP" = (
 /obj/machinery/shieldgen,
@@ -31376,10 +31669,9 @@
 	pixel_y = 11
 	},
 /obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/radio,
 /obj/item/seeds/coffee,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/turf/open/floor/grass,
 /area/hydroponics)
 "wwA" = (
 /obj/machinery/advanced_airlock_controller/directional/east,
@@ -31430,15 +31722,11 @@
 /turf/open/floor/engine,
 /area/engine/gravity_generator)
 "wyu" = (
-/obj/structure/closet/l3closet,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/gloves/color/latex,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/obj/machinery/chem_master/condimaster,
+/turf/open/floor/grass,
 /area/hydroponics)
 "wyv" = (
 /obj/structure/cable{
@@ -31452,6 +31740,7 @@
 	pixel_x = 6;
 	pixel_y = 26
 	},
+/obj/structure/closet/secure_closet/atmospherics,
 /turf/open/floor/engine,
 /area/engine/atmos)
 "wzs" = (
@@ -31660,8 +31949,7 @@
 "wEX" = (
 /obj/machinery/newscaster/directional/east,
 /obj/structure/bodycontainer/morgue{
-	dir = 8;
-	icon_state = "morgue1"
+	dir = 8
 	},
 /turf/open/floor/carpet/ship,
 /area/chapel/office)
@@ -31768,8 +32056,7 @@
 /area/tcommsat/server)
 "wIk" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 8;
-	icon_state = "pipe11-2"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -31843,15 +32130,11 @@
 	})
 "wKT" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/shield_generator,
-/obj/structure/cable/white{
-	icon_state = "0-2"
-	},
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
-	icon_state = "0-2"
+	icon_state = "2-8"
 	},
 /turf/open/floor/engine,
 /area/science/misc_lab{
@@ -31912,7 +32195,6 @@
 /turf/open/floor/carpet/ship/red_carpet,
 /area/ai_monitored/security/armory/security)
 "wMg" = (
-/obj/structure/closet/secure_closet/atmospherics,
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank Custom 1";
 	dir = 8
@@ -31923,6 +32205,7 @@
 	name = "Atmos RC";
 	pixel_x = 30
 	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/engine,
 /area/engine/atmos)
 "wMr" = (
@@ -31980,8 +32263,7 @@
 /area/maintenance/department/engine)
 "wNk" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/layer_manifold/visible,
 /turf/open/floor/engine,
@@ -32165,7 +32447,7 @@
 /obj/item/toy/plush/lizardplushie{
 	squeak_override = list('sound/items/bikehorn.ogg' = 1)
 	},
-/turf/open/floor/carpet/ship,
+/turf/open/floor/carpet,
 /area/crew_quarters/lounge{
 	name = "Cafeteria"
 	})
@@ -32229,9 +32511,6 @@
 	},
 /obj/structure/cable/white{
 	icon_state = "4-8"
-	},
-/obj/structure/chair/office/light{
-	dir = 4
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
@@ -32396,7 +32675,6 @@
 /area/maintenance/department/engine/atmos)
 "xcx" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
-/obj/machinery/meter,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -32411,7 +32689,7 @@
 /area/medical/medbay/lobby)
 "xcP" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/structure/cable{
+/obj/structure/cable/white{
 	icon_state = "4-8"
 	},
 /turf/open/floor/engine,
@@ -32708,7 +32986,6 @@
 /turf/open/floor/carpet/ship/blue,
 /area/medical/storage)
 "xqr" = (
-/obj/structure/sign/warning/electricshock,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -32792,9 +33069,6 @@
 	dir = 1;
 	name = "Oxygen to Mix"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "xtm" = (
@@ -32853,12 +33127,7 @@
 /area/security/brig)
 "xuy" = (
 /obj/machinery/seed_extractor,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/turf/open/floor/grass,
 /area/hydroponics)
 "xvn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -32943,7 +33212,12 @@
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/department/engine/atmos)
 "xxz" = (
-/obj/machinery/light_switch/east,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "xxR" = (
@@ -32995,6 +33269,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/structure/cable/white{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
@@ -33246,8 +33523,7 @@
 "xET" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks{
-	dir = 1;
-	icon_state = "soda_dispenser"
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -33289,8 +33565,7 @@
 /area/engine/atmospherics_engine)
 "xHw" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5;
-	icon_state = "pipe11-2"
+	dir = 5
 	},
 /obj/machinery/airalarm/kitchen_cold_room{
 	dir = 1;
@@ -33319,11 +33594,18 @@
 	name = "Hallway"
 	})
 "xHG" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Custom 3 to Mix"
-	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "custom_tank_1_doors";
+	pixel_x = 6;
+	pixel_y = 26
+	},
+/obj/machinery/computer/atmos_control/tank{
+	input_tag = "extra_1_input";
+	output_tag = "extra_1_output";
+	sensors = list("extra_1_sensor" = "Custom Tank 1")
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
@@ -33467,11 +33749,7 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmospherics_engine)
 "xPA" = (
-/obj/structure/chair/office/light{
-	dir = 8
-	},
-/obj/effect/landmark/start/station_engineer,
-/turf/open/floor/carpet/orange,
+/turf/open/floor/plating,
 /area/engine/engine_smes)
 "xQf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -33482,12 +33760,13 @@
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
 "xQv" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/cable/white{
+	icon_state = "0-4"
 	},
-/turf/closed/wall/r_wall/ship,
-/area/engine/atmos)
+/turf/open/floor/carpet/orange,
+/area/science/misc_lab{
+	name = "Shield Generator"
+	})
 "xQB" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -33510,6 +33789,11 @@
 	},
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/brig)
+"xQQ" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
+/area/hydroponics)
 "xRm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -33529,6 +33813,9 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet/ship,
 /area/storage/tools)
@@ -33612,8 +33899,7 @@
 /area/engine/engine_smes)
 "xVu" = (
 /obj/structure/chair/pew/left{
-	dir = 8;
-	icon_state = "pewend_left"
+	dir = 8
 	},
 /obj/machinery/camera/autoname,
 /obj/machinery/newscaster/directional/north,
@@ -33627,6 +33913,9 @@
 "xVL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
 "xWl" = (
@@ -33658,8 +33947,7 @@
 /area/maintenance/department/engine/atmos)
 "xWD" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 8;
-	icon_state = "connector_map-2"
+	dir = 8
 	},
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -33698,6 +33986,18 @@
 /area/crew_quarters/lounge{
 	name = "Cafeteria"
 	})
+"xXn" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/turf/open/floor/carpet/ship/orange_carpet,
+/area/engine/atmos)
 "xXA" = (
 /obj/machinery/air_sensor/atmos{
 	id_tag = "supermatter_fusion_sensor"
@@ -34006,9 +34306,11 @@
 	},
 /obj/item/reagent_containers/food/snacks/grown/tomato,
 /obj/structure/table,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#99FF99"
-	},
+/obj/machinery/smartfridge/disks,
+/obj/item/paper/guides/jobs/hydroponics,
+/obj/item/disk/plantgene,
+/obj/item/disk/plantgene,
+/turf/open/floor/grass,
 /area/hydroponics)
 "ygO" = (
 /obj/machinery/firealarm/directional/west,
@@ -34043,8 +34345,7 @@
 /area/security/brig)
 "yhu" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 8;
-	icon_state = "pipe11-2"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -34133,6 +34434,9 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 5
 	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "ykC" = (
@@ -34149,8 +34453,7 @@
 /obj/structure/closet/radiation,
 /obj/item/clothing/mask/gas,
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /turf/open/floor/carpet/ship,
 /area/storage/tools)
@@ -48139,11 +48442,11 @@ fZX
 qnU
 yca
 yca
-qnU
+ktr
 jAw
 dmx
-qnU
-yca
+qMz
+eLA
 pQB
 qpA
 qDt
@@ -48399,7 +48702,7 @@ gIm
 igN
 jJN
 dQI
-lhm
+rqW
 mFK
 lhm
 qxT
@@ -48656,10 +48959,10 @@ gMV
 jcs
 yca
 dmx
-uCh
-eLA
-sMn
-bYG
+ixQ
+yca
+yca
+yca
 ixQ
 rLG
 fca
@@ -48907,13 +49210,13 @@ fZX
 qnU
 cVE
 dDB
-fZX
+yca
 fZX
 fZX
 jgK
 fZX
 fZX
-fZX
+spS
 fZX
 fZX
 fZX
@@ -49155,7 +49458,7 @@ drp
 drp
 drp
 drp
-drp
+aaK
 awN
 atr
 aIO
@@ -49163,10 +49466,10 @@ fZX
 alj
 qnU
 diN
-yca
 fZX
-fBL
-cBF
+fZX
+fZX
+gqw
 jhe
 kcB
 kru
@@ -49221,7 +49524,7 @@ fcp
 aIO
 atr
 noN
-drp
+aaK
 drp
 drp
 drp
@@ -49418,18 +49721,18 @@ atr
 mjO
 aae
 cWs
-hdz
-vwd
-dFa
+afF
+aAj
 fZX
+dFa
 cBF
-cBF
+gMl
 cBF
 idH
-cDF
-cDF
+mvU
+xQv
 vbB
-pXT
+ube
 xTl
 vcz
 sun
@@ -49676,9 +49979,9 @@ icn
 oeJ
 yca
 qnU
-qib
-afF
+bhq
 aXe
+fuA
 gdi
 gdi
 dnt
@@ -49926,7 +50229,7 @@ drp
 drp
 drp
 drp
-drp
+aaK
 awN
 atr
 mjO
@@ -49934,16 +50237,16 @@ aae
 cWs
 hdz
 qib
-yca
 fZX
 cBF
 cBF
 cBF
+cBF
 wpX
-cDF
+mvU
 mvU
 gSp
-cDF
+mvU
 xTl
 aEx
 sun
@@ -49992,7 +50295,7 @@ xxr
 cxm
 atr
 noN
-drp
+aaK
 drp
 drp
 drp
@@ -50191,14 +50494,14 @@ oeJ
 alZ
 mds
 dwe
-yca
 fZX
+dFa
 cBF
 cBF
 cBF
 wpX
 kUj
-cDF
+uhW
 mSN
 qvl
 xTl
@@ -50450,9 +50753,9 @@ bIv
 fZX
 fZX
 fZX
+fBL
 xhn
-xhn
-xhn
+mhI
 xhn
 xhn
 vuk
@@ -50488,8 +50791,8 @@ bwH
 eUG
 uYb
 yjh
-kDM
 jEx
+hRi
 xHe
 tIw
 oYB
@@ -50697,7 +51000,7 @@ drp
 drp
 drp
 drp
-drp
+aaK
 awN
 atr
 aIO
@@ -50745,8 +51048,8 @@ qOb
 wnk
 wsB
 hNM
-kDM
 jEx
+hRi
 xHe
 uZj
 xOP
@@ -50763,7 +51066,7 @@ fcp
 aIO
 atr
 noN
-drp
+aaK
 drp
 drp
 drp
@@ -51002,8 +51305,8 @@ boZ
 ruX
 gQV
 jEx
-kDM
 jEx
+hRi
 xHe
 fLL
 oYB
@@ -51225,7 +51528,7 @@ cvq
 eet
 gZo
 jPD
-xhn
+qog
 mBR
 pFn
 qpo
@@ -51259,7 +51562,7 @@ fyI
 uxm
 uxm
 uxm
-pdT
+uxm
 ptB
 bpV
 qor
@@ -51468,7 +51771,7 @@ drp
 drp
 drp
 drp
-drp
+aaK
 awN
 atr
 atr
@@ -51517,7 +51820,7 @@ xEU
 jEx
 jEx
 kDM
-jEx
+ktz
 bll
 bZv
 lHT
@@ -51534,7 +51837,7 @@ fcp
 atr
 atr
 noN
-drp
+aaK
 drp
 drp
 drp
@@ -51999,7 +52302,7 @@ xhn
 sBe
 lTm
 ooA
-uIx
+oqZ
 vJq
 uZe
 fyA
@@ -52239,7 +52542,7 @@ drp
 drp
 drp
 drp
-drp
+aaK
 awN
 atr
 atr
@@ -52253,7 +52556,7 @@ cEq
 rSa
 dxo
 nSz
-uIx
+qCx
 iGp
 wVV
 uIx
@@ -52288,8 +52591,8 @@ oQw
 uuf
 xub
 lOk
-jwm
-oQw
+psX
+spV
 wqu
 dhZ
 jTc
@@ -52305,7 +52608,7 @@ fcp
 atr
 atr
 noN
-drp
+aaK
 drp
 drp
 drp
@@ -52509,15 +52812,15 @@ hNx
 deF
 oLv
 asf
-oqD
+pdT
 lBe
-iGp
+fuU
 rwu
 htu
 kvV
 jlz
 sFr
-iGp
+ksc
 fkn
 mvB
 fBF
@@ -52771,13 +53074,13 @@ dft
 qrE
 jlP
 kil
-gqw
+iGp
 ref
 tyf
 xPA
-vDo
-vDo
-vXM
+xPA
+xPA
+xPA
 xIU
 icn
 baX
@@ -52801,7 +53104,7 @@ nlP
 vnI
 wAn
 uWJ
-mhI
+iom
 dEj
 jtk
 kUF
@@ -53010,7 +53313,7 @@ drp
 drp
 drp
 drp
-drp
+aaK
 awN
 atr
 atr
@@ -53021,20 +53324,20 @@ fZX
 xhn
 dxz
 xhn
-xhn
+hXv
 eRM
 hQF
 lPN
 gZO
 vBq
 bBv
-iGp
+sJf
 ref
-fQc
-brX
-qDq
-vDo
-lny
+tyf
+xPA
+xPA
+xPA
+xPA
 kTR
 icn
 baX
@@ -53076,7 +53379,7 @@ fcp
 atr
 atr
 noN
-drp
+aaK
 drp
 drp
 drp
@@ -53288,7 +53591,7 @@ nwt
 utu
 jlz
 ggE
-iGp
+kKx
 bgh
 jnx
 uKW
@@ -53315,9 +53618,9 @@ aey
 aey
 aey
 aey
-xQv
-fJU
 aey
+fJU
+gVu
 eKW
 wjb
 ocH
@@ -53535,7 +53838,7 @@ tdX
 jEb
 nsv
 lfW
-nhI
+ixl
 pam
 aWd
 tYf
@@ -53781,7 +54084,7 @@ drp
 drp
 drp
 drp
-drp
+aaK
 awN
 atr
 atr
@@ -53847,7 +54150,7 @@ eav
 atr
 atr
 noN
-drp
+aaK
 drp
 drp
 drp
@@ -54343,7 +54646,7 @@ ocH
 cPt
 spr
 qkz
-aAj
+mBa
 epQ
 dFl
 kLT
@@ -54552,7 +54855,7 @@ drp
 drp
 drp
 drp
-drp
+aaK
 awN
 atr
 atr
@@ -54618,7 +54921,7 @@ fcp
 atr
 atr
 noN
-drp
+aaK
 drp
 drp
 drp
@@ -54810,7 +55113,7 @@ drp
 drp
 drp
 drp
-drp
+aaK
 awN
 atr
 fZX
@@ -54856,11 +55159,11 @@ bzL
 vJK
 seB
 rhr
-hDI
-fuA
+qkz
+bwC
 pYx
 pUQ
-kLT
+xXn
 qsv
 seB
 yaM
@@ -54874,7 +55177,7 @@ sLc
 fcp
 atr
 noN
-drp
+aaK
 drp
 drp
 drp
@@ -55114,7 +55417,7 @@ mCQ
 ylD
 urJ
 tQD
-qMz
+pQD
 qfb
 ssb
 kLT
@@ -55368,7 +55671,7 @@ mtu
 wzI
 wzI
 wzI
-ylD
+cSr
 pVA
 fmb
 czT
@@ -55581,7 +55884,7 @@ drp
 drp
 drp
 drp
-drp
+aaK
 awN
 atr
 fZX
@@ -55592,11 +55895,11 @@ vjQ
 mgr
 tSd
 tsa
-bhq
+qNi
 mdp
 lMR
 bjg
-gMl
+oEB
 oEB
 umm
 vLT
@@ -55621,11 +55924,11 @@ aeS
 aeg
 obP
 huN
-ocH
+vJa
 wyR
 kkK
 iNi
-ocH
+ylD
 cos
 drA
 pQD
@@ -55645,7 +55948,7 @@ qJx
 fcp
 atr
 noN
-drp
+aaK
 drp
 drp
 drp
@@ -55880,7 +56183,7 @@ iyG
 dqf
 vZI
 saI
-saI
+pXM
 jlR
 qRm
 fKc
@@ -56109,7 +56412,7 @@ gZv
 yjm
 hgE
 yjm
-kZs
+ePI
 jrd
 afa
 rVR
@@ -56139,7 +56442,7 @@ ocH
 qhb
 wMg
 eKE
-ylD
+ocH
 xHG
 icC
 bwC
@@ -56352,7 +56655,7 @@ drp
 drp
 drp
 drp
-drp
+aaK
 awN
 atr
 fZX
@@ -56416,7 +56719,7 @@ xWq
 fcp
 atr
 noN
-drp
+aaK
 drp
 drp
 drp
@@ -56893,11 +57196,11 @@ gbV
 bTh
 nJM
 nrv
-sEr
+hKU
 fhC
 gpD
 mDm
-ktr
+kUm
 vbj
 kUm
 uDy
@@ -57123,7 +57426,7 @@ drp
 drp
 drp
 drp
-drp
+aaK
 awN
 atr
 fZX
@@ -57133,12 +57436,12 @@ vcT
 fZX
 aIO
 acZ
-kZs
+iGh
 gTz
 mou
 hFT
-kZs
-jrd
+cYP
+cwp
 jYT
 eUQ
 lcc
@@ -57150,7 +57453,7 @@ fpa
 iUT
 ctM
 wnP
-ctM
+jxp
 wVk
 lDE
 mRb
@@ -57187,7 +57490,7 @@ iKc
 fcp
 atr
 noN
-drp
+aaK
 drp
 drp
 drp
@@ -57394,7 +57697,7 @@ eUI
 bTh
 oOV
 acZ
-acZ
+pES
 acZ
 kew
 urH
@@ -57407,7 +57710,7 @@ gbV
 bTh
 aeg
 jbE
-aeg
+gXp
 tUM
 iCe
 xfo
@@ -57430,7 +57733,7 @@ ijG
 pQD
 hkP
 kub
-hDI
+qkz
 kts
 ocH
 ocH
@@ -57653,7 +57956,7 @@ kmg
 hPI
 inY
 qNi
-qNi
+tVf
 rwS
 msz
 mwC
@@ -57664,7 +57967,7 @@ iRm
 pfq
 hsH
 jbE
-aeg
+gXp
 mze
 stH
 stH
@@ -57684,10 +57987,10 @@ ono
 tWJ
 llp
 ijG
-aaK
+mBa
 qFK
 gYI
-hDI
+qkz
 fIa
 tWJ
 dos
@@ -57910,7 +58213,7 @@ tBz
 had
 dnw
 dnw
-dnw
+lfS
 qtV
 kXr
 byW
@@ -58183,7 +58486,7 @@ dzd
 gjr
 vuq
 ykC
-fwS
+uXh
 bYe
 uPa
 eMg
@@ -58423,9 +58726,9 @@ fZX
 fZX
 gSJ
 fZX
-ixl
 fZX
-gvD
+fZX
+dvs
 fZX
 iWs
 tTl
@@ -58697,7 +59000,7 @@ msZ
 uRt
 vuq
 iuR
-vuq
+nOY
 bck
 vuq
 rgN
@@ -58937,7 +59240,7 @@ dmx
 fLB
 mrt
 woX
-iGh
+yca
 dmx
 jaY
 fZX
@@ -59468,7 +59771,7 @@ azI
 dYV
 cnN
 abm
-olz
+liO
 lmx
 jJX
 aqQ
@@ -59725,7 +60028,7 @@ fNy
 fNy
 tqr
 kYR
-oiy
+qcC
 aAG
 jwj
 oiy
@@ -59982,7 +60285,7 @@ hub
 fNy
 lZW
 abm
-olz
+liO
 lmx
 tuR
 jAk
@@ -60244,7 +60547,7 @@ bJZ
 lFW
 wKz
 tLu
-rSl
+mHk
 wTV
 mXW
 lUr
@@ -60753,7 +61056,7 @@ vth
 eaL
 jrV
 alP
-olz
+liO
 tfi
 tuR
 olz
@@ -61010,7 +61313,7 @@ eaL
 eaL
 oME
 abm
-olz
+liO
 tfi
 wzs
 wyc
@@ -61261,7 +61564,7 @@ tHT
 aaf
 wSO
 cgH
-eaL
+jAo
 mZG
 vNP
 eaL
@@ -61288,7 +61591,7 @@ vEp
 tCK
 uMi
 ttB
-qCx
+mrY
 gsj
 asE
 ofF
@@ -61517,14 +61820,14 @@ eMe
 tHT
 ueZ
 poZ
-eaL
+jAo
 tzb
 wvG
-spS
-spS
+eaL
+eaL
 hHa
 abm
-olz
+liO
 tfi
 aUX
 rQZ
@@ -61777,11 +62080,11 @@ nCH
 itT
 itT
 axl
-spS
+eaL
 qYb
 oGt
 roT
-olz
+liO
 bhA
 qck
 huD
@@ -62034,17 +62337,17 @@ wrR
 alw
 kHs
 nWp
-spS
-spS
+eaL
+eaL
 rqs
 abm
 jFF
 qRn
 tuR
 jAk
-jAk
-qQP
-jAk
+cpt
+blH
+cpt
 wMD
 jAk
 olz
@@ -62295,13 +62598,13 @@ eaL
 eaL
 hHa
 abm
-olz
+liO
 iGX
 lFW
 wKz
 tOn
-rSl
-rSl
+mHk
+mHk
 mXW
 rSl
 olz
@@ -62552,7 +62855,7 @@ eaL
 eaL
 rmU
 abm
-olz
+liO
 dzZ
 gDe
 akb
@@ -62801,7 +63104,7 @@ mNB
 mEF
 cRD
 hIF
-jDv
+bfa
 dzH
 oGt
 xhm
@@ -63323,7 +63626,7 @@ eaL
 eaL
 oGt
 rYe
-dSB
+tkg
 jKk
 bpE
 tdz
@@ -63580,7 +63883,7 @@ vNP
 eaL
 xiG
 vpH
-mDU
+pdJ
 rYC
 aTr
 tdz
@@ -63831,13 +64134,13 @@ aTh
 mZg
 jLV
 bDS
-hXv
+oGt
 oGt
 jaB
 bfT
 oGt
 cPY
-mDU
+pdJ
 pyL
 mDU
 tdz
@@ -64090,11 +64393,11 @@ jFE
 nSb
 uUZ
 qkx
-jDv
-jDv
+shv
+oUe
 uUZ
 ivA
-mDU
+pdJ
 tkZ
 uGt
 tdz
@@ -64338,8 +64641,8 @@ pqJ
 pXC
 bkc
 eje
-jDv
-jDv
+shv
+shv
 oYD
 vDr
 vBu
@@ -64348,7 +64651,7 @@ uJI
 bpD
 rLr
 vnF
-uPn
+vnF
 lLq
 qEk
 jhD
@@ -64594,21 +64897,21 @@ uUA
 uUA
 uUA
 uUZ
-rJM
+tun
 rDu
 nGg
 tZP
-gGC
+vBA
 sjs
-gGC
+vBA
 vCC
-iCs
+lWq
 tKX
 lWq
-lWq
+vnP
 dHs
 bsC
-mDU
+pdJ
 qlu
 asI
 tdz
@@ -64853,19 +65156,19 @@ uUA
 mTs
 tun
 hPx
-hPx
+ktK
 bfy
 hPx
 gmv
 hPx
-bfy
+lxp
 hPx
 hPx
-jDv
+kkw
 mYV
 nfK
 vpH
-mDU
+pdJ
 qlu
 asI
 arC
@@ -65109,20 +65412,20 @@ ryd
 uUA
 xuy
 tun
-hPx
-hPx
-bfy
-hPx
+hMd
+piI
+mvJ
+bLD
 vvf
-hPx
+ivv
 obl
-hPx
-hPx
-jDv
+grJ
+rAn
+shv
 gTJ
 nfK
 vpH
-mDU
+pdJ
 qlu
 uwD
 vzE
@@ -65365,18 +65668,18 @@ kPP
 ryd
 uUA
 upW
-doa
-oBF
-fXf
-lXR
-edA
-eSo
-edA
-lXR
-oBF
-oBF
+tun
+vBA
 shv
-gTJ
+tZP
+vBA
+eSo
+vBA
+tZP
+shv
+vBA
+shv
+nRc
 voL
 vpH
 eUy
@@ -65624,19 +65927,19 @@ uUA
 ygK
 tun
 vBA
-vBA
+tcj
 tai
-jDv
+vBA
 cfQ
-jDv
-tai
 vBA
-vBA
-jDv
-jDv
+tZP
+xQQ
+ndY
+shv
+eSr
 uUZ
 vpH
-mDU
+pdJ
 ihQ
 uwD
 hba
@@ -65881,19 +66184,19 @@ uUZ
 www
 myl
 ebe
-hPx
-bfy
+hTj
+mbW
 kAg
 mmr
 hPx
-bfy
-hPx
+lxp
+nnl
 pxn
 dQg
 sUi
 uUZ
 eJN
-mDU
+pdJ
 ihQ
 asI
 wGn
@@ -66150,7 +66453,7 @@ uUZ
 uUZ
 lQD
 biC
-mDU
+pdJ
 ihQ
 asI
 asI
@@ -66407,7 +66710,7 @@ saS
 saS
 coV
 buh
-saS
+fIp
 bNX
 aTU
 wLe
@@ -66921,7 +67224,7 @@ wMr
 dyy
 aCs
 oKP
-oKP
+npJ
 bSh
 qiY
 oKP
@@ -67178,7 +67481,7 @@ pJI
 fmX
 pmp
 mDU
-mDU
+pdJ
 ihQ
 oBd
 cYh
@@ -67433,11 +67736,11 @@ wEg
 nZj
 oHz
 oHz
-qog
-mDU
-mDU
+oHz
+gqi
+pdJ
 ihQ
-rqW
+gkH
 gkH
 gkH
 cfk
@@ -67692,7 +67995,7 @@ nVt
 qQd
 pMn
 mDU
-mDU
+pdJ
 ihQ
 txN
 uDQ
@@ -67949,7 +68252,7 @@ kRO
 kRO
 wGa
 mDU
-mDU
+pdJ
 ihQ
 okz
 bAS
@@ -68431,7 +68734,7 @@ drp
 drp
 drp
 drp
-drp
+aaK
 awN
 fyD
 eXv
@@ -68463,8 +68766,8 @@ oHz
 oHz
 oHz
 tLG
-mDU
-ihQ
+pdJ
+fOK
 gkH
 cfk
 cfk
@@ -68495,7 +68798,7 @@ wYY
 trj
 atr
 noN
-drp
+aaK
 drp
 drp
 drp
@@ -68720,7 +69023,7 @@ ebx
 eER
 hEi
 mDU
-mDU
+pdJ
 ihQ
 hEi
 eEp
@@ -68730,7 +69033,7 @@ wAq
 hqF
 wGj
 rCc
-ion
+jkY
 cJr
 vei
 tQh
@@ -68977,7 +69280,7 @@ uQs
 oBd
 oXv
 mDU
-mDU
+pdJ
 ihQ
 oXv
 cJr
@@ -69202,7 +69505,7 @@ drp
 drp
 drp
 drp
-drp
+aaK
 awN
 atr
 icn
@@ -69266,7 +69569,7 @@ mvd
 icn
 atr
 noN
-drp
+aaK
 drp
 drp
 drp
@@ -69748,7 +70051,7 @@ eqV
 lPZ
 lPZ
 eih
-aJG
+vSI
 eyl
 lPZ
 cJr
@@ -69973,7 +70276,7 @@ drp
 drp
 drp
 drp
-drp
+aaK
 awN
 atr
 icn
@@ -70037,7 +70340,7 @@ mvd
 icn
 atr
 noN
-drp
+aaK
 drp
 drp
 drp
@@ -70744,7 +71047,7 @@ drp
 drp
 drp
 drp
-drp
+aaK
 awN
 atr
 mjO
@@ -70808,7 +71111,7 @@ cog
 cxm
 atr
 noN
-drp
+aaK
 drp
 drp
 drp
@@ -71515,7 +71818,7 @@ drp
 drp
 drp
 drp
-drp
+aaK
 awN
 atr
 icn
@@ -71579,7 +71882,7 @@ trj
 icn
 atr
 noN
-drp
+aaK
 drp
 drp
 drp
@@ -72286,7 +72589,7 @@ drp
 drp
 drp
 drp
-drp
+aaK
 awN
 atr
 icn
@@ -72350,7 +72653,7 @@ mvd
 icn
 atr
 noN
-drp
+aaK
 drp
 drp
 drp
@@ -72836,7 +73139,7 @@ wAy
 mnK
 cLK
 nGw
-nGw
+cae
 nGw
 bfn
 eoI
@@ -73057,7 +73360,7 @@ drp
 drp
 drp
 drp
-drp
+aaK
 awN
 atr
 wLO
@@ -73121,7 +73424,7 @@ wYY
 trj
 atr
 noN
-drp
+aaK
 drp
 drp
 drp
@@ -73828,7 +74131,7 @@ drp
 drp
 drp
 drp
-drp
+aaK
 awN
 fyD
 wLO
@@ -73892,7 +74195,7 @@ wSE
 trj
 atr
 noN
-drp
+aaK
 drp
 drp
 drp
@@ -74599,7 +74902,7 @@ drp
 drp
 drp
 drp
-drp
+aaK
 awN
 fyD
 wLO
@@ -74663,7 +74966,7 @@ trj
 trj
 atr
 noN
-drp
+aaK
 drp
 drp
 drp
@@ -75370,7 +75673,7 @@ drp
 drp
 drp
 drp
-drp
+aaK
 awN
 fyD
 uhH
@@ -75434,7 +75737,7 @@ wYY
 mvd
 fyD
 noN
-drp
+aaK
 drp
 drp
 drp
@@ -75910,7 +76213,7 @@ xDV
 imL
 pYR
 pQv
-cSZ
+gPL
 pQv
 ssL
 nFJ
@@ -76167,7 +76470,7 @@ pQv
 pQv
 pQv
 pQv
-cSZ
+gPL
 pQv
 pMp
 iVI
@@ -76679,7 +76982,7 @@ wYY
 dEa
 oqm
 wYY
-cSZ
+gPL
 trj
 trj
 trj
@@ -76936,7 +77239,7 @@ wYY
 wYY
 pQv
 wYY
-cSZ
+gPL
 trj
 xxR
 ahJ
@@ -77193,7 +77496,7 @@ pQv
 pQv
 pQv
 wYY
-cSZ
+gPL
 trj
 aqq
 ijr
@@ -77450,7 +77753,7 @@ dPi
 kEI
 wYY
 wYY
-cSZ
+gPL
 trj
 jkX
 nTH
@@ -77963,8 +78266,8 @@ wYY
 wYY
 wYY
 wYY
-wYY
-cSZ
+pvX
+rZb
 trj
 gEx
 sin

--- a/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
@@ -79,7 +79,7 @@
 	name = "Chapel Departures"
 	},
 /obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/chapel/main)
 "ads" = (
 /obj/machinery/disposal/bin,
@@ -127,7 +127,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "aey" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
@@ -144,8 +144,12 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
 "afa" = (
-/obj/structure/sign/warning/vacuum,
-/turf/closed/wall/ship,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/closet/emcloset,
+/obj/item/storage/toolbox/emergency,
+/turf/open/floor/engine,
 /area/engine/engine_room)
 "afg" = (
 /obj/structure/cable/yellow{
@@ -154,7 +158,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -181,19 +185,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "afP" = (
-/obj/structure/cable/white{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/white{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
-	},
-/turf/open/floor/engine,
-/area/engine/engine_room)
+/obj/structure/hull_plate,
+/obj/structure/ladder,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "agH" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -363,7 +358,7 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "alw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -398,7 +393,7 @@
 /obj/structure/sign/directions/supply{
 	pixel_y = -28
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -557,14 +552,16 @@
 	name = "Cafeteria"
 	})
 "arC" = (
-/obj/structure/toilet,
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 10
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet/restrooms)
+/obj/machinery/disposal/bin,
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/computer/cryopod{
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/cryopods)
 "arT" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -578,23 +575,21 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
 "asf" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/carpet/ship/orange_carpet,
+/area/tcommsat/server)
+"asx" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/engine/engine_smes)
-"asx" = (
-/obj/machinery/door/poddoor/ship{
-	id = "stormdrive_vent"
-	},
-/obj/structure/sign/warning/radiation{
-	pixel_x = -32
-	},
-/turf/open/floor/engine,
-/area/engine/engine_room/external{
-	name = "Stormdrive Interior"
-	})
+/obj/machinery/telecomms/server/presets/security,
+/turf/open/floor/circuit,
+/area/tcommsat/server)
 "asE" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/holy/follower,
@@ -606,7 +601,7 @@
 /area/chapel/office)
 "asI" = (
 /turf/closed/wall/ship,
-/area/crew_quarters/toilet/restrooms)
+/area/crew_quarters/cryopods)
 "atq" = (
 /obj/structure/table,
 /obj/item/scalpel,
@@ -674,18 +669,12 @@
 /turf/open/floor/carpet/ship,
 /area/medical/virology)
 "awD" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
-	},
-/turf/open/floor/engine,
-/area/engine/engine_room)
+/obj/machinery/telecomms/receiver/preset_left,
+/turf/open/floor/circuit,
+/area/tcommsat/server)
 "awG" = (
 /obj/machinery/stasis,
 /obj/machinery/power/apc/auto_name/east,
@@ -703,7 +692,7 @@
 "awV" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/crew_quarters/bar)
 "axl" = (
 /obj/structure/table,
@@ -728,8 +717,9 @@
 	name = "Cafeteria"
 	})
 "ayF" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
+/obj/machinery/particle_accelerator/control_box,
+/obj/item/paper{
+	info = "<p>Reminder to add control rods to the Stormdrive engine BEFORE turning it on! Adding control rods requires the engine to be in maintenance mode, and it won't work if the reactor is powered!<br><br>Control rods are located in crate behind particle accelerator</p>"
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_room)
@@ -898,7 +888,7 @@
 /area/security/brig)
 "aBN" = (
 /obj/structure/table/wood,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -927,7 +917,7 @@
 	name = "Central Primary Hallway"
 	},
 /obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -989,13 +979,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
-"aIL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/newscaster/directional/north,
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet/restrooms)
 "aIO" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -1018,7 +1001,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -1042,7 +1025,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -1078,7 +1061,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/crew_quarters/bar)
 "aOm" = (
 /obj/structure/chair/office/light{
@@ -1122,11 +1105,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/obj/machinery/modular_computer/console/preset/engineering{
-	dir = 8
-	},
-/obj/structure/cable/white{
-	icon_state = "0-8"
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_room)
@@ -1151,9 +1131,6 @@
 "aQJ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
 	},
 /obj/machinery/holopad,
 /turf/open/floor/carpet/ship/orange_carpet,
@@ -1230,7 +1207,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/layer1{
 	dir = 1
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -1258,7 +1235,7 @@
 	name = "Central Primary Hallway"
 	},
 /obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -1337,6 +1314,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
 "aWr" = (
@@ -1456,16 +1434,12 @@
 /turf/open/floor/plating,
 /area/security/detectives_office)
 "aZG" = (
-/obj/machinery/door/poddoor/ship{
-	id = "stormdrive_vent"
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
 	},
-/obj/structure/sign/warning/radiation{
-	pixel_x = 32
-	},
-/turf/open/floor/engine,
-/area/engine/engine_room/external{
-	name = "Stormdrive Interior"
-	})
+/obj/machinery/telecomms/server/presets/engineering,
+/turf/open/floor/circuit,
+/area/tcommsat/server)
 "aZL" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -1506,7 +1480,8 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/obj/machinery/holopad/tutorial,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -1523,8 +1498,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/engine/engine_smes)
+/obj/machinery/telecomms/processor/preset_four,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5;
+	icon_state = "pipe11-2"
+	},
+/turf/open/floor/circuit,
+/area/tcommsat/server)
 "baX" = (
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -1571,6 +1551,7 @@
 /area/engine/break_room)
 "bcs" = (
 /obj/structure/closet/secure_closet/engineering_welding,
+/obj/item/clothing/gloves/color/black,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
 "bcT" = (
@@ -1615,7 +1596,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "bef" = (
 /obj/machinery/atmospherics/components/trinary/filter/critical{
@@ -1753,10 +1734,10 @@
 /turf/open/floor/carpet/ship/blue,
 /area/medical/chemistry)
 "bhd" = (
-/obj/machinery/telecomms/server/presets/common/birdstation,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
+	dir = 4
 	},
+/obj/machinery/telecomms/server/presets/common,
 /turf/open/floor/circuit,
 /area/tcommsat/server)
 "bhh" = (
@@ -1841,7 +1822,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -1861,7 +1842,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -1875,10 +1856,15 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
@@ -1893,7 +1879,7 @@
 	},
 /obj/machinery/newscaster/directional/west,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -1936,7 +1922,7 @@
 /obj/item/clothing/mask/surgical,
 /obj/item/clothing/gloves/color/latex,
 /obj/machinery/firealarm/directional/east,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -1970,7 +1956,7 @@
 	dir = 1
 	},
 /obj/machinery/photocopier,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "bnl" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -1990,7 +1976,7 @@
 /area/medical/patients_rooms/room_c)
 "boG" = (
 /obj/effect/landmark/observer_start,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -2045,12 +2031,14 @@
 	},
 /area/hydroponics)
 "bpE" = (
-/obj/machinery/portable_atmospherics/pump,
 /obj/machinery/atmospherics/components/unary/portables_connector/layer1{
 	dir = 1
 	},
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/carpet/ship/beige_carpet,
+/obj/machinery/portable_atmospherics/pump,
+/obj/structure/sign/solgov_seal{
+	pixel_y = -27
+	},
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -2113,7 +2101,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/nuclear_waste_spawner,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -2186,7 +2174,7 @@
 	codes_txt = "patrol;next_patrol=loc12";
 	location = "loc11"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -2339,7 +2327,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "bxI" = (
 /obj/structure/cable{
@@ -2402,7 +2390,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/junction,
+/obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_room)
 "byW" = (
@@ -2437,9 +2426,14 @@
 /turf/open/floor/carpet/royalblack,
 /area/chapel/main)
 "bAQ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/engine,
-/area/engine/engine_room)
+/obj/machinery/atmospherics/components/binary/passive_gate{
+	dir = 1;
+	name = "Stormdrive Output to Space"
+	},
+/turf/closed/wall/r_wall/ship,
+/area/engine/engine_room/external{
+	name = "Stormdrive Interior"
+	})
 "bAS" = (
 /turf/open/floor/carpet/ship,
 /area/shuttle/turbolift/secondary)
@@ -2515,7 +2509,7 @@
 /area/medical/storage)
 "bED" = (
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "bEV" = (
 /obj/item/folder/red,
@@ -2571,7 +2565,7 @@
 /area/security/detectives_office)
 "bHD" = (
 /obj/machinery/vending/snack/random,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -2620,7 +2614,7 @@
 	req_one_access_txt = "12;25;28;35"
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bJZ" = (
 /obj/structure/cable{
@@ -2707,7 +2701,7 @@
 	codes_txt = "patrol;next_patrol=loc3";
 	location = "loc2"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -2776,7 +2770,7 @@
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "bOX" = (
 /obj/structure/cable{
@@ -2824,7 +2818,7 @@
 /obj/structure/table/wood/poker,
 /obj/structure/extinguisher_cabinet/west,
 /obj/item/storage/bag/money,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "bQY" = (
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
@@ -2880,7 +2874,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -2975,7 +2969,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -3038,13 +3032,10 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/break_room)
 "bZf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet/restrooms)
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/telecomms/broadcaster/preset_left,
+/turf/open/floor/circuit,
+/area/tcommsat/server)
 "bZp" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -3103,11 +3094,11 @@
 /turf/open/floor/carpet/ship,
 /area/security/detectives_office)
 "bZQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 6
 	},
-/turf/open/floor/carpet/ship/orange_carpet,
-/area/engine/engine_room)
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/department/engine)
 "cap" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3184,6 +3175,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/auto_name/west,
+/obj/effect/spawner/lootdrop/gloves,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/medbay/lobby)
 "cei" = (
@@ -3241,7 +3233,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/crew_quarters/bar)
 "cfQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -3324,7 +3316,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/crew_quarters/bar)
 "chG" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -3489,7 +3481,7 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/airlock/ship/maintenance,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/maintenance/department/engine/atmos)
 "cnN" = (
 /obj/machinery/lazylift_button,
@@ -3532,14 +3524,15 @@
 	name = "Central Primary Hallway"
 	},
 /obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
 "cpm" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/crew_quarters/heads/chief)
 "cqD" = (
@@ -3601,19 +3594,11 @@
 	name = "Interrogation Room"
 	})
 "csv" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/airlock/ship/public{
-	name = "Primary Bathroom"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/toilet/restrooms)
+/turf/open/floor/plating/airless,
+/area/maintenance/department/engine)
 "csT" = (
 /obj/machinery/status_display/evac,
 /turf/closed/wall/ship,
@@ -3626,7 +3611,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "ctD" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
@@ -3646,6 +3631,7 @@
 "ctJ" = (
 /obj/machinery/airalarm/directional/east,
 /obj/structure/reagent_dispensers/foamtank/hull_repair_juice,
+/obj/item/extinguisher/advanced/hull_repair_juice,
 /turf/open/floor/plating,
 /area/engine/break_room)
 "ctM" = (
@@ -3723,15 +3709,13 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cvq" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6;
+	icon_state = "pipe11-2"
 	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/engine/engine_room)
+/obj/machinery/telecomms/bus/preset_three,
+/turf/open/floor/circuit,
+/area/tcommsat/server)
 "cvH" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -3784,23 +3768,13 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/crew_quarters/heads/chief)
 "cyM" = (
-/obj/machinery/computer/cryopod{
-	pixel_y = 32
+/obj/machinery/telecomms/server/presets/supply,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6;
+	icon_state = "pipe11-2"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/carpet/ship/blue,
-/area/medical/medbay/central)
+/turf/open/floor/circuit,
+/area/tcommsat/server)
 "czK" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -3864,8 +3838,8 @@
 	name = "Shield Generator"
 	})
 "cBU" = (
-/obj/machinery/telecomms/receiver/preset_left/birdstation,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/telecomms/broadcaster/preset_right,
 /turf/open/floor/circuit,
 /area/tcommsat/server)
 "cCI" = (
@@ -3896,14 +3870,19 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
 "cEq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/plating,
-/area/engine/engine_smes)
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6;
+	icon_state = "pipe11-2"
+	},
+/obj/machinery/telecomms/bus/preset_one,
+/turf/open/floor/circuit,
+/area/tcommsat/server)
 "cEr" = (
 /obj/machinery/door/window{
 	dir = 8;
@@ -3955,7 +3934,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -4042,7 +4021,7 @@
 	pixel_x = -3;
 	pixel_y = 7
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "cMJ" = (
 /obj/structure/sign/directions/security{
@@ -4066,7 +4045,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -4117,7 +4096,7 @@
 /obj/machinery/camera/autoname{
 	dir = 6
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -4196,7 +4175,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -4260,7 +4239,7 @@
 /obj/structure/sign/poster/random{
 	pixel_y = 32
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "cUl" = (
 /obj/structure/cable{
@@ -4298,9 +4277,7 @@
 	name = "Cafeteria"
 	})
 "cVh" = (
-/obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/tcommsat/server)
 "cVD" = (
@@ -4342,13 +4319,10 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"cXg" = (
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet/restrooms)
 "cYh" = (
 /obj/structure/closet/emcloset,
 /obj/item/storage/toolbox/emergency,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -4531,14 +4505,11 @@
 /turf/open/floor/carpet/ship,
 /area/shuttle/turbolift/quaternary)
 "deF" = (
-/obj/structure/chair/office/light,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
 	},
-/obj/effect/landmark/start/station_engineer,
 /turf/open/floor/carpet/ship/orange_carpet,
-/area/engine/storage)
+/area/tcommsat/server)
 "deI" = (
 /obj/machinery/status_display/evac,
 /turf/closed/wall/ship,
@@ -4556,7 +4527,6 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -4581,12 +4551,32 @@
 /area/crew_quarters/lounge{
 	name = "Cafeteria"
 	})
-"dgw" = (
-/obj/structure/cable/yellow{
+"dgs" = (
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/carpet/ship/orange_carpet,
-/area/engine/engine_room)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/computer/ship/viewscreen,
+/turf/open/floor/carpet/ship/blue,
+/area/medical/medbay/central)
+"dgw" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/obj/machinery/telecomms/server/presets/munitions,
+/turf/open/floor/circuit,
+/area/tcommsat/server)
 "dgW" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -4728,7 +4718,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -4818,16 +4808,18 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "dpE" = (
-/obj/structure/chair/office/light{
-	dir = 8
-	},
-/turf/open/floor/carpet/ship/orange_carpet,
-/area/engine/storage)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/closed/wall/r_wall/ship,
+/area/engine/engine_room/external{
+	name = "Stormdrive Interior"
+	})
 "dpG" = (
 /obj/vehicle/ridden/wheelchair{
 	dir = 8
 	},
-/obj/item/radio/intercom/directional/north,
+/obj/machinery/computer/cryopod{
+	pixel_y = 32
+	},
 /turf/open/floor/carpet/ship/blue,
 /area/medical/patients_rooms/room_c)
 "dpM" = (
@@ -4881,14 +4873,16 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "drc" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
+/obj/machinery/door/poddoor/ship{
+	id = "stormdrive_vent"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
+/obj/structure/sign/warning/radiation{
+	pixel_x = -32
 	},
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet/restrooms)
+/turf/open/floor/engine,
+/area/engine/engine_room/external{
+	name = "Stormdrive Interior"
+	})
 "drl" = (
 /obj/effect/spawner/room/threexthree,
 /turf/template_noop,
@@ -4923,21 +4917,18 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
 "drQ" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -11
+/obj/machinery/door/poddoor/ship{
+	id = "stormdrive_vent"
 	},
-/obj/structure/mirror{
-	pixel_x = -27;
-	pixel_y = -2
-	},
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet/restrooms)
+/turf/open/floor/engine,
+/area/engine/engine_room/external{
+	name = "Stormdrive Interior"
+	})
 "dsz" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/carpet/red,
@@ -4954,7 +4945,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/crew_quarters/bar)
 "dti" = (
 /obj/machinery/cryopod{
@@ -5014,9 +5005,8 @@
 /turf/open/floor/wood,
 /area/chapel/main)
 "dwk" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
+/obj/structure/closet/radiation,
+/obj/item/clothing/mask/gas,
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "dwp" = (
@@ -5045,8 +5035,11 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/engine/engine_smes)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/ship/orange_carpet,
+/area/tcommsat/server)
 "dxw" = (
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 5
@@ -5060,12 +5053,12 @@
 	id = "ceshutter"
 	},
 /turf/open/floor/plating,
-/area/engine/engine_smes)
+/area/tcommsat/server)
 "dxC" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -5091,7 +5084,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -5191,7 +5184,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -5226,7 +5219,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "dCB" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
@@ -5300,13 +5293,14 @@
 	dir = 4
 	},
 /obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/crew_quarters/bar)
 "dDB" = (
 /obj/structure/table_frame,
 /obj/structure/bedsheetbin{
 	anchored = 0
 	},
+/obj/effect/spawner/lootdrop/gloves,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "dDL" = (
@@ -5371,7 +5365,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "dFl" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
@@ -5451,6 +5445,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/chair/office/light{
+	dir = 8
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
 "dJw" = (
@@ -5462,10 +5459,10 @@
 /turf/open/floor/carpet/ship/blue,
 /area/medical/medbay/lobby)
 "dJO" = (
-/obj/machinery/ntnet_relay,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
+/obj/machinery/telecomms/receiver/preset_right,
 /turf/open/floor/circuit,
 /area/tcommsat/server)
 "dKn" = (
@@ -5542,22 +5539,21 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
 "dOt" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
+/obj/machinery/door/poddoor/ship{
+	id = "stormdrive_vent"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
+/obj/structure/sign/warning/radiation{
+	pixel_x = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 4
-	},
-/turf/open/floor/carpet/ship/orange_carpet,
-/area/engine/atmos)
+/turf/open/floor/engine,
+/area/engine/engine_room/external{
+	name = "Stormdrive Interior"
+	})
 "dOO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -5662,7 +5658,7 @@
 /area/security/prison)
 "dSB" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -5712,8 +5708,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/item/clothing/gloves/color/black,
 /obj/item/t_scanner,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "dVZ" = (
 /obj/structure/sign/departments/minsky/medical/clone/cloning2,
@@ -5725,20 +5722,26 @@
 	},
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/crew_quarters/bar)
 "dWd" = (
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 8
+/obj/machinery/cryopod{
+	dir = 4
 	},
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet/restrooms)
+/obj/structure/sign/poster/random{
+	pixel_x = -32
+	},
+/obj/machinery/camera/autoname{
+	dir = 5
+	},
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/cryopods)
 "dWk" = (
 /obj/item/chair,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -5850,11 +5853,10 @@
 /area/gateway)
 "dZY" = (
 /obj/structure/cable/white{
-	icon_state = "2-8"
+	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
+/obj/structure/cable/white{
+	icon_state = "1-2"
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
@@ -5938,19 +5940,13 @@
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "ebK" = (
-/obj/structure/cable/white{
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/ship/external/glass{
-	name = "External Access Stormdrive";
-	req_one_access_txt = "13"
-	},
-/turf/open/floor/engine/vacuum,
-/area/engine/engine_room)
+/turf/open/floor/carpet,
+/area/hallway/secondary/entry{
+	name = "Arrivals"
+	})
 "ebP" = (
 /obj/structure/table/reinforced,
 /obj/item/coin/iron,
@@ -6010,13 +6006,13 @@
 	},
 /area/hydroponics)
 "eet" = (
-/obj/structure/table,
-/obj/item/analyzer,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5;
+	icon_state = "pipe11-2"
 	},
-/turf/open/floor/carpet/ship/orange_carpet,
-/area/engine/engine_room)
+/obj/machinery/telecomms/bus/preset_two,
+/turf/open/floor/circuit,
+/area/tcommsat/server)
 "eeK" = (
 /obj/machinery/light{
 	dir = 4
@@ -6086,6 +6082,7 @@
 /obj/item/gun/energy/disabler,
 /obj/item/gun/energy/disabler,
 /obj/item/gun/energy/disabler,
+/obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/carpet/ship/red_carpet,
 /area/ai_monitored/security/armory/security)
 "ehU" = (
@@ -6109,7 +6106,7 @@
 	name = "Tool Storage"
 	},
 /obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "eiK" = (
 /obj/machinery/computer/rdconsole/production{
@@ -6163,20 +6160,6 @@
 	color = "#99FF99"
 	},
 /area/hydroponics)
-"ejf" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/hallway/primary/central{
-	name = "Hallway"
-	})
 "ejp" = (
 /obj/structure/cable/white{
 	icon_state = "0-2"
@@ -6220,6 +6203,7 @@
 	},
 /obj/item/clothing/head/beret/black,
 /obj/item/cartridge/security,
+/obj/effect/spawner/lootdrop/gloves,
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/main{
 	name = "Security War Room"
@@ -6261,7 +6245,7 @@
 "elN" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -6340,6 +6324,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "epp" = (
@@ -6380,13 +6367,16 @@
 	name = "Chapel Departures"
 	},
 /obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/chapel/main)
 "epQ" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "eqI" = (
@@ -6417,7 +6407,7 @@
 /obj/structure/closet/radiation,
 /obj/item/clothing/mask/gas,
 /obj/machinery/light,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "ern" = (
 /obj/structure/cable{
@@ -6442,9 +6432,12 @@
 /area/medical/medbay/lobby)
 "eto" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/atmospherics/components/binary/pump/layer1{
+	on = 1;
+	target_pressure = 2000
+	},
 /obj/machinery/door/airlock/ship/external/glass{
 	name = "External Access Deck 2 Starboard";
 	req_one_access_txt = "13"
@@ -6592,13 +6585,9 @@
 	name = "Tool Storage"
 	},
 /obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "eyq" = (
-/obj/structure/particle_accelerator/power_box{
-	dir = 1;
-	icon_state = "power_box"
-	},
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
@@ -6694,7 +6683,7 @@
 	pixel_x = -12;
 	pixel_y = 2
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -6822,7 +6811,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -6832,7 +6821,7 @@
 	},
 /obj/machinery/newscaster/security_unit/north,
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -6867,22 +6856,22 @@
 /turf/open/floor/engine,
 /area/engine/atmos)
 "eKJ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/particle_accelerator/particle_emitter/right{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4;
+	icon_state = "pipe11-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "eKW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 9
 	},
@@ -6891,9 +6880,6 @@
 /obj/machinery/door/airlock/ship/engineering{
 	name = "Supermatter Engine";
 	req_one_access_txt = "24"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
@@ -6911,7 +6897,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "eLK" = (
 /obj/structure/cable{
@@ -6967,11 +6953,16 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/crew_quarters/heads/chief)
 "eNK" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor/window,
-/obj/structure/window/plasma/fulltile,
-/turf/open/floor/plating,
-/area/engine/engine_room)
+/obj/machinery/air_sensor/atmos{
+	id_tag = "stormdrive_chamber_sensor"
+	},
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine/vacuum,
+/area/engine/engine_room/external{
+	name = "Stormdrive Interior"
+	})
 "eNL" = (
 /obj/structure/closet/l3closet,
 /obj/item/clothing/mask/surgical,
@@ -6983,7 +6974,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -7170,7 +7161,7 @@
 /area/medical/medbay/lobby)
 "eUy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -7186,21 +7177,18 @@
 	name = "Supermatter Core"
 	})
 "eUI" = (
-/obj/structure/sign/warning/radiation,
-/turf/closed/wall/r_wall/ship,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/airlock/ship/external/glass{
+	name = "External Access Stormdrive";
+	req_one_access_txt = "13"
+	},
+/turf/open/floor/engine/vacuum,
 /area/engine/engine_room)
 "eUQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
-	},
-/obj/item/radio/intercom/directional/north,
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "eUT" = (
@@ -7233,6 +7221,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "eWn" = (
@@ -7265,14 +7256,15 @@
 /turf/closed/wall/r_wall/ship,
 /area/security/warden)
 "eXF" = (
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/ship/public{
-	name = "Bathroom Cell"
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet/restrooms)
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/cryopods)
 "eXH" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -7302,7 +7294,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "eYA" = (
 /obj/machinery/firealarm/directional/west,
@@ -7334,7 +7326,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 10
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -7385,10 +7377,10 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "fbI" = (
-/obj/machinery/door/firedoor/window,
-/obj/structure/grille,
-/obj/structure/window/plasma/fulltile,
-/turf/open/floor/plating,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine,
 /area/engine/engine_room)
 "fbW" = (
 /obj/structure/guncase/shotgun{
@@ -7486,7 +7478,7 @@
 "feG" = (
 /obj/structure/closet/radiation,
 /obj/item/clothing/mask/gas,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -7529,7 +7521,7 @@
 /area/maintenance/central/secondary)
 "fgM" = (
 /obj/structure/extinguisher_cabinet/west,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "fgO" = (
 /obj/structure/table,
@@ -7576,10 +7568,11 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/break_room)
 "fhM" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
+/obj/structure/chair/comfy/shuttle{
+	dir = 8;
+	name = "safety seat"
 	},
+/obj/machinery/advanced_airlock_controller/directional/north,
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "fhR" = (
@@ -7748,7 +7741,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -7800,15 +7793,6 @@
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_room)
-"fqo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet/restrooms)
 "fqZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
@@ -7863,7 +7847,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -7892,12 +7876,12 @@
 /turf/open/floor/plating,
 /area/security/warden)
 "ftt" = (
-/obj/structure/particle_accelerator/fuel_chamber{
-	dir = 1;
-	icon_state = "fuel_chamber"
-	},
 /obj/structure/cable/white{
 	icon_state = "1-2"
+	},
+/obj/structure/particle_accelerator/particle_emitter/center{
+	dir = 1;
+	icon_state = "emitter_center"
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_room)
@@ -7951,6 +7935,7 @@
 	},
 /obj/item/stack/packageWrap,
 /obj/item/twohanded/binoculars,
+/obj/item/clothing/gloves/color/black,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
 "fuA" = (
@@ -8071,7 +8056,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/extinguisher_cabinet/east,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -8113,6 +8098,7 @@
 	pixel_x = -26;
 	pixel_y = 25
 	},
+/obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/engine,
 /area/science/misc_lab{
 	name = "Shield Generator"
@@ -8166,11 +8152,15 @@
 	},
 /area/engine/atmos)
 "fDx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/machinery/atmospherics/components/binary/pump/layer1{
+	dir = 1;
+	on = 1;
+	target_pressure = 2000
+	},
 /obj/machinery/door/airlock/ship/external/glass{
 	name = "External Access Deck 2 Starboard";
 	req_one_access_txt = "13"
@@ -8192,16 +8182,19 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "fFd" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
+/obj/machinery/meter/atmos/distro_loop{
+	pixel_x = -6;
+	pixel_y = -6;
+	target_layer = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
@@ -8263,7 +8256,7 @@
 /obj/item/clothing/head/helmet/space/plasmaman,
 /obj/item/tank/internals/plasmaman/belt,
 /obj/item/tank/internals/plasmaman/belt,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -8277,7 +8270,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/crew_quarters/bar)
 "fIa" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos{
@@ -8351,7 +8344,15 @@
 "fJU" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
+	dir = 4
+	},
+/obj/machinery/meter/atmos/distro_loop{
+	pixel_x = -6;
+	pixel_y = -6;
+	target_layer = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/closed/wall/r_wall/ship,
 /area/engine/atmos)
@@ -8374,11 +8375,11 @@
 /turf/open/floor/carpet/royalblack,
 /area/chapel/main)
 "fKo" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+/obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
-/turf/open/floor/engine,
-/area/engine/engine_room)
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/department/engine)
 "fLB" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
@@ -8417,7 +8418,7 @@
 /obj/machinery/camera/autoname{
 	dir = 5
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -8605,22 +8606,14 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/security/brig)
-"fUj" = (
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/hallway/primary/central{
-	name = "Hallway"
-	})
 "fUq" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/power/apc/auto_name/west,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/disposalpipe/trunk{
+/obj/structure/chair{
 	dir = 4
 	},
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet/restrooms)
+/turf/open/floor/carpet,
+/area/hallway/secondary/entry{
+	name = "Arrivals"
+	})
 "fUz" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -8630,6 +8623,12 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"fUM" = (
+/obj/structure/table/wood,
+/obj/item/clothing/gloves/color/black,
+/obj/effect/spawner/lootdrop/gloves,
+/turf/open/floor/wood,
+/area/chapel/main)
 "fVK" = (
 /obj/structure/closet/crate/medical,
 /obj/item/storage/firstaid/advanced{
@@ -8720,7 +8719,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "fYJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -8738,7 +8737,7 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -8831,7 +8830,7 @@
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 1
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -9001,7 +9000,7 @@
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -9111,9 +9110,7 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
-	},
+/obj/machinery/light_switch/west,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "grf" = (
@@ -9154,7 +9151,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/crew_quarters/bar)
 "gsj" = (
 /obj/structure/table/wood,
@@ -9203,8 +9200,9 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "gub" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
+/obj/structure/cable/yellow,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_room)
@@ -9214,7 +9212,7 @@
 "guT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -9229,8 +9227,11 @@
 /turf/open/floor/plating,
 /area/medical/surgery)
 "gwM" = (
-/obj/machinery/telecomms/hub/preset,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/telecomms/server/presets/service,
 /turf/open/floor/circuit,
 /area/tcommsat/server)
 "gwP" = (
@@ -9259,11 +9260,12 @@
 "gxq" = (
 /obj/structure/closet/secure_closet/engineering_welding,
 /obj/machinery/firealarm/directional/west,
+/obj/item/clothing/gloves/color/black,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
 "gxI" = (
-/obj/machinery/announcement_system,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/telecomms/hub/preset,
 /turf/open/floor/circuit,
 /area/tcommsat/server)
 "gyD" = (
@@ -9292,7 +9294,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/crew_quarters/bar)
 "gzR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -9357,13 +9359,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/crew_quarters/heads/chief)
-"gDb" = (
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet/restrooms)
 "gDe" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9396,7 +9391,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -9544,11 +9539,12 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/gravity_generator)
 "gLP" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/telecomms/processor/preset_one,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
 	},
-/turf/open/floor/plating,
-/area/engine/engine_smes)
+/turf/open/floor/circuit,
+/area/tcommsat/server)
 "gMj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/toxin_output,
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1,
@@ -9750,13 +9746,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/airlock/ship/maintenance{
-	name = "Maintenance Access Stormdrive";
-	req_one_access_txt = "10"
-	},
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall/ship,
 /area/engine/engine_room)
 "gTa" = (
 /obj/structure/table,
@@ -9800,17 +9790,13 @@
 /turf/open/floor/carpet/red,
 /area/ai_monitored/security/armory/lockup)
 "gTz" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/computer/atmos_control{
-	dir = 4;
-	name = "Stormdrive Core Sensor";
-	sensors = list("stormdrive_chamber_sensor" = "Stormdrive Chamber")
-	},
-/turf/open/floor/engine,
-/area/engine/engine_room)
+/turf/open/floor/engine/vacuum,
+/area/engine/engine_room/external{
+	name = "Stormdrive Interior"
+	})
 "gTJ" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/carpet/ship/beige_carpet{
@@ -9823,6 +9809,16 @@
 	dir = 8
 	},
 /obj/machinery/light_switch/east,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/window/southright,
 /turf/open/floor/plating,
 /area/engine/break_room)
 "gTW" = (
@@ -9857,7 +9853,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/assistant,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "gUH" = (
 /obj/structure/sink/kitchen{
@@ -9877,7 +9873,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -9962,7 +9958,7 @@
 	name = "Maintenance Access Bar";
 	req_one_access_txt = "12;25;28;35"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/plating,
 /area/maintenance/department/engine)
 "gZo" = (
 /obj/structure/cable{
@@ -9971,8 +9967,10 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/tcommsat/server)
 "gZv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/closed/wall/r_wall/ship,
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/turf/open/floor/engine/vacuum,
 /area/engine/engine_room/external{
 	name = "Stormdrive Interior"
 	})
@@ -10015,20 +10013,19 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "hae" = (
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/ship/external/glass{
-	name = "External Access Stormdrive";
-	req_one_access_txt = "13"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
 	},
-/turf/open/floor/engine/vacuum,
+/turf/open/floor/engine,
 /area/engine/engine_room)
 "har" = (
 /obj/machinery/air_sensor/atmos/toxin_tank,
@@ -10045,15 +10042,8 @@
 /turf/open/floor/carpet/blue,
 /area/medical/medbay/lobby)
 "hba" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet/restrooms)
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/cryopods)
 "hbl" = (
 /obj/structure/closet/secure_closet/security/sec,
 /turf/open/floor/carpet/ship/red_carpet,
@@ -10083,7 +10073,6 @@
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/checkpoint/escape)
 "hbR" = (
-/obj/machinery/telecomms/broadcaster/preset_left/birdstation,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/circuit,
 /area/tcommsat/server)
@@ -10181,17 +10170,13 @@
 "hgi" = (
 /obj/structure/closet/firecloset/full,
 /obj/machinery/computer/lore_terminal,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "hgE" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 8;
-	name = "scrubbers pipe"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
 	},
-/obj/machinery/door/firedoor/window,
-/obj/structure/grille,
-/obj/structure/window/plasma/fulltile,
-/turf/open/floor/plating,
+/turf/open/floor/engine/vacuum,
 /area/engine/engine_room/external{
 	name = "Stormdrive Interior"
 	})
@@ -10224,11 +10209,12 @@
 	pixel_x = -4;
 	pixel_y = 2
 	},
+/obj/item/clothing/gloves/color/black,
 /obj/item/cartridge/engineering,
 /turf/open/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
 "hid" = (
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "hiR" = (
 /obj/machinery/cryopod,
@@ -10424,7 +10410,9 @@
 /turf/open/floor/wood,
 /area/chapel/main)
 "hsH" = (
-/obj/machinery/newscaster/directional/north,
+/obj/structure/reagent_dispensers/water_cooler{
+	anchored = 0
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
 "hts" = (
@@ -10572,7 +10560,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/assistant,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -10642,6 +10630,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
@@ -10720,7 +10711,7 @@
 "hEi" = (
 /obj/structure/closet/emcloset,
 /obj/item/storage/toolbox/mechanical,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -10728,28 +10719,25 @@
 /obj/structure/closet/emcloset,
 /obj/item/storage/toolbox/emergency,
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "hFT" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/electrical{
-	pixel_x = 6;
-	pixel_y = 8
-	},
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/toolbox/mechanical,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/item/gps/engineering,
-/turf/open/floor/carpet/ship/orange_carpet,
-/area/engine/engine_room)
+/obj/structure/reagent_dispensers/water_cooler{
+	anchored = 0
+	},
+/turf/open/floor/engine/vacuum,
+/area/engine/engine_room/external{
+	name = "Stormdrive Interior"
+	})
 "hGa" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
+	},
+/obj/machinery/computer/cryopod{
+	pixel_y = 32
 	},
 /turf/open/floor/carpet/ship/blue,
 /area/medical/patients_rooms/room_a)
@@ -10825,7 +10813,11 @@
 /obj/machinery/computer/warrant{
 	dir = 8
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/obj/machinery/computer/ship/viewscreen{
+	pixel_x = 32;
+	pixel_y = -6
+	},
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -10857,7 +10849,8 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/obj/machinery/holopad/tutorial,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -10884,7 +10877,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -10948,8 +10941,8 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
 "hJP" = (
-/obj/item/extinguisher/advanced/hull_repair_juice,
-/obj/structure/reagent_dispensers/foamtank/hull_repair_juice,
+/obj/structure/chair/office/light,
+/obj/effect/landmark/start/station_engineer,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
 "hLi" = (
@@ -10959,7 +10952,7 @@
 	name = "Judicial Office";
 	req_one_access_txt = "38"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/security/execution/education)
 "hLp" = (
 /obj/machinery/disposal/bin,
@@ -11057,11 +11050,15 @@
 /turf/open/floor/carpet/ship/red_carpet,
 /area/crew_quarters/heads/hos)
 "hPI" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
+	dir = 8
 	},
-/turf/open/floor/carpet/ship/orange_carpet,
+/obj/machinery/button/door{
+	id = "stormdrive_vent";
+	pixel_x = -26;
+	pixel_y = -6
+	},
+/turf/open/floor/engine,
 /area/engine/engine_room)
 "hPU" = (
 /obj/structure/cable{
@@ -11101,7 +11098,10 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/east,
-/turf/open/floor/carpet/ship/beige_carpet,
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -11156,7 +11156,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/item/beacon,
 /obj/item/paper/pamphlet/ruin/spacehotel,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -11285,14 +11285,13 @@
 /turf/open/floor/carpet/ship,
 /area/medical/morgue)
 "iaF" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
 	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/turf/open/floor/carpet/ship/orange_carpet,
-/area/engine/engine_room)
+/turf/closed/wall/r_wall/ship,
+/area/engine/engine_room/external{
+	name = "Stormdrive Interior"
+	})
 "iaN" = (
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/carpet/ship/orange_carpet,
@@ -11366,7 +11365,7 @@
 	dir = 1
 	},
 /obj/machinery/vending/snack/random,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "idx" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -11399,7 +11398,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "ieg" = (
 /obj/machinery/computer/ship/navigation/public{
@@ -11530,10 +11529,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/structure/sign/solgov_seal{
-	pixel_y = -27
-	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -11628,11 +11624,19 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "imf" = (
-/obj/structure/closet/emcloset,
-/obj/item/storage/toolbox/emergency,
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/item/book/manual/wiki/engineering_guide,
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "imh" = (
@@ -11654,7 +11658,7 @@
 /area/crew_quarters/heads/cmo)
 "imE" = (
 /obj/item/beacon,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "imL" = (
 /obj/structure/closet/secure_closet/evidence,
@@ -11672,7 +11676,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -11696,22 +11700,13 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/crew_quarters/bar)
 "inY" = (
-/obj/structure/cable/white{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 10
-	},
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/turf/open/floor/engine/vacuum,
-/area/engine/engine_room/external{
-	name = "Stormdrive Interior"
-	})
+/obj/machinery/atmospherics/components/binary/valve/digital,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/engine,
+/area/engine/engine_room)
 "iok" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -11839,7 +11834,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/crew_quarters/bar)
 "isN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
@@ -11888,6 +11883,17 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
+"ivb" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/carpet/ship,
+/area/hallway/primary/central{
+	name = "Hallway"
+	})
 "ivA" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -11898,7 +11904,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -11930,11 +11936,14 @@
 /turf/closed/wall/r_wall/ship,
 /area/engine/engine_room)
 "ixl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/airlock/ship/maintenance{
+	name = "Maintenance Access Stormdrive";
+	req_one_access_txt = "10"
 	},
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet/restrooms)
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "ixL" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -12086,6 +12095,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/item/holosign_creator/engineering,
 /obj/item/holosign_creator/atmos,
+/obj/item/clothing/gloves/color/black,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
 "iBm" = (
@@ -12095,6 +12105,9 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmospherics_engine)
@@ -12209,11 +12222,9 @@
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/kitchen)
 "iGh" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on,
-/turf/open/floor/plating/airless,
-/area/engine/engine_room/external{
-	name = "Stormdrive Interior"
-	})
+/obj/machinery/status_display/evac/east,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "iGp" = (
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
@@ -12230,7 +12241,7 @@
 	name = "Central Primary Hallway"
 	},
 /obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -12282,12 +12293,9 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "iHd" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/sign/poster/random{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet/restrooms)
+/obj/machinery/cryopod,
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/cryopods)
 "iHq" = (
 /obj/structure/table,
 /obj/item/circular_saw,
@@ -12343,7 +12351,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -12455,9 +12463,8 @@
 /turf/open/floor/carpet/ship/blue,
 /area/medical/medbay/lobby)
 "iRm" = (
-/obj/structure/table,
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 5
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_room)
@@ -12478,7 +12485,7 @@
 /area/maintenance/department/medical)
 "iTi" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -12542,14 +12549,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/airlock/ship/engineering/glass{
+	name = "Stormdrive Engine";
+	req_one_access_txt = "10"
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
+/turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_room)
 "iVi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -12631,30 +12637,6 @@
 	},
 /turf/open/floor/engine/air,
 /area/engine/atmos)
-"jay" = (
-/obj/structure/table,
-/obj/item/lightreplacer{
-	pixel_y = 7
-	},
-/obj/item/storage/belt/utility,
-/obj/item/flashlight{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/carpet/ship/orange_carpet,
-/area/engine/storage)
 "jaB" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/hydroponics_pod_people,
@@ -12704,12 +12686,6 @@
 /turf/open/floor/wood,
 /area/chapel/main)
 "jbE" = (
-/obj/structure/chair/office/light{
-	dir = 8
-	},
-/obj/structure/chair/office/light{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -12811,7 +12787,7 @@
 /obj/item/clothing/mask/gas,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/machinery/airalarm/directional/north,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "jcY" = (
 /obj/machinery/computer/slot_machine,
@@ -12821,7 +12797,7 @@
 	pixel_y = -3;
 	value = 660
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "jda" = (
 /obj/machinery/conveyor{
@@ -12866,7 +12842,7 @@
 /turf/open/floor/carpet/royalblack,
 /area/chapel/main)
 "jex" = (
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -12967,7 +12943,7 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -12987,7 +12963,7 @@
 	})
 "jhD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -13023,7 +12999,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/crew_quarters/bar)
 "jiG" = (
 /obj/structure/chair{
@@ -13066,6 +13042,7 @@
 	},
 /obj/item/clothing/head/beret/black,
 /obj/item/cartridge/security,
+/obj/effect/spawner/lootdrop/gloves,
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/main{
 	name = "Security War Room"
@@ -13113,7 +13090,7 @@
 	pixel_x = 4
 	},
 /obj/item/reagent_containers/food/drinks/coffee,
-/obj/structure/disposalpipe/junction/flip{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
@@ -13249,13 +13226,14 @@
 	name = "Hallway"
 	})
 "jrd" = (
-/turf/closed/wall/ship,
-/area/engine/engine_room)
+/obj/structure/sign/warning/radiation,
+/turf/closed/wall/r_wall/ship,
+/area/engine/engine_room/external{
+	name = "Stormdrive Interior"
+	})
 "jre" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/open/floor/carpet/ship/orange_carpet,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/engine,
 /area/engine/engine_room)
 "jrr" = (
 /obj/structure/table,
@@ -13317,7 +13295,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -13334,21 +13312,6 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmospherics_engine)
-"jvc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/particle_accelerator/particle_emitter/left{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engine_room)
 "jvx" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -13393,11 +13356,11 @@
 /area/engine/atmospherics_engine)
 "jwx" = (
 /obj/structure/table,
-/obj/machinery/computer/libraryconsole/bookmanagement,
 /obj/machinery/computer/lore_terminal,
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 6
 	},
+/obj/machinery/computer/libraryconsole,
 /turf/open/floor/carpet/ship,
 /area/security/prison)
 "jxg" = (
@@ -13682,11 +13645,11 @@
 /turf/open/floor/engine/plasma,
 /area/engine/atmos)
 "jIh" = (
-/obj/machinery/telecomms/bus/preset_one/birdstation,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5;
 	icon_state = "pipe11-2"
 	},
+/obj/machinery/ntnet_relay,
 /turf/open/floor/circuit,
 /area/tcommsat/server)
 "jJd" = (
@@ -13737,16 +13700,16 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -13767,7 +13730,7 @@
 /obj/structure/piano{
 	icon_state = "piano"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "jLK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -13775,7 +13738,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -13915,9 +13878,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "jPD" = (
-/obj/machinery/telecomms/relay/preset/telecomms{
-	name = "Deck 2 telecommunications relay"
-	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
@@ -14020,6 +13980,9 @@
 /area/medical/genetics/cloning)
 "jSP" = (
 /obj/machinery/holopad,
+/obj/machinery/computer/cryopod{
+	pixel_y = 32
+	},
 /turf/open/floor/carpet/ship/blue,
 /area/medical/patients_rooms/room_b)
 "jSQ" = (
@@ -14159,27 +14122,28 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "jXZ" = (
 /obj/machinery/atmospherics/components/trinary/mixer/airmix/inverse{
 	dir = 1
 	},
-/obj/machinery/light_switch/west,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "jYT" = (
-/obj/structure/closet/l3closet,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/gloves/color/latex,
-/obj/machinery/camera/autoname{
-	dir = 8
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/status_display/evac/east,
+/obj/structure/closet/firecloset/full,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/glasses/welding,
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "jYY" = (
@@ -14195,19 +14159,10 @@
 /turf/open/floor/carpet/ship/blue,
 /area/medical/surgery)
 "jZw" = (
-/obj/item/control_rod,
-/obj/item/control_rod,
-/obj/item/control_rod,
-/obj/item/control_rod,
-/obj/item/control_rod,
-/obj/item/control_rod,
-/obj/structure/closet/crate/engineering{
-	name = "control rod crate"
-	},
-/obj/item/control_rod,
-/obj/item/control_rod,
-/obj/item/control_rod,
-/obj/item/control_rod,
+/obj/structure/table,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/obj/item/analyzer,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_room)
 "jZK" = (
@@ -14262,14 +14217,6 @@
 	},
 /turf/open/floor/wood,
 /area/chapel/main)
-"kbE" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/hallway/primary/central{
-	name = "Hallway"
-	})
 "kcB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -14302,8 +14249,11 @@
 /turf/open/floor/carpet/red,
 /area/security/warden)
 "kew" = (
-/obj/structure/sign/warning/enginesafety,
-/turf/closed/wall/r_wall/ship,
+/obj/structure/closet/l3closet,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/engine,
 /area/engine/engine_room)
 "kfG" = (
 /obj/structure/cable/yellow{
@@ -14380,10 +14330,13 @@
 	name = "Atmospherics Canister Storage"
 	})
 "kgy" = (
-/turf/closed/wall/r_wall/ship,
-/area/security/main{
-	name = "Security War Room"
-	})
+/obj/structure/rack,
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/engine,
+/area/engine/engine_room)
 "kgM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -14474,7 +14427,7 @@
 /obj/structure/sign/poster/random{
 	pixel_y = 32
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "kkK" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -14520,9 +14473,7 @@
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
+/obj/machinery/computer/lore_terminal,
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "knu" = (
@@ -14551,7 +14502,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -14707,12 +14658,17 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "kty" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/machinery/camera/autoname{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "kub" = (
@@ -14892,7 +14848,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/crew_quarters/bar)
 "kzb" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
@@ -14912,7 +14868,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -15022,6 +14978,14 @@
 	},
 /turf/open/floor/carpet/ship/blue,
 /area/medical/patients_rooms/room_c)
+"kEj" = (
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/airlock/ship/maintenance{
+	name = "Maintenance Access Cryostasis Storage"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine/atmos)
 "kEp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -15044,10 +15008,14 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/atmospherics/components/binary/pump/layer1{
+	dir = 1;
+	on = 1;
+	target_pressure = 2000
+	},
 /obj/machinery/door/airlock/ship/external/glass{
 	name = "Arrival Shuttle Dock"
 	},
@@ -15106,7 +15074,7 @@
 "kGj" = (
 /obj/structure/closet/radiation,
 /obj/item/clothing/mask/gas,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "kGu" = (
 /obj/machinery/computer/ship/navigation/public{
@@ -15198,7 +15166,7 @@
 /obj/item/storage/toolbox/emergency{
 	pixel_x = -2
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "kIR" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
@@ -15252,10 +15220,8 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname,
-/obj/structure/reagent_dispensers/water_cooler{
-	anchored = 0
-	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/carpet/ship,
 /area/crew_quarters/bar)
 "kMH" = (
 /obj/structure/cable{
@@ -15345,14 +15311,13 @@
 /turf/open/floor/carpet/ship,
 /area/shuttle/turbolift/quinary)
 "kQj" = (
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/tcommsat/server)
 "kQp" = (
@@ -15440,10 +15405,14 @@
 "kSR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/junction,
 /obj/machinery/camera/autoname{
 	dir = 8
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/disposal/bin,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_room)
 "kSY" = (
@@ -15452,7 +15421,7 @@
 	},
 /obj/machinery/firealarm/directional/west,
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -15481,7 +15450,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -15550,7 +15519,7 @@
 /area/engine/atmospherics_engine)
 "kVt" = (
 /obj/effect/turf_decal/arrows,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -15632,7 +15601,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "kYR" = (
 /obj/structure/cable/yellow{
@@ -15711,6 +15680,10 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4;
+	icon_state = "pipe11-2"
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
@@ -15829,7 +15802,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -15862,12 +15835,11 @@
 /turf/open/floor/plating,
 /area/security/prison)
 "lfG" = (
-/obj/machinery/holopad,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -15890,10 +15862,6 @@
 	},
 /area/crew_quarters/kitchen/coldroom)
 "lfW" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
 /obj/machinery/button/door{
 	id = "ceshutter";
 	pixel_x = 6;
@@ -15995,11 +15963,11 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
@@ -16076,7 +16044,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -16122,6 +16090,7 @@
 /obj/structure/table,
 /obj/item/clothing/ears/earmuffs,
 /obj/item/clothing/glasses/meson/engine/tray,
+/obj/item/clothing/gloves/color/black,
 /obj/item/gps/engineering,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
@@ -16167,10 +16136,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "lsF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/atmospherics/components/binary/pump/layer1{
+	dir = 1;
+	on = 1;
+	target_pressure = 2000
+	},
 /obj/machinery/door/airlock/ship/external/glass{
 	name = "External Access Deck 2 Port";
 	req_one_access_txt = "13"
@@ -16193,7 +16166,7 @@
 	},
 /obj/item/coin/iron,
 /obj/machinery/status_display/ai/west,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "lta" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -16333,7 +16306,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -16421,8 +16394,9 @@
 "lAF" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/maintenance/three,
+/obj/item/clothing/gloves/color/black,
 /obj/effect/spawner/lootdrop/gloves,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "lAG" = (
 /turf/open/floor/carpet/blue,
@@ -16444,13 +16418,16 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "lBq" = (
-/obj/machinery/airalarm/directional/north,
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/machinery/computer/cryopod{
+	pixel_y = 32
+	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/carpet/ship,
 /area/security/prison)
 "lBt" = (
@@ -16543,7 +16520,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -16576,7 +16553,7 @@
 "lGF" = (
 /obj/structure/closet/radiation,
 /obj/item/clothing/mask/gas,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "lGG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -16596,7 +16573,7 @@
 	})
 "lHi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -16723,7 +16700,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -16802,16 +16779,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "lNi" = (
@@ -16821,7 +16790,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/item/twohanded/required/kirbyplants/random,
+/obj/structure/chair/office/light,
+/obj/effect/landmark/start/station_engineer,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
 "lNr" = (
@@ -16959,15 +16929,12 @@
 /obj/structure/sign/poster/random{
 	pixel_x = -32
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "lTG" = (
 /obj/structure/sign/warning/electricshock,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /turf/closed/wall/r_wall/ship,
-/area/engine/engine_smes)
+/area/tcommsat/server)
 "lTU" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -16979,7 +16946,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -17011,6 +16978,9 @@
 	})
 "lUK" = (
 /obj/effect/landmark/event_spawn,
+/obj/structure/particle_accelerator/particle_emitter/right{
+	dir = 1
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_room)
 "lVn" = (
@@ -17019,7 +16989,7 @@
 	},
 /obj/structure/extinguisher_cabinet/east,
 /obj/machinery/vending/cola/random,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -17049,10 +17019,13 @@
 /area/medical/medbay/lobby)
 "lWp" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/atmospherics/components/binary/pump/layer1{
+	on = 1;
+	target_pressure = 2000
+	},
 /obj/machinery/door/airlock/ship/external/glass{
 	name = "Escape Shuttle Dock"
 	},
@@ -17212,11 +17185,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/obj/item/geiger_counter{
+	scanning = 1
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
@@ -17253,7 +17229,7 @@
 "mfH" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/landmark/start/assistant,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/crew_quarters/bar)
 "mfI" = (
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
@@ -17323,7 +17299,7 @@
 	name = "Central Primary Hallway"
 	},
 /obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -17349,13 +17325,12 @@
 	name = "Cafeteria"
 	})
 "miK" = (
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/airlock/ship/public{
-	name = "Shower"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
 	},
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet/restrooms)
+/obj/effect/landmark/start/station_engineer,
+/turf/open/floor/engine,
+/area/engine/engine_room)
 "miQ" = (
 /obj/structure/closet/emcloset,
 /obj/item/storage/toolbox/emergency,
@@ -17376,7 +17351,7 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet/east,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/crew_quarters/bar)
 "mkI" = (
 /obj/machinery/stasis,
@@ -17465,18 +17440,18 @@
 /turf/open/floor/carpet/blue,
 /area/security/brig)
 "mmZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
 /obj/machinery/power/terminal,
 /obj/structure/cable/white{
 	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmospherics_engine)
@@ -17528,25 +17503,22 @@
 /turf/open/floor/carpet/ship/blue,
 /area/medical/apothecary)
 "mnS" = (
-/obj/machinery/recharge_station,
-/obj/item/coin/iron,
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 10
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/landmark/start/cyborg,
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet/restrooms)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/cryopods)
 "mou" = (
-/obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4;
 	icon_state = "pipe11-2"
 	},
-/obj/machinery/door/firedoor/window,
-/obj/structure/window/plasma/fulltile,
-/turf/open/floor/plating,
+/turf/open/floor/engine/vacuum,
 /area/engine/engine_room/external{
 	name = "Stormdrive Interior"
 	})
@@ -17649,11 +17621,21 @@
 /turf/open/floor/carpet/ship,
 /area/chapel/office)
 "msz" = (
-/obj/machinery/camera/autoname{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/engine/engine_smes)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 9
+	},
+/obj/machinery/meter,
+/turf/open/floor/engine,
+/area/engine/engine_room)
 "msK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -17727,9 +17709,6 @@
 	dir = 9;
 	icon_state = "pipe11-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "mvu" = (
@@ -17738,6 +17717,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
@@ -17785,14 +17767,12 @@
 /turf/open/floor/plating,
 /area/hydroponics)
 "mwC" = (
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/airlock/ship/maintenance{
-	name = "Maintenance Access Bathroom";
-	req_one_access_txt = "12"
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/turf/open/floor/engine,
+/area/engine/engine_room)
 "mxd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -17949,7 +17929,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/closed/wall/r_wall/ship,
+/obj/machinery/telecomms/server/presets/medical,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/turf/open/floor/circuit,
 /area/tcommsat/server)
 "mCQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/carbon_output,
@@ -17984,7 +17968,7 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/maintenance/central/secondary)
 "mDF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -17997,11 +17981,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "mDU" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/machinery/atmospherics/components/unary/portables_connector/layer3{
-	dir = 1
-	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -18055,31 +18035,25 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "mFV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/binary/passive_gate{
-	dir = 8;
 	name = "Stormdrive Output to Waste"
 	},
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/engine,
-/area/engine/engine_room)
+/turf/closed/wall/r_wall/ship,
+/area/engine/engine_room/external{
+	name = "Stormdrive Interior"
+	})
 "mGa" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment{
-	dir = 10
+	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -18128,14 +18102,12 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "mIt" = (
-/obj/machinery/computer/lore_terminal,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/obj/machinery/button/door{
-	id = "stormdrive_vent";
-	pixel_x = -26;
-	pixel_y = -6
+/obj/machinery/computer/atmos_control{
+	dir = 8;
+	name = "Stormdrive Core Sensor";
+	sensors = list("stormdrive_chamber_sensor" = "Stormdrive Chamber")
 	},
-/turf/open/floor/engine,
+/turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_room)
 "mIz" = (
 /obj/machinery/lazylift_button,
@@ -18412,7 +18384,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/crew_quarters/bar)
 "mSy" = (
 /obj/structure/table/wood,
@@ -18420,15 +18392,12 @@
 /turf/open/floor/wood,
 /area/chapel/main)
 "mSC" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/chair/office/light{
 	dir = 4
 	},
-/obj/machinery/camera/autoname{
-	dir = 6
-	},
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet/restrooms)
+/obj/effect/landmark/start/station_engineer,
+/turf/open/floor/carpet/ship/orange_carpet,
+/area/engine/engine_room)
 "mSN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -18496,12 +18465,9 @@
 /turf/open/floor/carpet/ship/blue,
 /area/medical/medbay/central)
 "mUq" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/structure/curtain,
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet/restrooms)
+/obj/effect/spawner/room/fivexfour,
+/turf/template_noop,
+/area/maintenance/department/engine/atmos)
 "mUs" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -18518,8 +18484,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "mUN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/landmark/start/station_engineer,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_room)
 "mVk" = (
@@ -18604,7 +18573,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/crew_quarters/bar)
 "mXO" = (
 /turf/template_noop,
@@ -18670,6 +18639,7 @@
 /obj/item/storage/box/drinkingglasses{
 	pixel_x = -4
 	},
+/obj/item/clothing/head/hardhat/cakehat,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/kitchen)
 "nab" = (
@@ -18771,6 +18741,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
+/obj/structure/table,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
 "neN" = (
@@ -18780,6 +18751,10 @@
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
+"nfe" = (
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/plating,
+/area/maintenance/department/engine/atmos)
 "nfv" = (
 /obj/machinery/suit_storage_unit/cmo,
 /turf/open/floor/carpet/ship/blue,
@@ -18858,12 +18833,6 @@
 /obj/item/computer_hardware/card_slot,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/crew_quarters/heads/chief)
-"nhz" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/turf/open/floor/carpet/ship/orange_carpet,
-/area/tcommsat/server)
 "nhI" = (
 /turf/closed/wall/r_wall/ship,
 /area/crew_quarters/heads/chief)
@@ -19014,7 +18983,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "nnK" = (
 /obj/effect/spawner/room/threexfive,
@@ -19044,10 +19013,6 @@
 /area/security/main{
 	name = "Security War Room"
 	})
-"noC" = (
-/obj/machinery/advanced_airlock_controller/directional/east,
-/turf/open/floor/engine,
-/area/engine/engine_room)
 "noN" = (
 /obj/structure/hull_plate/end,
 /turf/open/floor/plating/airless,
@@ -19064,7 +19029,6 @@
 /area/security/prison)
 "npk" = (
 /obj/structure/table/glass,
-/obj/item/restraints/handcuffs,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -19093,14 +19057,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "nrv" = (
-/obj/structure/table,
-/obj/item/storage/box/donkpockets,
-/obj/item/tank/internals/emergency_oxygen{
-	pixel_x = -8
-	},
-/obj/item/clothing/mask/breath{
-	pixel_x = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -19115,9 +19071,6 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
@@ -19157,7 +19110,7 @@
 "nsN" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/firealarm/directional/north,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "nsQ" = (
 /obj/machinery/vending/tool,
@@ -19185,8 +19138,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
-/obj/machinery/camera/autoname{
-	dir = 8
+/obj/machinery/telecomms/processor/preset_two,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/circuit,
@@ -19346,12 +19300,16 @@
 	},
 /area/crew_quarters/kitchen/coldroom)
 "nxn" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4;
-	name = "safety seat"
+/obj/machinery/door/firedoor/window,
+/obj/structure/grille,
+/obj/structure/cable/white{
+	icon_state = "1-2"
 	},
-/turf/open/floor/engine,
-/area/engine/engine_room)
+/obj/structure/window/plasma/fulltile,
+/turf/open/floor/plating,
+/area/engine/engine_room/external{
+	name = "Stormdrive Interior"
+	})
 "nxM" = (
 /obj/machinery/cryopod,
 /turf/open/floor/carpet/ship/blue,
@@ -19377,7 +19335,7 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "3;12"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/maintenance/department/security)
 "nzf" = (
 /obj/machinery/air_sensor/atmos/nitrous_tank,
@@ -19435,9 +19393,6 @@
 /turf/open/floor/wood,
 /area/maintenance/department/medical)
 "nCk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
@@ -19488,7 +19443,7 @@
 /area/maintenance/department/engine/atmos)
 "nEC" = (
 /obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "nET" = (
 /obj/structure/table,
@@ -19581,8 +19536,11 @@
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/prison)
 "nHH" = (
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/engine,
+/obj/machinery/computer/ship/reactor_control_computer{
+	dir = 8;
+	reactor_id = 1
+	},
+/turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_room)
 "nIN" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
@@ -19717,9 +19675,24 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/firealarm/directional/east,
+/obj/structure/reagent_dispensers/foamtank/hull_repair_juice,
+/obj/item/extinguisher/advanced/hull_repair_juice,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
 "nPo" = (
+/obj/item/control_rod,
+/obj/item/control_rod,
+/obj/item/control_rod,
+/obj/item/control_rod,
+/obj/item/control_rod,
+/obj/item/control_rod,
+/obj/structure/closet/crate/engineering{
+	name = "control rod crate"
+	},
+/obj/item/control_rod,
+/obj/item/control_rod,
+/obj/item/control_rod,
+/obj/item/control_rod,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -19786,8 +19759,7 @@
 	},
 /area/hydroponics)
 "nRw" = (
-/obj/machinery/holopad/tutorial,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -19826,11 +19798,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
-/obj/machinery/door/airlock/ship/engineering/glass,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/carpet/ship/orange_carpet,
-/area/engine/engine_smes)
+/turf/closed/wall/r_wall/ship,
+/area/tcommsat/server)
 "nSL" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -19908,9 +19877,6 @@
 /area/ai_monitored/security/armory/security)
 "nUQ" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
@@ -20084,7 +20050,7 @@
 	codes_txt = "patrol;next_patrol=loc1";
 	location = "loc12"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "odC" = (
 /obj/structure/window/reinforced{
@@ -20137,9 +20103,7 @@
 "ofM" = (
 /obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall/ship,
-/area/security/main{
-	name = "Security War Room"
-	})
+/area/security/prison)
 "ogg" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -20252,13 +20216,15 @@
 	name = "Cafeteria"
 	})
 "omv" = (
-/obj/machinery/door/poddoor/ship{
-	id = "stormdrive_vent"
+/obj/structure/table,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 6;
+	pixel_y = 8
 	},
-/turf/open/floor/engine,
-/area/engine/engine_room/external{
-	name = "Stormdrive Interior"
-	})
+/obj/item/storage/toolbox/mechanical,
+/obj/item/gps/engineering,
+/turf/open/floor/carpet/ship/orange_carpet,
+/area/engine/engine_room)
 "omQ" = (
 /obj/structure/bed/dogbed/cayenne,
 /mob/living/simple_animal/hostile/carp/cayenne,
@@ -20279,16 +20245,19 @@
 /turf/open/floor/carpet/ship/red_carpet,
 /area/crew_quarters/heads/hos)
 "onb" = (
-/obj/structure/disposalpipe/junction/flip,
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet/restrooms)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/cryopods)
 "ono" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrous_input,
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
 "ons" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -20337,7 +20306,7 @@
 /obj/structure/table/wood,
 /obj/item/storage/box/matches,
 /obj/item/coin/iron,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "oqm" = (
 /obj/machinery/door/firedoor/border_only/directional/north,
@@ -20368,9 +20337,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall/ship,
-/area/engine/engine_smes)
+/area/tcommsat/server)
 "oqO" = (
 /obj/machinery/computer/ship/navigation/public{
 	dir = 8;
@@ -20389,10 +20357,9 @@
 	name = "Security War Room"
 	})
 "otb" = (
-/obj/structure/closet/firecloset/full,
-/obj/item/clothing/glasses/welding,
 /obj/machinery/airalarm/directional/east,
-/turf/open/floor/engine,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/r_wall/ship,
 /area/engine/engine_room)
 "otm" = (
 /turf/open/floor/carpet/ship/blue,
@@ -20404,7 +20371,7 @@
 	},
 /obj/machinery/recharge_station,
 /obj/effect/landmark/start/cyborg,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -20424,7 +20391,7 @@
 	dir = 8
 	},
 /obj/item/radio/intercom/directional/west,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "out" = (
 /obj/structure/disposalpipe/segment,
@@ -20437,7 +20404,7 @@
 /obj/machinery/atmospherics/pipe/manifold/purple/hidden{
 	dir = 1
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/crew_quarters/bar)
 "ouJ" = (
 /obj/structure/cable{
@@ -20505,7 +20472,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -20555,17 +20522,6 @@
 	},
 /turf/open/floor/carpet/ship/red_carpet,
 /area/ai_monitored/security/armory/security)
-"ozB" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/hallway/primary/central{
-	name = "Hallway"
-	})
 "ozF" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -20644,7 +20600,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -20652,7 +20608,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -20672,9 +20628,6 @@
 /turf/open/floor/wood,
 /area/security/detectives_office)
 "oEB" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
@@ -20741,14 +20694,17 @@
 /turf/open/floor/carpet/ship/blue,
 /area/medical/genetics/cloning)
 "oHO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 8;
+	name = "scrubbers pipe"
 	},
-/obj/item/geiger_counter{
-	scanning = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engine_room)
+/obj/machinery/door/firedoor/window,
+/obj/structure/grille,
+/obj/structure/window/plasma/fulltile,
+/turf/open/floor/plating,
+/area/engine/engine_room/external{
+	name = "Stormdrive Interior"
+	})
 "oHT" = (
 /obj/structure/chair/pew/left{
 	dir = 8;
@@ -20824,6 +20780,7 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = 30
 	},
+/obj/effect/spawner/lootdrop/gloves,
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/checkpoint/medical)
 "oKP" = (
@@ -20832,7 +20789,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -20856,9 +20813,12 @@
 	name = "Supermatter Core"
 	})
 "oLv" = (
-/obj/machinery/newscaster/directional/east,
-/turf/open/floor/plating,
-/area/engine/engine_smes)
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/carpet/ship/orange_carpet,
+/area/tcommsat/server)
 "oLX" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -20878,11 +20838,13 @@
 /obj/structure/sign/solgov_flag/right{
 	layer = 2.79
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/obj/machinery/jukebox,
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "oMr" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
@@ -20952,14 +20914,17 @@
 	name = "Security War Room"
 	})
 "oOV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4;
+	icon_state = "pipe11-2"
 	},
-/obj/machinery/atmospherics/components/binary/valve/digital{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engine_room)
+/obj/machinery/door/firedoor/window,
+/obj/structure/grille,
+/obj/structure/window/plasma/fulltile,
+/turf/open/floor/plating,
+/area/engine/engine_room/external{
+	name = "Stormdrive Interior"
+	})
 "oPt" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -21010,7 +20975,7 @@
 "oRD" = (
 /obj/machinery/light,
 /obj/machinery/autolathe,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "oRJ" = (
 /obj/structure/table,
@@ -21025,7 +20990,7 @@
 /obj/item/storage/toolbox/mechanical{
 	pixel_x = -2
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "oSd" = (
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
@@ -21216,7 +21181,7 @@
 /area/security/brig)
 "oXv" = (
 /obj/structure/closet/firecloset/full,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -21306,6 +21271,10 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4;
+	icon_state = "pipe11-2"
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
@@ -21439,10 +21408,9 @@
 /turf/open/floor/carpet/ship/blue,
 /area/medical/chemistry)
 "pfq" = (
-/obj/structure/chair/office/light,
-/obj/effect/landmark/start/station_engineer,
-/turf/open/floor/carpet/ship/orange_carpet,
-/area/engine/storage)
+/obj/structure/sign/warning/enginesafety,
+/turf/closed/wall/r_wall/ship,
+/area/engine/engine_room)
 "pgc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -21600,7 +21568,7 @@
 	pixel_x = -3;
 	pixel_y = 7
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "pnE" = (
 /obj/machinery/meter/atmos/distro_loop{
@@ -21717,7 +21685,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -21731,7 +21699,7 @@
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "ptb" = (
 /obj/structure/rack,
@@ -21768,7 +21736,7 @@
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "ptg" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2{
@@ -21830,6 +21798,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/item/clothing/gloves/color/black,
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/checkpoint/engineering)
 "pvr" = (
@@ -21883,7 +21852,7 @@
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Tool Storage"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "pwz" = (
 /obj/structure/disposalpipe/segment{
@@ -21893,7 +21862,7 @@
 	name = "starmap console"
 	},
 /obj/machinery/computer/ship/viewscreen,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/crew_quarters/bar)
 "pxf" = (
 /obj/machinery/air_sensor/atmos/mix_tank,
@@ -21957,16 +21926,16 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -22054,14 +22023,13 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "pES" = (
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engine_room)
+/obj/machinery/door/firedoor/window,
+/obj/structure/grille,
+/obj/structure/window/plasma/fulltile,
+/turf/open/floor/plating,
+/area/engine/engine_room/external{
+	name = "Stormdrive Interior"
+	})
 "pEZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
@@ -22126,7 +22094,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "pIL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -22190,7 +22158,7 @@
 /area/gateway)
 "pJI" = (
 /obj/machinery/vending/cola/random,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -22241,7 +22209,7 @@
 	})
 "pKS" = (
 /obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "pLi" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -22270,7 +22238,7 @@
 /area/engine/atmospherics_engine)
 "pLS" = (
 /obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "pLV" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -22351,7 +22319,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -22478,6 +22446,13 @@
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmospherics_engine)
+"pSQ" = (
+/obj/machinery/cryopod,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/cryopods)
 "pSS" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -22533,24 +22508,30 @@
 "pTY" = (
 /obj/machinery/recharge_station,
 /obj/effect/landmark/start/cyborg,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "pUK" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
 /obj/machinery/light,
-/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
+/obj/structure/particle_accelerator/end_cap{
+	dir = 1;
+	icon_state = "end_cap"
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_room)
 "pUQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
 	},
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "pVA" = (
@@ -22582,15 +22563,6 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/security/prison)
-"pWQ" = (
-/obj/machinery/atmospherics/components/binary/passive_gate{
-	dir = 1;
-	name = "Stormdrive Output to Space"
-	},
-/turf/closed/wall/r_wall/ship,
-/area/engine/engine_room/external{
-	name = "Stormdrive Interior"
-	})
 "pXC" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/structure/cable/yellow{
@@ -22623,10 +22595,17 @@
 	dir = 8;
 	icon_state = "manifold-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "pYR" = (
 /obj/structure/closet/secure_closet/evidence,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/obj/item/clothing/neck/stethoscope,
+/obj/item/clothing/neck/stethoscope,
+/obj/item/clothing/neck/stethoscope,
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/main{
 	name = "Security War Room"
@@ -22646,7 +22625,7 @@
 	dir = 8
 	},
 /obj/item/clothing/mask/gas,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "qaI" = (
 /turf/closed/wall/r_wall/ship,
@@ -22670,10 +22649,11 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
-	icon_state = "1-4"
-	},
 /obj/effect/landmark/nuclear_waste_spawner,
+/obj/structure/particle_accelerator/fuel_chamber{
+	dir = 1;
+	icon_state = "fuel_chamber"
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_room)
 "qbc" = (
@@ -22753,8 +22733,9 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet/east,
-/obj/structure/closet/radiation,
-/obj/item/clothing/mask/gas,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "qeG" = (
@@ -22783,7 +22764,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/crew_quarters/bar)
 "qfb" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos{
@@ -22826,7 +22807,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -22834,7 +22815,7 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "qga" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
@@ -22848,6 +22829,9 @@
 "qgs" = (
 /obj/vehicle/ridden/wheelchair{
 	dir = 8
+	},
+/obj/machinery/computer/cryopod{
+	pixel_y = 32
 	},
 /turf/open/floor/carpet/ship/blue,
 /area/medical/patients_rooms/room_d)
@@ -22933,7 +22917,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -22949,7 +22933,7 @@
 	name = "Central Primary Hallway"
 	},
 /obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -23006,7 +22990,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -23047,7 +23034,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -23128,7 +23115,7 @@
 /obj/machinery/vending/tool,
 /obj/machinery/airalarm/directional/north,
 /obj/structure/extinguisher_cabinet/west,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "qoX" = (
 /obj/structure/rack,
@@ -23231,7 +23218,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
 "qsv" = (
@@ -23244,12 +23230,12 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "qsQ" = (
-/obj/structure/particle_accelerator/end_cap{
-	dir = 1;
-	icon_state = "end_cap"
-	},
 /obj/structure/cable/white{
 	icon_state = "1-2"
+	},
+/obj/structure/particle_accelerator/power_box{
+	dir = 1;
+	icon_state = "power_box"
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_room)
@@ -23266,9 +23252,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8
-	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "qtY" = (
@@ -23340,13 +23323,13 @@
 /obj/item/clothing/neck/squad,
 /obj/item/clothing/neck/squad,
 /obj/item/clothing/neck/squad,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "qvE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "qvK" = (
 /obj/machinery/door/poddoor/ship/preopen{
@@ -23356,16 +23339,23 @@
 /turf/open/floor/plating,
 /area/engine/storage)
 "qvL" = (
-/obj/machinery/igniter{
-	id = "superigniter"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/engine/vacuum,
-/area/engine/supermatter{
-	name = "Supermatter Core"
-	})
+/obj/structure/table,
+/obj/item/storage/box/donkpockets,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/clothing/mask/breath{
+	pixel_x = 4
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = -8
+	},
+/turf/open/floor/carpet/ship/orange_carpet,
+/area/engine/storage)
 "qwd" = (
 /obj/machinery/light,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -23426,7 +23416,7 @@
 	})
 "qxg" = (
 /obj/structure/chair/stool/bar,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/crew_quarters/bar)
 "qxT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -23538,19 +23528,17 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/structure/table,
+/obj/item/lightreplacer{
+	pixel_y = 7
+	},
+/obj/item/storage/belt/utility,
+/obj/item/flashlight{
+	pixel_x = 1;
+	pixel_y = 5
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
-"qAh" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
-	},
-/turf/open/floor/engine,
-/area/engine/engine_room)
 "qAi" = (
 /obj/machinery/modular_computer/console/preset/engineering{
 	dir = 4;
@@ -23665,7 +23653,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -23741,18 +23729,11 @@
 	name = "Stormdrive Interior"
 	})
 "qGN" = (
-/obj/structure/toilet{
-	dir = 8
+/obj/machinery/cryopod{
+	dir = 4
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 10
-	},
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet/restrooms)
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/cryopods)
 "qGQ" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -23789,7 +23770,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "qIn" = (
 /obj/machinery/meter/atmos/distro_loop{
@@ -23808,21 +23789,21 @@
 	name = "Arrivals"
 	})
 "qIt" = (
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/structure/particle_accelerator/particle_emitter/center{
-	dir = 1;
-	icon_state = "emitter_center"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4;
+	icon_state = "pipe11-2"
+	},
+/obj/structure/cable/white{
+	icon_state = "1-2"
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
@@ -23831,7 +23812,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/assistant,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -23857,7 +23838,7 @@
 /obj/structure/closet/l3closet,
 /obj/item/clothing/mask/surgical,
 /obj/item/clothing/gloves/color/latex,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -23921,7 +23902,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "qNi" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
@@ -23973,6 +23954,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/item/holosign_creator/engineering,
 /obj/item/holosign_creator/atmos,
+/obj/item/clothing/gloves/color/black,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
 "qPq" = (
@@ -24130,8 +24112,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/engine/engine_smes)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/ship/orange_carpet,
+/area/tcommsat/server)
 "qTF" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -24354,7 +24339,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/crew_quarters/bar)
 "rgN" = (
 /obj/machinery/firealarm/directional/south,
@@ -24488,16 +24473,12 @@
 /turf/open/floor/carpet/ship,
 /area/medical/morgue)
 "rmP" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/junction/flip{
-	dir = 1
-	},
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet/restrooms)
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/carpet/ship/orange_carpet,
+/area/engine/storage)
 "rmU" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/papersack{
@@ -24590,13 +24571,11 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "rop" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/chair/office/light{
+	dir = 8
 	},
-/turf/open/floor/engine/vacuum,
-/area/engine/engine_room/external{
-	name = "Stormdrive Interior"
-	})
+/turf/open/floor/carpet/ship/orange_carpet,
+/area/engine/storage)
 "roT" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -24615,6 +24594,7 @@
 /area/medical/storage)
 "rpY" = (
 /obj/structure/table,
+/obj/item/clothing/gloves/color/black,
 /obj/item/restraints/handcuffs,
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/main{
@@ -24651,11 +24631,11 @@
 /turf/closed/wall/ship,
 /area/shuttle/turbolift/secondary)
 "rrN" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/telecomms/processor/preset_three,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
 /turf/open/floor/circuit,
 /area/tcommsat/server)
 "rrO" = (
@@ -24678,19 +24658,19 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/assistant,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "rtj" = (
 /obj/structure/chair/stool/bar,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/crew_quarters/bar)
 "rtl" = (
 /obj/structure/ladder,
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -24758,6 +24738,9 @@
 /area/engine/engine_smes)
 "rww" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_room)
 "rwz" = (
@@ -24790,8 +24773,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "rxk" = (
@@ -24956,7 +24938,7 @@
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/checkpoint/medical)
 "rEo" = (
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/crew_quarters/bar)
 "rEF" = (
 /obj/structure/disposalpipe/segment,
@@ -24965,7 +24947,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "rFu" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
@@ -25009,7 +24991,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/crew_quarters/bar)
 "rHe" = (
 /obj/structure/frame/computer{
@@ -25075,7 +25057,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -25284,7 +25266,7 @@
 /obj/machinery/camera/autoname{
 	dir = 5
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -25295,8 +25277,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
-/turf/open/floor/plating,
-/area/engine/engine_smes)
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/obj/machinery/telecomms/bus/preset_four,
+/turf/open/floor/circuit,
+/area/tcommsat/server)
 "rSl" = (
 /obj/structure/table,
 /turf/open/floor/carpet/ship,
@@ -25312,7 +25298,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/maintenance/central/secondary)
 "rTD" = (
 /obj/structure/cable{
@@ -25432,9 +25418,14 @@
 	name = "Arrivals"
 	})
 "rYe" = (
-/obj/structure/closet/firecloset/full,
-/turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/sign/solgov_seal,
+/turf/open/floor/carpet/ship,
+/area/hallway/primary/central{
+	name = "Hallway"
+	})
 "rYf" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
 /obj/machinery/door/poddoor/ship/preopen{
@@ -25458,14 +25449,22 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "rYC" = (
-/obj/machinery/computer/ship/reactor_control_computer{
-	dir = 4;
-	reactor_id = 1;
-	req_access = null;
-	req_one_access_txt = "10;11"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/carpet/ship/orange_carpet,
-/area/engine/engine_room)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/carpet/ship,
+/area/hallway/primary/central{
+	name = "Hallway"
+	})
 "rYV" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/machinery/atmospherics/components/unary/portables_connector/layer1{
@@ -25547,7 +25546,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -25735,15 +25734,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Cafeteria"
-	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/effect/landmark/zebra_interlock_point,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Cafeteria"
+	},
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/lounge{
 	name = "Cafeteria"
@@ -25888,7 +25887,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/layer3{
 	dir = 1
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -25998,7 +25997,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 5
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -26044,16 +26043,20 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "sxj" = (
-/obj/machinery/firealarm/directional/east,
 /obj/machinery/computer/atmos_control{
 	dir = 8;
 	name = "Supermatter Core Sensor";
 	sensors = list("sm_sense" = "Supermatter Core")
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmospherics_engine)
 "sxk" = (
-/obj/machinery/telecomms/processor/preset_one/birdstation,
 /obj/machinery/firealarm{
 	pixel_x = -26;
 	pixel_y = 25
@@ -26062,19 +26065,20 @@
 	dir = 6;
 	icon_state = "pipe11-2"
 	},
+/obj/machinery/telecomms/server/presets/command,
 /turf/open/floor/circuit,
 /area/tcommsat/server)
 "sxO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "syf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/crew_quarters/bar)
 "sze" = (
 /obj/machinery/light{
@@ -26148,7 +26152,7 @@
 /area/crew_quarters/kitchen)
 "sDX" = (
 /obj/machinery/light,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -26218,7 +26222,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/crew_quarters/bar)
 "sHA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -26293,9 +26297,12 @@
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
 "sKA" = (
-/obj/structure/table_frame,
-/turf/open/floor/plating,
-/area/engine/engine_smes)
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/carpet/ship/orange_carpet,
+/area/tcommsat/server)
 "sKV" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -26346,7 +26353,7 @@
 /obj/structure/closet/l3closet,
 /obj/item/clothing/gloves/color/latex,
 /obj/item/clothing/mask/surgical,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "sMd" = (
 /obj/structure/table/wood,
@@ -26365,10 +26372,13 @@
 /area/security/checkpoint/escape)
 "sME" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/atmospherics/components/binary/pump/layer1{
+	on = 1;
+	target_pressure = 2000
+	},
 /obj/machinery/door/airlock/ship/external/glass{
 	name = "External Access Deck 2 Starboard";
 	req_one_access_txt = "13"
@@ -26404,11 +26414,15 @@
 /obj/item/clothing/ears/earmuffs,
 /obj/item/clothing/gloves/color/yellow,
 /obj/item/storage/belt/utility/full,
-/obj/item/pipe_dispenser,
 /obj/machinery/camera/autoname{
 	dir = 8
 	},
 /obj/item/holosign_creator/atmos,
+/obj/item/clothing/gloves/color/black,
+/obj/item/pipe_dispenser,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/firealarm/directional/east,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmospherics_engine)
 "sPd" = (
@@ -26506,7 +26520,6 @@
 	pixel_y = 3
 	},
 /obj/item/stack/packageWrap,
-/obj/item/extinguisher/advanced/hull_repair_juice,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/break_room)
 "sTO" = (
@@ -26567,7 +26580,7 @@
 /area/security/prison)
 "sVp" = (
 /obj/machinery/vending/assist,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "sVq" = (
 /obj/structure/cable{
@@ -26638,6 +26651,7 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
+/obj/item/clothing/gloves/color/black,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
 "sXQ" = (
@@ -26690,7 +26704,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "tai" = (
 /obj/structure/cable{
@@ -26747,7 +26761,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -26858,7 +26872,7 @@
 	pixel_x = -3;
 	pixel_y = 7
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "tfI" = (
 /obj/machinery/atmospherics/pipe/manifold4w/general/visible,
@@ -26915,16 +26929,18 @@
 	codes_txt = "patrol;next_patrol=loc3-1";
 	location = "loc3"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
 "thS" = (
-/obj/machinery/jukebox,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/obj/structure/reagent_dispensers/water_cooler{
+	anchored = 0
+	},
+/turf/open/floor/carpet/ship,
 /area/crew_quarters/bar)
 "thW" = (
 /obj/structure/table,
@@ -26955,8 +26971,12 @@
 /turf/open/floor/carpet/ship/blue,
 /area/medical/patients_rooms/room_b)
 "tim" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/plasteel/fifty,
+/obj/machinery/modular_computer/console/preset/engineering{
+	dir = 8
+	},
+/obj/structure/cable/white{
+	icon_state = "0-4"
+	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_room)
 "tiC" = (
@@ -26972,7 +26992,7 @@
 /area/crew_quarters/kitchen/coldroom)
 "tiJ" = (
 /obj/machinery/holopad,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "tjt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -27040,11 +27060,22 @@
 	name = "Cafeteria"
 	})
 "tkZ" = (
-/obj/structure/reagent_dispensers/water_cooler{
-	anchored = 0
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/carpet/ship/orange_carpet,
-/area/engine/storage)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/carpet/ship,
+/area/hallway/primary/central{
+	name = "Hallway"
+	})
 "tlD" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -27053,7 +27084,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -27189,7 +27220,7 @@
 /obj/structure/reagent_dispensers/water_cooler{
 	anchored = 0
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -27207,7 +27238,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "trZ" = (
 /obj/structure/chair{
@@ -27217,11 +27248,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/crew_quarters/bar)
 "tsa" = (
 /obj/machinery/atmospherics/components/binary/pump,
-/obj/machinery/airalarm/directional/east,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/engine,
 /area/engine/engine_room/external{
 	name = "Stormdrive Interior"
@@ -27343,7 +27374,7 @@
 "txp" = (
 /obj/structure/extinguisher_cabinet/west,
 /obj/machinery/vending/clothing,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -27440,14 +27471,12 @@
 	},
 /area/hydroponics)
 "tBz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/components/binary/passive_gate{
 	dir = 4;
 	name = "Stormdrive Input to Waste"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "tCh" = (
@@ -27474,14 +27503,9 @@
 /turf/open/floor/carpet/ship/blue,
 /area/medical/medbay/lobby)
 "tDB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 8
-	},
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet/restrooms)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/cryopods)
 "tFI" = (
 /obj/machinery/light_switch/east,
 /turf/open/floor/wood,
@@ -27635,7 +27659,7 @@
 /area/engine/atmospherics_engine)
 "tLG" = (
 /obj/machinery/airalarm/directional/north,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -27785,7 +27809,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 5
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "tRb" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -27914,6 +27938,8 @@
 	name = "External Access Deck 2 Fore Starboard";
 	req_one_access_txt = "13"
 	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "tWJ" = (
@@ -28181,15 +28207,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/binary/pump/layer1{
+	dir = 4;
+	on = 1;
+	target_pressure = 2000
 	},
 /obj/machinery/door/airlock/ship/external/glass{
 	name = "External Access Deck 2 Arch";
 	req_one_access_txt = "13"
-	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
@@ -28229,10 +28257,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 5
-	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "ung" = (
@@ -28262,7 +28287,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -28388,7 +28413,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "urt" = (
 /obj/structure/disposalpipe/segment{
@@ -28401,10 +28426,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/water_vapor,
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "urJ" = (
@@ -28453,8 +28474,17 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
 "utV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/components/binary/pump/layer1{
+	dir = 1;
+	on = 1;
+	target_pressure = 2000
+	},
+/obj/machinery/door/airlock/ship/external/glass{
+	name = "External Access Stormdrive";
+	req_one_access_txt = "13"
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
@@ -28469,7 +28499,7 @@
 /obj/structure/sign/poster/random{
 	pixel_x = -32
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "uuf" = (
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -28520,12 +28550,9 @@
 /turf/closed/wall/ship,
 /area/shuttle/turbolift/quaternary)
 "uwD" = (
-/obj/item/soap/nanotrasen,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet/restrooms)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/crew_quarters/cryopods)
 "uwN" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/reagent_containers/food/snacks/grown/pumpkin{
@@ -28562,7 +28589,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/assistant,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/crew_quarters/bar)
 "uzp" = (
 /obj/structure/cable{
@@ -28591,7 +28618,6 @@
 /obj/structure/sign/solgov_flag{
 	layer = 2.79
 	},
-/obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /turf/open/floor/light/colour_cycle/dancefloor_b,
 /area/crew_quarters/bar)
@@ -28713,17 +28739,15 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/patients_rooms/room_c)
 "uGt" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/atmospherics/components/unary/portables_connector/layer3{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/structure/extinguisher_cabinet/east,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -28829,7 +28853,7 @@
 /area/lawoffice)
 "uKi" = (
 /obj/machinery/vending/cigarette,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -28859,7 +28883,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -28874,7 +28898,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -28952,7 +28976,7 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/manifold/purple/hidden,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/crew_quarters/bar)
 "uPa" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -29055,7 +29079,12 @@
 /area/crew_quarters/heads/cmo)
 "uSU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/atmospherics/components/binary/pump/layer1{
+	on = 1;
+	target_pressure = 2000
+	},
 /obj/machinery/door/airlock/ship/external/glass{
 	name = "External Access Deck 2 Fore Starboard";
 	req_one_access_txt = "13"
@@ -29097,7 +29126,7 @@
 "uUz" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/firealarm/directional/west,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "uUA" = (
 /turf/closed/wall/ship,
@@ -29556,11 +29585,17 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -29593,7 +29628,7 @@
 	codes_txt = "patrol;next_patrol=loc9";
 	location = "loc8"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -29687,8 +29722,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/sign/solgov_seal,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -29716,10 +29750,10 @@
 /turf/open/floor/carpet/ship,
 /area/medical/morgue)
 "vre" = (
-/obj/machinery/telecomms/message_server/preset,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
 	},
+/obj/machinery/announcement_system,
 /turf/open/floor/circuit,
 /area/tcommsat/server)
 "vrH" = (
@@ -29759,9 +29793,8 @@
 /turf/open/floor/carpet/ship/blue,
 /area/medical/medbay/lobby)
 "vrO" = (
-/obj/machinery/particle_accelerator/control_box,
-/obj/item/paper{
-	info = "<p>Reminder to add control rods to the Stormdrive engine BEFORE turning it on! Adding control rods requires the engine to be in maintenance mode, and it won't work if the reactor is powered!<br><br>Control rods are located in crate behind particle accelerator</p>"
+/obj/structure/particle_accelerator/particle_emitter/left{
+	dir = 1
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_room)
@@ -29822,9 +29855,6 @@
 /area/crew_quarters/kitchen)
 "vtl" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "vuk" = (
@@ -29868,13 +29898,19 @@
 	name = "Atmospherics Canister Storage"
 	})
 "vuZ" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/engine/vacuum,
-/area/engine/engine_room/external{
-	name = "Stormdrive Interior"
-	})
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Central Primary Hallway"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/cryopods)
 "vvf" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -29960,15 +29996,11 @@
 /turf/open/floor/engine,
 /area/gateway)
 "vzE" = (
-/obj/structure/chair/office/light{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/start/station_engineer,
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/turf/open/floor/carpet/ship/orange_carpet,
-/area/engine/engine_room)
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/cryopods)
 "vzU" = (
 /obj/structure/table,
 /obj/machinery/airalarm/directional/north,
@@ -29982,6 +30014,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/engine,
 /area/engine/engine_room/external{
 	name = "Stormdrive Interior"
@@ -30081,7 +30114,7 @@
 /obj/structure/table/wood,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -30172,7 +30205,7 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -30379,7 +30412,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "vLb" = (
 /obj/structure/cable{
@@ -30417,12 +30450,14 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 5
+	},
+/obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "vMm" = (
@@ -30521,7 +30556,7 @@
 /area/engine/atmospherics_engine)
 "vRl" = (
 /obj/structure/table/wood,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/crew_quarters/bar)
 "vRn" = (
 /obj/machinery/atmospherics/components/trinary/filter/critical{
@@ -30553,10 +30588,11 @@
 	},
 /obj/structure/table,
 /obj/machinery/cell_charger,
-/obj/item/gps/engineering,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/item/clothing/gloves/color/black,
+/obj/item/gps/engineering,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
 "vSU" = (
@@ -30609,6 +30645,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security)
+"vVc" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/open/floor/carpet/ship,
+/area/hallway/primary/central{
+	name = "Hallway"
+	})
 "vVh" = (
 /obj/structure/table/optable,
 /turf/open/floor/carpet/ship/blue,
@@ -30763,7 +30813,7 @@
 /obj/machinery/light,
 /obj/effect/spawner/lootdrop/maintenance/six,
 /obj/effect/spawner/lootdrop/costume,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "wbh" = (
 /obj/machinery/door/firedoor/window,
@@ -30775,7 +30825,7 @@
 	})
 "wbo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -30819,9 +30869,6 @@
 /area/maintenance/department/engine)
 "wer" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
 /obj/machinery/atmospherics/components/binary/pump/layer1{
 	dir = 1;
 	name = "Oxygen to Stormdrive Gas Mix Tank"
@@ -30847,9 +30894,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4;
+	icon_state = "pipe11-2"
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
@@ -31040,9 +31093,6 @@
 /area/engine/atmospherics_engine)
 "wmQ" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
 	dir = 6
 	},
@@ -31065,8 +31115,6 @@
 /turf/open/floor/wood,
 /area/chapel/main)
 "wnP" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -31129,8 +31177,8 @@
 /turf/closed/wall/ship,
 /area/engine/break_room)
 "wpv" = (
-/obj/structure/reagent_dispensers/watertank,
 /obj/machinery/airalarm/directional/north,
+/obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
 "wpN" = (
@@ -31303,6 +31351,7 @@
 	pixel_y = 4
 	},
 /obj/item/storage/box/handcuffs,
+/obj/item/clothing/gloves/color/black,
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/main{
 	name = "Security War Room"
@@ -31319,6 +31368,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/effect/spawner/lootdrop/gloves,
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "wvG" = (
@@ -31566,7 +31616,7 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -31675,7 +31725,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/crew_quarters/bar)
 "wGj" = (
 /obj/structure/table/glass,
@@ -31695,9 +31745,14 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
 "wGn" = (
-/obj/structure/sign/departments/restroom,
-/turf/closed/wall/ship,
-/area/crew_quarters/toilet/restrooms)
+/obj/machinery/newscaster/directional/north,
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/landmark/event_spawn,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/cryopods)
 "wHu" = (
 /obj/structure/table/glass,
 /obj/item/storage/firstaid/brute{
@@ -31763,14 +31818,8 @@
 "wJq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/ship/engineering/glass{
-	name = "Stormdrive Engine";
-	req_one_access_txt = "10"
-	},
-/turf/open/floor/carpet/ship/orange_carpet,
+/turf/closed/wall/r_wall/ship,
 /area/engine/engine_room)
 "wJD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -31830,15 +31879,19 @@
 	name = "Shield Generator"
 	})
 "wLe" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/meter/atmos/distro_loop{
-	pixel_x = -6;
-	pixel_y = -6;
-	target_layer = 1
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/closed/wall/r_wall/ship,
-/area/engine/atmos)
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/carpet/ship,
+/area/hallway/primary/central{
+	name = "Hallway"
+	})
 "wLi" = (
 /turf/open/floor/engine,
 /area/gateway)
@@ -31900,7 +31953,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -31974,7 +32027,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -32014,12 +32067,11 @@
 /turf/open/floor/plating,
 /area/security/warden)
 "wQa" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
-/area/engine/engine_room)
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/cryopods)
 "wQr" = (
 /obj/machinery/door/firedoor/window,
 /obj/structure/grille,
@@ -32062,13 +32114,17 @@
 /area/security/detectives_office)
 "wSd" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "wSy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/atmospherics/components/binary/pump/layer1{
+	dir = 1;
+	on = 1;
+	target_pressure = 2000
+	},
 /obj/machinery/door/airlock/ship/external/glass{
 	name = "External Access Deck 2 Fore Port";
 	req_one_access_txt = "2"
@@ -32076,8 +32132,13 @@
 /turf/open/floor/plating,
 /area/security/prison)
 "wSz" = (
-/turf/open/floor/plating,
-/area/engine/engine_smes)
+/obj/machinery/camera/autoname,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/machinery/telecomms/server/presets/science,
+/turf/open/floor/circuit,
+/area/tcommsat/server)
 "wSE" = (
 /obj/structure/closet/radiation,
 /obj/item/clothing/mask/gas,
@@ -32283,6 +32344,7 @@
 	},
 /obj/item/clothing/head/beret/black,
 /obj/item/cartridge/security,
+/obj/effect/spawner/lootdrop/gloves,
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/main{
 	name = "Security War Room"
@@ -32333,7 +32395,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "xcv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -32389,13 +32451,13 @@
 /turf/template_noop,
 /area/maintenance/department/medical)
 "xeE" = (
-/obj/structure/reagent_dispensers/water_cooler{
-	anchored = 0
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/turf/open/floor/engine/vacuum,
-/area/engine/engine_room/external{
-	name = "Stormdrive Interior"
-	})
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/cryopods)
 "xeI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -32728,7 +32790,7 @@
 	pixel_x = -3;
 	pixel_y = 7
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "xsC" = (
 /obj/machinery/holopad,
@@ -32925,6 +32987,7 @@
 	pixel_x = -26;
 	pixel_y = 25
 	},
+/obj/machinery/reagentgrinder,
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#99FF99"
 	},
@@ -33150,9 +33213,12 @@
 	name = "Security War Room"
 	})
 "xEj" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet/restrooms)
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/cryopods)
 "xEo" = (
 /obj/structure/rack,
 /obj/structure/cable{
@@ -33177,7 +33243,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/power/apc/auto_name/north,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -33267,7 +33333,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -33350,7 +33416,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/primary/central{
 	name = "Hallway"
 	})
@@ -33483,7 +33549,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 "xRJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -33501,7 +33567,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -33524,6 +33590,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/genetics/cloning)
 "xTb" = (
@@ -33583,7 +33650,7 @@
 /area/engine/atmospherics_engine)
 "xWl" = (
 /obj/machinery/firealarm/directional/east,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/crew_quarters/bar)
 "xWn" = (
 /obj/structure/closet/emcloset,
@@ -33623,21 +33690,11 @@
 	},
 /area/crew_quarters/kitchen/coldroom)
 "xWF" = (
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
-/obj/machinery/door/airlock/ship/external/glass{
-	name = "External Access Stormdrive";
-	req_one_access_txt = "13"
-	},
-/turf/open/floor/engine,
-/area/engine/engine_room)
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/cryopods)
 "xWT" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -33666,6 +33723,9 @@
 /obj/machinery/air_sensor/atmos{
 	id_tag = "supermatter_fusion_sensor"
 	},
+/obj/machinery/igniter{
+	id = "superigniter"
+	},
 /turf/open/floor/engine/vacuum,
 /area/engine/supermatter{
 	name = "Supermatter Core"
@@ -33686,15 +33746,12 @@
 "xYo" = (
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/machinery/door/airlock/ship/maintenance{
+	name = "Maintenance Access Cryostasis Storage";
+	req_one_access_txt = "12"
 	},
-/obj/machinery/door/airlock/ship/external/glass{
-	name = "External Access Stormdrive";
-	req_one_access_txt = "13"
-	},
-/turf/open/floor/engine,
-/area/engine/engine_room)
+/turf/open/floor/plating,
+/area/maintenance/department/engine/atmos)
 "xZu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -33866,10 +33923,7 @@
 /area/security/checkpoint/engineering)
 "ydV" = (
 /obj/structure/cable/white{
-	icon_state = "1-8"
-	},
-/obj/machinery/air_sensor/atmos{
-	id_tag = "stormdrive_chamber_sensor"
+	icon_state = "1-2"
 	},
 /turf/open/floor/engine/vacuum,
 /area/engine/engine_room/external{
@@ -33899,6 +33953,8 @@
 	pixel_y = 5
 	},
 /obj/item/paper/guides/jobs/engi/gravity_gen,
+/obj/item/book/manual/wiki/engineering_singulo_tesla,
+/obj/item/book/manual/wiki/tcomms,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
 "yeR" = (
@@ -33994,7 +34050,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/crew_quarters/bar)
 "yhk" = (
 /obj/machinery/door/window/brigdoor/security/cell/southright{
@@ -34039,7 +34095,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "yii" = (
-/obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
 "yiE" = (
@@ -34059,13 +34115,10 @@
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
 "yjm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/turf/closed/wall/r_wall/ship,
+/turf/open/floor/engine/vacuum,
 /area/engine/engine_room/external{
 	name = "Stormdrive Interior"
 	})
@@ -34120,7 +34173,7 @@
 	dir = 4;
 	icon_state = "rwindow"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/storage/tools)
 
 (1,1,1) = {"
@@ -43506,7 +43559,7 @@ drp
 drp
 drp
 drp
-drp
+eLi
 drp
 drp
 drp
@@ -45815,7 +45868,7 @@ drp
 drp
 drp
 drp
-eLi
+drp
 drp
 drp
 drp
@@ -50924,13 +50977,13 @@ drp
 drp
 drp
 awN
-atr
+afP
 atr
 fZX
 qib
 qnU
 fZX
-nhz
+sKA
 hNx
 hNx
 hNx
@@ -50986,7 +51039,7 @@ fcp
 azc
 fcp
 atr
-atr
+afP
 noN
 drp
 drp
@@ -51189,8 +51242,8 @@ eye
 fZX
 dJO
 hNx
-hNx
-hNx
+cvq
+eet
 gZo
 jPD
 xhn
@@ -51701,11 +51754,11 @@ fZX
 vwd
 eye
 fZX
-xhn
-xhn
-xhn
+asx
+hNx
+cyM
 mCw
-xhn
+gZo
 xhn
 xhn
 rDV
@@ -51959,11 +52012,11 @@ vwd
 npq
 fZX
 wSz
-msz
+hNx
 gLP
 baQ
 qTn
-gzI
+xhn
 sBe
 lTm
 ooA
@@ -52215,8 +52268,8 @@ fZX
 qib
 qnU
 fZX
-wSz
-wSz
+awD
+hNx
 cEq
 rSa
 dxo
@@ -52473,11 +52526,11 @@ qib
 qnU
 fZX
 sKA
-sKA
-wSz
+hNx
+deF
 oLv
 asf
-wEb
+oqD
 lBe
 iGp
 rwu
@@ -52708,7 +52761,7 @@ drp
 drp
 drp
 drp
-drp
+eLi
 drp
 drp
 drp
@@ -52729,10 +52782,10 @@ fZX
 qib
 qnU
 fZX
-wSz
-wSz
-wSz
-gzI
+aZG
+bZf
+dgw
+xhn
 lTG
 oqD
 dft
@@ -52986,10 +53039,10 @@ fZX
 aiS
 toc
 fZX
-gzI
+xhn
 dxz
-gzI
-gzI
+xhn
+xhn
 eRM
 hQF
 lPN
@@ -53020,7 +53073,7 @@ baX
 sgW
 hvY
 sRW
-qvL
+wUY
 wUY
 wUY
 wnk
@@ -53285,7 +53338,7 @@ aey
 aey
 xQv
 fJU
-wLe
+aey
 eKW
 wjb
 ocH
@@ -53486,7 +53539,7 @@ drp
 drp
 drp
 drp
-eLi
+drp
 drp
 drp
 drp
@@ -54314,7 +54367,7 @@ qkz
 aAj
 epQ
 dFl
-dOt
+kLT
 kts
 ocH
 ocH
@@ -55051,8 +55104,8 @@ mxk
 tMI
 dkv
 eeS
-eeS
-rVR
+jre
+kgy
 nPo
 jNp
 gbV
@@ -55305,21 +55358,21 @@ rKq
 aYX
 qKA
 lkK
-oMr
+hae
 epn
 eeS
 eeS
 rVR
-eeS
+miK
 jNp
 gbV
 gbV
-bZQ
+gbV
 gbV
 bTh
 wpv
 wyv
-eiX
+rmP
 yeH
 fsv
 fsv
@@ -55573,7 +55626,7 @@ mUN
 rww
 gub
 gbV
-kew
+bTh
 yii
 wyv
 aeg
@@ -55814,25 +55867,25 @@ dmx
 oZt
 fZX
 fZX
-fZX
-acZ
-acZ
+bZQ
+dpE
+dpE
 bAQ
 oHO
 mFV
-eeS
-eeS
+iaF
+acZ
 dwk
-fFd
+rVR
 wfv
 jNp
 gbV
 gbV
 gbV
-gbV
+omv
 tJU
 hJP
-wyv
+qvL
 aeg
 ixS
 aWJ
@@ -56069,26 +56122,26 @@ atr
 fZX
 yca
 vcT
-yca
 bYG
 fZX
-iGh
+csv
+acZ
 gZv
-pWQ
+yjm
 hgE
 yjm
-eUI
+kZs
 jrd
 afa
-awD
+rVR
 oZs
 jNp
 gbV
 gbV
-gbV
+mSC
 jZw
 xXW
-tkZ
+aeg
 neF
 aeg
 iHM
@@ -56326,28 +56379,28 @@ atr
 fZX
 qDt
 vcT
-yca
 sMn
 fZX
-drp
-asx
-vuZ
+baX
+drc
+kZs
+kZs
 fbf
-inY
-ebK
+kZs
+kZs
 pES
-xWF
-afP
+eeS
+rVR
 eKJ
 jNp
 lUK
-gbV
-gbV
+mIt
+nHH
 tim
 wEZ
 lNj
 qAa
-aeg
+rop
 mze
 fsv
 fsv
@@ -56584,10 +56637,10 @@ fZX
 isN
 hWp
 bdF
-yca
 oeJ
-drp
-omv
+baX
+drQ
+kZs
 kZs
 aDE
 ydV
@@ -56841,25 +56894,25 @@ fZX
 elW
 yca
 vcT
-eLA
 fZX
-drp
-aZG
-rop
+baX
+dOt
+kZs
+kZs
 eaN
-xeE
-hae
-noC
-xYo
-fhM
-jvc
-gTz
+kZs
+kZs
+pES
+eeS
+eeS
+oZs
+jNp
 vrO
-rYC
+gbV
 ayF
-hPI
-cvq
-deF
+gbV
+bTh
+nJM
 nrv
 sEr
 fhC
@@ -57095,26 +57148,26 @@ drp
 awN
 atr
 fZX
-yca
-yca
-vcT
+eLA
 uCh
+vcT
 fZX
-drp
+aIO
 acZ
-acZ
+kZs
+gTz
 mou
-acZ
-eUI
+hFT
+kZs
 jrd
-jrd
+jYT
 eUQ
 lcc
 vXD
 fpa
 aQJ
-iaF
-hFT
+fpa
+fpa
 iUT
 ctM
 wnP
@@ -57357,25 +57410,25 @@ dmx
 oZt
 dmx
 fZX
-fZX
 bTh
-mIt
+eUI
+bTh
 oOV
-nHH
-eeS
-eeS
-eeS
-qAh
+acZ
+acZ
+acZ
+kew
+urH
 wfv
 dzi
 gbV
-dgw
-vzE
-eet
-wQa
-pfq
-jay
-dpE
+gbV
+gbV
+gbV
+bTh
+aeg
+jbE
+aeg
 tUM
 iCe
 xfo
@@ -57614,22 +57667,22 @@ yca
 vcT
 yca
 yca
-fZX
-eeS
-fKo
+bTh
+fhM
+bTh
 kmg
-qNi
-qNi
+hPI
+inY
 qNi
 qNi
 rwS
-oZs
-dzi
+msz
+mwC
 gbV
-jre
+gbV
 aQm
 iRm
-bTh
+pfq
 hsH
 jbE
 aeg
@@ -57872,7 +57925,7 @@ eFR
 hhj
 rYq
 fZX
-eeS
+fFd
 utV
 tBz
 had
@@ -58134,7 +58187,7 @@ otb
 oMr
 kty
 qeo
-jYT
+eeS
 xxz
 urH
 eEv
@@ -58386,12 +58439,12 @@ vcT
 dmx
 dmx
 fZX
-fZX
+fKo
 fZX
 fZX
 gSJ
 fZX
-fZX
+ixl
 fZX
 gvD
 fZX
@@ -58905,7 +58958,7 @@ dmx
 fLB
 mrt
 woX
-yca
+iGh
 dmx
 jaY
 fZX
@@ -59904,7 +59957,7 @@ drp
 drp
 drp
 drp
-drp
+eLi
 drp
 drp
 drp
@@ -60184,7 +60237,7 @@ drp
 vpI
 pTY
 hEY
-rEo
+njS
 uuc
 ouq
 bQq
@@ -60446,8 +60499,8 @@ hpH
 sAK
 sAK
 sAK
-rEo
-rEo
+njS
+njS
 dmx
 pox
 dmx
@@ -61204,7 +61257,7 @@ drp
 drp
 drp
 drp
-eLi
+drp
 drp
 drp
 drp
@@ -61217,8 +61270,8 @@ hpH
 sAK
 sAK
 sAK
-rEo
-vRl
+njS
+qCE
 dmx
 jPB
 dmx
@@ -61270,7 +61323,7 @@ drp
 drp
 drp
 drp
-eLi
+drp
 drp
 drp
 drp
@@ -61729,7 +61782,7 @@ vpI
 oMl
 sxO
 fYa
-rEo
+njS
 urq
 alr
 ctw
@@ -62048,7 +62101,7 @@ drp
 drp
 drp
 drp
-drp
+eLi
 drp
 drp
 drp
@@ -63037,12 +63090,12 @@ sIS
 ewk
 siD
 dsG
-dsG
-dsG
-dsG
-dsG
-dsG
-dsG
+tdz
+tdz
+tdz
+tdz
+tdz
+tdz
 tdz
 tdz
 tdz
@@ -63290,20 +63343,20 @@ kry
 eaL
 eaL
 oGt
-kbE
+rYe
 dSB
 jKk
 bpE
-asI
-mUq
-mUq
-mUq
-mUq
+tdz
+mXO
+mXO
+mXO
 mUq
 tdz
 xWq
-nTe
-rYe
+xWq
+fmP
+vrK
 lij
 tdz
 oHT
@@ -63547,17 +63600,17 @@ vym
 vNP
 eaL
 xiG
-kbE
-fUj
-jKk
+vpH
+mDU
+rYC
 aTr
-asI
-cXg
-cXg
-uwD
-cXg
-cXg
 tdz
+mXO
+mXO
+mXO
+mXO
+tdz
+xWq
 xWq
 xWq
 xWq
@@ -63805,16 +63858,16 @@ jaB
 bfT
 oGt
 cPY
-fUj
+mDU
 pyL
 mDU
-asI
-asI
-asI
-asI
-miK
-asI
 tdz
+mXO
+mXO
+mXO
+mXO
+xYo
+xWq
 xWq
 iVR
 xWq
@@ -64062,16 +64115,16 @@ jDv
 jDv
 uUZ
 ivA
-fUj
-pyL
 mDU
-wGn
-fUq
-drQ
-drQ
-cXg
-cXg
-mwC
+tkZ
+uGt
+tdz
+mXO
+mXO
+mXO
+mXO
+tdz
+xWq
 xWq
 xWq
 xWq
@@ -64322,13 +64375,13 @@ qEk
 jhD
 mGa
 uGt
-csv
-rmP
-bZf
-drc
-cXg
-xEj
 tdz
+mXO
+mXO
+mXO
+mXO
+tdz
+xWq
 xWq
 xWq
 xWq
@@ -64576,19 +64629,19 @@ lWq
 lWq
 dHs
 bsC
-fUj
+mDU
 qlu
 asI
-asI
-asI
-mSC
-ixl
-asI
-asI
+tdz
+tdz
+tdz
+tdz
+tdz
+tdz
 tdz
 xWq
-fmP
-vrK
+nTe
+nfe
 jDo
 tdz
 lNi
@@ -64832,15 +64885,15 @@ hPx
 jDv
 mYV
 nfK
-kbE
-fUj
+vpH
+mDU
 qlu
 asI
 arC
 eXF
 dWd
-fqo
-eXF
+qGN
+xEj
 qGN
 tdz
 xWq
@@ -65067,8 +65120,8 @@ gOQ
 mgx
 jex
 hxk
-lKG
-fZb
+ebK
+fUq
 biX
 jex
 ioU
@@ -65089,16 +65142,16 @@ hPx
 jDv
 gTJ
 nfK
-kbE
-fUj
+vpH
+mDU
 qlu
-asI
-asI
-asI
-gDb
+uwD
+vzE
+wQa
 hba
-asI
-asI
+hba
+hba
+hba
 tdz
 xWq
 fFV
@@ -65346,17 +65399,17 @@ oBF
 shv
 gTJ
 voL
-kbE
+vpH
 eUy
 vlc
-asI
+vuZ
 mnS
-eXF
+xeE
 onb
 tDB
-eXF
-qGN
-tdz
+xWF
+hba
+kEj
 xWq
 fFV
 ivT
@@ -65604,15 +65657,15 @@ jDv
 jDv
 uUZ
 vpH
-fUj
+mDU
 ihQ
-asI
-asI
-asI
-aIL
-cXg
-asI
-asI
+uwD
+hba
+hba
+hba
+hba
+hba
+hba
 tdz
 xWq
 fFV
@@ -65861,15 +65914,15 @@ dQg
 sUi
 uUZ
 eJN
-fUj
-qlu
+mDU
+ihQ
 asI
-arC
-eXF
-dWd
+wGn
 iHd
-eXF
-qGN
+iHd
+iHd
+iHd
+pSQ
 tdz
 cnD
 fFV
@@ -65882,7 +65935,7 @@ jdX
 iTm
 mVk
 mVk
-eoO
+fUM
 tdY
 rWz
 eKy
@@ -66118,17 +66171,17 @@ uUZ
 uUZ
 lQD
 biC
-fUj
-qlu
+mDU
+ihQ
 asI
 asI
+uwD
+uwD
+uwD
+uwD
 asI
 asI
-asI
-asI
-asI
-asI
-fUj
+mDU
 dSB
 fHD
 fHD
@@ -66352,7 +66405,7 @@ kMh
 byz
 vll
 qIM
-jex
+nRw
 qIM
 uLk
 jex
@@ -66378,18 +66431,18 @@ buh
 saS
 bNX
 aTU
-saS
-ejf
-rRE
+wLe
 saS
 saS
 saS
-ozB
+saS
+ivb
+saS
 saS
 saS
 saS
 thP
-ejf
+vVc
 fMR
 saS
 adl
@@ -66620,35 +66673,35 @@ qwd
 beZ
 kTT
 unu
-fUj
+mDU
 wOB
-fUj
+mDU
 dBg
-fUj
-kbE
+mDU
+vpH
 aKd
-fUj
-fUj
+mDU
+mDU
 sDX
 dEz
-fUj
+mDU
 boG
 glB
 quX
-fUj
-fUj
-fUj
-fUj
+mDU
+mDU
+mDU
+mDU
 wOB
-fUj
-fUj
-fUj
+mDU
+mDU
+mDU
 aKd
-fUj
-fUj
-fUj
-kbE
-fUj
+mDU
+mDU
+mDU
+vpH
+mDU
 qhP
 cRV
 cet
@@ -67135,9 +67188,9 @@ jqX
 dSB
 vDM
 dWk
-fUj
+mDU
 dSB
-fUj
+mDU
 uQs
 rTu
 uQs
@@ -67145,9 +67198,9 @@ uQs
 pJI
 fmX
 pmp
-fUj
-fUj
-qlu
+mDU
+mDU
+ihQ
 oBd
 cYh
 oXv
@@ -67402,9 +67455,9 @@ nZj
 oHz
 oHz
 qog
-fUj
-fUj
-qlu
+mDU
+mDU
+ihQ
 rqW
 gkH
 gkH
@@ -67659,9 +67712,9 @@ oNI
 nVt
 qQd
 pMn
-fUj
-fUj
-qlu
+mDU
+mDU
+ihQ
 txN
 uDQ
 ucB
@@ -67916,9 +67969,9 @@ oHz
 kRO
 kRO
 wGa
-fUj
-fUj
-qlu
+mDU
+mDU
+ihQ
 okz
 bAS
 bAS
@@ -68431,8 +68484,8 @@ oHz
 oHz
 oHz
 tLG
-fUj
-qlu
+mDU
+ihQ
 gkH
 cfk
 cfk
@@ -68687,9 +68740,9 @@ uQs
 ebx
 eER
 hEi
-fUj
-fUj
-qlu
+mDU
+mDU
+ihQ
 hEi
 eEp
 mLK
@@ -68944,9 +68997,9 @@ uQs
 uQs
 oBd
 oXv
-fUj
-fUj
-qlu
+mDU
+mDU
+ihQ
 oXv
 cJr
 rOj
@@ -69458,9 +69511,9 @@ hid
 lGF
 hYn
 eNL
-fUj
+mDU
 rtl
-qlu
+ihQ
 blv
 oVl
 hSM
@@ -70757,7 +70810,7 @@ tCh
 tCh
 tCh
 tCh
-cyM
+ogg
 mPp
 pOj
 xHL
@@ -71225,7 +71278,7 @@ drp
 drp
 drp
 drp
-eLi
+drp
 drp
 awN
 atr
@@ -71548,14 +71601,14 @@ icn
 atr
 noN
 drp
+drp
+drp
+drp
+drp
+drp
+drp
+drp
 eLi
-drp
-drp
-drp
-drp
-drp
-drp
-drp
 drp
 drp
 drp
@@ -72499,7 +72552,7 @@ drp
 drp
 drp
 drp
-drp
+eLi
 drp
 drp
 drp
@@ -72770,7 +72823,7 @@ drp
 drp
 drp
 awN
-atr
+afP
 wLO
 wLO
 wLO
@@ -72830,7 +72883,7 @@ vXd
 nRL
 trj
 trj
-atr
+afP
 noN
 drp
 drp
@@ -73327,7 +73380,7 @@ ksS
 ksS
 ksS
 ksS
-ogg
+dgs
 mPp
 mPp
 pQv
@@ -75861,11 +75914,11 @@ uhH
 lHO
 qwe
 yck
-uhH
+abs
 abs
 nHC
 abs
-kgy
+abs
 xaq
 oKs
 oKs
@@ -76112,19 +76165,19 @@ drp
 drp
 abs
 abs
-uhH
-uhH
-uhH
-uhH
-uhH
-uhH
-uhH
+abs
+abs
+abs
+abs
+abs
+abs
+abs
 lBq
 pVE
 slU
-kgy
-kgy
-kgy
+abs
+abs
+abs
 ofM
 trj
 pQv
@@ -80524,7 +80577,7 @@ drp
 drp
 drp
 drp
-eLi
+drp
 drp
 drp
 drp
@@ -80993,7 +81046,7 @@ drp
 drp
 drp
 drp
-eLi
+drp
 drp
 drp
 drp
@@ -81297,7 +81350,7 @@ drp
 drp
 drp
 drp
-drp
+eLi
 drp
 drp
 drp
@@ -81529,7 +81582,7 @@ drp
 drp
 drp
 drp
-eLi
+drp
 drp
 drp
 drp
@@ -82276,6 +82329,7 @@ drp
 drp
 drp
 drp
+eLi
 drp
 drp
 drp
@@ -82305,8 +82359,7 @@ drp
 drp
 drp
 drp
-drp
-drp
+eLi
 drp
 drp
 drp

--- a/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
@@ -2727,16 +2727,11 @@
 	dir = 8;
 	icon_state = "pipe11-2"
 	},
-/obj/machinery/airalarm/kitchen_cold_room{
-	pixel_y = 22
-	},
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/machinery/processor,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=33;n2=124;TEMP=253.15"
-	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
 "bOr" = (
 /obj/structure/cable{
@@ -5588,7 +5583,9 @@
 /obj/structure/table,
 /obj/machinery/computer/secure_data/laptop,
 /obj/item/clothing/accessory/armband/hydro,
-/obj/machinery/door/window/westright,
+/obj/machinery/door/window/westright{
+	req_one_access_txt = "3;4;38;63"
+	},
 /turf/open/floor/carpet/ship/red_carpet,
 /area/hydroponics)
 "dQu" = (
@@ -6925,9 +6922,7 @@
 	dir = 8;
 	target_temperature = 253.15
 	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=33;n2=124;TEMP=253.15"
-	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
 "eMg" = (
 /obj/machinery/photocopier,
@@ -8475,9 +8470,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=33;n2=124;TEMP=253.15"
-	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
 "fQc" = (
 /obj/structure/cable/yellow{
@@ -13119,9 +13112,7 @@
 	icon_state = "pipe11-2"
 	},
 /obj/structure/closet/secure_closet/freezer/meat,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=33;n2=124;TEMP=253.15"
-	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
 "jnr" = (
 /obj/structure/window/reinforced{
@@ -15857,9 +15848,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=33;n2=124;TEMP=253.15"
-	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
 "lfW" = (
 /obj/machinery/button/door{
@@ -16203,9 +16192,7 @@
 	icon_state = "pipe11-2"
 	},
 /obj/structure/closet/secure_closet/freezer/kitchen/maintenance,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=33;n2=124;TEMP=253.15"
-	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
 "luh" = (
 /obj/structure/chair{
@@ -18761,9 +18748,7 @@
 /area/crew_quarters/heads/cmo)
 "nfw" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=33;n2=124;TEMP=253.15"
-	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
 "nfK" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -19295,9 +19280,7 @@
 	icon_state = "0-2"
 	},
 /obj/structure/closet/secure_closet/freezer/kitchen/maintenance,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=33;n2=124;TEMP=253.15"
-	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
 "nxn" = (
 /obj/machinery/door/firedoor/window,
@@ -20561,9 +20544,7 @@
 	icon_state = "pipe11-2"
 	},
 /obj/structure/closet/secure_closet/freezer/meat,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=33;n2=124;TEMP=253.15"
-	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
 "oBd" = (
 /turf/closed/wall/ship,
@@ -21789,9 +21770,7 @@
 	dir = 8;
 	icon_state = "pipe11-2"
 	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=33;n2=124;TEMP=253.15"
-	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
 "pvk" = (
 /obj/structure/closet/secure_closet/security/engine,
@@ -26558,7 +26537,9 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/machinery/door/window/westleft,
+/obj/machinery/door/window/westleft{
+	req_one_access_txt = "3;4;38;63"
+	},
 /turf/open/floor/carpet/ship/red_carpet,
 /area/hydroponics)
 "sUV" = (
@@ -26986,9 +26967,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=33;n2=124;TEMP=253.15"
-	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
 "tiJ" = (
 /obj/machinery/holopad,
@@ -27136,9 +27115,7 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=33;n2=124;TEMP=253.15"
-	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
 "tpZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -28405,9 +28382,7 @@
 /area/medical/storage)
 "uqv" = (
 /obj/machinery/icecream_vat,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=33;n2=124;TEMP=253.15"
-	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
 "urq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -33313,9 +33288,11 @@
 	dir = 5;
 	icon_state = "pipe11-2"
 	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=33;n2=124;TEMP=253.15"
+/obj/machinery/airalarm/kitchen_cold_room{
+	dir = 1;
+	pixel_y = -24
 	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
 "xHB" = (
 /obj/structure/table/glass,
@@ -33685,9 +33662,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/item/wrench,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=33;n2=124;TEMP=253.15"
-	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
 "xWF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{

--- a/_maps/map_files/Aetherwhisp/Aetherwhisp2.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp2.dmm
@@ -214,6 +214,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
+"aic" = (
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "aiE" = (
 /obj/machinery/chem_master,
 /turf/open/floor/carpet/ship/purple_carpet,
@@ -245,21 +253,9 @@
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/checkpoint/science/research)
 "ajO" = (
-/obj/structure/closet/secure_closet/master_at_arms{
-	anchored = 0
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/item/encryptionkey/heads/master_at_arms,
-/obj/item/radio/headset/heads/captain/alt{
-	desc = "A special headset that protects ears from some loud noises.";
-	keyslot = null;
-	name = "noise cancelling headphones"
-	},
-/obj/item/clothing/ears/earmuffs,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/head/welding,
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
@@ -281,24 +277,24 @@
 /turf/open/floor/carpet/ship,
 /area/science/server)
 "alT" = (
-/obj/structure/chair/stool/bar,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/purple/hidden{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/maintenance/fore)
+/obj/effect/landmark/carpspawn,
+/turf/open/space/basic,
+/area/space/nearstation)
 "alU" = (
 /turf/closed/wall/r_wall/ship,
 /area/engine/engineering/hangar{
 	name = "Bridge Gravity Generator"
 	})
 "alV" = (
-/obj/machinery/photocopier,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/obj/machinery/camera{
+	c_tag = "External Viewport Munitions 1";
+	dir = 8
+	},
+/obj/structure/hull_plate/end{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "aml" = (
 /obj/structure/reagent_dispensers/water_cooler{
 	anchored = 0
@@ -306,11 +302,12 @@
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
 "amF" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+/obj/machinery/camera{
+	c_tag = "External Viewport Munitions 2";
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/maintenance/fore)
+/turf/open/space/basic,
+/area/nsv/weapons/fore)
 "amO" = (
 /obj/structure/table/wood,
 /obj/structure/cable{
@@ -372,6 +369,20 @@
 /obj/structure/bookcase/random/religion,
 /turf/open/floor/wood,
 /area/library)
+"aoe" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/atmospherics/components/binary/pump/layer1{
+	on = 1;
+	target_pressure = 2000
+	},
+/obj/machinery/door/airlock/ship/external/glass{
+	name = "External Access Deck 1 Fore Starboard";
+	req_one_access_txt = "13"
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "aon" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -479,9 +490,7 @@
 	},
 /obj/machinery/disposal/bin,
 /turf/open/floor/carpet/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/area/nsv/hanger/deck2/port)
 "aqW" = (
 /obj/structure/rack,
 /obj/item/shovel{
@@ -517,14 +526,14 @@
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
 "asv" = (
-/obj/machinery/computer/ship/dradis{
-	dir = 4
+/obj/machinery/door/airlock/ship/external/glass{
+	name = "External Access Deck 1 Fore Port";
+	req_one_access_txt = "72"
 	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
-	},
-/area/nsv/weapons/fore)
+/turf/open/floor/plating,
+/area/nsv/weapons/port{
+	name = "Weapons Storage"
+	})
 "ati" = (
 /obj/item/ship_weapon/ammunition/missile,
 /obj/item/ship_weapon/ammunition/missile{
@@ -542,8 +551,13 @@
 /obj/item/ship_weapon/ammunition/missile{
 	pixel_y = 2
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/engine,
-/area/nsv/hanger)
+/area/nsv/weapons/port{
+	name = "Weapons Storage"
+	})
 "atw" = (
 /obj/structure/extinguisher_cabinet/west,
 /obj/machinery/vending/snack/random,
@@ -552,20 +566,10 @@
 	name = "Science Lobby"
 	})
 "atB" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/vending/boozeomat,
-/turf/closed/wall/ship,
+/turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "auU" = (
 /obj/machinery/status_display/ai/north,
@@ -575,37 +579,6 @@
 	name = "nanoweave carpet (bluer)"
 	},
 /area/bridge/meeting_room)
-"ava" = (
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
-	},
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
-"avZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
-	},
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
 "aws" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -658,35 +631,20 @@
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/department/science/xenobiology)
 "axP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/bridge)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/turf/open/floor/engine,
+/area/nsv/weapons/port{
+	name = "Weapons Storage"
+	})
 "ayF" = (
 /obj/structure/closet/wardrobe/grey,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "ayK" = (
-/obj/item/ship_weapon/ammunition/missile{
-	pixel_y = 10
-	},
-/obj/item/ship_weapon/ammunition/missile,
-/obj/item/ship_weapon/ammunition/missile{
-	pixel_y = 6
-	},
-/obj/item/ship_weapon/ammunition/missile{
-	pixel_y = 4
-	},
-/obj/item/ship_weapon/ammunition/missile{
-	pixel_y = 2
-	},
-/obj/item/ship_weapon/ammunition/missile,
-/turf/open/floor/engine,
-/area/nsv/hanger)
+/turf/open/floor/plating,
+/area/nsv/weapons/port{
+	name = "Weapons Storage"
+	})
 "ayS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -747,9 +705,8 @@
 /turf/closed/wall/ship,
 /area/quartermaster/storage)
 "aAA" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/turf/open/floor/engine,
+/area/nsv/weapons/fore)
 "aAE" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -760,17 +717,15 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "aAP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/machinery/door/airlock/vault/ship{
+	name = "Hangar Storage";
+	req_one_access_txt = "72"
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/computer/monitor,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
-	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/engine,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -993,9 +948,6 @@
 /mob/living/simple_animal/slime/random,
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"aIV" = (
-/turf/open/floor/engine,
-/area/nsv/weapons/fore)
 "aJr" = (
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
@@ -1041,17 +993,11 @@
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/xenobiology)
 "aKh" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/structure/sign/solgov_flag{
+	layer = 2.79
 	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
-	},
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/turf/open/floor/engine,
+/area/nsv/weapons/fore)
 "aKo" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -1064,25 +1010,12 @@
 	},
 /area/bridge/meeting_room/council)
 "aKK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
-	},
+/turf/open/floor/carpet/red,
 /area/nsv/weapons/fore)
 "aKU" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/machinery/vending/coffee,
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -1142,31 +1075,17 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"aMs" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
-	},
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
 "aMY" = (
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/structure/sign/solgov_flag/right{
+	layer = 2.79
+	},
+/turf/open/floor/engine,
+/area/nsv/weapons/fore)
 "aON" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light{
+/obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
@@ -1217,9 +1136,8 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 6
 	},
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/turf/open/floor/engine,
+/area/nsv/weapons/fore)
 "aQw" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
@@ -1243,6 +1161,25 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
+"aRI" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/obj/machinery/vending/boozeomat/all_access,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "aRL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/template_noop,
@@ -1432,6 +1369,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"bbg" = (
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/maintenance/fore)
 "bbq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -1448,13 +1389,11 @@
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "bbt" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/machinery/camera{
-	c_tag = "External Access Bridge";
+/obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/bridge)
+/turf/closed/wall/r_wall/ship,
+/area/nsv/weapons/fore)
 "bbu" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1569,7 +1508,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/wood,
 /area/maintenance/fore)
 "bfy" = (
 /mob/living/simple_animal/mouse,
@@ -1761,6 +1700,16 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/ai_monitored/turret_protected/ai)
+"bnm" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "bnr" = (
 /obj/structure/window/plasma/reinforced{
 	dir = 1
@@ -1827,14 +1776,20 @@
 /turf/open/floor/carpet/ship,
 /area/quartermaster/miningoffice)
 "bpU" = (
-/obj/item/flashlight/lamp,
-/obj/structure/table/glass,
-/obj/machinery/keycard_auth{
-	pixel_x = 24;
-	pixel_y = 24
+/obj/structure/disposalpipe/junction/flip{
+	dir = 8
 	},
-/mob/living/simple_animal/pet/cat/kitten{
-	name = "Professor Mew"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
@@ -1946,13 +1901,7 @@
 	name = "Science Lobby"
 	})
 "bts" = (
-/obj/structure/chair/stool/bar,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
-	},
+/obj/structure/table/wood/poker,
 /turf/open/floor/wood,
 /area/maintenance/fore)
 "btO" = (
@@ -2035,16 +1984,17 @@
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
 "bvn" = (
-/obj/machinery/recharge_station,
-/obj/item/trash/chips,
-/obj/effect/landmark/start/cyborg,
-/turf/open/floor/wood,
-/area/maintenance/fore)
+/obj/structure/shuttle/engine/large{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "bvI" = (
-/obj/machinery/advanced_airlock_controller/directional/north,
-/obj/machinery/suit_storage_unit/standard_unit,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/engine,
+/area/nsv/weapons/port{
+	name = "Weapons Storage"
+	})
 "bwh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
@@ -2129,6 +2079,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
+"bxt" = (
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "bxy" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westleft,
@@ -2148,13 +2102,22 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/airlock/ship/maintenance{
-	name = "Maintenance Access Public EVA Storage"
+	name = "Maintenance Access Public EVA Storage";
+	req_one_access_txt = "12"
 	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
 	},
 /area/maintenance/fore)
+"bxC" = (
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "captainoffice"
+	},
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/crew_quarters/heads/captain/private)
 "bxI" = (
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/firedoor/border_only/directional/north,
@@ -2186,10 +2149,10 @@
 	},
 /turf/open/openspace,
 /area/shuttle/turbolift/primary)
-"byo" = (
-/obj/machinery/computer/ship/munitions_computer/west,
-/turf/open/floor/engine,
-/area/nsv/weapons/fore)
+"byn" = (
+/obj/structure/table_frame/wood,
+/turf/open/floor/wood,
+/area/maintenance/fore)
 "byP" = (
 /obj/structure/shuttle/engine/large{
 	dir = 8
@@ -2318,19 +2281,6 @@
 	},
 /turf/open/floor/holofloor/wood,
 /area/bridge/showroom/corporate)
-"bBv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/closet/bombcloset,
-/obj/item/clothing/gloves/color/black,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
-	},
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
 "bBO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -2375,10 +2325,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "bDz" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 6
-	},
-/turf/open/floor/engine,
+/obj/machinery/atmospherics/components/unary/portables_connector,
+/turf/closed/wall/r_wall/ship,
 /area/nsv/weapons/fore)
 "bDF" = (
 /obj/structure/cable/yellow{
@@ -2391,10 +2339,13 @@
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/lab)
 "bDO" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
-/turf/open/floor/engine,
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
 /area/nsv/weapons/fore)
 "bFb" = (
 /obj/machinery/door/firedoor/border_only/directional/north,
@@ -2561,10 +2512,13 @@
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/robotics/lab)
 "bKJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/turf/open/floor/engine,
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
 /area/nsv/weapons/fore)
 "bKW" = (
 /turf/open/floor/engine,
@@ -2610,6 +2564,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -2653,13 +2610,6 @@
 /area/nsv/hanger/deck2/starboard{
 	name = "Launch tubes 1 and 2"
 	})
-"bRf" = (
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/heads/captain)
 "bRE" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable{
@@ -2690,13 +2640,13 @@
 	name = "Science Lobby"
 	})
 "bTh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
-	},
+/turf/open/floor/carpet/red,
 /area/nsv/weapons/fore)
 "bTt" = (
 /turf/open/floor/plating,
@@ -2762,9 +2712,7 @@
 	},
 /area/bridge)
 "bWz" = (
-/obj/structure/bed,
-/obj/machinery/newscaster/security_unit/north,
-/obj/effect/landmark/start/captain,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "bWC" = (
@@ -2798,33 +2746,16 @@
 /turf/open/floor/carpet/purple,
 /area/science/lab)
 "bXu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/airlock/vault/ship{
-	name = "Maintenance Access Munitions Weapons Bay";
-	req_one_access_txt = "3;69"
+/obj/machinery/door/airlock/ship/external/glass{
+	name = "External Access Deck 1 Fore Port";
+	req_one_access_txt = "72"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
-	},
-/area/nsv/weapons/fore)
-"bXx" = (
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/airlock/ship/maintenance{
-	name = "Maintenance Access Captain Quarters";
-	req_one_access_txt = "20"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/captain/private)
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/engine,
+/area/nsv/weapons/port{
+	name = "Weapons Storage"
+	})
 "bXL" = (
 /obj/structure/closet/secure_closet/hop,
 /turf/open/floor/carpet/ship/blue{
@@ -3016,6 +2947,14 @@
 /obj/machinery/suit_storage_unit/rd,
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/mixing)
+"cgr" = (
+/obj/machinery/light_switch/west,
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
+"cgx" = (
+/obj/machinery/atmospherics/pipe/manifold/purple/hidden,
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/fore)
 "ciw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -3026,29 +2965,16 @@
 /turf/open/floor/plating,
 /area/nsv/hanger)
 "ciy" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /turf/closed/wall/ship,
-/area/crew_quarters/heads/captain)
+/area/maintenance/department/cargo)
 "ciQ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/grille,
+/obj/machinery/atmospherics/pipe/manifold/purple/hidden{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/turf/open/floor/plating,
+/area/nsv/weapons/fore)
 "cji" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -3102,17 +3028,12 @@
 /turf/open/floor/plating,
 /area/nsv/hanger)
 "ckp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/effect/turf_decal/delivery/white,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/turf/open/floor/engine,
+/area/nsv/weapons/fore)
 "ckx" = (
 /obj/machinery/modular_computer/console/preset/civilian{
 	dir = 1
@@ -3165,10 +3086,9 @@
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/xenobiology)
 "cmO" = (
-/obj/structure/reagent_dispensers/fueltank/aviation_fuel,
-/obj/machinery/computer/ship/viewscreen,
+/obj/structure/frame/machine,
 /turf/open/floor/engine,
-/area/nsv/hanger)
+/area/nsv/weapons/fore)
 "cnq" = (
 /obj/machinery/modular_computer/console/preset/civilian{
 	dir = 8
@@ -3350,11 +3270,9 @@
 /turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "crV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/obj/structure/table_frame,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "csi" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -3373,6 +3291,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
@@ -3405,15 +3326,25 @@
 /turf/open/floor/carpet/ship,
 /area/bridge/meeting_room/council)
 "ctR" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/closed/wall/ship,
-/area/maintenance/fore)
+/turf/open/floor/engine,
+/area/nsv/weapons/fore)
+"cul" = (
+/obj/structure/table/glass,
+/obj/item/pinpointer/nuke,
+/obj/item/disk/nuclear,
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "cuz" = (
-/obj/structure/piano,
-/turf/open/floor/wood,
-/area/maintenance/fore)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/engine,
+/area/nsv/weapons/port{
+	name = "Weapons Storage"
+	})
 "cuN" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -3424,30 +3355,34 @@
 	name = "Science Lobby"
 	})
 "cvl" = (
-/obj/machinery/shower{
-	dir = 8;
-	name = "emergency shower"
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/turf/open/floor/engine,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
 "cvr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/airlock/ship/maintenance{
-	name = "Maintenance Access Bridge";
-	req_one_access_txt = "19"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/airlock/ship/command{
+	name = "Captain Office";
+	req_access_txt = "20"
+	},
+/turf/open/floor/carpet/ship/blue{
+	color = "#9999DD";
+	name = "nanoweave carpet (bluer)"
+	},
 /area/maintenance/department/bridge)
 "cvL" = (
 /obj/machinery/shower{
@@ -3459,8 +3394,23 @@
 /obj/item/bikehorn/rubberducky,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
+"cvP" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "cww" = (
-/obj/effect/landmark/start/munitions_tech,
+/obj/structure/table,
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
@@ -3471,8 +3421,8 @@
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/mixing)
 "cwO" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
@@ -3558,11 +3508,11 @@
 /turf/open/space/basic,
 /area/maintenance/disposal)
 "cAg" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/maintenance/fore)
+/obj/structure/reagent_dispensers/fueltank/aviation_fuel,
+/turf/open/floor/engine,
+/area/nsv/weapons/port{
+	name = "Weapons Storage"
+	})
 "cAB" = (
 /obj/machinery/light{
 	dir = 1
@@ -3623,29 +3573,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
 "cDp" = (
-/obj/structure/closet/secure_closet/fighter_pilot,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/head/hardhat,
-/obj/item/clothing/head/hardhat,
-/obj/item/radio/headset/heads/captain/alt{
-	desc = "A special headset that protects ears from some loud noises.";
-	keyslot = null;
-	name = "noise cancelling headphones"
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/item/radio/headset/heads/captain/alt{
-	desc = "A special headset that protects ears from some loud noises.";
-	keyslot = null;
-	name = "noise cancelling headphones"
-	},
-/obj/item/clothing/ears/earmuffs,
-/obj/item/clothing/ears/earmuffs,
-/obj/item/encryptionkey/atc,
-/obj/item/encryptionkey/atc,
-/turf/open/floor/carpet/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/turf/open/floor/engine,
+/area/nsv/hanger/deck2/port)
 "cDB" = (
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
@@ -3738,25 +3671,11 @@
 	},
 /area/bridge/meeting_room/council)
 "cHv" = (
-/obj/item/disk/holodisk/donutstation{
-	pixel_x = 4;
-	pixel_y = 6
-	},
-/obj/item/disk/holodisk/donutstation/enginewars{
-	pixel_x = 2;
-	pixel_y = 4
-	},
-/obj/machinery/cell_charger,
-/obj/structure/table/glass,
-/obj/structure/extinguisher_cabinet/west,
-/obj/item/disk/holodisk/galactica_history/history{
-	pixel_y = 2
-	},
-/obj/item/disk/holodisk/example{
-	pixel_x = -2
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/plating,
+/area/nsv/weapons/port{
+	name = "Weapons Storage"
+	})
 "cHx" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 1
@@ -3782,18 +3701,11 @@
 	},
 /area/ai_monitored/turret_protected/aisat_interior)
 "cII" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/purple/hidden{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/chair,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/turf/closed/wall/r_wall/ship,
+/area/nsv/weapons/fore)
 "cIR" = (
-/obj/machinery/computer/ship/dradis/minor{
+/obj/machinery/computer/ship/navigation{
 	dir = 4
 	},
 /turf/open/floor/carpet/ship,
@@ -3961,10 +3873,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/carpet/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/nsv/hanger/deck2/port)
 "cOU" = (
 /obj/machinery/door/firedoor/window,
 /obj/structure/grille,
@@ -4075,11 +3988,6 @@
 /obj/item/computer_hardware/card_slot,
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
-"cUW" = (
-/turf/open/floor/plating,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
 "cUY" = (
 /obj/machinery/vending/cart,
 /turf/open/floor/carpet/ship/blue{
@@ -4158,14 +4066,11 @@
 	},
 /area/bridge/meeting_room/council)
 "cYk" = (
-/obj/structure/chair/office{
+/obj/structure/frame/computer{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/turf/open/floor/engine,
+/area/nsv/weapons/fore)
 "cYv" = (
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
@@ -4175,9 +4080,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
 "cYB" = (
-/obj/structure/reagent_dispensers/fueltank/aviation_fuel,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /turf/open/floor/engine,
-/area/nsv/hanger)
+/area/nsv/weapons/fore)
 "cYJ" = (
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 5
@@ -4199,23 +4104,9 @@
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "cZH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 8;
-	sortType = 33
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
-	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/engine,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -4232,8 +4123,14 @@
 /turf/open/floor/engine,
 /area/science/explab)
 "dbe" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
@@ -4249,12 +4146,17 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "dbI" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/directions/plaque/munitions{
+	dir = 4;
+	pixel_y = -7
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/nsv/weapons/fore)
+/turf/closed/wall/ship,
+/area/nsv/weapons/port{
+	name = "Weapons Storage"
+	})
 "dbK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4290,26 +4192,31 @@
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms)
 "ddz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/machinery/firealarm{
+	pixel_x = -26;
+	pixel_y = 25
+	},
+/obj/machinery/disposal/deliveryChute{
+	name = "munitions delivery chute"
+	},
+/obj/machinery/door/window/southright,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/airlock/ship/station{
-	name = "Captain Office Bathroom";
-	req_one_access_txt = "20"
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/heads/captain)
-"ddE" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/landmark/start/munitions_tech,
-/turf/open/floor/engine,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
 /area/nsv/weapons/fore)
 "deP" = (
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
@@ -4318,14 +4225,20 @@
 /turf/template_noop,
 /area/maintenance/department/science/xenobiology)
 "dfp" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/landmark/start/munitions_tech,
-/turf/open/floor/engine,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
 /area/nsv/weapons/fore)
 "dfE" = (
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank{
@@ -4400,6 +4313,12 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
+"dkt" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 8
+	},
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/fore)
 "dkR" = (
 /obj/item/trash/can/food/peaches/maint,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -4543,7 +4462,6 @@
 /area/shuttle/turbolift/tertiary)
 "dpg" = (
 /obj/machinery/status_display/supply/west,
-/obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/engine,
 /area/nsv/hanger)
 "dpF" = (
@@ -4578,15 +4496,13 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "dqX" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
-"dsx" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 9
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
-/obj/structure/grille,
-/turf/open/floor/plating,
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
 /area/nsv/weapons/fore)
 "dtt" = (
 /obj/structure/chair/stool,
@@ -4632,6 +4548,11 @@
 	},
 /turf/open/floor/plating,
 /area/bridge/meeting_room/council)
+"dtY" = (
+/obj/structure/table/wood,
+/obj/structure/showcase/machinery/microwave,
+/turf/open/floor/wood,
+/area/maintenance/fore)
 "duf" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -4682,13 +4603,12 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "dvP" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
+/obj/effect/turf_decal/delivery/white,
+/obj/structure/munitions_trolley,
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
 	},
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/turf/open/floor/engine,
 /area/nsv/weapons/fore)
 "dwt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -4728,11 +4648,23 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "dyW" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/button/door{
-	id = "captainoffice";
-	pixel_x = 6;
-	pixel_y = 26
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/airlock/ship/command{
+	name = "Captain Quarters";
+	req_access_txt = "20"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
@@ -4815,32 +4747,13 @@
 /turf/closed/wall/ship,
 /area/shuttle/turbolift/tertiary)
 "dAw" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/delivery/white,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/airlock/ship/command{
-	name = "Captain Office";
-	req_access_txt = "20"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
-	},
-/turf/open/floor/carpet/ship/blue{
-	color = "#9999DD";
-	name = "nanoweave carpet (bluer)"
-	},
-/area/crew_quarters/heads/captain)
+/area/nsv/weapons/fore)
 "dAH" = (
 /obj/machinery/vending/wardrobe/cargo_wardrobe,
 /turf/open/floor/carpet/ship,
@@ -4905,26 +4818,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "dCE" = (
-/obj/structure/sign/solgov_seal,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/smes{
-	charge = 800000;
-	input_level = 20000;
-	name = "low-priority department power storage unit";
-	output_level = 20000
-	},
+/obj/effect/landmark/start/munitions_tech,
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
 	},
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/area/nsv/weapons/fore)
 "dCU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -5038,12 +4937,19 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "dJc" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	dir = 4;
-	id = "captainoffice"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "dJw" = (
 /obj/structure/disposalpipe/segment,
@@ -5147,14 +5053,15 @@
 /turf/open/floor/engine,
 /area/nsv/hanger)
 "dND" = (
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/airlock/ship/maintenance{
-	name = "Maintenance Access Captain Office";
-	req_one_access_txt = "20"
+/obj/item/storage/lockbox/medal,
+/obj/item/storage/secure/briefcase{
+	pixel_x = -5;
+	pixel_y = 2
 	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/captain)
+/obj/item/storage/lockbox/loyalty,
+/obj/structure/table/glass,
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "dOf" = (
 /turf/closed/wall/r_wall/ship,
 /area/quartermaster/storage)
@@ -5214,6 +5121,9 @@
 	info = "<p>Engineering notice: There are three wire colors used on the Aetherwhisp 6 ship model. White cable is wired to the Stormdrive MK-4 and the supermatter crystal near atmospherics. These lead to their own SMES located nearby. Yellow wires are department distribution wires, which deliver power from the engines SMES to deparment SMES. Red wires deliver power from department SMES to department APCs.</p>"
 	},
 /obj/machinery/newscaster/directional/west,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -5297,13 +5207,18 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "dTI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/computer/monitor{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/sign/solgov_seal,
+/turf/open/floor/engine,
+/area/nsv/weapons/fore)
 "dTT" = (
 /obj/machinery/atmospherics/pipe/simple/multiz,
 /obj/effect/landmark/blobstart,
@@ -5346,28 +5261,26 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "dUX" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/engine,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
+"dVk" = (
+/obj/item/chair,
+/turf/open/floor/wood,
+/area/maintenance/fore)
 "dVr" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/landmark/start/mime,
@@ -5387,6 +5300,19 @@
 /obj/item/wrench,
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/mixing)
+"dXt" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/carpet/ship/blue{
+	color = "#9999DD";
+	name = "nanoweave carpet (bluer)"
+	},
+/area/bridge)
 "dXB" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -5416,14 +5342,6 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms)
-"ebt" = (
-/obj/effect/turf_decal/delivery/white,
-/obj/item/ship_weapon/ammunition/torpedo/torpedo_casing,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
-	},
-/area/nsv/weapons/fore)
 "eci" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
@@ -5431,13 +5349,9 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/auxiliary)
 "ecq" = (
-/obj/structure/table,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/pipe_dispenser,
-/obj/item/assault_pod/mining,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/effect/turf_decal/delivery/white,
+/turf/open/floor/engine,
+/area/nsv/weapons/fore)
 "ecu" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -5490,8 +5404,9 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "edT" = (
-/obj/structure/sign/solgov_flag{
-	layer = 2.79
+/obj/machinery/ship_weapon/energy/beam,
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
 /turf/open/floor/engine,
 /area/nsv/weapons/fore)
@@ -5554,26 +5469,24 @@
 /turf/closed/wall/ship,
 /area/bridge/meeting_room/council)
 "ehJ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/machinery/power/terminal{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
+/obj/effect/landmark/start/munitions_tech,
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/area/nsv/weapons/fore)
 "ehL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/layer1{
 	dir = 4
@@ -5632,12 +5545,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "ele" = (
-/obj/effect/turf_decal/delivery/white,
-/obj/machinery/ship_weapon/torpedo_launcher/east,
-/obj/structure/cable/white{
-	icon_state = "1-2"
+/obj/machinery/computer/ship/dradis{
+	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
 /area/nsv/weapons/fore)
 "elq" = (
 /obj/machinery/recharge_station,
@@ -5663,6 +5577,13 @@
 "eoy" = (
 /turf/closed/wall/ship,
 /area/shuttle/turbolift/secondary)
+"epQ" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "captainoffice"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/captain/private)
 "eqj" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
@@ -5691,6 +5612,26 @@
 	name = "nanoweave carpet (bluer)"
 	},
 /area/bridge)
+"eqT" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks/beer,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "erD" = (
 /obj/item/clothing/mask/surgical,
 /obj/item/clothing/gloves/color/latex,
@@ -5721,10 +5662,18 @@
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/mixing)
 "euo" = (
-/obj/machinery/hydroponics/soil,
-/obj/effect/spawner/lootdrop/maintenance/four,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/effect/landmark/start/munitions_tech,
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
+/area/nsv/weapons/fore)
 "euE" = (
 /obj/machinery/door/poddoor/ship{
 	dir = 4;
@@ -5802,16 +5751,14 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "ewG" = (
-/obj/structure/table/glass,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/obj/item/reagent_containers/food/drinks/flask/gold,
-/obj/machinery/door/window/southleft{
-	req_access_txt = "20"
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
 	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/area/nsv/weapons/fore)
 "ewJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -5935,10 +5882,14 @@
 /turf/open/floor/circuit,
 /area/science/server)
 "eBb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/maintenance/fore)
 "eBz" = (
 /obj/structure/disposalpipe/segment{
@@ -5971,6 +5922,13 @@
 	name = "nanoweave carpet (bluer)"
 	},
 /area/bridge/meeting_room/council)
+"eCc" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "eCw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6011,10 +5969,26 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"eDY" = (
+/obj/structure/chair,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/maintenance/fore)
 "eEM" = (
 /obj/structure/displaycase/labcage,
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/crew_quarters/heads/hor)
+"eET" = (
+/obj/machinery/modular_computer/console/preset/command{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "eFu" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -6149,16 +6123,18 @@
 	},
 /area/bridge/meeting_room)
 "eIS" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
 	},
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/area/nsv/weapons/fore)
 "eJM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -6207,9 +6183,17 @@
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/robotics/lab)
 "eKz" = (
-/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/engine,
-/area/nsv/hanger)
+/area/nsv/weapons/fore)
 "eKM" = (
 /obj/structure/chair/comfy{
 	dir = 4
@@ -6258,10 +6242,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
-"eMo" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/turf/closed/wall/r_wall/ship,
-/area/nsv/weapons/fore)
 "eMq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -6319,9 +6299,7 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/open/floor/carpet/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/area/nsv/hanger/deck2/port)
 "eND" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/six,
@@ -6343,11 +6321,10 @@
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/xenobiology)
 "eOT" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
+/obj/machinery/light{
+	dir = 1
 	},
+/turf/open/floor/engine,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -6432,15 +6409,20 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
+"eTM" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "eUm" = (
 /turf/closed/wall/r_wall/ship,
 /area/quartermaster/warehouse)
 "eUI" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/landmark/start/munitions_tech,
+/turf/open/floor/engine,
+/area/nsv/weapons/fore)
 "eUJ" = (
 /obj/effect/spawner/room/tenxfive,
 /turf/template_noop,
@@ -6742,10 +6724,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "fcK" = (
-/obj/machinery/atmospherics/pipe/manifold/purple/hidden{
-	dir = 1
+/obj/effect/turf_decal/delivery/white,
+/obj/structure/closet/bombcloset,
+/obj/item/clothing/gloves/color/black,
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
 	},
-/turf/closed/wall/r_wall/ship,
 /area/nsv/weapons/fore)
 "fdh" = (
 /obj/machinery/firealarm/directional/east,
@@ -6774,19 +6759,7 @@
 	},
 /area/ai_monitored/turret_protected/aisat_interior)
 "fhi" = (
-/obj/structure/closet/crate/secure/weapon,
-/obj/item/ship_weapon/parts/torpedo/propulsion_system,
-/obj/item/ship_weapon/parts/torpedo/propulsion_system,
-/obj/item/ship_weapon/parts/torpedo/propulsion_system,
-/obj/item/ship_weapon/parts/torpedo/guidance_system,
-/obj/item/ship_weapon/parts/torpedo/guidance_system,
-/obj/item/ship_weapon/parts/torpedo/guidance_system,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
@@ -6915,15 +6888,19 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/science/server)
+"fkg" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/maintenance/fore)
 "fki" = (
 /obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/landmark/start/air_traffic_controller,
 /turf/open/floor/carpet/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/area/nsv/hanger/deck2/port)
 "fko" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6947,9 +6924,7 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/area/nsv/hanger/deck2/port)
 "fkz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/machinery/light{
@@ -7008,11 +6983,8 @@
 /turf/open/floor/plating,
 /area/science/server)
 "fmj" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/engine,
 /area/nsv/weapons/fore)
@@ -7022,6 +6994,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
@@ -7069,25 +7047,27 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "fpd" = (
-/obj/machinery/firealarm/directional/west,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/structure/closet/secure_closet/fighter_pilot,
 /obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/head/hardhat,
 /obj/item/clothing/head/hardhat,
 /obj/item/radio/headset/heads/captain/alt{
 	desc = "A special headset that protects ears from some loud noises.";
 	keyslot = null;
 	name = "noise cancelling headphones"
 	},
-/obj/item/clothing/ears/earmuffs,
-/obj/item/encryptionkey/munitions_tech,
-/obj/structure/closet/secure_closet/munitions_technician,
-/obj/item/clothing/head/welding,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
+/obj/item/radio/headset/heads/captain/alt{
+	desc = "A special headset that protects ears from some loud noises.";
+	keyslot = null;
+	name = "noise cancelling headphones"
 	},
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/encryptionkey/atc,
+/obj/item/encryptionkey/atc,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/engine,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -7134,15 +7114,17 @@
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/robotics/lab)
 "fqv" = (
-/obj/item/storage/lockbox/medal,
-/obj/item/storage/secure/briefcase{
-	pixel_x = -5;
-	pixel_y = 2
+/obj/structure/closet/secure_closet/freezer/kitchen/maintenance,
+/obj/item/kitchen/knife,
+/obj/item/reagent_containers/food/condiment/enzyme,
+/obj/item/reagent_containers/food/condiment/saltshaker,
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3;
+	pixel_y = 4
 	},
-/obj/item/storage/lockbox/loyalty,
-/obj/structure/table/glass,
-/obj/machinery/light_switch/west,
-/obj/machinery/status_display/evac/north,
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "fqG" = (
@@ -7181,18 +7163,6 @@
 /obj/effect/landmark/start/cyborg,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"frR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
-	},
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
 "fsp" = (
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/xenobiology)
@@ -7305,8 +7275,7 @@
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/robotics/lab)
 "fyA" = (
-/obj/structure/sign/warning/docking,
-/turf/closed/wall/r_wall/ship,
+/turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "fyC" = (
 /obj/structure/cable/yellow{
@@ -7322,7 +7291,7 @@
 /area/maintenance/department/cargo)
 "fyE" = (
 /obj/machinery/atmospherics/pipe/simple/multiz,
-/turf/open/floor/plating,
+/turf/open/floor/wood,
 /area/maintenance/fore)
 "fyO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -7340,8 +7309,11 @@
 /turf/open/floor/wood,
 /area/library)
 "fzt" = (
-/obj/structure/cable/white{
-	icon_state = "1-2"
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/engine,
 /area/nsv/weapons/fore)
@@ -7428,9 +7400,9 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "fDP" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain/private)
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/engine,
+/area/nsv/weapons/fore)
 "fEG" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty,
@@ -7547,14 +7519,27 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "fKd" = (
-/obj/effect/spawner/lootdrop/crate_spawner,
-/turf/open/floor/plating,
-/area/nsv/weapons/fore)
-"fKk" = (
-/obj/structure/bookcase/random,
-/obj/machinery/computer/ship/viewscreen,
-/turf/open/floor/carpet,
+/turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/heads/captain/private)
+"fKk" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 8;
+	sortType = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/carpet/red,
+/area/nsv/weapons/fore)
 "fKm" = (
 /obj/effect/spawner/lootdrop/crate_spawner,
 /turf/open/floor/plating,
@@ -7597,6 +7582,12 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/carpet/ship,
 /area/ai_monitored/turret_protected/ai)
+"fLU" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/maintenance/fore)
 "fLX" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -7638,8 +7629,7 @@
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
 "fOG" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
+/obj/item/banner/science,
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/lab)
 "fOI" = (
@@ -7690,11 +7680,11 @@
 /turf/open/floor/carpet/ship,
 /area/ai_monitored/turret_protected/ai)
 "fQY" = (
-/obj/structure/cable/white{
-	icon_state = "0-2"
-	},
 /obj/machinery/modular_computer/console/preset/engineering{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
 	},
 /turf/open/floor/engine,
 /area/nsv/weapons/fore)
@@ -7737,15 +7727,15 @@
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/robotics/lab)
 "fTa" = (
-/obj/structure/chair/office{
-	dir = 4
+/obj/effect/turf_decal/delivery/white,
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/turf/open/floor/engine,
+/area/nsv/weapons/fore)
 "fTg" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -7759,13 +7749,30 @@
 	},
 /area/bridge/meeting_room)
 "fTx" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/machinery/door/airlock/ship/external/glass{
-	name = "External Access Deck 1 Fore Starboard";
-	req_one_access_txt = "13"
+/obj/machinery/ship_weapon/energy,
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/turf/open/floor/engine,
+/area/nsv/weapons/fore)
+"fTA" = (
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/structure/table/glass,
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Captain's Desk";
+	departmentType = 5;
+	desc = "A console intended to send requests to different departments on the station. This one is equipped with prototype holographic keyboard software, because you deserve it.";
+	name = "Captain RC";
+	pixel_x = -32;
+	pixel_y = -32
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "fTH" = (
 /obj/structure/table,
 /obj/item/storage/fancy/donut_box,
@@ -7859,7 +7866,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/wood,
 /area/maintenance/fore)
 "fWX" = (
 /obj/structure/cable{
@@ -7886,17 +7893,19 @@
 	name = "Bridge Gravity Generator"
 	})
 "fXx" = (
-/obj/item/paper_bin,
 /obj/structure/table,
+/obj/item/pet_carrier,
+/obj/item/paper_bin,
 /obj/item/pen,
 /obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/carpet/ship,
 /area/janitor)
 "fXN" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/matches,
-/turf/open/floor/wood,
-/area/maintenance/fore)
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/nsv/weapons/fore)
 "fXR" = (
 /obj/machinery/camera{
 	c_tag = "Elevator Council Chamber 2";
@@ -7931,21 +7940,32 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/area/nsv/hanger/deck2/port)
 "fZG" = (
-/obj/effect/turf_decal/delivery/white,
-/obj/machinery/airalarm/directional/north,
+/obj/machinery/computer/lore_terminal,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/smes{
+	charge = 800000;
+	input_level = 20000;
+	name = "low-priority department power storage unit";
+	output_level = 20000
+	},
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
 	},
 /area/nsv/weapons/fore)
 "gag" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/engine,
-/area/nsv/hanger)
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 5
+	},
+/turf/closed/wall/r_wall/ship,
+/area/nsv/weapons/fore)
 "gal" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -8032,15 +8052,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
-"ggX" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
-	},
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
 "ghh" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
@@ -8055,17 +8066,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "ghx" = (
@@ -8214,9 +8222,7 @@
 "gmW" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/carpet/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/area/nsv/hanger/deck2/port)
 "gns" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -8269,22 +8275,11 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "gqs" = (
-/obj/structure/closet/bombcloset,
-/obj/item/clothing/gloves/color/black,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
-"gqO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/turf/open/floor/engine,
+/area/nsv/hanger/deck2/port)
 "gqQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -8302,7 +8297,6 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/status_display/evac/west,
 /turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "grs" = (
@@ -8368,6 +8362,13 @@
 /obj/structure/sign/departments/minsky/supply/janitorial,
 /turf/closed/wall/ship,
 /area/janitor)
+"gxD" = (
+/obj/structure/table/glass,
+/obj/item/flashlight/lamp,
+/obj/item/computer_hardware/card_slot,
+/obj/item/cartridge/captain,
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "gxM" = (
 /obj/item/storage/box/snappops,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -8476,13 +8477,47 @@
 	dir = 4;
 	pixel_y = -39
 	},
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = 2
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = 2
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -10
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -10
+	},
 /turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "gzH" = (
-/obj/structure/sign/solgov_flag/right{
-	layer = 2.79
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
 	},
-/turf/open/floor/engine,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
 /area/nsv/weapons/fore)
 "gzY" = (
 /obj/machinery/door/firedoor/border_only/directional/north,
@@ -8513,26 +8548,20 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "gBC" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
 	},
-/turf/open/floor/carpet/ship/blue{
-	color = "#9999DD";
-	name = "nanoweave carpet (bluer)"
-	},
-/area/bridge/meeting_room)
+/area/nsv/weapons/fore)
 "gBZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -8576,13 +8605,20 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "gDg" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
+/obj/structure/closet/crate/secure/weapon,
+/obj/item/ship_weapon/parts/torpedo/propulsion_system,
+/obj/item/ship_weapon/parts/torpedo/propulsion_system,
+/obj/item/ship_weapon/parts/torpedo/propulsion_system,
+/obj/item/ship_weapon/parts/torpedo/guidance_system,
+/obj/item/ship_weapon/parts/torpedo/guidance_system,
+/obj/item/ship_weapon/parts/torpedo/guidance_system,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
+/obj/machinery/camera/autoname{
+	dir = 1
 	},
+/turf/open/floor/carpet/red,
 /area/nsv/weapons/fore)
 "gDr" = (
 /obj/structure/bed/dogbed/ian{
@@ -8606,6 +8642,25 @@
 	},
 /turf/open/floor/circuit,
 /area/science/server)
+"gDM" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 8;
+	sortType = 12
+	},
+/turf/open/floor/carpet/ship/purple_carpet,
+/area/science/lab)
 "gDN" = (
 /turf/open/floor/carpet/ship,
 /area/bridge/showroom{
@@ -8717,13 +8772,8 @@
 "gMX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/turf/open/floor/plating,
+/turf/closed/wall/ship,
 /area/maintenance/fore)
 "gNA" = (
 /mob/living/simple_animal/bot/secbot/pingsky,
@@ -8781,6 +8831,15 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
+"gQz" = (
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/bridge)
 "gQN" = (
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -8789,6 +8848,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"gQT" = (
+/obj/structure/table/glass,
+/obj/machinery/power/apc/auto_name/north,
+/obj/item/storage/box/pinpointer_pairs,
+/obj/item/hand_tele,
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "gRQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -8832,15 +8898,20 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/turf/open/floor/engine,
+/area/nsv/hanger/deck2/port)
 "gTW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
+/area/nsv/weapons/fore)
 "gUl" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -8906,7 +8977,6 @@
 /turf/open/floor/carpet/ship,
 /area/quartermaster/qm)
 "gXt" = (
-/obj/item/electronics/airlock,
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
@@ -8922,6 +8992,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
+/obj/item/electronics/airlock,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "gXM" = (
@@ -8941,9 +9012,7 @@
 	req_access_txt = "73"
 	},
 /turf/open/floor/carpet/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/area/nsv/hanger/deck2/port)
 "gYd" = (
 /obj/item/nanite_remote,
 /obj/structure/table/glass,
@@ -9057,6 +9126,16 @@
 	},
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/robotics/lab)
+"hbl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/meter/atmos/distro_loop{
+	pixel_x = -6;
+	pixel_y = -6;
+	target_layer = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "hbD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -9064,16 +9143,14 @@
 /turf/open/floor/plating,
 /area/nsv/hanger)
 "hbP" = (
-/obj/structure/table,
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/west,
-/obj/structure/cable{
-	icon_state = "0-2"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "hbS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -9108,6 +9185,15 @@
 	},
 /turf/template_noop,
 /area/maintenance/department/cargo)
+"hdn" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "hdP" = (
 /obj/machinery/computer/bounty{
 	dir = 4
@@ -9130,19 +9216,23 @@
 /area/science/xenobiology)
 "hfr" = (
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
+	dir = 6
 	},
-/obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "hfz" = (
-/obj/structure/table/glass,
-/obj/item/flashlight/lamp,
+/obj/item/camera,
+/obj/item/melee/chainofcommand,
+/obj/structure/table,
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
-/obj/item/computer_hardware/card_slot,
-/obj/item/cartridge/captain,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "hfB" = (
@@ -9170,10 +9260,8 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/turf/open/floor/engine,
+/area/nsv/hanger/deck2/port)
 "hgk" = (
 /obj/structure/closet/emcloset,
 /obj/item/storage/toolbox/emergency,
@@ -9209,14 +9297,15 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "hgV" = (
-/obj/structure/sign/warning/pods,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/turf/closed/wall/r_wall/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
+/area/nsv/weapons/fore)
 "hgZ" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/structure/disposalpipe/segment{
@@ -9233,18 +9322,6 @@
 	name = "nanoweave carpet (bluer)"
 	},
 /area/crew_quarters/heads/hop)
-"hhK" = (
-/obj/machinery/computer/ship/fighter_controller,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
-	},
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
 "hhU" = (
 /obj/docking_port/stationary{
 	dwidth = 1;
@@ -9308,11 +9385,14 @@
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "hkI" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/engine,
+/area/nsv/weapons/fore)
 "hkM" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plating,
@@ -9331,11 +9411,6 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
-"hlr" = (
-/obj/structure/bed,
-/obj/item/bedsheet/orange,
-/turf/open/floor/carpet/ship,
-/area/nsv/hanger/deck2/port)
 "hlA" = (
 /obj/machinery/computer/rdconsole/robotics{
 	dir = 8
@@ -9373,8 +9448,12 @@
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/xenobiology)
 "hpq" = (
-/obj/structure/bookcase/random,
-/obj/machinery/computer/lore_terminal,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "hpA" = (
@@ -9413,16 +9492,11 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "hqO" = (
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
@@ -9440,13 +9514,13 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "hro" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
@@ -9478,8 +9552,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "hto" = (
-/obj/structure/displaycase/captain,
-/obj/machinery/firealarm/directional/west,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "hts" = (
@@ -9550,6 +9625,32 @@
 "hvV" = (
 /turf/closed/wall/ship,
 /area/quartermaster/warehouse)
+"hvY" = (
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = 2
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = 2
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -10
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -10
+	},
+/turf/open/floor/carpet/ship/blue{
+	color = "#9999DD";
+	name = "nanoweave carpet (bluer)"
+	},
+/area/bridge/meeting_room)
 "hwX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -9634,6 +9735,13 @@
 	},
 /turf/open/floor/engine,
 /area/science/explab)
+"hAI" = (
+/obj/machinery/camera{
+	c_tag = "External Access Science Construction Zone";
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "hAL" = (
 /obj/machinery/modular_computer/console/preset/civilian{
 	dir = 4
@@ -9644,8 +9752,19 @@
 /turf/open/floor/carpet/ship,
 /area/janitor)
 "hAO" = (
-/obj/effect/turf_decal/delivery/white,
-/obj/structure/munitions_trolley,
+/obj/structure/sign/solgov_seal,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/smes{
+	charge = 800000;
+	input_level = 20000;
+	name = "low-priority department power storage unit";
+	output_level = 20000
+	},
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
@@ -9662,8 +9781,24 @@
 /turf/open/floor/carpet/ship,
 /area/quartermaster/qm)
 "hDk" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
+/obj/item/ship_weapon/ammunition/missile{
+	pixel_y = 10
+	},
+/obj/item/ship_weapon/ammunition/missile,
+/obj/item/ship_weapon/ammunition/missile{
+	pixel_y = 6
+	},
+/obj/item/ship_weapon/ammunition/missile{
+	pixel_y = 4
+	},
+/obj/item/ship_weapon/ammunition/missile{
+	pixel_y = 2
+	},
+/obj/item/ship_weapon/ammunition/missile,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -9686,16 +9821,6 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/science/server)
-"hFC" = (
-/obj/effect/turf_decal/delivery/white,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
-	},
-/area/nsv/weapons/fore)
 "hFL" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -9757,12 +9882,7 @@
 	name = "Battle Bridge"
 	})
 "hHF" = (
-/obj/effect/turf_decal/delivery/white,
-/obj/structure/closet/crate/secure/weapon,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
-	},
+/turf/closed/wall/ship,
 /area/nsv/weapons/fore)
 "hHQ" = (
 /obj/structure/cable/yellow{
@@ -9805,9 +9925,11 @@
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/mixing)
 "hJi" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/engine,
+/area/nsv/weapons/fore)
 "hJk" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9871,6 +9993,16 @@
 /obj/structure/extinguisher_cabinet/west,
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
+"hMg" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance/eight,
+/obj/item/shuttle_creator,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "hMn" = (
 /obj/structure/table/wood,
 /obj/item/trash/can{
@@ -9900,25 +10032,30 @@
 	name = "nanoweave carpet (bluer)"
 	},
 /area/bridge/meeting_room)
+"hNy" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "hOv" = (
-/obj/effect/turf_decal/delivery/white,
-/obj/item/ship_weapon/ammunition/torpedo/probe,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
 /area/nsv/weapons/fore)
 "hOJ" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
-	},
+/turf/open/floor/engine,
 /area/nsv/weapons/fore)
 "hPa" = (
 /obj/structure/rack,
@@ -9941,11 +10078,9 @@
 /turf/open/floor/carpet/ship,
 /area/quartermaster/office)
 "hQz" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/obj/item/flashlight/lamp,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "hQH" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -9965,6 +10100,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
+"hRl" = (
+/obj/structure/closet/crate,
+/obj/effect/landmark/blobstart,
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/wood,
+/area/maintenance/fore)
 "hRp" = (
 /obj/structure/table,
 /obj/machinery/button/door{
@@ -10065,8 +10206,8 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "hWj" = (
-/obj/machinery/atmospherics/components/unary/portables_connector,
-/turf/closed/wall/r_wall/ship,
+/obj/structure/munitions_trolley,
+/turf/open/floor/engine,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -10080,13 +10221,7 @@
 	},
 /area/crew_quarters/heads/hop)
 "hWC" = (
-/obj/structure/table,
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/obj/item/storage/fancy/cigarettes/cigars,
-/obj/item/lighter,
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
@@ -10281,20 +10416,6 @@
 	name = "nanoweave carpet (bluer)"
 	},
 /area/bridge/meeting_room/council)
-"icI" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
-	},
-/area/nsv/weapons/fore)
 "idc" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10314,12 +10435,22 @@
 /turf/open/floor/carpet/ship,
 /area/bridge/meeting_room/council)
 "ifd" = (
-/obj/effect/turf_decal/delivery/white,
-/obj/structure/cable/white{
-	icon_state = "1-2"
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/engine,
-/area/nsv/weapons/fore)
+/obj/structure/closet/secure_closet/puce{
+	name = "random puce event";
+	opened = 1
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/radio/headset/heads/captain/alt{
+	desc = "A special headset that protects ears from some loud noises.";
+	keyslot = null;
+	name = "noise cancelling headphones"
+	},
+/obj/item/clothing/head/soft/yellow,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "igo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10374,9 +10505,16 @@
 	},
 /area/bridge/meeting_room/council)
 "ijl" = (
-/obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
 /area/nsv/weapons/fore)
 "ijt" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
@@ -10388,6 +10526,10 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
+"ijE" = (
+/obj/machinery/suit_storage_unit/captain,
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "ikq" = (
 /obj/machinery/light{
 	dir = 8
@@ -10403,16 +10545,16 @@
 /turf/closed/wall/r_wall/ship,
 /area/ai_monitored/turret_protected/ai_upload)
 "ila" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/structure/closet/secure_closet/munitions_technician,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/radio/headset/heads/captain/alt{
+	desc = "A special headset that protects ears from some loud noises.";
+	keyslot = null;
+	name = "noise cancelling headphones"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
-	},
+/obj/item/encryptionkey/munitions_tech,
+/obj/item/clothing/head/hardhat,
+/obj/item/clothing/ears/earmuffs,
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
@@ -10454,15 +10596,23 @@
 /obj/structure/sign/solgov_flag{
 	layer = 2.79
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
 	},
 /area/bridge)
 "imE" = (
-/obj/structure/closet/secure_closet/freezer/kitchen/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/open/floor/engine,
+/area/nsv/weapons/fore)
 "inv" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -10662,6 +10812,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"iyw" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "iyA" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10798,16 +10954,10 @@
 	},
 /area/ai_monitored/turret_protected/aisat_interior)
 "iDh" = (
-/obj/docking_port/stationary{
-	dir = 2;
-	dwidth = 11;
-	height = 22;
-	id = "unused_6";
-	name = "Deck 2 Fore Starboard";
-	width = 35
-	},
-/turf/open/space/basic,
-/area/space)
+/obj/structure/grille,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/turf/open/floor/plating,
+/area/nsv/weapons/fore)
 "iEg" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -10869,21 +11019,12 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "iIi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
+/turf/closed/wall/ship,
 /area/maintenance/department/bridge)
 "iIB" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -10896,28 +11037,8 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
-"iIK" = (
-/obj/structure/closet/crate/secure/weapon,
-/obj/item/ship_weapon/parts/torpedo/iff_card,
-/obj/item/ship_weapon/parts/torpedo/iff_card,
-/obj/item/ship_weapon/parts/torpedo/iff_card,
-/obj/item/ship_weapon/parts/torpedo/warhead,
-/obj/item/ship_weapon/parts/torpedo/warhead,
-/obj/item/ship_weapon/parts/torpedo/warhead,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
-	},
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/turf/open/floor/engine,
+/area/nsv/hanger/deck2/port)
 "iIQ" = (
 /obj/structure/closet/secure_closet/personal{
 	anchored = 1
@@ -10940,7 +11061,12 @@
 	},
 /area/crew_quarters/heads/hop)
 "iKw" = (
-/obj/machinery/hydroponics/soil,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "iKA" = (
@@ -10951,14 +11077,30 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/carpet/ship,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
-"iMe" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+"iLi" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/cable/white{
+	icon_state = "0-4"
+	},
+/obj/machinery/modular_computer/console/preset/engineering{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
+"iMe" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/obj/structure/chair{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/maintenance/fore)
 "iMh" = (
 /turf/closed/wall/r_wall/ship,
@@ -10968,14 +11110,10 @@
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "iNc" = (
-/obj/item/storage/fancy/cigarettes/cigars/havana,
-/obj/item/lighter{
-	pixel_x = 5;
-	pixel_y = -3
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
-/obj/structure/table/glass,
-/obj/item/radio/intercom/directional/north,
-/obj/item/twohanded/binoculars,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "iNX" = (
@@ -11060,6 +11198,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/structure/reagent_dispensers/beerkeg,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/maintenance/fore)
 "iQE" = (
@@ -11121,10 +11263,23 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "iSw" = (
-/obj/machinery/recharge_station,
-/obj/effect/landmark/start/cyborg,
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/heads/captain)
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
+/area/nsv/weapons/port{
+	name = "Weapons Storage"
+	})
 "iSB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -11140,9 +11295,31 @@
 	},
 /area/bridge/meeting_room/council)
 "iUx" = (
-/obj/structure/chair,
-/turf/open/floor/wood,
-/area/maintenance/fore)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/airlock/vault/ship{
+	name = "Munitions Weapons Bay";
+	req_one_access_txt = "69"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
+/area/nsv/weapons/port{
+	name = "Weapons Storage"
+	})
 "iUD" = (
 /obj/machinery/holopad,
 /obj/structure/cable{
@@ -11221,7 +11398,11 @@
 	},
 /area/bridge)
 "iXF" = (
-/turf/closed/wall/ship,
+/obj/structure/table/glass,
+/obj/machinery/microwave{
+	pixel_y = 6
+	},
+/turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "jag" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
@@ -11243,6 +11424,14 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
+"jao" = (
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/door/airlock/ship/external/glass{
+	name = "External Access Deck 1 Fore Starboard";
+	req_one_access_txt = "13"
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "jaE" = (
 /obj/machinery/computer/monitor{
 	dir = 8
@@ -11344,6 +11533,10 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -11407,13 +11600,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
 "jhR" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
@@ -11497,12 +11687,23 @@
 /turf/open/floor/engine,
 /area/science/explab)
 "jkD" = (
-/obj/structure/reagent_dispensers/beerkeg,
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/wood,
-/area/maintenance/fore)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
+/area/nsv/weapons/fore)
 "jkW" = (
 /turf/closed/wall/r_wall/ship,
 /area/science/xenobiology)
@@ -11597,8 +11798,14 @@
 /turf/open/floor/engine,
 /area/science/robotics/lab)
 "jqk" = (
-/obj/structure/sign/warning/explosives/alt,
-/turf/closed/wall/r_wall/ship,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
 /area/nsv/weapons/fore)
 "jqA" = (
 /obj/structure/window/reinforced{
@@ -11683,34 +11890,25 @@
 	},
 /area/bridge/meeting_room/council)
 "jsi" = (
-/obj/machinery/requests_console{
-	department = "Munitions";
-	departmentType = 2;
-	pixel_y = 28
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/power/smes{
-	charge = 800000;
-	input_level = 20000;
-	name = "low-priority department power storage unit";
-	output_level = 20000
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/ship/command/glass{
+	name = "Master At Arms Office";
+	req_access_txt = "70"
 	},
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
 	},
+/area/nsv/weapons/fore)
+"jsv" = (
+/turf/closed/wall/ship,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
-"jsv" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/nsv/weapons/fore)
 "jtR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -11810,9 +12008,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "jyl" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/airalarm/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "jyN" = (
@@ -11820,11 +12018,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
 "jyV" = (
-/obj/effect/turf_decal/delivery/white,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/engine,
+/obj/machinery/atmospherics/pipe/manifold/purple/hidden,
+/obj/structure/grille,
+/turf/open/floor/plating,
 /area/nsv/weapons/fore)
 "jzk" = (
 /obj/structure/closet/emcloset,
@@ -11912,6 +12108,10 @@
 /obj/item/lipstick/random,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"jCe" = (
+/obj/machinery/status_display/ai,
+/turf/closed/wall/ship,
+/area/bridge)
 "jCh" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -11978,6 +12178,12 @@
 /obj/structure/frame/computer,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"jEE" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/bridge)
 "jFo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -12040,18 +12246,6 @@
 "jHL" = (
 /turf/closed/wall/ship,
 /area/shuttle/turbolift/primary)
-"jHO" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
-	},
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
 "jHU" = (
 /obj/machinery/nuclearbomb/selfdestruct,
 /obj/machinery/airalarm/directional/west,
@@ -12157,20 +12351,23 @@
 /turf/open/floor/engine,
 /area/nsv/hanger)
 "jLE" = (
-/obj/structure/closet/secure_closet/freezer/kitchen/maintenance,
-/obj/item/kitchen/knife,
-/obj/item/reagent_containers/food/condiment/enzyme,
-/obj/item/reagent_containers/food/condiment/saltshaker,
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 3;
-	pixel_y = 4
+/obj/machinery/recharge_station,
+/obj/machinery/camera/autoname{
+	dir = 4
 	},
+/obj/effect/landmark/start/cyborg,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
+/area/nsv/weapons/fore)
 "jLM" = (
 /obj/structure/window/plasma/reinforced{
 	dir = 4
@@ -12252,21 +12449,22 @@
 	width = 35
 	},
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "jPK" = (
 /obj/structure/sign/warning/vacuum,
 /turf/closed/wall/ship,
 /area/maintenance/disposal)
 "jPM" = (
-/obj/structure/extinguisher_cabinet/north,
-/obj/machinery/computer/cargo/request,
+/obj/effect/turf_decal/delivery/white,
+/obj/item/ship_weapon/ammunition/torpedo/torpedo_casing,
+/obj/structure/cable/white{
+	icon_state = "2-4"
+	},
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
 	},
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/area/nsv/weapons/fore)
 "jQc" = (
 /turf/closed/wall/r_wall/ship,
 /area/nsv/hanger)
@@ -12294,12 +12492,16 @@
 /turf/open/floor/plating,
 /area/crew_quarters/dorms)
 "jTp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/obj/effect/turf_decal/delivery/white,
+/obj/item/ship_weapon/ammunition/torpedo/torpedo_casing,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
+/area/nsv/weapons/fore)
 "jTF" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -12384,20 +12586,18 @@
 /turf/open/floor/carpet,
 /area/library)
 "jYl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/structure/sign/warning/vacuum{
 	pixel_y = -32
 	},
+/obj/machinery/power/deck_relay,
 /obj/structure/cable/white{
-	icon_state = "2-4"
+	icon_state = "0-2"
 	},
 /obj/structure/cable/white{
-	icon_state = "4-8"
+	icon_state = "2-8"
+	},
+/obj/structure/cable/white{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
@@ -12429,8 +12629,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "jZB" = (
-/obj/structure/closet/crate,
-/obj/effect/landmark/blobstart,
+/obj/structure/frame/machine,
+/obj/effect/landmark/start/cyborg,
 /turf/open/floor/wood,
 /area/maintenance/fore)
 "jZL" = (
@@ -12665,6 +12865,22 @@
 	name = "nanoweave carpet (bluer)"
 	},
 /area/ai_monitored/turret_protected/aisat_interior)
+"kgC" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/modular_computer/console/preset/command{
+	dir = 8
+	},
+/obj/item/paper{
+	info = "<p>Executive Officer notice: Modular computers are currently experiencing technical difficulties regarding their ID modification hardware. The 'identification card authentication module' supports 2 ID slots, and was previously paired with the 'ID Card Modification' program that also supported 2 IDs. There was recently a software update that removed the need to insert your own ID to authenticate and log in. However, it did not update the hardware, nor does it allow you to remove an ID from the authentication slot anymore.<br><br>To edit IDs with a modular computer without losing your ID, insert the target's ID but NEVER insert your own ID. You will still be able to log in if you are wearing it. Make sure you never put more than 1 ID in the modular computer.<br><br>If you do accidentally lose your own ID and getting a new one without your XO access is borderline impossible, contact Central Command. Politely ask them to remote into the console, then run subroutine '/proc/eject_id'<br><br>Have a secure shift</p>";
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/machinery/airalarm/directional/east,
+/obj/structure/cable/white{
+	icon_state = "0-8"
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "khp" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -12686,38 +12902,10 @@
 	},
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/checkpoint/supply)
-"khX" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 6
-	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
-	},
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
-"kjG" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/effect/landmark/start/munitions_tech,
-/turf/open/floor/carpet/red,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+"kiM" = (
+/obj/item/skub,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "kjL" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
@@ -12759,7 +12947,13 @@
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/robotics/lab)
 "kkg" = (
-/obj/structure/chair/office,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "kkw" = (
@@ -12845,7 +13039,7 @@
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/maintenance/department/science/central)
 "knK" = (
-/obj/structure/table/wood,
+/obj/structure/chair,
 /turf/open/floor/wood,
 /area/maintenance/fore)
 "koF" = (
@@ -12910,7 +13104,7 @@
 	width = 12
 	},
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "krz" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -12973,11 +13167,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "kth" = (
-/obj/structure/table/wood,
-/obj/structure/showcase/machinery/microwave,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/turf/open/floor/wood,
-/area/maintenance/fore)
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
+/area/nsv/weapons/fore)
 "kud" = (
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
@@ -13067,6 +13264,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "kzd" = (
@@ -13121,12 +13319,15 @@
 /turf/closed/wall/r_wall/ship,
 /area/security/checkpoint/science/research)
 "kAW" = (
-/obj/item/camera,
-/obj/item/melee/chainofcommand,
-/obj/structure/table/glass,
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/landmark/start/munitions_tech,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/engine,
+/area/nsv/weapons/fore)
 "kAX" = (
 /obj/structure/reagent_dispensers/water_cooler{
 	anchored = 0
@@ -13269,19 +13470,25 @@
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/department/cargo)
 "kJc" = (
-/obj/machinery/recharge_station,
-/obj/machinery/camera/autoname{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
 	},
-/obj/effect/landmark/start/cyborg,
-/obj/structure/cable/yellow{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
-	},
+/turf/open/floor/plating,
 /area/nsv/weapons/fore)
 "kJu" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -13358,16 +13565,14 @@
 /turf/open/floor/carpet/ship,
 /area/bridge/meeting_room/council)
 "kOb" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
 	},
-/turf/open/floor/engine,
 /area/nsv/weapons/fore)
 "kOy" = (
 /obj/structure/table,
@@ -13377,12 +13582,10 @@
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/robotics/lab)
 "kOE" = (
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/airlock/ship/command{
-	name = "Captain Quarters";
-	req_access_txt = "20"
-	},
+/obj/structure/table/glass,
+/obj/machinery/firealarm/directional/west,
+/obj/item/clothing/gloves/color/black,
+/obj/item/storage/fancy/donut_box,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "kPd" = (
@@ -13565,14 +13768,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "kWz" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
+/obj/structure/table/wood/poker,
+/obj/item/dice/d6{
+	pixel_x = -13;
+	pixel_y = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+/obj/item/dice/d6,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/purple/hidden{
-	dir = 1
 	},
 /turf/open/floor/wood,
 /area/maintenance/fore)
@@ -13703,32 +13906,14 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "lgc" = (
-/obj/machinery/modular_computer/console/preset/command,
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
+/obj/machinery/modular_computer/console/preset/engineering{
+	dir = 8
 	},
-/obj/machinery/light{
-	dir = 1
+/obj/structure/cable/white{
+	icon_state = "0-8"
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
-	},
-/obj/item/paper{
-	info = "<p>Executive Officer notice: Modular computers are currently experiencing technical difficulties regarding their ID modification hardware. The 'identification card authentication module' supports 2 ID slots, and was previously paired with the 'ID Card Modification' program that also supported 2 IDs. There was recently a software update that removed the need to insert your own ID to authenticate and log in. However, it did not update the hardware, nor does it allow you to remove an ID from the authentication slot anymore.<br><br>To edit IDs with a modular computer without losing your ID, insert the target's ID but NEVER insert your own ID. You will still be able to log in if you are wearing it. Make sure you never put more than 1 ID in the modular computer.<br><br>If you do accidentally lose your own ID and getting a new one without your XO access is borderline impossible, contact Central Command. Politely ask them to remote into the console, then run subroutine '/proc/eject_id'<br><br>Have a secure shift</p>";
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
-"lgq" = (
-/obj/structure/shuttle/engine/large{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/engine,
+/area/nsv/weapons/fore)
 "lgz" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -13768,19 +13953,15 @@
 /turf/open/floor/plating,
 /area/science/server)
 "ljY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall/ship,
 /area/nsv/weapons/fore)
 "llu" = (
 /obj/machinery/firealarm/directional/east,
@@ -13808,9 +13989,7 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/area/nsv/hanger/deck2/port)
 "llI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/engine,
@@ -13843,9 +14022,12 @@
 	dir = 10
 	},
 /turf/open/floor/carpet/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/area/nsv/hanger/deck2/port)
+"lnm" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "lnt" = (
 /obj/machinery/light,
 /turf/open/floor/carpet/ship/blue{
@@ -13854,12 +14036,8 @@
 	},
 /area/ai_monitored/turret_protected/aisat_interior)
 "lnD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
-	},
+/obj/structure/table/wood/poker,
+/obj/effect/holodeck_effect/cards,
 /turf/open/floor/wood,
 /area/maintenance/fore)
 "loz" = (
@@ -13923,10 +14101,8 @@
 	},
 /area/bridge)
 "lpX" = (
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
-	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/nsv/weapons/fore)
 "lqr" = (
 /obj/machinery/camera/autoname{
@@ -13995,6 +14171,19 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
+"lqE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/maintenance/fore)
 "lqN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -14045,6 +14234,13 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"lsF" = (
+/obj/effect/turf_decal/delivery/white,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/engine,
+/area/nsv/weapons/fore)
 "ltr" = (
 /obj/structure/extinguisher_cabinet/east,
 /obj/effect/turf_decal/stripes/line,
@@ -14075,6 +14271,12 @@
 "luj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -14162,7 +14364,7 @@
 	},
 /area/bridge/meeting_room)
 "lBK" = (
-/obj/machinery/vending/clothing,
+/obj/machinery/vending/wardrobe/curator_wardrobe,
 /turf/open/floor/carpet,
 /area/library)
 "lDf" = (
@@ -14188,11 +14390,27 @@
 	},
 /area/teleporter)
 "lDA" = (
-/obj/machinery/ship_weapon/energy,
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/engine,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/purple/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
 /area/nsv/weapons/fore)
 "lDE" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible/layer1{
@@ -14206,19 +14424,32 @@
 	name = "Launch tubes 1 and 2"
 	})
 "lDM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/structure/closet/secure_closet/fighter_pilot,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/head/hardhat,
+/obj/item/clothing/head/hardhat,
+/obj/item/radio/headset/heads/captain/alt{
+	desc = "A special headset that protects ears from some loud noises.";
+	keyslot = null;
+	name = "noise cancelling headphones"
+	},
+/obj/item/radio/headset/heads/captain/alt{
+	desc = "A special headset that protects ears from some loud noises.";
+	keyslot = null;
+	name = "noise cancelling headphones"
+	},
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/encryptionkey/atc,
+/obj/item/encryptionkey/atc,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
-	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/engine,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -14242,21 +14473,11 @@
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/lab)
 "lFj" = (
-/obj/structure/table,
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
-	},
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/turf/closed/wall/ship,
+/area/nsv/weapons/fore)
 "lGt" = (
 /obj/structure/table/wood,
 /obj/item/soapstone/empty{
@@ -14296,12 +14517,10 @@
 /area/science/mixing)
 "lHv" = (
 /obj/machinery/atmospherics/components/unary/portables_connector,
-/obj/item/flashlight/lantern,
-/obj/effect/landmark/event_spawn,
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/wood,
 /area/maintenance/fore)
 "lHE" = (
 /obj/structure/window/reinforced,
@@ -14319,13 +14538,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "lIn" = (
-/obj/structure/frame/computer{
-	dir = 8
-	},
-/obj/item/circuitboard/computer/security,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
-	},
+/obj/structure/piano,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "lIu" = (
@@ -14363,11 +14576,17 @@
 /turf/closed/wall/r_wall/ship,
 /area/science/server)
 "lIC" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/closed/wall/r_wall/ship,
-/area/maintenance/department/cargo)
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
+/area/nsv/weapons/fore)
 "lIX" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -14415,14 +14634,11 @@
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/lab)
 "lJg" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
+/obj/machinery/power/apc/auto_name/north,
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
 	},
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/effect/landmark/start/munitions_tech,
-/turf/open/floor/carpet/red,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -14459,14 +14675,16 @@
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
 "lLv" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+/obj/structure/munitions_trolley,
+/obj/item/ship_weapon/ammunition/torpedo/nuke/fabio,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/maintenance/fore)
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
+/area/nsv/weapons/fore)
 "lLF" = (
 /obj/structure/closet/firecloset/full,
 /obj/machinery/light{
@@ -14513,6 +14731,10 @@
 	name = "nanoweave carpet (bluer)"
 	},
 /area/bridge/meeting_room/council)
+"lPa" = (
+/obj/structure/sign/warning/vacuum,
+/turf/closed/wall/ship,
+/area/maintenance/fore)
 "lPP" = (
 /obj/item/clothing/mask/surgical,
 /obj/item/clothing/gloves/color/latex,
@@ -14522,6 +14744,28 @@
 	name = "nanoweave carpet (bluer)"
 	},
 /area/bridge/meeting_room)
+"lPV" = (
+/obj/machinery/computer/ship/navigation/public{
+	dir = 8;
+	name = "starmap console"
+	},
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/machinery/computer/ship/viewscreen{
+	pixel_x = 32;
+	pixel_y = -6
+	},
+/obj/machinery/status_display/ai/south,
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
+"lRX" = (
+/obj/machinery/door/airlock/ship/external/glass{
+	name = "External Access Deck 1 Fore";
+	req_one_access_txt = "19"
+	},
+/turf/open/floor/plating,
+/area/bridge)
 "lSc" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/computer/communications{
@@ -14736,12 +14980,21 @@
 	pixel_y = 25
 	},
 /turf/open/floor/carpet/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/area/nsv/hanger/deck2/port)
+"mdB" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/wood,
+/area/maintenance/fore)
 "meH" = (
 /turf/closed/wall/ship,
 /area/crew_quarters/toilet/auxiliary)
+"meQ" = (
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "captainoffice"
+	},
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/crew_quarters/heads/captain/private)
 "mfe" = (
 /obj/structure/ladder,
 /obj/structure/cable/yellow{
@@ -14784,16 +15037,15 @@
 	},
 /area/bridge)
 "mge" = (
-/obj/docking_port/stationary{
-	dir = 4;
-	dwidth = 2;
-	height = 13;
-	id = "ferry_home";
-	name = "Deck 2 Centcom Ferry Port";
-	width = 5
+/obj/machinery/computer/ship/fighter_controller,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/space/basic,
-/area/space)
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
+/area/nsv/weapons/fore)
 "mgq" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -14818,16 +15070,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"mgG" = (
-/obj/machinery/shower{
-	dir = 4;
-	layer = 3.5
-	},
-/obj/structure/curtain,
-/obj/item/soap/deluxe,
-/obj/item/bikehorn/rubberducky,
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/heads/captain)
 "mhv" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -14869,8 +15111,18 @@
 	name = "Science Lobby"
 	})
 "mix" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/landmark/start/master_at_arms,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
 	},
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
@@ -14879,37 +15131,50 @@
 /area/nsv/weapons/fore)
 "mjb" = (
 /obj/structure/extinguisher_cabinet/east,
-/turf/closed/wall/r_wall/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/obj/structure/bed,
+/obj/item/bedsheet/orange,
+/turf/open/floor/carpet/ship,
+/area/nsv/hanger/deck2/port)
 "mjO" = (
 /obj/structure/lattice/catwalk,
 /turf/open/floor/fakespace,
 /area/space/nearstation)
 "mjR" = (
-/obj/machinery/advanced_airlock_controller/directional/north,
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/computer/ship/viewscreen,
+/obj/machinery/computer/ship/navigation/public{
+	name = "starmap console"
 	},
-/obj/machinery/power/deck_relay,
-/obj/structure/cable/white{
-	icon_state = "0-2"
+/obj/item/radio/intercom/directional{
+	pixel_x = 30;
+	pixel_y = 25
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/bridge)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
+/area/nsv/weapons/fore)
 "mkr" = (
-/obj/structure/frame/machine,
-/turf/open/floor/engine,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
 /area/nsv/weapons/fore)
 "mkK" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/table,
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/camera/autoname{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
+/obj/item/storage/fancy/cigarettes/cigars,
+/obj/item/lighter,
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
 	},
-/turf/open/floor/engine,
 /area/nsv/weapons/fore)
 "mkZ" = (
 /obj/structure/closet/emcloset,
@@ -15011,6 +15276,11 @@
 /obj/item/clothing/ears/earmuffs,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
+"mnf" = (
+/obj/item/flashlight/lantern,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "mnG" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -15154,10 +15424,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/turf/open/floor/engine,
+/area/nsv/hanger/deck2/port)
 "mrw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -15173,6 +15441,10 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"msr" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "msM" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -15310,7 +15582,10 @@
 /area/science/server)
 "mvk" = (
 /obj/structure/table/wood,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/maintenance/fore)
 "mvC" = (
 /obj/machinery/holopad,
@@ -15320,15 +15595,7 @@
 	},
 /area/ai_monitored/storage/eva)
 "mwE" = (
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/airlock/vault/ship{
-	name = "Munitions Weapon Bay";
-	req_one_access_txt = "3;69"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
+/obj/structure/extinguisher_cabinet/west,
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
@@ -15353,10 +15620,24 @@
 /turf/closed/wall/ship,
 /area/crew_quarters/toilet/locker)
 "myc" = (
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/beer,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
+/area/nsv/weapons/fore)
 "mye" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -15396,7 +15677,7 @@
 	},
 /area/ai_monitored/storage/eva)
 "mzd" = (
-/obj/machinery/vending/coffee,
+/obj/machinery/vending/cigarette,
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -15456,21 +15737,14 @@
 /turf/open/floor/plating,
 /area/science/server)
 "mAY" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/structure/cable/white{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 9
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/area/nsv/weapons/fore)
 "mBc" = (
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
@@ -15516,10 +15790,16 @@
 /turf/open/floor/plating,
 /area/science/server)
 "mCr" = (
-/obj/effect/turf_decal/delivery/white,
-/obj/machinery/status_display/evac/south,
-/obj/structure/closet/bombcloset,
-/obj/item/clothing/gloves/color/black,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
@@ -15552,10 +15832,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/turf/open/floor/engine,
+/area/nsv/hanger/deck2/port)
 "mFu" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/ship/blue{
@@ -15589,6 +15867,15 @@
 	},
 /turf/closed/wall/ship,
 /area/shuttle/turbolift/primary)
+"mGS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "mGW" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -15631,36 +15918,12 @@
 	},
 /area/ai_monitored/turret_protected/aisat_interior)
 "mHQ" = (
-/obj/structure/table/glass,
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable{
-	icon_state = "0-2"
+/obj/structure/sign/solgov_flag{
+	layer = 2.79
 	},
-/obj/item/storage/box/pinpointer_pairs,
-/obj/item/hand_tele,
+/obj/machinery/vending/coffee,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
-"mIw" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 8;
-	sortType = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/carpet/red,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
 "mIC" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/machinery/light{
@@ -15732,9 +15995,18 @@
 /obj/machinery/light_switch/east,
 /obj/item/book/manual/wiki/telescience,
 /turf/open/floor/carpet/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/area/nsv/hanger/deck2/port)
+"mLZ" = (
+/obj/docking_port/stationary{
+	dir = 4;
+	dwidth = 2;
+	height = 13;
+	id = "ferry_home";
+	name = "Deck 2 Centcom Ferry Port";
+	width = 5
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "mMp" = (
 /obj/effect/spawner/lootdrop/costume,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -15770,10 +16042,11 @@
 /turf/open/floor/carpet/blue,
 /area/bridge)
 "mNk" = (
-/obj/structure/closet/crate,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/nsv/weapons/fore)
 "mNm" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -15812,6 +16085,11 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/carpet/ship,
 /area/quartermaster/miningoffice)
+"mOS" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "mPz" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -15844,6 +16122,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -15865,9 +16149,8 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "mUo" = (
-/obj/effect/turf_decal/delivery/white,
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
 	},
 /turf/open/floor/engine,
 /area/nsv/weapons/fore)
@@ -15889,11 +16172,13 @@
 	},
 /area/teleporter)
 "mXo" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/structure/lattice,
+/obj/machinery/camera{
+	c_tag = "External Viewport Munitions 3";
+	dir = 4
 	},
-/turf/closed/wall/ship,
-/area/crew_quarters/heads/captain)
+/turf/open/space/basic,
+/area/nsv/weapons/fore)
 "mXu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -15910,9 +16195,7 @@
 "mYa" = (
 /obj/machinery/computer/ship/fighter_controller,
 /turf/open/floor/carpet/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/area/nsv/hanger/deck2/port)
 "mYb" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
 /turf/open/floor/plating,
@@ -15957,11 +16240,10 @@
 /turf/closed/wall/ship,
 /area/bridge/meeting_room)
 "mZR" = (
-/obj/structure/ladder,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 5
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall/ship,
 /area/maintenance/fore)
 "mZX" = (
 /obj/machinery/computer/holodeck{
@@ -16013,10 +16295,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "ndN" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/shovel/spade,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/nsv/hanger/deck2/port)
 "ndO" = (
 /obj/structure/table,
 /obj/item/paicard,
@@ -16027,9 +16308,11 @@
 	name = "Science Lobby"
 	})
 "nea" = (
-/obj/machinery/atmospherics/pipe/manifold/purple/hidden,
-/turf/closed/wall/r_wall/ship,
-/area/maintenance/fore)
+/obj/machinery/suit_storage_unit/pilot,
+/turf/open/floor/engine,
+/area/nsv/weapons/port{
+	name = "Weapons Storage"
+	})
 "neC" = (
 /obj/machinery/door/window/southleft{
 	name = "Cyborg Upload Console Window";
@@ -16038,13 +16321,25 @@
 /turf/open/floor/carpet/ship,
 /area/ai_monitored/turret_protected/ai_upload)
 "neY" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/machinery/modular_computer/console/preset/engineering{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/turf/open/floor/engine,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
 /area/nsv/weapons/fore)
 "nfd" = (
 /obj/machinery/camera{
@@ -16125,10 +16420,22 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "niS" = (
-/obj/effect/turf_decal/delivery/white,
-/obj/structure/munitions_trolley,
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/requests_console{
+	department = "Munitions";
+	departmentType = 2;
+	pixel_y = 28
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/power/smes{
+	charge = 800000;
+	input_level = 20000;
+	name = "low-priority department power storage unit";
+	output_level = 20000
 	},
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
@@ -16145,6 +16452,15 @@
 	},
 /turf/template_noop,
 /area/maintenance/department/science/xenobiology)
+"njf" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "njl" = (
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
@@ -16156,11 +16472,11 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/auxiliary)
 "njy" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 9
 	},
-/turf/open/floor/engine,
+/obj/structure/grille,
+/turf/open/floor/plating,
 /area/nsv/weapons/fore)
 "njN" = (
 /obj/structure/disposalpipe/segment{
@@ -16205,6 +16521,24 @@
 	name = "nanoweave carpet (bluer)"
 	},
 /area/ai_monitored/nuke_storage)
+"nkV" = (
+/obj/machinery/atmospherics/components/binary/pump/layer1{
+	dir = 1;
+	on = 1;
+	target_pressure = 2000
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/airlock/ship/external/glass{
+	name = "External Access Deck 1 Fore";
+	req_one_access_txt = "19"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/bridge)
 "nkW" = (
 /turf/closed/wall/ship,
 /area/maintenance/department/cargo)
@@ -16213,15 +16547,17 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
 "nlX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/meter/atmos/distro_loop{
-	pixel_x = -6;
-	pixel_y = -6;
-	target_layer = 1
+/obj/machinery/suit_storage_unit/pilot,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/nsv/weapons/port{
+	name = "Weapons Storage"
+	})
 "nmh" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/machinery/camera/autoname,
@@ -16241,13 +16577,10 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/dorms)
 "nmy" = (
-/obj/item/storage/toolbox/emergency,
-/obj/structure/table/glass,
-/obj/item/flashlight/lamp,
-/obj/machinery/status_display/evac/north,
-/obj/structure/cable/white{
-	icon_state = "1-2"
+/obj/structure/sign/solgov_flag/right{
+	layer = 2.79
 	},
+/obj/machinery/vending/cigarette,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "nmS" = (
@@ -16367,9 +16700,21 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "nsd" = (
-/obj/structure/table/glass,
-/obj/item/pinpointer/nuke,
-/obj/item/disk/nuclear,
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/coin/plasma{
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/obj/item/coin/gold{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/coin/plasma{
+	pixel_x = 4;
+	pixel_y = -2
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "nsy" = (
@@ -16423,9 +16768,20 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "nuK" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/item/clothing/suit/hazardvest,
+/obj/item/radio/headset/heads/captain/alt{
+	desc = "A special headset that protects ears from some loud noises.";
+	keyslot = null;
+	name = "noise cancelling headphones"
 	},
+/obj/item/encryptionkey/munitions_tech,
+/obj/item/clothing/head/hardhat,
+/obj/item/clothing/ears/earmuffs,
+/obj/structure/closet/secure_closet/puce,
+/obj/item/clothing/glasses/welding,
+/obj/item/storage/belt/utility/full,
+/obj/item/clothing/head/soft/yellow,
+/obj/structure/extinguisher_cabinet/east,
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
@@ -16455,6 +16811,18 @@
 	},
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/xenobiology)
+"nvK" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/ship/blue{
+	color = "#9999DD";
+	name = "nanoweave carpet (bluer)"
+	},
+/area/bridge)
 "nvP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
@@ -16587,9 +16955,7 @@
 	req_one_access_txt = "73"
 	},
 /turf/open/floor/carpet/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/area/nsv/hanger/deck2/port)
 "nBF" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -16643,9 +17009,18 @@
 	name = "Battle Bridge"
 	})
 "nCR" = (
-/obj/item/chair,
-/turf/open/floor/wood,
-/area/maintenance/fore)
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/obj/effect/landmark/start/master_at_arms,
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
+/area/nsv/weapons/fore)
 "nEh" = (
 /obj/structure/disposalpipe/junction{
 	dir = 8
@@ -16733,7 +17108,8 @@
 /area/crew_quarters/heads/hor)
 "nGN" = (
 /obj/machinery/firealarm/directional/east,
-/obj/item/banner/science,
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/bin,
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/lab)
 "nHi" = (
@@ -16780,11 +17156,14 @@
 	name = "Launch tubes 1 and 2"
 	})
 "nJz" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
 	},
-/turf/closed/wall/ship,
-/area/maintenance/fore)
+/area/nsv/weapons/fore)
 "nJG" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -16807,6 +17186,15 @@
 	},
 /turf/template_noop,
 /area/maintenance/department/cargo)
+"nKU" = (
+/obj/structure/table/glass,
+/obj/item/reagent_containers/food/drinks/flask/gold,
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
+"nLr" = (
+/obj/structure/closet/secure_closet/captains,
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "nLy" = (
 /obj/machinery/modular_computer/console/preset/civilian{
 	dir = 8
@@ -16820,7 +17208,7 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/turf/closed/wall/r_wall/ship,
+/turf/closed/wall/ship,
 /area/maintenance/department/bridge)
 "nLY" = (
 /obj/machinery/bluespace_beacon,
@@ -16848,14 +17236,18 @@
 	},
 /area/teleporter)
 "nMw" = (
-/obj/item/flashlight/lamp,
-/obj/machinery/recharger,
-/obj/structure/table/glass,
-/obj/structure/sign/solgov_flag{
-	layer = 2.79
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
+/area/nsv/weapons/fore)
 "nMx" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable{
@@ -16870,12 +17262,16 @@
 /turf/open/floor/fakespace,
 /area/space/nearstation)
 "nNm" = (
-/obj/item/chair/stool/bar,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
+/obj/effect/turf_decal/delivery/white,
+/obj/structure/closet/crate/secure/weapon,
+/obj/structure/cable/white{
+	icon_state = "1-2"
 	},
-/turf/open/floor/wood,
-/area/maintenance/fore)
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
+/area/nsv/weapons/fore)
 "nNs" = (
 /obj/structure/filingcabinet,
 /obj/machinery/light,
@@ -16885,11 +17281,7 @@
 	},
 /area/crew_quarters/heads/hop)
 "nNJ" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 5
-	},
-/obj/structure/grille,
-/turf/open/floor/plating,
+/turf/open/floor/engine,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -16897,6 +17289,16 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/xenobiology)
+"nNN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/ladder,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "nNQ" = (
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/holofloor/wood,
@@ -16983,14 +17385,23 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
+"nSj" = (
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 11;
+	height = 22;
+	id = "unused_6";
+	name = "Deck 2 Fore Starboard";
+	width = 35
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "nSn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
 /turf/open/floor/carpet/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/area/nsv/hanger/deck2/port)
 "nSK" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/ship,
@@ -17172,15 +17583,8 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hop)
 "nXi" = (
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/structure/table/glass,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
+/obj/machinery/recharger,
+/obj/structure/table,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "nXp" = (
@@ -17205,13 +17609,11 @@
 /turf/open/floor/carpet/orange,
 /area/quartermaster/storage)
 "nYQ" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "External Viewport Munitions 3";
-	dir = 4
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/area/nsv/weapons/fore)
 "nYY" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -17339,9 +17741,9 @@
 /turf/closed/wall/r_wall/ship,
 /area/quartermaster/storage)
 "oec" = (
-/obj/structure/table_frame/wood,
-/turf/open/floor/wood,
-/area/maintenance/fore)
+/obj/machinery/computer/ship/munitions_computer/west,
+/turf/open/floor/engine,
+/area/nsv/weapons/fore)
 "ofC" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -17594,16 +17996,19 @@
 /turf/open/floor/plating,
 /area/science/server)
 "otL" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/firealarm/directional/east,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/obj/effect/turf_decal/delivery/white,
+/obj/machinery/ship_weapon/torpedo_launcher/east,
+/turf/open/floor/engine,
+/area/nsv/weapons/fore)
 "otW" = (
 /turf/closed/wall/ship,
 /area/quartermaster/miningoffice)
+"otX" = (
+/obj/machinery/atmospherics/pipe/manifold/purple/hidden{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "ouB" = (
 /obj/structure/closet/crate/solarpanel_small,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -17643,21 +18048,11 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "ovU" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/manifold/purple/hidden{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/turf/closed/wall/r_wall/ship,
+/area/nsv/weapons/fore)
 "ovW" = (
 /obj/machinery/shower{
 	dir = 8;
@@ -17683,16 +18078,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/turf/open/floor/engine,
+/area/nsv/hanger/deck2/port)
 "oxt" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/heads/captain)
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "oyu" = (
 /obj/structure/table,
 /obj/item/circular_saw,
@@ -17774,14 +18165,19 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "oAM" = (
-/obj/effect/turf_decal/delivery/white,
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/engine,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	dir = 4
+	},
+/turf/closed/wall/r_wall/ship,
 /area/nsv/weapons/fore)
 "oAO" = (
 /obj/structure/hull_plate/end{
@@ -17790,10 +18186,12 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "oCi" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 8
+/obj/effect/turf_decal/delivery/white,
+/obj/item/ship_weapon/ammunition/torpedo/probe,
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
 	},
-/turf/closed/wall/r_wall/ship,
 /area/nsv/weapons/fore)
 "oCv" = (
 /obj/machinery/disposal/bin,
@@ -17877,7 +18275,22 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "oHb" = (
-/turf/closed/wall/ship,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -17908,9 +18321,11 @@
 /turf/open/floor/carpet/orange,
 /area/quartermaster/warehouse)
 "oIn" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/turf/open/floor/wood,
-/area/maintenance/fore)
+/obj/structure/shuttle/engine/propulsion{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "oIw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -17936,27 +18351,21 @@
 	},
 /area/crew_quarters/heads/hop)
 "oIU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/west,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/binary/valve/digital{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
 	},
-/obj/structure/cable,
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
@@ -18045,11 +18454,12 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "oMa" = (
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/turf/closed/wall/r_wall/ship,
-/area/crew_quarters/heads/captain/private)
+/obj/machinery/suit_storage_unit/pilot,
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/engine,
+/area/nsv/weapons/port{
+	name = "Weapons Storage"
+	})
 "oMg" = (
 /obj/structure/toilet,
 /obj/structure/disposalpipe/trunk,
@@ -18059,6 +18469,13 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/dorms)
+"oMV" = (
+/obj/structure/frame/computer{
+	dir = 8
+	},
+/obj/item/circuitboard/computer/security,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "oNa" = (
 /obj/machinery/teleport/station,
 /obj/structure/cable/yellow{
@@ -18121,9 +18538,26 @@
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/checkpoint/science/research)
 "oQQ" = (
-/obj/machinery/computer/arcade,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/obj/structure/closet/secure_closet/master_at_arms{
+	anchored = 0
+	},
+/obj/item/encryptionkey/heads/master_at_arms,
+/obj/item/radio/headset/heads/captain/alt{
+	desc = "A special headset that protects ears from some loud noises.";
+	keyslot = null;
+	name = "noise cancelling headphones"
+	},
+/obj/item/clothing/ears/earmuffs,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/head/welding,
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
+/area/nsv/weapons/fore)
 "oQZ" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -18170,22 +18604,19 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/wood,
 /area/maintenance/fore)
 "oTv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/atmospherics/components/binary/pump/layer1{
-	on = 1;
-	target_pressure = 2000
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/door/airlock/ship/external/glass{
-	name = "External Access Deck 1 Fore Starboard";
-	req_one_access_txt = "13"
+/obj/structure/closet/bombcloset,
+/obj/item/clothing/gloves/color/black,
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
 	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/area/nsv/weapons/fore)
 "oUw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -18262,8 +18693,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "oYb" = (
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "oYv" = (
 /turf/template_noop,
 /area/maintenance/department/cargo)
@@ -18296,9 +18731,7 @@
 /obj/machinery/computer/ship/viewscreen,
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/carpet/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/area/nsv/hanger/deck2/port)
 "oZm" = (
 /obj/structure/reagent_dispensers/foamtank/hull_repair_juice,
 /obj/item/extinguisher/advanced/hull_repair_juice,
@@ -18370,6 +18803,14 @@
 	name = "nanoweave carpet (bluer)"
 	},
 /area/ai_monitored/storage/eva)
+"pca" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/taco{
+	name = "taigo"
+	},
+/obj/item/storage/box/matches,
+/turf/open/floor/wood,
+/area/maintenance/fore)
 "pci" = (
 /mob/living/simple_animal/slime,
 /turf/open/floor/engine,
@@ -18381,23 +18822,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "pde" = (
-/obj/machinery/firealarm{
-	pixel_x = -26;
-	pixel_y = 25
-	},
-/obj/machinery/disposal/deliveryChute{
-	name = "munitions delivery chute"
-	},
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/door/window/southright,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
@@ -18405,9 +18834,24 @@
 	},
 /area/nsv/weapons/fore)
 "pdJ" = (
-/obj/machinery/computer/communications,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/airlock/vault/ship{
+	name = "Maintenance Access Munitions Weapons Bay";
+	req_one_access_txt = "69"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
+/area/nsv/weapons/fore)
 "pdT" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -18428,17 +18872,18 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "pes" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/airalarm/directional/north,
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/gloves,
+/obj/item/stack/packageWrap,
+/obj/item/destTagger{
+	pixel_x = 4;
+	pixel_y = 3
 	},
-/obj/machinery/computer/monitor{
-	dir = 8
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
 	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/sign/solgov_seal,
-/turf/open/floor/engine,
 /area/nsv/weapons/fore)
 "pey" = (
 /turf/open/floor/plating,
@@ -18496,10 +18941,11 @@
 /area/bridge/showroom/corporate)
 "pfn" = (
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/carpet/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/nsv/hanger/deck2/port)
 "pfA" = (
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating,
@@ -18577,9 +19023,11 @@
 	name = "Science Lobby"
 	})
 "pia" = (
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/closed/wall/r_wall/ship,
+/area/crew_quarters/heads/captain/private)
 "pii" = (
 /obj/structure/chair/office,
 /turf/open/floor/carpet/ship,
@@ -18613,19 +19061,17 @@
 /area/nsv/hanger)
 "pjH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/manifold/purple/hidden{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 8;
+	sortType = 33
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
 	},
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
@@ -18690,7 +19136,7 @@
 "plQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/ship/cargo{
-	req_one_access_txt = "31;41;48;64;69"
+	req_one_access_txt = "31;41;48;64;69;72"
 	},
 /turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
@@ -18793,10 +19239,22 @@
 	},
 /turf/open/floor/engine/n2,
 /area/maintenance/fore)
+"ppZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/maintenance/fore)
 "pqG" = (
-/obj/structure/frame/computer{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/west,
 /turf/open/floor/engine,
 /area/nsv/weapons/fore)
 "prn" = (
@@ -18986,17 +19444,9 @@
 /turf/open/floor/plating,
 /area/janitor)
 "pwi" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/floor/carpet/ship/blue{
-	color = "#9999DD";
-	name = "nanoweave carpet (bluer)"
-	},
-/area/bridge/meeting_room)
+/obj/structure/closet/crate,
+/turf/open/floor/plating,
+/area/nsv/weapons/fore)
 "pwo" = (
 /obj/structure/sign/directions/plaque/atc{
 	dir = 4;
@@ -19010,20 +19460,18 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/area/nsv/hanger/deck2/port)
 "pwr" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "pwR" = (
-/obj/machinery/door/airlock/ship/external/glass{
-	name = "External Access Deck 1 Fore";
-	req_one_access_txt = "19"
+/obj/machinery/atmospherics/pipe/manifold/purple/hidden{
+	dir = 8
 	},
+/obj/structure/grille,
 /turf/open/floor/plating,
-/area/maintenance/department/bridge)
+/area/nsv/weapons/fore)
 "pxt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -19032,6 +19480,11 @@
 /area/bridge/showroom{
 	name = "Battle Bridge"
 	})
+"pxQ" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/four,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "pye" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -19048,8 +19501,15 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "pyZ" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/turf/open/floor/engine,
+/obj/effect/turf_decal/delivery/white,
+/obj/structure/munitions_trolley,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
 /area/nsv/weapons/fore)
 "pzy" = (
 /obj/structure/closet/radiation,
@@ -19060,10 +19520,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "pAq" = (
-/obj/structure/grille,
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
-/area/bridge)
+/obj/machinery/light,
+/turf/open/floor/engine,
+/area/nsv/weapons/port{
+	name = "Weapons Storage"
+	})
 "pAW" = (
 /obj/machinery/power/deck_relay,
 /obj/structure/cable/yellow{
@@ -19232,7 +19693,16 @@
 	},
 /area/ai_monitored/nuke_storage)
 "pGe" = (
-/obj/effect/landmark/event_spawn,
+/obj/structure/closet/crate/secure/weapon,
+/obj/item/ship_weapon/parts/torpedo/iff_card,
+/obj/item/ship_weapon/parts/torpedo/iff_card,
+/obj/item/ship_weapon/parts/torpedo/iff_card,
+/obj/item/ship_weapon/parts/torpedo/warhead,
+/obj/item/ship_weapon/parts/torpedo/warhead,
+/obj/item/ship_weapon/parts/torpedo/warhead,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
@@ -19251,12 +19721,12 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/area/nsv/hanger/deck2/port)
 "pHk" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/plating,
+/obj/item/analyzer,
+/obj/item/trash/chips,
+/turf/open/floor/wood,
 /area/maintenance/fore)
 "pHm" = (
 /obj/structure/chair{
@@ -19275,9 +19745,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "pIP" = (
-/obj/structure/closet/crate,
-/turf/open/floor/plating,
-/area/nsv/weapons/fore)
+/obj/machinery/status_display/evac,
+/turf/closed/wall/r_wall/ship,
+/area/crew_quarters/heads/captain/private)
 "pIQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -19312,9 +19782,14 @@
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "pKc" = (
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/machinery/light,
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
+/area/nsv/weapons/port{
+	name = "Weapons Storage"
+	})
 "pKf" = (
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
@@ -19361,8 +19836,8 @@
 /area/science/mixing)
 "pLu" = (
 /obj/machinery/atmospherics/components/unary/portables_connector,
-/obj/item/analyzer,
-/turf/open/floor/plating,
+/obj/structure/table_frame/wood,
+/turf/open/floor/wood,
 /area/maintenance/fore)
 "pLv" = (
 /turf/open/floor/carpet/ship,
@@ -19403,10 +19878,14 @@
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "pOB" = (
-/obj/machinery/vending/boozeomat/all_access,
-/obj/machinery/light_switch/east,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
+/area/nsv/weapons/port{
+	name = "Weapons Storage"
+	})
 "pOE" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -19433,15 +19912,13 @@
 	},
 /area/bridge/meeting_room)
 "pOZ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/obj/item/weldingtool,
+/obj/item/wirecutters,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "pPA" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -19492,6 +19969,15 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"pRr" = (
+/obj/item/storage/toolbox/emergency,
+/obj/structure/table/glass,
+/obj/item/flashlight/lamp,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "pRx" = (
 /obj/machinery/light_switch/east,
 /obj/structure/chair/office,
@@ -19560,14 +20046,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
 "pUe" = (
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/airlock/vault/ship{
-	name = "Munitions Weapon Bay";
-	req_one_access_txt = "3;69"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/light_switch/west,
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
 	},
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
@@ -19622,6 +20105,10 @@
 	name = "nanoweave carpet (bluer)"
 	},
 /area/ai_monitored/storage/eva)
+"pXb" = (
+/obj/effect/spawner/room/fivexthree,
+/turf/template_noop,
+/area/maintenance/fore)
 "pXj" = (
 /obj/machinery/portable_atmospherics/canister/water_vapor,
 /turf/open/floor/plating,
@@ -19673,6 +20160,14 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
+"qaB" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
 "qbg" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/layer3{
 	dir = 8
@@ -19735,8 +20230,14 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "qdS" = (
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/engine,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
 /area/nsv/weapons/fore)
 "qea" = (
 /obj/structure/closet/l3closet,
@@ -19964,9 +20465,7 @@
 /obj/item/encryptionkey/atc,
 /obj/item/encryptionkey/atc,
 /turf/open/floor/carpet/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/area/nsv/hanger/deck2/port)
 "qmn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -19994,12 +20493,26 @@
 /turf/open/floor/wood,
 /area/library)
 "qnc" = (
-/obj/structure/closet/bombcloset,
-/obj/item/clothing/gloves/color/black,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
+/obj/structure/closet/secure_closet/fighter_pilot,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/head/hardhat,
+/obj/item/clothing/head/hardhat,
+/obj/item/radio/headset/heads/captain/alt{
+	desc = "A special headset that protects ears from some loud noises.";
+	keyslot = null;
+	name = "noise cancelling headphones"
 	},
+/obj/item/radio/headset/heads/captain/alt{
+	desc = "A special headset that protects ears from some loud noises.";
+	keyslot = null;
+	name = "noise cancelling headphones"
+	},
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/encryptionkey/atc,
+/obj/item/encryptionkey/atc,
+/turf/open/floor/engine,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -20019,17 +20532,6 @@
 	},
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/medical/genetics)
-"qpF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
-	},
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
 "qpG" = (
 /obj/machinery/modular_computer/console/preset/civilian{
 	dir = 4
@@ -20038,35 +20540,37 @@
 /turf/open/floor/wood,
 /area/library)
 "qqk" = (
-/obj/machinery/modular_computer/console/preset/command{
-	dir = 8
+/obj/structure/table/glass,
+/obj/machinery/door/window/westleft{
+	req_one_access_txt = "20"
 	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Captain's Desk";
-	departmentType = 5;
-	desc = "A console intended to send requests to different departments on the station. This one is equipped with prototype holographic keyboard software, because you deserve it.";
-	name = "Captain RC";
-	pixel_x = 32;
-	pixel_y = -32
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "qqW" = (
 /turf/open/floor/carpet/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/area/nsv/hanger/deck2/port)
 "qrf" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "qru" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 8
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/airlock/ship/maintenance{
+	name = "Maintenance Access Master At Arms Office";
+	req_one_access_txt = "70"
 	},
-/turf/closed/wall/r_wall/ship,
-/area/maintenance/fore)
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
+/area/maintenance/department/cargo)
 "qrB" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/machinery/atmospherics/components/unary/portables_connector/layer1{
@@ -20089,12 +20593,15 @@
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
 "qsp" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/obj/structure/cable/white{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain/private)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "qsN" = (
 /obj/machinery/dna_scannernew,
 /turf/open/floor/carpet/ship/purple_carpet,
@@ -20117,22 +20624,14 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "qur" = (
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/bridge)
+/obj/machinery/photocopier,
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "quw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /turf/open/floor/wood,
 /area/maintenance/fore)
 "qvk" = (
@@ -20196,20 +20695,10 @@
 /obj/machinery/door/window/eastright,
 /turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
-"qxi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
-	},
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+"qxs" = (
+/obj/structure/displaycase/captain,
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "qxH" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/circuit,
@@ -20233,22 +20722,23 @@
 /turf/open/floor/carpet/ship,
 /area/quartermaster/office)
 "qyc" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/eight,
-/obj/item/shuttle_creator,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/structure/curtain,
+/obj/item/soap/deluxe,
+/obj/item/bikehorn/rubberducky,
+/obj/machinery/shower{
+	dir = 4;
+	layer = 3.5
+	},
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/heads/captain/private)
 "qyG" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/start/bridge,
 /turf/open/floor/carpet/blue,
 /area/bridge/meeting_room)
-"qyI" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
 "qyR" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -20269,9 +20759,7 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/area/nsv/hanger/deck2/port)
 "qzy" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/libraryconsole,
@@ -20355,16 +20843,10 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "qBT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
-	},
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/obj/effect/spawner/lootdrop/crate_spawner,
+/obj/item/chair,
+/turf/open/floor/plating,
+/area/nsv/weapons/fore)
 "qCH" = (
 /obj/structure/table,
 /obj/structure/cable{
@@ -20373,9 +20855,7 @@
 /obj/machinery/computer/lore_terminal,
 /obj/item/key/fighter_tug,
 /turf/open/floor/carpet/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/area/nsv/hanger/deck2/port)
 "qCO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -20397,9 +20877,15 @@
 /turf/template_noop,
 /area/maintenance/fore)
 "qFg" = (
-/obj/structure/extinguisher_cabinet/west,
-/turf/closed/wall/r_wall/ship,
-/area/maintenance/department/cargo)
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
+/area/nsv/weapons/fore)
 "qGo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -20597,20 +21083,15 @@
 	dir = 8
 	},
 /obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
@@ -20667,7 +21148,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/purple/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -20680,7 +21164,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
+/obj/item/chair/stool/bar,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/wood,
 /area/maintenance/fore)
 "qTk" = (
 /obj/structure/table/wood,
@@ -20704,20 +21190,25 @@
 	pixel_x = 7;
 	pixel_y = 2
 	},
-/obj/item/multitool{
-	pixel_x = 4;
-	pixel_y = -1
-	},
-/obj/item/flashlight/lamp,
 /obj/structure/table/glass,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/item/clothing/ears/earmuffs,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
+/obj/item/clothing/accessory/medal/silver{
+	color = "#ffcc00";
+	desc = "A high quality and decorated medal to show you are appreciated!";
+	name = "custom medal"
+	},
+/obj/item/multitool{
+	pixel_x = 4;
+	pixel_y = -1
+	},
+/obj/item/flashlight/lamp,
+/obj/item/clothing/ears/earmuffs,
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -20927,6 +21418,15 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/dorms)
+"qZU" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/carpet/ship/blue{
+	color = "#9999DD";
+	name = "nanoweave carpet (bluer)"
+	},
+/area/bridge)
 "rae" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/light{
@@ -20941,15 +21441,11 @@
 /turf/closed/wall/ship,
 /area/nsv/hanger)
 "rbA" = (
-/obj/structure/table/glass,
-/obj/structure/sign/solgov_flag/right{
-	layer = 2.79
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 9
 	},
-/obj/machinery/microwave{
-	pixel_y = 6
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "rbB" = (
 /obj/structure/table,
 /obj/item/screwdriver,
@@ -21029,9 +21525,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
 "rdY" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/structure/reagent_dispensers/foamtank/hull_repair_juice,
+/obj/item/extinguisher/advanced/hull_repair_juice,
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
@@ -21090,7 +21585,22 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "rgf" = (
-/obj/structure/closet/secure_closet/captains,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light_switch/east,
+/obj/machinery/computer/communications{
+	dir = 8
+	},
+/obj/machinery/button/door{
+	desc = "A remote control switch for the captain's front door.";
+	id = "CaptainFoyer";
+	name = "Captain Front Door Control";
+	normaldoorcontrol = 1;
+	pixel_x = 26;
+	pixel_y = -10
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "rgn" = (
@@ -21149,8 +21659,9 @@
 	c_tag = "External Viewport Bridge";
 	dir = 4
 	},
+/obj/structure/lattice,
 /turf/open/space/basic,
-/area/space)
+/area/bridge)
 "rhB" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -21298,32 +21809,19 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "rpP" = (
-/obj/machinery/airalarm/directional/north,
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/gloves,
-/obj/item/stack/packageWrap,
-/obj/item/destTagger{
-	pixel_x = 4;
-	pixel_y = 3
-	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
-	},
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/nsv/weapons/fore)
 "rqo" = (
 /turf/closed/wall/ship,
 /area/science{
 	name = "Science Lobby"
 	})
 "rqS" = (
-/obj/structure/table/glass,
-/obj/item/clothing/gloves/color/black,
-/obj/item/storage/fancy/donut_box,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/obj/item/storage/toolbox/emergency,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "rrd" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/engine,
@@ -21354,12 +21852,6 @@
 	name = "nanoweave carpet (bluer)"
 	},
 /area/bridge/meeting_room/council)
-"rtl" = (
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/nsv/weapons/fore)
 "rtY" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/border_only/directional/south,
@@ -21395,8 +21887,16 @@
 	},
 /area/ai_monitored/turret_protected/aisat_interior)
 "rvq" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/obj/item/twohanded/required/kirbyplants/random,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/computer/monitor,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
@@ -21433,7 +21933,6 @@
 /area/quartermaster/storage)
 "rwj" = (
 /obj/structure/table,
-/obj/machinery/airalarm/directional/east,
 /obj/item/stack/wrapping_paper,
 /obj/item/stack/packageWrap{
 	pixel_x = 2;
@@ -21547,8 +22046,11 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
@@ -21571,29 +22073,29 @@
 /turf/open/openspace,
 /area/shuttle/turbolift/secondary)
 "rDI" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/status_display/evac,
+/turf/closed/wall/ship,
+/area/quartermaster/storage)
+"rEj" = (
+/obj/machinery/camera{
+	c_tag = "External Access Bridge";
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/obj/machinery/suit_storage_unit/standard_unit,
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
 "rEp" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
 /obj/structure/cable/white{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
@@ -21625,6 +22127,12 @@
 	name = "nanoweave carpet (bluer)"
 	},
 /area/bridge/meeting_room)
+"rFk" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/cultivator,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "rGV" = (
 /obj/machinery/modular_computer/console/preset/civilian{
 	dir = 4
@@ -21663,28 +22171,15 @@
 	},
 /area/teleporter)
 "rHJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
-	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
-	},
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/obj/machinery/atmospherics/pipe/manifold/purple/hidden,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "rHS" = (
 /obj/structure/sign/warning/vacuum,
 /turf/closed/wall/ship,
@@ -21906,7 +22401,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
@@ -21922,6 +22420,9 @@
 	},
 /area/crew_quarters/heads/hop)
 "rNy" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 5
+	},
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/nsv/weapons/fore)
@@ -21977,22 +22478,23 @@
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/checkpoint/supply)
 "rQB" = (
-/obj/structure/reagent_dispensers/fueltank/aviation_fuel,
-/obj/structure/sign/solgov_seal,
-/turf/open/floor/engine,
-/area/nsv/hanger)
-"rQF" = (
-/obj/machinery/atmospherics/pipe/manifold/purple/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
 	},
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/nsv/weapons/fore)
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/department/cargo)
 "rRn" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "rRR" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
 /obj/machinery/light/small{
 	dir = 4;
 	pixel_y = 10
@@ -22001,15 +22503,8 @@
 	pixel_x = 27;
 	pixel_y = -2
 	},
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
-	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/heads/captain)
+/area/crew_quarters/heads/captain/private)
 "rSk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -22264,12 +22759,11 @@
 /turf/open/floor/plating,
 /area/nsv/hanger)
 "rZv" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
 	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/wood,
-/area/maintenance/fore)
+/turf/closed/wall/r_wall/ship,
+/area/crew_quarters/heads/captain/private)
 "rZZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22288,11 +22782,9 @@
 /turf/open/floor/carpet/ship,
 /area/bridge/meeting_room/council)
 "sba" = (
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/turf/closed/wall/ship,
-/area/maintenance/department/bridge)
+/obj/structure/bookcase/random,
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "sbm" = (
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
@@ -22357,20 +22849,15 @@
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/xenobiology)
 "sdb" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
+/obj/structure/closet/bombcloset,
+/obj/item/clothing/gloves/color/black,
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
 	},
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/effect/landmark/start/munitions_tech,
-/turf/open/floor/carpet/red,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -22388,9 +22875,14 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "sdA" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall/ship,
-/area/crew_quarters/heads/captain)
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/nsv/weapons/fore)
 "sdK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -22505,11 +22997,18 @@
 	pixel_y = -6;
 	target_layer = 1
 	},
-/turf/open/floor/plating,
+/obj/structure/table_frame/wood,
+/obj/machinery/atmospherics/pipe/manifold/purple/hidden{
+	dir = 1
+	},
+/turf/open/floor/wood,
 /area/maintenance/fore)
 "skH" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
@@ -22517,10 +23016,7 @@
 	},
 /area/bridge)
 "skI" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
-/turf/open/floor/carpet,
+/turf/closed/wall/ship,
 /area/crew_quarters/heads/captain/private)
 "skW" = (
 /obj/machinery/holopad,
@@ -22553,7 +23049,6 @@
 	dir = 4
 	},
 /obj/machinery/light_switch/east,
-/obj/structure/munitions_trolley,
 /turf/open/floor/engine,
 /area/nsv/hanger)
 "slO" = (
@@ -22621,9 +23116,7 @@
 "snA" = (
 /obj/machinery/suit_storage_unit/pilot,
 /turf/open/floor/carpet/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/area/nsv/hanger/deck2/port)
 "snU" = (
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen";
@@ -22651,6 +23144,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/mixing)
+"soH" = (
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/pipe_dispenser,
+/obj/item/assault_pod/mining,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "soY" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -22685,6 +23186,10 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
+"spx" = (
+/obj/structure/sign/warning/docking,
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/department/bridge)
 "spy" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -22733,10 +23238,9 @@
 /turf/closed/wall/r_wall/ship,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "ssn" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/nsv/weapons/fore)
+/obj/machinery/recharge_station,
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/heads/captain/private)
 "ssq" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -22748,8 +23252,9 @@
 /turf/open/floor/carpet/ship,
 /area/quartermaster/office)
 "sss" = (
-/obj/structure/munitions_trolley,
-/obj/item/ship_weapon/ammunition/torpedo/nuke/fabio,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -22781,9 +23286,7 @@
 /obj/machinery/status_display/evac/north,
 /obj/structure/extinguisher_cabinet/west,
 /turf/open/floor/carpet/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/area/nsv/hanger/deck2/port)
 "sua" = (
 /obj/structure/rack,
 /obj/item/storage/briefcase{
@@ -22829,21 +23332,15 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet/east,
 /obj/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "suU" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 5
+	dir = 4
 	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/turf/open/floor/engine,
+/area/nsv/weapons/fore)
 "svv" = (
 /turf/open/openspace,
 /area/shuttle/turbolift/quinary)
@@ -22864,20 +23361,24 @@
 /turf/closed/wall/ship,
 /area/quartermaster/storage)
 "sxI" = (
-/obj/item/storage/fancy/heart_box,
-/obj/item/folder/blue,
-/obj/item/folder/yellow{
+/obj/item/disk/holodisk/donutstation{
 	pixel_x = 4;
+	pixel_y = 6
+	},
+/obj/item/disk/holodisk/donutstation/enginewars{
+	pixel_x = 2;
 	pixel_y = 4
 	},
-/obj/structure/table/glass,
-/obj/item/encryptionkey/munitions_tech{
-	pixel_x = 4;
-	pixel_y = 4
+/obj/machinery/cell_charger,
+/obj/item/disk/holodisk/galactica_history/history{
+	pixel_y = 2
 	},
-/obj/item/encryptionkey/atc,
-/obj/structure/cable/white{
-	icon_state = "1-2"
+/obj/item/disk/holodisk/example{
+	pixel_x = -2
+	},
+/obj/structure/table,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
@@ -22932,12 +23433,6 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
-"syB" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 5
-	},
-/turf/closed/wall/r_wall/ship,
-/area/nsv/weapons/fore)
 "szu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -23044,28 +23539,30 @@
 /area/nsv/hanger/deck2/starboard{
 	name = "Launch tubes 1 and 2"
 	})
-"sBN" = (
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/airlock/ship/external/glass{
-	name = "Escape Pod Munitions";
-	req_one_access_txt = "3;69;72"
-	},
+"sBB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "sBU" = (
 /obj/structure/disposalpipe/segment,
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/carpet/orange,
 /area/quartermaster/storage)
 "sCc" = (
-/obj/structure/dresser{
-	anchored = 0
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/effect/landmark/start/captain,
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
@@ -23100,8 +23597,17 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "sET" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 10
+	},
+/turf/open/floor/wood,
 /area/maintenance/fore)
 "sFH" = (
 /obj/machinery/door/firedoor/border_only/directional/north,
@@ -23170,16 +23676,22 @@
 	dir = 8;
 	name = "emergency shower"
 	},
-/obj/structure/munitions_trolley,
 /turf/open/floor/engine,
 /area/nsv/hanger)
-"sJp" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/taco{
-	name = "taigo"
+"sIz" = (
+/obj/structure/lattice,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/open/floor/wood,
-/area/maintenance/fore)
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space/nearstation)
+"sJp" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall/ship,
+/area/nsv/weapons/fore)
 "sKw" = (
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/vending/clothing,
@@ -23205,6 +23717,22 @@
 	},
 /turf/open/floor/plating,
 /area/science/server)
+"sLR" = (
+/obj/item/storage/fancy/heart_box,
+/obj/item/folder/blue,
+/obj/item/folder/yellow{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/structure/table/glass,
+/obj/item/encryptionkey/munitions_tech{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/encryptionkey/atc,
+/obj/machinery/status_display/ai/south,
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "sLS" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -23245,6 +23773,29 @@
 	},
 /turf/open/floor/circuit,
 /area/science/server)
+"sPa" = (
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = 2
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = 2
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -10
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -10
+	},
+/turf/open/floor/carpet/ship/purple_carpet,
+/area/science/lab)
 "sPf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -23323,9 +23874,13 @@
 /turf/closed/wall/ship,
 /area/maintenance/department/science/xenobiology)
 "sRk" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
 	},
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/effect/landmark/start/munitions_tech,
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
@@ -23366,26 +23921,19 @@
 	},
 /turf/open/floor/holofloor/wood,
 /area/bridge/showroom/corporate)
-"sUo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment{
+"sUy" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
-	},
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
-"sUy" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/item/statuebust,
+/turf/open/floor/plating,
+/area/nsv/weapons/fore)
+"sUF" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
 	},
 /turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/area/crew_quarters/heads/captain/private)
 "sUM" = (
 /obj/effect/decal/cleanable/ash,
 /obj/effect/turf_decal/stripes/line{
@@ -23500,20 +24048,24 @@
 	},
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/science/xenobiology)
+"sZC" = (
+/obj/machinery/atmospherics/pipe/manifold/purple/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "tae" = (
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/gloves/color/latex,
-/obj/structure/closet/l3closet/security,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/status_display/evac,
+/turf/closed/wall/ship,
+/area/security/checkpoint/supply)
+"tay" = (
+/obj/structure/closet/emcloset,
+/obj/item/storage/toolbox/emergency,
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"tay" = (
-/obj/structure/table/wood,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/turf/open/floor/wood,
-/area/maintenance/fore)
 "taE" = (
 /obj/structure/closet/l3closet,
 /obj/item/clothing/mask/surgical,
@@ -23543,9 +24095,9 @@
 /turf/open/floor/carpet/ship,
 /area/nsv/hanger/deck2/port)
 "tdZ" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/obj/structure/table,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "tek" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -23615,18 +24167,10 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "tgY" = (
-/obj/machinery/computer/ship/viewscreen,
-/obj/machinery/computer/ship/navigation/public{
-	dir = 4;
-	name = "starmap console"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
-	},
+/turf/closed/wall/r_wall/ship,
 /area/nsv/weapons/fore)
 "thf" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped{
@@ -23663,6 +24207,12 @@
 /area/science{
 	name = "Science Lobby"
 	})
+"tlr" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/shovel/spade,
+/obj/effect/spawner/lootdrop/maintenance/four,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "tlt" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -23686,11 +24236,10 @@
 /turf/open/floor/circuit,
 /area/science/server)
 "tlN" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 1
-	},
-/turf/closed/wall/r_wall/ship,
-/area/maintenance/fore)
+/obj/structure/closet/bombcloset,
+/obj/item/clothing/gloves/color/black,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "tlV" = (
 /obj/structure/shuttle/engine/huge{
 	dir = 8
@@ -23698,11 +24247,14 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "tmq" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/docking_port/stationary{
+	dwidth = 1;
+	height = 4;
+	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
+	width = 3
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/space/nearstation)
 "tmX" = (
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/carpet/ship/purple_carpet,
@@ -23719,38 +24271,17 @@
 /obj/item/key/fighter_tug,
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/carpet/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/area/nsv/hanger/deck2/port)
 "tof" = (
-/obj/machinery/vending/cigarette,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/machinery/light,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "toh" = (
-/obj/item/coin/plasma{
-	pixel_x = -5;
-	pixel_y = -3
+/obj/structure/closet/firecloset{
+	opened = 1
 	},
-/obj/item/coin/gold{
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/coin/plasma{
-	pixel_x = 4;
-	pixel_y = -2
-	},
-/obj/item/storage/toolbox/emergency,
-/obj/effect/holodeck_effect/cards{
-	pixel_x = 4;
-	pixel_y = 8
-	},
-/obj/structure/table/glass,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "toN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -23795,14 +24326,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "tqD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/heads/captain)
+/obj/structure/sign/warning/pods,
+/turf/closed/wall/ship,
+/area/maintenance/department/cargo)
 "tqH" = (
 /obj/structure/table/wood,
 /obj/item/trash/can{
@@ -23840,6 +24366,10 @@
 "tqY" = (
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/airlock/ship/external/glass{
+	name = "Escape Pod Munitions";
+	req_one_access_txt = "3;69;72"
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "trM" = (
@@ -23944,11 +24474,8 @@
 /turf/open/floor/carpet/ship,
 /area/maintenance/department/science/xenobiology)
 "tva" = (
-/obj/machinery/ship_weapon/energy/beam,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/engine,
+/obj/structure/sign/warning/explosives/alt,
+/turf/closed/wall/r_wall/ship,
 /area/nsv/weapons/fore)
 "tvj" = (
 /obj/structure/displaycase/trophy,
@@ -24065,24 +24592,12 @@
 	},
 /area/ai_monitored/storage/eva)
 "tyk" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/obj/machinery/door/window/southright{
-	req_access_txt = "20"
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "tyD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -24093,14 +24608,20 @@
 	},
 /area/bridge/meeting_room/council)
 "tyV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/airlock/ship/maintenance{
+	name = "Maintenance Access Captain Office";
+	req_one_access_txt = "20"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "tzi" = (
 /obj/machinery/photocopier,
 /turf/open/floor/wood,
@@ -24110,13 +24631,17 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "tAS" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/airlock/ship/station{
+	name = "Captain Office Bathroom";
+	req_one_access_txt = "20"
+	},
+/obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
-/obj/structure/window/reinforced,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/heads/captain/private)
 "tBl" = (
 /obj/machinery/computer/apc_control{
 	dir = 4
@@ -24209,21 +24734,6 @@
 	},
 /turf/template_noop,
 /area/maintenance/department/science/central)
-"tFk" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/obj/effect/landmark/start/master_at_arms,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
-	},
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
 "tFJ" = (
 /obj/item/storage/briefcase,
 /obj/structure/table/wood,
@@ -24321,6 +24831,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/light_switch/east,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "tKC" = (
@@ -24355,13 +24866,12 @@
 /turf/closed/wall/r_wall/ship,
 /area/science/mixing)
 "tLU" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/cultivator,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
@@ -24380,17 +24890,9 @@
 /turf/template_noop,
 /area/maintenance/department/science/xenobiology)
 "tND" = (
-/obj/structure/table/wood/poker,
-/obj/item/dice/d6{
-	pixel_x = -13;
-	pixel_y = 5
-	},
-/obj/item/dice/d6,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 6
-	},
-/turf/open/floor/wood,
-/area/maintenance/fore)
+/obj/machinery/vending/boozeomat,
+/turf/closed/wall/ship,
+/area/crew_quarters/heads/captain/private)
 "tNS" = (
 /obj/machinery/computer/monitor,
 /obj/structure/cable{
@@ -24463,6 +24965,12 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
+"tPA" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "tQd" = (
 /turf/open/floor/carpet/purple,
 /area/science/xenobiology)
@@ -24538,26 +25046,10 @@
 /turf/closed/wall/r_wall/ship,
 /area/science/mixing/chamber)
 "tSv" = (
-/obj/machinery/computer/lore_terminal,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/smes{
-	charge = 800000;
-	input_level = 20000;
-	name = "low-priority department power storage unit";
-	output_level = 20000
-	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
-	},
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "tTd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/structure/disposalpipe/segment,
@@ -24580,7 +25072,6 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/suit_storage_unit/pilot,
 /turf/open/floor/engine,
 /area/nsv/hanger)
 "tUI" = (
@@ -24605,6 +25096,10 @@
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
+"tVt" = (
+/obj/structure/closet/secure_closet/freezer/kitchen/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "tVQ" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
@@ -24613,9 +25108,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "tWA" = (
-/obj/machinery/atmospherics/components/unary/portables_connector,
-/turf/closed/wall/r_wall/ship,
-/area/nsv/weapons/fore)
+/obj/structure/table/glass,
+/obj/item/flashlight/lamp,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "tWG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -24655,20 +25154,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "tXj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/bridge)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "tXG" = (
 /obj/structure/table,
 /obj/item/storage/box/disks{
@@ -24683,6 +25175,12 @@
 	},
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/medical/genetics)
+"tXJ" = (
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/gloves/color/latex,
+/obj/structure/closet/l3closet/security,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "tXM" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -24696,12 +25194,12 @@
 	},
 /area/crew_quarters/heads/hop)
 "tXU" = (
-/obj/machinery/atmospherics/pipe/manifold/purple/hidden{
-	dir = 8
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
 	},
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/nsv/weapons/fore)
+/obj/machinery/computer/arcade,
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "tXY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -24813,9 +25311,8 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/obj/item/statuebust,
-/turf/open/floor/plating,
-/area/nsv/weapons/fore)
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/heads/captain/private)
 "ubx" = (
 /obj/machinery/shower{
 	dir = 8;
@@ -24893,7 +25390,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/engine,
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
 /area/nsv/weapons/fore)
 "ueX" = (
 /obj/structure/chair/office/light,
@@ -24947,16 +25447,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "uhs" = (
-/obj/item/folder/blue,
-/obj/item/folder/red{
-	pixel_x = 4;
-	pixel_y = 4
+/obj/structure/dresser{
+	anchored = 0
 	},
-/obj/item/pen/fountain/captain,
-/obj/structure/table/glass,
-/obj/structure/window/reinforced,
+/obj/machinery/computer/lore_terminal,
 /turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/area/crew_quarters/heads/captain/private)
 "uhz" = (
 /obj/machinery/vending/wardrobe/science_wardrobe,
 /obj/structure/cable/yellow{
@@ -24987,6 +25483,10 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/quartermaster/miningoffice)
+"uhY" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/fore)
 "uin" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
 	dir = 1;
@@ -25020,20 +25520,26 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "ujq" = (
-/obj/structure/chair/office{
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/nsv/weapons/fore)
+"ujZ" = (
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
-	},
-/area/nsv/weapons/fore)
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
 "ukZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -25076,8 +25582,14 @@
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/lab)
 "ulC" = (
-/obj/structure/cable/white{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
@@ -25098,15 +25610,22 @@
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
 "umH" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/structure/cable/white{
+	icon_state = "1-2"
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "unh" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -25116,8 +25635,8 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/airlock/vault/ship{
-	name = "Munitions Weapons Bay";
-	req_one_access_txt = "3;69;72"
+	name = "Munitions and Hangar Storage";
+	req_one_access_txt = "69;72"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25126,31 +25645,30 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/area/nsv/hanger/deck2/port)
 "uno" = (
-/obj/machinery/light_switch/west,
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/structure/closet/secure_closet/munitions_technician,
+/obj/structure/closet/secure_closet/fighter_pilot,
 /obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/head/hardhat,
+/obj/item/clothing/head/hardhat,
 /obj/item/radio/headset/heads/captain/alt{
 	desc = "A special headset that protects ears from some loud noises.";
 	keyslot = null;
 	name = "noise cancelling headphones"
 	},
-/obj/item/encryptionkey/munitions_tech,
-/obj/item/clothing/head/hardhat,
-/obj/item/clothing/head/welding,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
+/obj/item/radio/headset/heads/captain/alt{
+	desc = "A special headset that protects ears from some loud noises.";
+	keyslot = null;
+	name = "noise cancelling headphones"
 	},
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/encryptionkey/atc,
+/obj/item/encryptionkey/atc,
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/light_switch/west,
+/turf/open/floor/engine,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -25336,12 +25854,10 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "uwa" = (
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/airlock/ship/maintenance{
-	name = "Maintenance Access Master At Arms Office";
-	req_one_access_txt = "70"
+/obj/structure/window/reinforced{
+	dir = 8
 	},
+/obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
@@ -25350,14 +25866,14 @@
 	name = "Weapons Storage"
 	})
 "uwM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
+/obj/machinery/shower{
+	dir = 8;
+	name = "emergency shower"
 	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
 /area/nsv/weapons/fore)
 "uxC" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
@@ -25412,22 +25928,11 @@
 	name = "Launch tubes 1 and 2"
 	})
 "uBw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/atmospherics/components/binary/pump/layer1{
-	dir = 4;
-	on = 1;
-	target_pressure = 2000
-	},
-/obj/machinery/door/airlock/ship/external/glass{
-	name = "External Access Deck 1 Fore";
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/airlock/ship/maintenance{
+	name = "Maintenance Access Bridge";
 	req_one_access_txt = "19"
-	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
@@ -25447,14 +25952,9 @@
 	},
 /area/ai_monitored/turret_protected/aisat_interior)
 "uCf" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/obj/machinery/status_display/evac,
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/department/cargo)
 "uCu" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -25590,13 +26090,19 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "uHX" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/airlock/vault/ship{
+	name = "Munitions Weapon Bay";
+	req_one_access_txt = "69"
 	},
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
-/turf/open/floor/engine,
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
 /area/nsv/weapons/fore)
 "uIi" = (
 /obj/machinery/computer/ship/navigation/public{
@@ -25631,6 +26137,13 @@
 /obj/item/clothing/ears/earmuffs,
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
+"uJt" = (
+/obj/structure/chair/office,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "uKd" = (
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/auxiliary)
@@ -25766,9 +26279,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/landmark/start/munitions_tech,
 /turf/open/floor/carpet/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/area/nsv/hanger/deck2/port)
 "uPH" = (
 /obj/structure/closet/radiation,
 /obj/item/clothing/mask/gas,
@@ -25784,13 +26295,19 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "uQi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/machinery/button/door{
 	id = "bridgewindows";
 	pixel_x = 6;
 	pixel_y = 26
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
@@ -25819,6 +26336,10 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/plating,
 /area/science/server)
+"uRe" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/turf/open/floor/wood,
+/area/maintenance/fore)
 "uRF" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/structure/window/reinforced,
@@ -25946,10 +26467,8 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/turf/open/floor/engine,
+/area/nsv/hanger/deck2/port)
 "uXQ" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/layer1{
 	dir = 8
@@ -25958,7 +26477,13 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
-/obj/machinery/status_display/evac/north,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -26053,21 +26578,15 @@
 /turf/open/floor/carpet,
 /area/library)
 "vcH" = (
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/stamp/captain,
-/obj/structure/table/glass,
-/obj/structure/window/reinforced,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/structure/door_assembly/door_assembly_mhatch,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "vdl" = (
-/obj/structure/table/glass,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
-	},
-/obj/machinery/light_switch/east,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/obj/machinery/status_display/ai,
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/department/cargo)
 "vdR" = (
 /obj/machinery/door/poddoor/ship{
 	id = "launchbay_tube2";
@@ -26092,6 +26611,12 @@
 /area/nsv/hanger/deck2/starboard{
 	name = "Launch tubes 1 and 2"
 	})
+"vdZ" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "veo" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
 /obj/machinery/door/poddoor/shutters/ship/preopen{
@@ -26129,6 +26654,15 @@
 "vgH" = (
 /turf/closed/wall/ship,
 /area/science/mixing/chamber)
+"vhN" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "vii" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
@@ -26229,16 +26763,21 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "vlU" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/airlock/ship/maintenance{
+	name = "Maintenance Access Munitions and Hangar Storage";
+	req_one_access_txt = "69;72"
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/nsv/weapons/port{
+	name = "Weapons Storage"
+	})
 "vma" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/closed/wall/r_wall/ship,
+/turf/open/floor/engine,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -26258,9 +26797,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "vnw" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
-	},
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/nsv/weapons/fore)
@@ -26277,6 +26813,15 @@
 /obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/carpet/ship,
 /area/quartermaster/miningoffice)
+"vnD" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/ship/blue{
+	color = "#9999DD";
+	name = "nanoweave carpet (bluer)"
+	},
+/area/bridge)
 "voS" = (
 /obj/machinery/door/window{
 	dir = 8;
@@ -26293,8 +26838,7 @@
 /turf/open/floor/engine,
 /area/nsv/hanger)
 "vqy" = (
-/obj/machinery/atmospherics/pipe/manifold/purple/hidden,
-/obj/structure/grille,
+/obj/machinery/suit_storage_unit/pilot,
 /turf/open/floor/plating,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
@@ -26318,6 +26862,26 @@
 "vrD" = (
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = 2
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = 2
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -10
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -10
 	},
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms)
@@ -26430,6 +26994,10 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms)
+"vvJ" = (
+/obj/effect/spawner/room/threexfive,
+/turf/template_noop,
+/area/maintenance/fore)
 "vvY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -26503,6 +27071,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/engine,
 /area/science/robotics/lab)
+"vzB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood,
+/area/maintenance/fore)
 "vzQ" = (
 /obj/structure/chair{
 	dir = 1
@@ -26534,10 +27111,11 @@
 	},
 /area/bridge)
 "vAr" = (
-/obj/structure/cable/white{
-	icon_state = "1-4"
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plating,
 /area/nsv/weapons/fore)
 "vAx" = (
 /obj/machinery/door/poddoor/ship{
@@ -26603,6 +27181,10 @@
 /obj/item/clothing/ears/earmuffs,
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/robotics/lab)
+"vCH" = (
+/obj/structure/closet/crate,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "vCI" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -26658,13 +27240,18 @@
 /area/nsv/hanger/deck2/starboard{
 	name = "Launch tubes 1 and 2"
 	})
+"vDP" = (
+/turf/closed/wall/ship,
+/area/bridge)
 "vEs" = (
-/obj/machinery/camera{
-	c_tag = "External Access Science Construction Zone";
-	dir = 8
+/obj/structure/table/glass,
+/obj/item/paint/blue,
+/obj/item/razor,
+/obj/structure/mirror{
+	pixel_y = 28
 	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "vEt" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -26704,12 +27291,9 @@
 /turf/open/floor/carpet/ship,
 /area/ai_monitored/turret_protected/ai_upload)
 "vGa" = (
-/obj/machinery/camera{
-	c_tag = "External Viewport Munitions 2";
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/newscaster/security_unit/north,
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "vGt" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -26857,23 +27441,13 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/engine,
-/area/nsv/weapons/fore)
-"vKa" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/cable/white{
-	icon_state = "1-4"
-	},
+/obj/structure/grille,
 /turf/open/floor/plating,
-/area/maintenance/department/bridge)
+/area/maintenance/department/cargo)
+"vKa" = (
+/obj/structure/bookcase/manuals/engineering,
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "vKc" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -26911,6 +27485,12 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"vKN" = (
+/obj/structure/rack,
+/obj/structure/extinguisher_cabinet/east,
+/obj/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "vKS" = (
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/carpet/ship,
@@ -26922,6 +27502,13 @@
 /obj/effect/landmark/start/roboticist,
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/robotics/lab)
+"vLp" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/wood,
+/area/maintenance/fore)
 "vMr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -26935,14 +27522,6 @@
 /turf/open/floor/wood,
 /area/library)
 "vMA" = (
-/obj/machinery/computer/ship/viewscreen,
-/obj/machinery/computer/ship/navigation/public{
-	name = "starmap console"
-	},
-/obj/item/radio/intercom/directional{
-	pixel_x = 30;
-	pixel_y = 25
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -26975,11 +27554,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 8;
-	sortType = 12
-	},
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/carpet/ship/purple_carpet,
@@ -27034,19 +27612,6 @@
 /turf/open/floor/plating,
 /area/teleporter)
 "vNI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/landmark/start/master_at_arms,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
-	},
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
@@ -27128,13 +27693,15 @@
 /turf/open/floor/wood,
 /area/library)
 "vRT" = (
-/obj/structure/closet/emcloset,
-/obj/item/storage/toolbox/emergency,
-/obj/machinery/light/small{
-	dir = 1
+/obj/item/radio/intercom/directional/north,
+/obj/structure/bed,
+/obj/effect/landmark/start/captain,
+/obj/machinery/firealarm{
+	pixel_x = 26;
+	pixel_y = 25
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "vSx" = (
 /obj/item/paper_bin,
 /obj/item/pen,
@@ -27192,13 +27759,13 @@
 	},
 /area/ai_monitored/storage/eva)
 "vVH" = (
-/obj/structure/chair/office,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/structure/table/glass,
+/obj/effect/holodeck_effect/cards{
+	pixel_x = 4;
+	pixel_y = 8
 	},
-/obj/effect/landmark/start/captain,
 /turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/area/crew_quarters/heads/captain/private)
 "vVL" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -27233,20 +27800,28 @@
 /turf/open/floor/carpet/ship,
 /area/nsv/hanger/deck2/port)
 "vWo" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "vWs" = (
 /obj/structure/closet/emcloset,
 /obj/item/storage/toolbox/emergency,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -27358,8 +27933,15 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/closed/wall/r_wall/ship,
-/area/nsv/weapons/fore)
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/west,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/heads/captain/private)
 "wbJ" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -27391,20 +27973,8 @@
 /turf/open/floor/circuit,
 /area/science/server)
 "weG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/meter/atmos/distro_loop{
-	pixel_x = -6;
-	pixel_y = -6;
-	target_layer = 1
-	},
-/obj/structure/cable/white{
-	icon_state = "1-8"
-	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/advanced_airlock_controller/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "weM" = (
@@ -27481,9 +28051,7 @@
 "wiG" = (
 /obj/machinery/modular_computer/console/preset/civilian,
 /turf/open/floor/carpet/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/area/nsv/hanger/deck2/port)
 "wiL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -27502,11 +28070,19 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "wiQ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/junction{
 	dir = 1
 	},
 /turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/area/crew_quarters/heads/captain/private)
 "wjg" = (
 /obj/item/storage/toolbox/electrical{
 	pixel_x = -3;
@@ -27611,6 +28187,16 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"wlJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "wlO" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -27632,11 +28218,11 @@
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/lab)
 "wnz" = (
-/obj/structure/grille,
-/obj/machinery/atmospherics/pipe/manifold/purple/hidden{
-	dir = 1
+/obj/effect/turf_decal/delivery/white,
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
 	},
-/turf/open/floor/plating,
 /area/nsv/weapons/fore)
 "wnL" = (
 /turf/open/floor/engine,
@@ -27662,9 +28248,9 @@
 /turf/closed/wall/ship,
 /area/science/lab)
 "wqr" = (
-/obj/effect/turf_decal/delivery/white,
-/obj/structure/closet/bombcloset,
-/obj/item/clothing/gloves/color/black,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
@@ -27678,11 +28264,20 @@
 /turf/open/floor/engine,
 /area/maintenance/fore)
 "wqW" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/bridge)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "wry" = (
 /obj/structure/sign/departments/minsky/supply/cargo{
 	pixel_y = 32
@@ -27691,13 +28286,27 @@
 /turf/open/floor/carpet/ship,
 /area/quartermaster/office)
 "wsy" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/obj/machinery/door/window/westright{
+	req_one_access_txt = "20"
 	},
-/obj/structure/reagent_dispensers/foamtank/hull_repair_juice,
-/obj/item/extinguisher/advanced/hull_repair_juice,
-/turf/open/floor/plating,
-/area/nsv/hanger)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/holopad,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "wty" = (
 /obj/machinery/camera{
 	c_tag = "Elevator Science Wing";
@@ -27828,10 +28437,18 @@
 /turf/open/openspace,
 /area/shuttle/turbolift/primary)
 "wzq" = (
-/obj/structure/table/wood/poker,
-/obj/effect/holodeck_effect/cards,
-/turf/open/floor/wood,
-/area/maintenance/fore)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "wzA" = (
 /obj/machinery/computer/bank_machine,
 /turf/open/floor/circuit,
@@ -27917,7 +28534,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/wood,
 /area/maintenance/fore)
 "wDg" = (
 /obj/item/slime_scanner,
@@ -27940,10 +28557,7 @@
 /turf/open/floor/wood,
 /area/library)
 "wEx" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
@@ -27964,9 +28578,20 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/auxiliary)
 "wEG" = (
-/obj/structure/sign/warning/vacuum,
-/turf/closed/wall/ship,
-/area/maintenance/fore)
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "wEX" = (
 /obj/machinery/status_display/ai,
 /turf/closed/wall/r_wall/ship,
@@ -28154,20 +28779,17 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "wMe" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 10
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/area/crew_quarters/heads/captain/private)
 "wMB" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -28275,9 +28897,6 @@
 /area/bridge/meeting_room)
 "wRu" = (
 /obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -28288,19 +28907,15 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/turf/open/floor/engine,
+/area/nsv/hanger/deck2/port)
 "wRX" = (
 /obj/machinery/status_display/evac,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/closed/wall/r_wall/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/turf/open/floor/engine,
+/area/nsv/hanger/deck2/port)
 "wSa" = (
 /obj/item/instrument/piano_synth,
 /turf/open/floor/carpet,
@@ -28320,6 +28935,11 @@
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
 	},
+/area/bridge)
+"wSu" = (
+/obj/structure/grille,
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating,
 /area/bridge)
 "wSw" = (
 /obj/structure/closet,
@@ -28414,10 +29034,18 @@
 /turf/open/floor/carpet/ship,
 /area/quartermaster/office)
 "wUl" = (
-/obj/structure/cable/white{
-	icon_state = "2-8"
+/obj/machinery/computer/ship/viewscreen,
+/obj/machinery/computer/ship/navigation/public{
+	dir = 4;
+	name = "starmap console"
 	},
-/turf/open/floor/engine,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
 /area/nsv/weapons/fore)
 "wUp" = (
 /obj/machinery/light/small{
@@ -28537,10 +29165,13 @@
 /turf/open/floor/engine,
 /area/science/robotics/lab)
 "xbR" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/closed/wall/ship,
+/turf/open/floor/engine,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -28554,18 +29185,17 @@
 	},
 /area/bridge/meeting_room)
 "xdB" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light,
-/obj/structure/reagent_dispensers/foamtank/hull_repair_juice,
-/obj/item/extinguisher/advanced/hull_repair_juice,
-/turf/open/floor/plating,
-/area/nsv/hanger)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "xem" = (
-/obj/machinery/atmospherics/pipe/manifold/purple/hidden{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "xeY" = (
 /obj/structure/window/reinforced,
 /obj/structure/cable{
@@ -28640,9 +29270,22 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
 "xhK" = (
-/obj/structure/table/wood/poker,
-/turf/open/floor/wood,
-/area/maintenance/fore)
+/obj/item/flashlight/lamp,
+/obj/structure/table/glass,
+/obj/machinery/keycard_auth{
+	pixel_x = 24;
+	pixel_y = 24
+	},
+/mob/living/simple_animal/pet/cat/kitten{
+	name = "Professor Mew"
+	},
+/obj/machinery/button/door{
+	id = "captainoffice";
+	pixel_x = 38;
+	pixel_y = 26
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "xin" = (
 /obj/machinery/computer/rdconsole/experiment,
 /obj/item/clipboard,
@@ -28663,10 +29306,19 @@
 /turf/open/floor/engine,
 /area/science/robotics/lab)
 "xiw" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/turf/open/floor/engine,
+/obj/machinery/door/airlock/vault/ship{
+	name = "Munitions Weapon Bay";
+	req_one_access_txt = "69"
+	},
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
 /area/nsv/weapons/fore)
 "xiM" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -28700,6 +29352,15 @@
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/mixing)
+"xlb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/closed/wall/ship,
+/area/maintenance/fore)
 "xll" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -28722,15 +29383,25 @@
 	},
 /turf/closed/wall/ship,
 /area/science/xenobiology)
+"xls" = (
+/obj/machinery/advanced_airlock_controller/directional/north,
+/obj/machinery/suit_storage_unit/standard_unit,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "xlu" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/carpet/ship,
 /area/quartermaster/miningoffice)
+"xlD" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 6
+	},
+/turf/closed/wall/ship,
+/area/maintenance/fore)
 "xmk" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/suit_storage_unit/pilot,
 /turf/open/floor/engine,
 /area/nsv/hanger)
 "xnd" = (
@@ -28751,6 +29422,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/purple/hidden{
 	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
@@ -28948,12 +29624,8 @@
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/xenobiology)
 "xwj" = (
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/turf/open/floor/plating,
+/obj/structure/chair/stool/bar,
+/turf/open/floor/wood,
 /area/maintenance/fore)
 "xwB" = (
 /obj/structure/table/wood,
@@ -28978,6 +29650,12 @@
 	},
 /turf/open/floor/holofloor/wood,
 /area/bridge/showroom/corporate)
+"xwZ" = (
+/obj/machinery/atmospherics/pipe/manifold/purple/hidden{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/maintenance/fore)
 "xxs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
@@ -28988,9 +29666,16 @@
 	},
 /area/teleporter)
 "xxV" = (
-/obj/machinery/computer/ship/navigation/public{
-	dir = 8;
-	name = "starmap console"
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/stamp/captain,
+/obj/structure/table/glass,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/light,
+/obj/structure/cable/white{
+	icon_state = "1-2"
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
@@ -29001,17 +29686,27 @@
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/crew_quarters/heads/hor)
 "xxY" = (
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/engine,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
 /area/nsv/weapons/fore)
 "xxZ" = (
-/obj/effect/turf_decal/delivery/white,
-/turf/open/floor/engine,
+/obj/machinery/computer/cargo/request,
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
 /area/nsv/weapons/fore)
 "xyi" = (
 /obj/structure/cable{
@@ -29036,6 +29731,23 @@
 /obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
+"xAz" = (
+/obj/machinery/meter/atmos/distro_loop{
+	pixel_x = -6;
+	pixel_y = -6;
+	target_layer = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/bridge)
 "xAR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29066,20 +29778,15 @@
 	},
 /area/bridge)
 "xDN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/disposalpipe/junction/flip{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
+/obj/structure/table/glass,
+/obj/item/storage/fancy/cigarettes/cigars/havana,
+/obj/item/twohanded/binoculars,
+/obj/item/lighter{
+	pixel_x = 5;
+	pixel_y = -3
 	},
 /turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/area/crew_quarters/heads/captain/private)
 "xET" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -29107,9 +29814,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/carpet/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/area/nsv/hanger/deck2/port)
 "xFT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/carpet/ship/purple_carpet,
@@ -29303,9 +30008,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "xLV" = (
-/obj/machinery/suit_storage_unit/standard_unit,
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "captainoffice"
+	},
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/crew_quarters/heads/captain/private)
 "xLZ" = (
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /turf/closed/wall/ship,
@@ -29335,8 +30044,10 @@
 	},
 /area/bridge/meeting_room)
 "xMA" = (
-/obj/machinery/suit_storage_unit/captain,
-/turf/open/floor/carpet,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/closed/wall/ship,
 /area/crew_quarters/heads/captain/private)
 "xMO" = (
 /turf/closed/wall/r_wall/ship,
@@ -29345,17 +30056,8 @@
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/fore)
 "xNg" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
@@ -29474,6 +30176,26 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = 2
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = 2
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -10
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -10
+	},
 /turf/open/floor/carpet/ship,
 /area/janitor)
 "xRz" = (
@@ -29507,14 +30229,17 @@
 	},
 /area/maintenance/department/cargo)
 "xRL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/ship/command/glass{
-	name = "Master At Arms Office";
-	req_access_txt = "70"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
@@ -29708,18 +30433,12 @@
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/xenobiology)
 "ybj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/airlock/ship/maintenance{
-	name = "Maintenance Access Captain Office";
-	req_one_access_txt = "20"
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/captain)
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "ybo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -29727,15 +30446,24 @@
 /turf/open/floor/plating,
 /area/nsv/hanger)
 "ybT" = (
-/obj/machinery/camera{
-	c_tag = "External Viewport Munitions 1";
+/obj/item/folder/blue,
+/obj/item/folder/red{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/pen/fountain/captain,
+/obj/structure/table/glass,
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/hull_plate/end{
-	dir = 1
+/obj/structure/cable/white{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/structure/cable/white{
+	icon_state = "2-4"
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "ycm" = (
 /obj/machinery/status_display/supply,
 /turf/closed/wall/r_wall/ship,
@@ -29810,6 +30538,12 @@
 "yeh" = (
 /turf/open/floor/carpet,
 /area/library)
+"yeG" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "yfh" = (
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/engine,
@@ -29894,31 +30628,12 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "yjN" = (
-/obj/item/encryptionkey/atc,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/head/hardhat,
-/obj/item/clothing/head/hardhat,
-/obj/item/radio/headset/heads/captain/alt{
-	desc = "A special headset that protects ears from some loud noises.";
-	keyslot = null;
-	name = "noise cancelling headphones"
-	},
-/obj/item/radio/headset/heads/captain/alt{
-	desc = "A special headset that protects ears from some loud noises.";
-	keyslot = null;
-	name = "noise cancelling headphones"
-	},
-/obj/item/clothing/ears/earmuffs,
-/obj/item/clothing/ears/earmuffs,
 /obj/structure/disposalpipe/segment,
-/obj/structure/closet/secure_closet/fighter_pilot,
-/obj/item/encryptionkey/atc,
-/obj/item/encryptionkey/atc,
-/turf/open/floor/carpet/ship,
-/area/nsv/weapons/port{
-	name = "Weapons Storage"
-	})
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/nsv/hanger/deck2/port)
 "ykx" = (
 /obj/structure/table,
 /obj/item/storage/box/mousetraps{
@@ -40066,95 +40781,95 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -40323,95 +41038,95 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -40580,95 +41295,95 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -40837,95 +41552,95 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -41094,95 +41809,95 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -41351,95 +42066,95 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -41608,95 +42323,95 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -41865,95 +42580,95 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -42122,95 +42837,95 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -42379,95 +43094,95 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-aEe
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+alT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -42636,95 +43351,95 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -42893,95 +43608,95 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 agZ
 agZ
 tlV
 agZ
 agZ
 tlV
-nZT
-nZT
-nZT
-nZT
-nZT
 agZ
 agZ
-tlV
 agZ
 agZ
-tlV
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
 agZ
 agZ
 tlV
 agZ
 agZ
 tlV
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 agZ
 agZ
 tlV
 agZ
 agZ
 tlV
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+tlV
+agZ
+agZ
+tlV
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -43150,26 +43865,6 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
 agZ
 agZ
 agZ
@@ -43177,33 +43872,19 @@ agZ
 agZ
 agZ
 agZ
-byP
-nZT
-agZ
-byP
 agZ
 agZ
 agZ
 agZ
 agZ
 agZ
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 agZ
 agZ
 agZ
@@ -43212,7 +43893,7 @@ agZ
 agZ
 agZ
 byP
-nZT
+agZ
 agZ
 byP
 agZ
@@ -43221,24 +43902,58 @@ agZ
 agZ
 agZ
 agZ
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+byP
+agZ
+agZ
+byP
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -43407,24 +44122,24 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 agZ
 byP
 agZ
@@ -43435,7 +44150,6 @@ agZ
 agZ
 agZ
 agZ
-nZT
 agZ
 agZ
 agZ
@@ -43444,23 +44158,6 @@ agZ
 agZ
 agZ
 agZ
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
 agZ
 agZ
 agZ
@@ -43469,7 +44166,25 @@ agZ
 agZ
 agZ
 agZ
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 agZ
 agZ
 agZ
@@ -43480,22 +44195,22 @@ agZ
 agZ
 agZ
 byP
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -43664,24 +44379,24 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 agZ
 agZ
 iMh
@@ -43703,19 +44418,19 @@ bdI
 iMh
 iMh
 sdP
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 sdP
 iMh
 iMh
@@ -43737,22 +44452,22 @@ bdI
 iMh
 agZ
 agZ
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -43921,21 +44636,21 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 agZ
 aqx
 iMh
@@ -43960,19 +44675,19 @@ hja
 aRw
 kxO
 kSx
-nZT
+agZ
 sdP
-nZT
-nZT
+agZ
+agZ
 sdP
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
 sdP
-nZT
-nZT
+agZ
+agZ
 sdP
-nZT
+agZ
 kSx
 kxO
 qfE
@@ -43997,19 +44712,19 @@ bdI
 iMh
 agZ
 wLC
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -44178,21 +44893,21 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 agZ
 agZ
 axG
@@ -44217,19 +44932,19 @@ hkc
 irp
 iMh
 sdP
-nZT
+agZ
 sdP
 hbT
 hbT
 sdP
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
 sdP
 hbT
 hbT
 sdP
-nZT
+agZ
 sdP
 iMh
 rfK
@@ -44254,19 +44969,19 @@ aBn
 fCZ
 agZ
 agZ
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -44435,22 +45150,22 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 sdP
 iMh
 ftr
@@ -44480,7 +45195,7 @@ kDL
 kDL
 iMh
 iMh
-iMh
+ptx
 iMh
 iMh
 kDL
@@ -44510,20 +45225,20 @@ hiR
 xOL
 iMh
 sdP
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -44692,22 +45407,22 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 iMh
 iMh
 wim
@@ -44767,20 +45482,20 @@ hxX
 bdB
 fjA
 iMh
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -44949,19 +45664,19 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-dqX
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+sdP
 oAO
 aee
 sdP
@@ -45027,17 +45742,17 @@ iMh
 sdP
 aee
 mpX
-dqX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+sdP
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -45206,19 +45921,19 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
 aee
 hvg
@@ -45284,17 +45999,17 @@ fCZ
 fMW
 aee
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -45463,19 +46178,19 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
 aee
 hbT
@@ -45541,17 +46256,17 @@ ptx
 hbT
 aee
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -45720,19 +46435,19 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-dqX
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+sdP
 oAO
 aee
 hvg
@@ -45798,17 +46513,17 @@ fCZ
 fMW
 aee
 mpX
-dqX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+sdP
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -45977,19 +46692,19 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
 aee
 hbT
@@ -46055,17 +46770,17 @@ ptx
 hbT
 aee
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -46234,19 +46949,19 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
 aee
 hvg
@@ -46312,17 +47027,17 @@ fCZ
 fMW
 aee
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -46491,19 +47206,19 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-dqX
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+sdP
 oAO
 aee
 sdP
@@ -46569,17 +47284,17 @@ iMh
 sdP
 aee
 mpX
-dqX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+sdP
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -46748,19 +47463,19 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
 bUF
 aee
@@ -46826,17 +47541,17 @@ iMh
 aee
 bUF
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -47005,19 +47720,19 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
 aee
 aee
@@ -47083,17 +47798,17 @@ iMh
 aee
 aee
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -47262,19 +47977,19 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-dqX
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+sdP
 oAO
 aee
 aee
@@ -47340,17 +48055,17 @@ iMh
 aee
 aee
 mpX
-dqX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+sdP
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -47519,19 +48234,19 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
 aee
 aee
@@ -47597,17 +48312,17 @@ iMh
 aee
 aee
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -47776,19 +48491,19 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
 aee
 aee
@@ -47854,17 +48569,17 @@ iMh
 aee
 aee
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -48033,19 +48748,19 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-dqX
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+sdP
 oAO
 aee
 aee
@@ -48111,17 +48826,17 @@ iMh
 aee
 aee
 mpX
-dqX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+sdP
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -48290,19 +49005,19 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
 aee
 owl
@@ -48368,17 +49083,17 @@ iMh
 aee
 aee
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -48547,19 +49262,19 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
 aee
 owl
@@ -48625,17 +49340,17 @@ iMh
 aee
 aee
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-aEe
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+alT
+agZ
 nZT
 nZT
 nZT
@@ -48804,19 +49519,19 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-dqX
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+sdP
 oAO
 aee
 owl
@@ -48882,17 +49597,17 @@ iMh
 aee
 aee
 mpX
-dqX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+sdP
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -49061,19 +49776,19 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
 aee
 aee
@@ -49139,17 +49854,17 @@ iMh
 aee
 aee
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -49318,19 +50033,19 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
 aee
 aee
@@ -49360,12 +50075,12 @@ kJw
 kJw
 kJw
 kJw
+kJw
 cTw
 cTw
 cTw
-kJw
-kJw
-kJw
+cTw
+cTw
 kJw
 fDk
 fDk
@@ -49396,17 +50111,17 @@ iMh
 aee
 aee
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -49575,19 +50290,19 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-dqX
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+sdP
 oAO
 aee
 aee
@@ -49653,17 +50368,17 @@ oXb
 aee
 aee
 mpX
-dqX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+sdP
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -49832,19 +50547,19 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
 aee
 owl
@@ -49910,17 +50625,17 @@ iMh
 aee
 aee
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -50089,19 +50804,19 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
 aee
 owl
@@ -50167,17 +50882,17 @@ iMh
 aee
 aee
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -50346,19 +51061,19 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-dqX
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+sdP
 oAO
 aee
 aee
@@ -50424,17 +51139,17 @@ iMh
 aee
 aee
 mpX
-dqX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+sdP
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -50603,20 +51318,20 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-dqX
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+sdP
 oAO
 aee
 kJw
@@ -50680,18 +51395,18 @@ tZs
 iMh
 aee
 mpX
-dqX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+sdP
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -50860,20 +51575,20 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
 owl
 cTw
@@ -50937,18 +51652,18 @@ udo
 iMh
 aee
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -51117,20 +51832,20 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
 owl
 cTw
@@ -51194,18 +51909,18 @@ lNh
 fgg
 aee
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -51374,20 +52089,20 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-dqX
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+sdP
 oAO
 aee
 kJw
@@ -51451,18 +52166,18 @@ fgg
 fgg
 fgg
 mpX
-dqX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+sdP
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -51631,20 +52346,20 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
 aee
 kJw
@@ -51708,18 +52423,18 @@ cSK
 uIO
 pLt
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -51888,20 +52603,20 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
 owl
 veo
@@ -51965,18 +52680,18 @@ tLw
 fgg
 fgg
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -52145,20 +52860,20 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-dqX
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+sdP
 oAO
 owl
 veo
@@ -52222,18 +52937,18 @@ qAw
 fgg
 uDg
 mpX
-dqX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+sdP
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -52402,20 +53117,20 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
 dDt
 kJw
@@ -52479,18 +53194,18 @@ lGW
 gnA
 oma
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -52659,20 +53374,20 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
 aee
 hla
@@ -52736,18 +53451,18 @@ nRe
 cBF
 owl
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -52916,20 +53631,20 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-dqX
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+sdP
 oAO
 aee
 hla
@@ -52993,18 +53708,18 @@ cfH
 fgg
 aee
 mpX
-dqX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+sdP
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -53173,20 +53888,20 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 hla
 hla
 hla
@@ -53250,18 +53965,18 @@ rlD
 qhB
 qhB
 qhB
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -53430,20 +54145,20 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 hla
 iar
 krf
@@ -53507,18 +54222,18 @@ rlD
 wxf
 vmV
 qhB
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -53687,19 +54402,19 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 czT
 hla
 jPK
@@ -53765,17 +54480,17 @@ usN
 krV
 ijt
 jPj
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -53944,20 +54659,20 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 hrT
 mTo
 yiU
@@ -54021,18 +54736,18 @@ rHS
 pgc
 cDf
 qhB
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -54201,20 +54916,20 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 hla
 hla
 hla
@@ -54261,7 +54976,7 @@ qmn
 yfh
 daU
 huI
-jby
+sPa
 mzE
 lVe
 prt
@@ -54278,18 +54993,18 @@ qhB
 qhB
 qhB
 qhB
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -54458,22 +55173,22 @@ nZT
 nZT
 nZT
 aEe
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 hbT
 eUm
 pUR
@@ -54532,21 +55247,21 @@ rlD
 rdB
 lYx
 qhB
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -54715,22 +55430,22 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 hbT
 fPU
 dKZ
@@ -54789,21 +55504,21 @@ rlD
 rdB
 ycY
 qhB
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -54972,22 +55687,22 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 hbT
 eUm
 jpf
@@ -55046,21 +55761,21 @@ nhj
 rdB
 nhj
 qhB
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -55229,22 +55944,22 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 sdP
 eUm
 xri
@@ -55303,21 +56018,21 @@ weM
 nVG
 qhB
 qhB
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -55486,23 +56201,23 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 hbT
 fPU
 umf
@@ -55559,22 +56274,22 @@ psL
 nhj
 nhj
 qhB
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -55743,23 +56458,23 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 sdP
 eUm
 eUm
@@ -55816,22 +56531,22 @@ qhB
 dvr
 qhB
 qhB
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -56000,25 +56715,25 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 eUm
 eMl
 bTt
@@ -56072,23 +56787,23 @@ uLJ
 aYO
 qOv
 qhB
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -56257,25 +56972,25 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 sdP
 cKb
 cKb
 cKb
 sdP
-nZT
-nZT
+agZ
+agZ
 eUm
 dOf
 rwe
@@ -56329,23 +57044,23 @@ qhB
 uce
 qhB
 mpY
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -56514,25 +57229,25 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 fQo
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
 hbT
 wSB
 fDL
@@ -56586,23 +57301,23 @@ qhB
 nhj
 nlL
 hbT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -56771,24 +57486,24 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 sdP
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
 fQo
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
 dOf
 sIr
 dOf
@@ -56843,23 +57558,23 @@ qhB
 nhj
 nlL
 hbT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -57028,24 +57743,24 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 dEK
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
 fQo
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
 oij
 bFb
 qvt
@@ -57100,23 +57815,23 @@ nhj
 nhj
 nlL
 hbT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -57285,16 +58000,16 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 dEK
 fQo
 fQo
@@ -57357,23 +58072,23 @@ jhz
 nhj
 qhB
 sdP
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 aEe
 nZT
 nZT
@@ -57542,23 +58257,23 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 dEK
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
 fQo
-nZT
-nZT
+agZ
+agZ
 krg
 oij
 gzY
@@ -57572,7 +58287,7 @@ bcQ
 rQu
 dBZ
 pue
-czE
+tae
 gAt
 xET
 bpE
@@ -57614,23 +58329,23 @@ dPP
 nhj
 qhB
 sdP
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -57799,24 +58514,24 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 dEK
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
 fQo
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
 dOf
 oOD
 oOD
@@ -57871,23 +58586,23 @@ xuR
 dFI
 nlL
 hbT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -58056,24 +58771,24 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 dEK
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
 fQo
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
 oij
 wlm
 qvt
@@ -58128,23 +58843,23 @@ nhj
 nhj
 nlL
 hbT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -58313,16 +59028,16 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 dEK
 fQo
 fQo
@@ -58385,23 +59100,23 @@ nEY
 nhj
 qhB
 sdP
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -58570,24 +59285,24 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 dEK
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oij
 hEz
 qvt
@@ -58642,23 +59357,23 @@ nhj
 nhj
 qhB
 sdP
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -58827,24 +59542,24 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 sdP
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 dOf
 sIr
 ocX
@@ -58899,23 +59614,23 @@ nhj
 nhj
 nlL
 hbT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -59084,25 +59799,25 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 hbT
 wSB
 fLX
@@ -59156,23 +59871,23 @@ jnh
 nhj
 nlL
 hbT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -59341,25 +60056,25 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 hbT
 wSB
 fLX
@@ -59370,7 +60085,7 @@ gvQ
 faB
 oOD
 oOD
-oOD
+rDI
 oOD
 oOD
 sys
@@ -59413,23 +60128,23 @@ nhj
 nhj
 qhB
 sdP
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -59598,25 +60313,25 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 hbT
 wSB
 uaQ
@@ -59669,24 +60384,24 @@ qhB
 nhj
 nhj
 qhB
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -59855,19 +60570,19 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 sdP
 son
 son
@@ -59920,30 +60635,30 @@ fas
 smo
 xXE
 nGN
-nUu
+gDM
 fsK
 qhB
 nhj
 nhj
 qhB
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
 sdP
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -60112,19 +60827,19 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 hbT
 qLS
 hdP
@@ -60190,17 +60905,17 @@ qhB
 qhB
 qhB
 sdP
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -60369,19 +61084,19 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 hbT
 qLS
 diA
@@ -60447,17 +61162,17 @@ cDN
 cDN
 nlL
 hbT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -60626,19 +61341,19 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 hbT
 qLS
 ldc
@@ -60704,17 +61419,17 @@ cDN
 cDN
 nlL
 hbT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -60883,19 +61598,19 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 sdP
 son
 son
@@ -60961,17 +61676,17 @@ cDN
 cDN
 nlL
 hbT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -61140,22 +61855,22 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 hbT
-nZT
+agZ
 son
 gLU
 tKH
@@ -61218,17 +61933,17 @@ qhB
 qhB
 qhB
 sdP
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -61397,22 +62112,22 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 hbT
-nZT
+agZ
 aGd
 wOQ
 bTU
@@ -61474,18 +62189,18 @@ nEY
 nlL
 nZT
 hbT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -61654,24 +62369,24 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 hbT
-nZT
+agZ
 jQc
-cYB
+bht
 bht
 bht
 bht
@@ -61731,18 +62446,18 @@ nhj
 nlL
 nZT
 hbT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -61911,24 +62626,24 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 hbT
-nZT
+agZ
 jQc
-cmO
+vpq
 mot
 qjS
 dCU
@@ -61988,18 +62703,18 @@ lTe
 qhB
 qhB
 qhB
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -62168,24 +62883,24 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 sdP
 jQc
 jQc
 jQc
-rQB
+vAz
 haa
 pey
 pey
@@ -62246,17 +62961,17 @@ nhj
 nhj
 qhB
 sdP
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -62425,19 +63140,19 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 hbT
 sqa
 kSf
@@ -62503,17 +63218,17 @@ kBT
 jyN
 nlL
 hbT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -62682,19 +63397,19 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 hbT
 sqa
 bht
@@ -62760,17 +63475,17 @@ bed
 rfC
 nlL
 hbT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -62939,19 +63654,19 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 hbT
 sqa
 cpk
@@ -63017,17 +63732,17 @@ nhj
 nhj
 nlL
 hbT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -63196,19 +63911,19 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 sdP
 jQc
 jQc
@@ -63274,17 +63989,17 @@ dPP
 xuR
 qhB
 sdP
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -63453,20 +64168,20 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
 owl
 jQc
@@ -63530,18 +64245,18 @@ reK
 qhB
 qhB
 qhB
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -63710,26 +64425,26 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
 owl
 jQc
 ePh
-ati
-ayK
+bht
+bht
 sIw
 slK
 eKQ
@@ -63787,18 +64502,18 @@ bTI
 qhB
 aee
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -63967,20 +64682,20 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
 mgr
 mgr
@@ -64044,18 +64759,18 @@ bTI
 qhB
 aee
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -64224,20 +64939,20 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-dqX
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+sdP
 oAO
 mDy
 mzQ
@@ -64301,18 +65016,18 @@ frq
 qhB
 aee
 mpX
-dqX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+sdP
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -64481,20 +65196,20 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
 mDy
 lDE
@@ -64558,18 +65273,18 @@ bTI
 qhB
 aee
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -64738,20 +65453,20 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
 mDy
 sBq
@@ -64815,18 +65530,18 @@ xpf
 qhB
 aee
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -64995,20 +65710,20 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-dqX
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+sdP
 reV
 mgr
 mgr
@@ -65024,7 +65739,7 @@ pKF
 mot
 qjS
 sWb
-wsy
+hbD
 fDk
 pcP
 nkW
@@ -65072,18 +65787,18 @@ nhj
 qhB
 aee
 mpX
-dqX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+sdP
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -65252,20 +65967,20 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
 jXx
 mzQ
@@ -65281,7 +65996,7 @@ ssI
 haa
 pey
 pey
-xdB
+mfj
 fDk
 qfd
 vlw
@@ -65329,18 +66044,18 @@ rlD
 qhB
 aee
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -65509,20 +66224,20 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
 jXx
 lDE
@@ -65586,18 +66301,18 @@ jxE
 xMP
 aee
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -65766,20 +66481,20 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-dqX
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+sdP
 oAO
 jXx
 sBq
@@ -65795,7 +66510,7 @@ cIY
 uNa
 wTG
 iEt
-eKz
+bht
 fDk
 pyG
 nkW
@@ -65843,18 +66558,18 @@ oVJ
 xMP
 aee
 mpX
-dqX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+sdP
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -66023,20 +66738,20 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
 mgr
 mgr
@@ -66045,14 +66760,14 @@ oIa
 oIa
 mgr
 mgr
-wjT
-wjT
+wNh
+wNh
 fko
 pwo
 rhj
 iaD
 kHX
-gag
+bht
 fDk
 rRn
 fDk
@@ -66100,18 +66815,18 @@ oVJ
 xMP
 aee
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -66280,20 +66995,20 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
 aee
 xnd
@@ -66306,10 +67021,10 @@ tnW
 cDp
 uXh
 wRX
-wjT
-wjT
+wNh
+wNh
 gXM
-wjT
+wNh
 fDk
 pyG
 fDk
@@ -66357,18 +67072,18 @@ oVJ
 xMP
 aee
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-aEe
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+alT
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -66537,20 +67252,20 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-dqX
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+sdP
 oAO
 owl
 wNh
@@ -66560,10 +67275,10 @@ lWB
 bUr
 qCH
 fki
-qqW
+gqs
 uXh
 mEV
-oHb
+bUr
 oYU
 fZF
 qmg
@@ -66614,18 +67329,18 @@ oVJ
 xMP
 aee
 mpX
-dqX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+sdP
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -66794,20 +67509,20 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
 owl
 mYb
@@ -66820,7 +67535,7 @@ qqW
 pfn
 hfC
 owU
-qyI
+ndN
 wiG
 lmX
 aqU
@@ -66871,18 +67586,18 @@ iOt
 xMP
 aee
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -67051,20 +67766,20 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
 owl
 mYb
@@ -67077,7 +67792,7 @@ uPA
 cOE
 wRu
 mrg
-qyI
+ndN
 mYa
 nSn
 gmW
@@ -67128,18 +67843,18 @@ nps
 xMP
 aee
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -67308,33 +68023,33 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-dqX
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+sdP
 oAO
 aee
 wNh
 ycv
 fvL
-hlr
+qqW
 bUr
 mLn
 qzr
 yjN
 iIB
 gTr
-oHb
+bUr
 mcT
 eNw
 snA
@@ -67385,18 +68100,18 @@ uvI
 xMP
 aee
 mpX
-dqX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+sdP
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -67565,36 +68280,36 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
-aee
+owl
 wNh
 mav
 tDA
 mjb
-wjT
-wjT
-wjT
-wjT
+wNh
+wNh
+wNh
+wNh
 unh
 pGn
-wjT
-oHb
-oHb
-oHb
+wNh
+bUr
+bUr
+bUr
 nkW
 pyG
 fDk
@@ -67642,18 +68357,18 @@ hys
 xMP
 aee
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -67822,37 +68537,37 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
-aee
+owl
 wNh
-wjT
-wjT
-wjT
-aKh
+wNh
+wNh
+wNh
+wNh
 uno
 fpd
 qnc
 dUX
-hgV
-cDN
-cDN
-cDN
-cDN
+vma
+nea
+oMa
+nea
 nkW
+vlP
 pyG
 fDk
 eIc
@@ -67895,22 +68610,22 @@ iOt
 eND
 uvI
 wSw
-xMP
+uvI
 xMP
 aee
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -68079,37 +68794,37 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-dqX
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+sdP
 oAO
-aee
-hbT
+owl
 wjT
+ati
+hDk
 hDk
 wjT
-qBT
 eOT
-khX
-gqO
-avZ
-sBN
-iaJ
-cDN
-cDN
-cDN
-qAT
+nNJ
+nNJ
+dUX
+vma
+nNJ
+nNJ
+pAq
+nkW
+tXJ
 pyG
 fDk
 iIV
@@ -68152,22 +68867,22 @@ iOt
 iOt
 iOt
 iOt
+iOt
 xMP
-hbT
 aee
 mpX
-dqX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+sdP
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -68336,37 +69051,37 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
 aee
-hbT
 wjT
-hDk
-wjT
+axP
+bvI
+cuz
 aAP
-aMs
 cZH
-cUW
+cZH
+cZH
 cvl
 vma
-cDN
-cDN
-cDN
-cDN
+nNJ
+nNJ
+nNJ
 nkW
+tay
 pyG
 fDk
 pIT
@@ -68403,28 +69118,28 @@ uvI
 iOt
 rfB
 gju
+uvI
 iOt
-gSZ
-iUx
-xhK
-gSZ
-gSZ
-uxC
-hbT
+oVJ
+oVJ
+oVJ
+oVJ
+vvJ
+xMP
 aee
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -68593,37 +69308,37 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
-bUF
-hbT
+owl
 wjT
-hDk
+hWj
+nNJ
+cAg
 wjT
-jsi
-kjG
 lDM
-ava
+lDM
+lDM
 oHb
 xbR
-oHb
-oHb
+nlX
+nlX
+nlX
 nkW
-nkW
-nkW
+nOW
 pyG
 fDk
 bXL
@@ -68660,28 +69375,28 @@ igE
 cji
 niv
 cBO
+uvI
 baL
-gSZ
-iUx
-wzq
-gSZ
-nCR
-uxC
-hbT
-bUF
+oVJ
+oVJ
+oVJ
+oVJ
+oVJ
+xMP
+aee
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -68850,37 +69565,37 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-dqX
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+sdP
 oAO
-aee
-hvg
+owl
+wjT
 hWj
 nNJ
+cAg
 wjT
-dCE
 sdb
-mIw
-qxi
+sdb
+sdb
 xRL
-sUo
+vMA
 aON
 ajO
 uwa
+nkW
 pyG
-tqY
 pyG
 fDk
 cUY
@@ -68917,28 +69632,28 @@ uvI
 iOt
 fJw
 vtr
+uvI
 iOt
-gSZ
-gSZ
-tND
-oIn
-oIn
-tlN
-fMW
+oVJ
+oVJ
+oVJ
+oVJ
+oVJ
+xMP
 aee
 mpX
-dqX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+sdP
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -69107,41 +69822,41 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
-aee
-hbT
+owl
 wjT
-ggX
+nNJ
+nNJ
+cAg
 wjT
-tSv
 lJg
-lDM
+vNI
 fhi
-oHb
+iSw
 sss
-qpF
-bBv
-nkW
+vNI
+vNI
+vNI
 vlU
+pyG
+pyG
 fDk
 fDk
 fDk
-fFC
-fFC
 aon
 aak
 kep
@@ -69173,29 +69888,29 @@ oNI
 dUP
 oqy
 buG
+uvI
+uvI
 iOt
 iOt
-jkD
-gSZ
-amF
-gSZ
-gSZ
-uxC
-hbT
+iOt
+iOt
+iOt
+iOt
+xMP
 aee
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -69364,40 +70079,40 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
 aee
-hbT
 wjT
-ggX
 wjT
-lFj
+bXu
+wjT
+wjT
 cwO
 vNI
-iIK
-qyI
-hhK
-tFk
-jHO
+vNI
+xRL
+vMA
+vNI
+vNI
+pKc
 nkW
-pyG
-fDk
-bRf
+uaY
+hfr
 oxt
-mgG
+oxt
 ciy
 jdS
 qQU
@@ -69430,29 +70145,29 @@ uvI
 viB
 iOt
 grs
+uvI
+uvI
 iOt
-pia
-oec
-knK
-lLv
-gSZ
-knK
-uxC
-hbT
+oVJ
+oVJ
+oVJ
+oVJ
+vvJ
+xMP
 aee
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -69621,45 +70336,45 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-dqX
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+sdP
 oAO
 aee
-hbT
+asv
+ayK
+ayK
+cHv
 wjT
-ggX
-wjT
-rpP
-frR
+ila
 ila
 nuK
-oHb
+xRL
 vMA
 rdY
 hWC
+pOB
 nkW
+tlN
+kJD
 pyG
-fDk
-iSw
-tqD
-rRR
-ciy
+pyG
+nkW
 bOv
-gBC
-kmx
 oVB
+kmx
+hvY
 jaE
 tlt
 mZf
@@ -69687,29 +70402,29 @@ uvI
 mMC
 iOt
 grs
-iOt
-aMY
-gSZ
-oec
-nNm
-gSZ
-iUx
-uxC
-hbT
+uvI
+uvI
+baL
+oVJ
+oVJ
+oVJ
+oVJ
+oVJ
+xMP
 aee
 mpX
-dqX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+sdP
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -69878,47 +70593,47 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
 aee
-hvg
-hWj
+wjT
+vqy
 vqy
 wjT
-jPM
-eIS
-rHJ
-nuK
-fMJ
+wjT
+wjT
+wjT
+wjT
+iUx
 dbI
 jsv
-fDk
+jsv
+jsv
 nkW
+nkW
+kJD
 pyG
-fDk
-ciy
-ddz
-ciy
-ciy
-ciy
-dAw
-ciy
-ciy
-ciy
-sdA
+pyG
+nkW
+abz
+nkW
+nkW
+nkW
+nkW
+vgv
 mZf
 bIk
 vjC
@@ -69944,29 +70659,29 @@ fXq
 fXq
 iOt
 grs
+uvI
+uvI
 iOt
-myc
-gSZ
-fXN
-alT
-oIn
-oIn
-tlN
-fMW
+oVJ
+oVJ
+oVJ
+oVJ
+oVJ
+xMP
 aee
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -70135,47 +70850,47 @@ aEe
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
 aee
-hbT
-fMJ
-vnw
-fMJ
+wjT
+wjT
+wjT
+wjT
 jqk
 pUe
 ljY
 mwE
-fMJ
+jkD
 tgY
-asv
-fDk
-vlP
+cDN
+cDN
+cDN
+cDN
+tqD
+kJD
 pyG
-fDk
-pdJ
-tyV
-cHv
-uhs
+pyG
+nkW
 hbP
-ehJ
+pyG
 oYb
-oYb
-hJi
-ciy
+pxQ
+tAj
+nkW
 eVa
 mFE
 vjC
@@ -70201,29 +70916,29 @@ xMP
 xMP
 iOt
 grs
-iOt
 uvI
-gSZ
-sJp
-lnD
-bvn
-knK
-uxC
-hbT
+iOt
+iOt
+iOt
+iOt
+iOt
+iOt
+xMP
+xMP
 aee
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -70392,20 +71107,20 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-dqX
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+sdP
 oAO
 aee
 hbT
@@ -70418,23 +71133,23 @@ oIU
 hro
 kJc
 ujq
-hOJ
-xfg
-tae
+cDN
+cDN
+cDN
 tmq
-xfg
-lgc
-ckp
-vVH
-ewG
-cYk
-ciQ
-fTa
-sUy
+tqY
+kJD
+pyG
+pyG
+nkW
+pcP
+pyG
+pyG
+pyG
 tof
-mXo
+nkW
 aKU
-pwi
+aGK
 vjC
 qyG
 xgz
@@ -70458,29 +71173,29 @@ cbI
 xMP
 fXq
 grs
+uvI
 iOt
-pOB
-cuz
+gSZ
 knK
 bts
 jZB
-cAg
-uxC
+gSZ
+xMP
 hbT
 aee
 mpX
-dqX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+sdP
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -70649,47 +71364,47 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
 aee
 hbT
 fMJ
-rQF
-eMo
+vnw
+fMJ
 rvq
 wEx
 pjH
-icI
+nYQ
 uwM
-uwM
-uwM
-bXu
-jTp
-cII
-ybj
-jLE
-suU
-wiQ
+tgY
+cDN
+cDN
+cDN
+cDN
+nkW
+kJD
+pyG
+pyG
 vcH
-oYb
-rDI
+pcP
+pyG
 rqS
-oYb
-oQQ
-ciy
+pyG
+pyG
+nkW
 auU
 aGK
 qYM
@@ -70715,29 +71430,29 @@ kXh
 xMP
 fXq
 grs
+uvI
 iOt
-iOt
-rZv
 gSZ
+knK
 lnD
-gSZ
-gSZ
-uxC
+hRl
+dVk
+xMP
 hbT
 aee
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -70906,47 +71621,47 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
 aee
-hvg
-tWA
-dsx
+hbT
+fMJ
+vnw
 fMJ
 niS
 sRk
-hFC
+hOv
 aKK
-ebt
-lpX
 hHF
-fDk
-vRT
+lFj
+hHF
+hHF
+nkW
+nkW
+nkW
 kJD
-fDk
-nMw
-xDN
-aAA
-tAS
-oYb
-rDI
+pyG
+pyG
+nkW
+pcP
+pyG
 toh
 hQz
-alV
-ciy
+pyG
+nkW
 wYA
 qXF
 hNg
@@ -70977,24 +71692,24 @@ iOt
 gSZ
 gSZ
 kWz
-kth
-tay
-tlN
-fMW
+gSZ
+gSZ
+xMP
+hbT
 aee
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -71163,47 +71878,47 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-dqX
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+sdP
 oAO
 aee
-hbT
-fMJ
+hvg
+bDz
 rNy
 fMJ
 hAO
-sRk
-hFC
+ehJ
+fKk
 bTh
-ebt
-lpX
+jsi
+lIC
 mCr
-fDk
-nOW
+oQQ
+qru
 hfr
-fDk
-rbA
-wMe
-dTI
 tyk
+rbA
+pyG
+pyG
+nkW
 pOZ
-mAY
+pyG
 crV
-oYb
 tdZ
-ciy
+tdZ
+nkW
 jCE
 uKq
 vjC
@@ -71232,26 +71947,26 @@ iOt
 xnh
 gMX
 iQp
-iQp
+ppZ
 quw
-gSZ
-knK
-uxC
-hbT
+uRe
+xwZ
+mZR
+fMW
 aee
 mpX
-dqX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+sdP
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -71420,47 +72135,47 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 oAO
 aee
 hbT
 fMJ
-rNy
+mkr
 fMJ
 fZG
-sRk
+euo
 hOv
 gDg
-ebt
-lpX
+hHF
+lLv
 wqr
-fDk
-gqs
+oTv
+nkW
 kJD
 fDk
-kAW
+fDk
 vdl
-oYb
-ovU
-otL
+fDk
+fDk
+tvH
 uCf
-oYb
-bVG
-bVG
-bVG
+fDk
+fDk
+fDk
+fDk
 qVT
 bVG
 sVW
@@ -71487,28 +72202,28 @@ obS
 uvI
 iOt
 grs
-iOt
 uvI
-uvI
-uvI
-imE
+byn
+bbg
+fLU
+gSZ
 mvk
 uxC
 hbT
 aee
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -71677,45 +72392,45 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-ybT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+oAO
 aee
 hbT
 fMJ
-rNy
+mkr
 fMJ
 cww
-sRk
+ewG
 mix
 pGe
 lpX
-lpX
-lpX
+mge
+nCR
 qFg
-fDk
-lIC
+nkW
+kJD
 fDk
 iXF
-iXF
+vVH
 kOE
 atB
-iXF
-sRS
+pRr
+gQT
 dND
-egQ
+sRS
 ylI
 dQg
 tBl
@@ -71744,28 +72459,28 @@ rCy
 uvI
 iOt
 gho
-iOt
-iOt
-iOt
+uvI
+gSZ
+pca
 xwj
-xMP
-xMP
-xMP
+gSZ
+eDY
+uxC
 hbT
 aee
 mpX
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -71934,47 +72649,47 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+sdP
+oAO
+aee
+hbT
 fMJ
-fMJ
-fMJ
-fMJ
-fMJ
+mkr
 fMJ
 pes
 kOb
 dfp
 bKJ
-ddE
-bKJ
-ddE
+hHF
+mjR
+nJz
 mkK
-ddE
-fmj
-hIh
+nkW
+kJD
+fDk
 fqv
 jyl
-fDP
+wBL
 xNg
 hto
-sRS
+wBL
 qur
-egQ
+sRS
 aMe
-oEO
+vnD
 jGs
 toW
 lpW
@@ -72000,29 +72715,29 @@ wuw
 rCy
 uvI
 iOt
-grs
+eqT
 uvI
-uvI
-uvI
-uvI
-viB
-mMC
-xMP
-xMP
-xMP
-xMP
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+gSZ
+byn
+xwj
+gSZ
+fkg
+uxC
+hbT
+aee
+mpX
+sdP
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -72191,43 +72906,43 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-fMJ
-rNy
-fMJ
-aIV
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+oAO
+aee
+hvg
+bDz
 jyV
-aIV
+fMJ
 xxZ
 uep
 neY
-aIV
-fQY
+bKJ
+fMJ
 vAr
-byo
-aIV
-pqG
+lpX
+fDk
+nkW
 vJA
-hIh
+fDk
 mHQ
 dbe
-dbe
+tXj
 hqO
-dbe
-bXx
+sBB
+tXj
 tXj
 cvr
 rNh
@@ -72257,29 +72972,29 @@ wuw
 rCy
 uvI
 iOt
-grs
+aRI
 uvI
-uvI
+gSZ
 pLu
 fyE
 pHk
 sjY
-iOt
-bvI
-xLV
-xMP
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+mZR
+fMW
+aee
+mpX
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -72448,47 +73163,47 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+oAO
+aee
+hbT
 fMJ
-rNy
-fMJ
-edT
 mkr
-pqG
+fMJ
 tva
 uHX
 oAM
 xiw
-mUo
+fMJ
 wUl
 ele
-fzt
+fDk
 ifd
-dvP
-oMa
+kJD
+fDk
 nmy
 ulC
-qsp
+wBL
 nXi
 sxI
 sba
 vKa
-egQ
+sRS
 ghx
-fbh
+nvK
 rCR
 pgj
 xiM
@@ -72516,27 +73231,27 @@ uvI
 baL
 gXt
 tKw
-tKw
+vzB
 fVU
 qSS
 wCZ
 iMe
-oTv
-nlX
-gTW
-fTx
-iDh
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+uxC
+hbT
+aee
+mpX
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -72705,47 +73420,47 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+sdP
+oAO
+aee
+hbT
 fMJ
-rNy
-fMJ
+ciQ
+cII
+ddz
+eIS
+lDA
 gzH
-aIV
-aIV
-aIV
-aIV
-lDA
-aIV
-lDA
-aIV
-aIV
-aIV
-mkr
-vJA
-hIh
+jLE
+myc
+nMw
+pdJ
+qsp
+rHJ
+tyV
 hpq
-wBL
-wBL
+wiQ
+ybj
 kkg
 hfz
-sRS
 iIi
-egQ
+iIi
+iIi
 imA
-oEO
+qZU
 mQB
 nFQ
 cPh
@@ -72772,28 +73487,28 @@ rCy
 uvI
 iOt
 vWo
-uvI
-uvI
+iOt
+vLp
 lHv
 bfk
 oTk
 eBb
-wEG
-hkI
-vEs
-xMP
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+uxC
+hbT
+aee
+mpX
+sdP
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -72962,45 +73677,45 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+oAO
+bUF
+hbT
 fMJ
+vnw
 fMJ
-fMJ
-aIV
-aIV
-aIV
-aIV
+dqX
 qdS
-rtl
+wEx
 xxY
-aIV
+wEx
 bDO
-aIV
-aIV
-aIV
-vJA
-hIh
-fKk
+nYQ
+fDk
+fDk
+rQB
+fDk
 wBL
+wqW
 wBL
-wBL
+hdn
 nsd
 sRS
-iIi
-egQ
+iLi
+sRS
 brD
 fbh
 mQB
@@ -73029,28 +73744,28 @@ rCy
 uvI
 iOt
 tLU
-euo
-uvI
-uvI
-pKc
-uvI
-uvI
 iOt
-xMP
-xMP
-xMP
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+mdB
+gSZ
+gSZ
+dtY
+lqE
+uxC
+hbT
+bUF
+mpX
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -73219,43 +73934,43 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-vGa
-hbT
-fMJ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+oAO
+aee
+hvg
 bDz
 njy
+fMJ
 pyZ
-pyZ
-eMo
-syB
-fMJ
-fMJ
-fMJ
-fMJ
-fMJ
-fMJ
+uep
+wnz
+gBC
+jPM
+mAY
+nNm
+pia
+qyc
 waX
-hIh
+pia
 umH
-wBL
-wBL
+wsy
+ybT
 qqk
 xxV
-sRS
+nLX
 jYl
 nLX
 xSx
@@ -73284,30 +73999,30 @@ uvI
 uvI
 rCy
 uvI
-ctR
+iOt
 qSy
-mNk
-xem
-sET
-sET
-sET
+iOt
+gSZ
+gSZ
+gSZ
+gSZ
 sET
 mZR
-xMP
-sdP
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+fMW
+aee
+mpX
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -73476,49 +74191,49 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+sdP
+oAO
+aee
 hbT
 fMJ
-oCi
+vnw
 fMJ
-fMJ
-fMJ
-fMJ
+dvP
+uep
 wnz
 ijl
-ijl
-ijl
-syB
+jTp
+nYQ
+fcK
 pIP
 fKd
 ubu
-hIh
+tAS
 bWz
-wBL
-wBL
+wzq
+vhN
 sCc
-sRS
+nKU
 sRS
 uBw
-egQ
-bVG
-bVG
+sRS
+jCe
+vDP
 uQi
-kgi
+dXt
 oEO
 oEO
 wFq
@@ -73541,30 +74256,30 @@ jqA
 nsZ
 kXA
 uvI
-nJz
+iOt
 iKw
-ndN
+iOt
 lIn
+uvI
+uvI
+tVt
+wlJ
 xMP
-xMP
-uxC
-uxC
-qru
-xMP
+hbT
+aee
+mpX
 sdP
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -73733,47 +74448,47 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
 agZ
-lgq
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+oAO
+aee
 hbT
-hbT
-sdP
 fMJ
+vnw
+fMJ
+dAw
+uep
 oCi
-fMJ
-fMJ
-fMJ
+gTW
+jTp
+nYQ
 fcK
-tXU
+hIh
 ssn
-dsx
+rRR
 hIh
 iNc
 bpU
-wBL
+kgC
 rgf
+cvP
 sRS
-mjR
 weG
-egQ
-sWO
-bVG
+ujZ
+xAz
+nkV
 uXQ
 vWs
 fCk
@@ -73784,7 +74499,7 @@ oae
 eqJ
 qbg
 bVG
-sWO
+wSu
 sWO
 sWO
 xMP
@@ -73793,35 +74508,35 @@ uvI
 uvI
 oZm
 dqc
-qyc
+uvI
 use
-ecq
+uvI
 suy
-aQt
-nea
-uxC
-uxC
-qru
+rfB
+iOt
+njf
+iOt
+iOt
+iOt
+iOt
+iOt
+xlb
 xMP
-sdP
 hbT
-hbT
+aee
+mpX
 agZ
-lgq
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -73990,46 +74705,46 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
 agZ
 agZ
-nZT
-nZT
-nZT
 agZ
-lgq
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+alV
+aee
 hbT
-hbT
+fMJ
+vnw
+fMJ
+dCE
+uep
 nYQ
-oCi
-oCi
-fMJ
-fMJ
+hgV
+kth
+nYQ
+nYQ
 hIh
 hIh
+rZv
+hIh
+tND
 dyW
 skI
 xMA
 sRS
-bbt
-axP
-egQ
-sWO
+sRS
+sRS
+qaB
+gQz
 bVG
 bVG
 euE
@@ -74042,43 +74757,43 @@ euE
 bVG
 bVG
 sWO
-bVG
-bVG
+xMP
+xMP
 xMP
 mMC
 uvI
 uvI
 pYv
+hMg
+uvI
+soH
+uvI
+vKN
+uvI
+iOt
+tPA
+uvI
+uvI
+uvI
+uvI
+uvI
+gju
 xMP
-xMP
-uxC
-uxC
-xMP
-qru
-qru
 hbT
-hbT
-agZ
-lgq
-nZT
-nZT
-nZT
+aee
+mpX
 agZ
 agZ
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -74247,95 +74962,95 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
 agZ
 agZ
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+fMJ
+fMJ
+fMJ
+fMJ
+fMJ
+fMJ
+dTI
+eKz
 eUI
+hkI
+kAW
+mNk
 eUI
-hbT
-hbT
-sdP
+pqG
+eUI
+sdA
 hIh
+tSv
 dJc
-dJc
-dJc
-egQ
+cgr
+eCc
+sRS
 fyA
-wqW
-egQ
-sWO
-sWO
-sWO
-sWO
-sWO
-sWO
-sWO
-sWO
-sWO
-sWO
-sWO
-sWO
-pAq
+sRS
+rEj
+jEE
 bVG
+sWO
+sWO
+sWO
+sWO
+sWO
+sWO
+sWO
+sWO
+sWO
+sWO
+sWO
+xMP
 fKm
 xMP
+iOt
+iOt
+iOt
+iOt
+iOt
+iOt
+iOt
+iOt
+iOt
+iOt
+iOt
+tPA
+uvI
+uvI
+uvI
+uvI
+uvI
+nNN
 xMP
-uxC
-uxC
 xMP
 xMP
-sdP
-hbT
-hbT
-sdP
-eUI
-eUI
-nZT
-nZT
+xMP
 agZ
 agZ
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -74504,95 +75219,95 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-sdP
-hbT
-hbT
-hbT
-sdP
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+fMJ
+vnw
+fMJ
+aAA
+ckp
+aAA
+ecq
+fmj
+fQY
+hJi
+lgc
+aAA
+oec
+aAA
+cYk
+suU
+hIh
+wBL
+wEG
+hNy
+bnm
 egQ
-pwR
 egQ
+egQ
+spx
+lRX
 bVG
-bVG
-bVG
-euE
-euE
-euE
 bVG
 euE
 euE
 euE
 bVG
+euE
+euE
+euE
 bVG
 bVG
 bVG
 xMP
 xMP
-sdP
-hbT
-hbT
-hbT
-sdP
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+xMP
+oVJ
+oVJ
+oVJ
+jxE
+iOt
+oVJ
+oVJ
+pXb
+iOt
+rFk
+tlr
+tPA
+uvI
+uvI
+uvI
+uvI
+uvI
+gju
+iOt
+xls
+msr
+xMP
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -74761,95 +75476,95 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-mge
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+fMJ
+vnw
+fMJ
+aKh
+cmO
+cYk
+edT
+fzt
+fTa
+hOJ
+lsF
+aAA
+otL
+aAA
+ecq
+suU
+hIh
+tWA
+wMe
+wBL
+fTA
+sLR
+hIh
+agZ
+agZ
+mLZ
+agZ
+agZ
+hbT
+hbT
+hbT
 rhw
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+hbT
+hbT
+hbT
+sdP
+agZ
+agZ
+agZ
+sdP
+xMP
+oVJ
+oVJ
+oVJ
+oVJ
+iOt
+oVJ
+oVJ
+oVJ
+iOt
+uvI
+uvI
+tPA
+uvI
+uvI
+kiM
+uvI
+uvI
+mGS
+aoe
+hbl
+lnm
+jao
+nSj
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -75018,95 +75733,95 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-aEe
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+fMJ
+vnw
+fMJ
+aMY
+aAA
+aAA
+aAA
+aAA
+fTx
+aAA
+fTx
+aAA
+aAA
+aAA
+cmO
+suU
+hIh
+tXU
+xdB
+wBL
+uJt
+gxD
+epQ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+hbT
+uxC
+oVJ
+oVJ
+oVJ
+oVJ
+baL
+oVJ
+oVJ
+oVJ
+baL
+vCH
+uvI
+tPA
+uvI
+uvI
+mnf
+uvI
+uvI
+uvI
+lPa
+yeG
+hAI
+xMP
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -75275,95 +75990,95 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+fMJ
+fMJ
+fMJ
+aAA
+aAA
+aAA
+aAA
+fDP
+fXN
+imE
+aAA
+mUo
+aAA
+aAA
+aAA
+suU
+hIh
+uhs
+xem
+wBL
+vdZ
+cul
+epQ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+hbT
+uxC
+oVJ
+oVJ
+oVJ
+oVJ
+iOt
+oVJ
+oVJ
+oVJ
+iOt
+oMV
+uvI
+tPA
+uvI
+uvI
+uvI
+uvI
+uvI
+uvI
+iOt
+xMP
+xMP
+xMP
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -75532,95 +76247,95 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+amF
+hbT
+fMJ
+aQt
+ctR
+cYB
+cYB
+cII
+gag
+fMJ
+fMJ
+fMJ
+fMJ
+fMJ
+fMJ
+sJp
+hIh
+vEs
+wBL
+wBL
+eET
+lPV
+hIh
+agZ
+agZ
+agZ
+agZ
+agZ
+sdP
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+sdP
+xMP
+oVJ
+oVJ
+oVJ
+oVJ
+iOt
+oVJ
+oVJ
+oVJ
+iOt
+bxt
+bxt
+tPA
+uvI
+uvI
+uvI
+uvI
+uvI
+uvI
+uvI
+xMP
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -75789,95 +76504,95 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+hbT
+fMJ
+bbt
+fMJ
+fMJ
+fMJ
+fMJ
+ciQ
+iDh
+iDh
+iDh
+gag
+pwi
+qBT
+sUy
+hIh
+vGa
+wBL
+wBL
+qxs
+hIh
+hIh
+fQo
+fQo
+fQo
+fQo
+fQo
+sIz
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+xMP
+xMP
+iOt
+aic
+iOt
+iOt
+iOt
+aic
+iOt
+iOt
+iOt
+xlD
+sZC
+eTM
+otX
+uhY
+uhY
+mOS
+mOS
+mZR
+xMP
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -76046,95 +76761,95 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+bvn
+hbT
+hbT
+sdP
+fMJ
+bbt
+fMJ
+fMJ
+fMJ
+ovU
+pwR
+rpP
+njy
+hIh
+vRT
+xhK
+wBL
+nLr
+meQ
+hbT
+agZ
+agZ
+agZ
+agZ
+agZ
+sdP
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+hbT
+uxC
+viB
+uvI
+rfB
+iOt
+uvI
+uvI
+uvI
+uvI
+iyw
+cgx
+uxC
+uxC
+dkt
+xMP
+sdP
+hbT
+hbT
+agZ
+bvn
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -76303,95 +77018,95 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+bvn
+hbT
+hbT
+mXo
+bbt
+bbt
+fMJ
+fMJ
+hIh
+hIh
+xDN
+sUF
+ijE
+meQ
+hbT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+hbT
+uxC
+mMC
+uvI
+vtr
+iOt
+xMP
+uxC
+uxC
+xMP
+dkt
+dkt
+hbT
+hbT
+agZ
+bvn
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -76560,95 +77275,95 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+oIn
+oIn
+hbT
+hbT
+sdP
+hIh
+xLV
+xLV
+bxC
+hIh
+sdP
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+sdP
+xMP
+uxC
+uxC
+xMP
+xMP
+sdP
+hbT
+hbT
+sdP
+oIn
+oIn
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -76817,97 +77532,97 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+sdP
+hbT
+hbT
+hbT
+sdP
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+sdP
+hbT
+hbT
+hbT
+sdP
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+nZT
+aEe
 nZT
 nZT
 nZT
@@ -77074,95 +77789,95 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -77331,95 +78046,95 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-aEe
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -77588,95 +78303,95 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -77845,95 +78560,95 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -78102,95 +78817,95 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -78359,95 +79074,95 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-aEe
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -78616,95 +79331,95 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -78873,95 +79588,95 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -79130,95 +79845,95 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+alT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -79387,95 +80102,95 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -79644,95 +80359,95 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -79901,95 +80616,95 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+alT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -80158,95 +80873,95 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
+agZ
 nZT
 nZT
 nZT
@@ -81007,7 +81722,7 @@ nZT
 nZT
 nZT
 nZT
-nZT
+aEe
 nZT
 nZT
 nZT

--- a/_maps/map_files/Aetherwhisp/Aetherwhisp2.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp2.dmm
@@ -2779,7 +2779,6 @@
 /obj/structure/bed,
 /obj/machinery/newscaster/security_unit/north,
 /obj/effect/landmark/start/captain,
-/obj/item/bedsheet/captain,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "bWC" = (

--- a/_maps/map_files/Aetherwhisp/Aetherwhisp2.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp2.dmm
@@ -134,7 +134,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "afy" = (
 /obj/structure/cable{
@@ -258,6 +258,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/head/welding,
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
@@ -357,8 +359,8 @@
 /obj/structure/closet/radiation,
 /obj/item/clothing/mask/gas,
 /obj/machinery/light_switch/west,
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "anx" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -404,7 +406,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "apr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -477,7 +479,7 @@
 	dir = 1
 	},
 /obj/machinery/disposal/bin,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -561,16 +563,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/airlock/ship/command{
-	name = "Captain Quarters";
-	req_access_txt = "20"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/obj/machinery/vending/boozeomat,
+/turf/closed/wall/ship,
 /area/crew_quarters/heads/captain/private)
 "auU" = (
 /obj/machinery/status_display/ai/north,
@@ -581,11 +578,6 @@
 	},
 /area/bridge/meeting_room)
 "ava" = (
-/obj/structure/closet{
-	anchored = 1
-	},
-/obj/item/clothing/head/welding,
-/obj/item/clothing/head/welding,
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
@@ -733,6 +725,7 @@
 /obj/item/clothing/gloves/color/latex,
 /obj/machinery/light_switch/east,
 /obj/effect/landmark/nuclear_waste_spawner/strong,
+/obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "azM" = (
@@ -745,8 +738,8 @@
 /area/quartermaster/warehouse)
 "aAf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "aAq" = (
 /obj/structure/ladder,
 /turf/open/floor/plating,
@@ -835,6 +828,7 @@
 	icon_state = "docs_generic";
 	name = "secret nanotrasen documentation"
 	},
+/obj/item/clothing/head/hardhat/cakehat,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "aBj" = (
@@ -872,7 +866,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/qm)
 "aCG" = (
 /obj/machinery/ai_slipper{
@@ -949,6 +943,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/safe/floor,
+/obj/item/gun/ballistic/revolver,
+/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
+/obj/item/disk/holodisk,
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -1094,10 +1092,22 @@
 	},
 /area/bridge/meeting_room)
 "aLi" = (
-/obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/machinery/disposal/deliveryChute{
+	dir = 8;
+	name = "Battle Bridge";
+	pixel_x = 5
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/window/westright,
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -1298,12 +1308,9 @@
 	pixel_y = -3
 	},
 /obj/item/radio/intercom/directional/north,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "aVq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/airlock/ship/command/glass{
@@ -1356,7 +1363,7 @@
 "aYn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/miningoffice)
 "aYq" = (
 /obj/machinery/computer/ship/navigation/public{
@@ -1485,7 +1492,7 @@
 /area/maintenance/department/science/xenobiology)
 "bcs" = (
 /obj/effect/turf_decal/bot,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "bcQ" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -1529,7 +1536,10 @@
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/department/science/xenobiology)
 "bdP" = (
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6;
+	icon_state = "warningline"
+	},
 /turf/open/floor/engine,
 /area/science/robotics/lab)
 "bed" = (
@@ -1542,7 +1552,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/hanger/deck2/port)
 "beq" = (
 /obj/structure/cable{
@@ -1597,8 +1607,8 @@
 "bfS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "bgo" = (
 /obj/structure/closet/secure_closet/security/science,
 /obj/structure/cable{
@@ -1625,9 +1635,9 @@
 	},
 /obj/machinery/power/smes{
 	charge = 800000;
-	input_level = 20000;
-	name = "low-priority department power storage unit";
-	output_level = 20000
+	input_level = 30000;
+	name = "department power storage unit";
+	output_level = 30000
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
@@ -1639,7 +1649,7 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/airlock/ship/engineering{
 	name = "Secondary Atmospherics";
-	req_one_access_txt = "24"
+	req_one_access_txt = "10;24"
 	},
 /turf/open/floor/engine,
 /area/maintenance/fore)
@@ -1661,7 +1671,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "biR" = (
 /obj/machinery/modular_computer/console/preset/civilian{
@@ -1675,7 +1685,7 @@
 	department = "Mining";
 	pixel_x = 28
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/miningoffice)
 "bju" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -1754,8 +1764,8 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/layer3{
 	dir = 1
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "bmY" = (
 /obj/machinery/computer/teleporter{
 	dir = 1
@@ -1802,6 +1812,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
+"bpc" = (
+/obj/structure/closet/l3closet/janitor,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/gloves/color/latex,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "bph" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -1821,7 +1837,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/miningoffice)
 "bpU" = (
 /obj/item/flashlight/lamp,
@@ -1896,7 +1912,7 @@
 /obj/item/storage/lockbox/medal/cargo,
 /obj/item/storage/box/fountainpens,
 /obj/structure/closet/secure_closet/quartermaster,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/qm)
 "brD" = (
 /obj/machinery/computer/crew,
@@ -1927,7 +1943,8 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/airlock/ship/station{
-	name = "Public Robotics Lobby"
+	name = "Public Robotics Lobby";
+	req_one_access_txt = "7;9;29;47"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2231,7 +2248,7 @@
 	dir = 5
 	},
 /obj/effect/landmark/start/shaft_miner,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/miningoffice)
 "bzV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -2316,10 +2333,11 @@
 /turf/open/floor/holofloor/wood,
 /area/bridge/showroom/corporate)
 "bBv" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/disposal/bin,
+/obj/structure/closet/bombcloset,
+/obj/item/clothing/gloves/color/black,
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
@@ -2362,6 +2380,9 @@
 /area/ai_monitored/nuke_storage)
 "bCV" = (
 /obj/machinery/holopad,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/engine,
 /area/science/robotics/lab)
 "bDm" = (
@@ -2438,7 +2459,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/miningoffice)
 "bHn" = (
 /obj/structure/window/reinforced,
@@ -2473,7 +2494,7 @@
 /obj/item/hand_labeler,
 /obj/item/hand_labeler_refill,
 /obj/machinery/computer/lore_terminal,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "bHT" = (
 /obj/structure/cable{
@@ -2539,6 +2560,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "bJz" = (
@@ -2609,8 +2631,10 @@
 	},
 /area/bridge/meeting_room)
 "bOA" = (
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/four,
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "bOM" = (
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -2623,14 +2647,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "bQi" = (
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 10
 	},
-/obj/machinery/door/airlock/ship/public{
-	name = "Bathroom Cell"
-	},
+/obj/machinery/recharge_station,
+/obj/effect/landmark/start/cyborg,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/auxiliary)
 "bQM" = (
@@ -2717,11 +2740,10 @@
 /turf/closed/wall/ship,
 /area/nsv/hanger/deck2/port)
 "bUF" = (
-/obj/machinery/computer/camera_advanced/base_construction{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/structure/hull_plate,
+/obj/structure/ladder,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "bUO" = (
 /obj/machinery/modular_computer/console/preset/civilian{
 	dir = 1;
@@ -2956,6 +2978,13 @@
 /obj/effect/landmark/start/librarian,
 /turf/open/floor/wood,
 /area/library)
+"cdX" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 10
+	},
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/toilet/auxiliary)
 "ceB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/closed/wall/r_wall/ship,
@@ -3046,9 +3075,9 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "cjJ" = (
-/obj/machinery/light,
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/obj/machinery/light/built,
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "cjW" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3150,9 +3179,10 @@
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/xenobiology)
 "cmO" = (
-/obj/machinery/status_display/ai,
-/turf/closed/wall/ship,
-/area/crew_quarters/cryopods)
+/obj/structure/reagent_dispensers/fueltank/aviation_fuel,
+/obj/machinery/computer/ship/viewscreen,
+/turf/open/floor/engine,
+/area/nsv/hanger)
 "cnq" = (
 /obj/machinery/modular_computer/console/preset/civilian{
 	dir = 8;
@@ -3211,9 +3241,10 @@
 /turf/open/floor/carpet/ship,
 /area/ai_monitored/turret_protected/ai)
 "cnL" = (
-/obj/machinery/computer/cryopod,
-/turf/closed/wall/ship,
-/area/crew_quarters/cryopods)
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/seven,
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "con" = (
 /obj/machinery/conveyor{
 	id = "disposal_mail";
@@ -3242,7 +3273,7 @@
 	dir = 4
 	},
 /obj/item/beacon,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/office)
 "cpP" = (
 /obj/structure/cable{
@@ -3332,7 +3363,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "crV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -3442,12 +3473,12 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "cww" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+/obj/effect/landmark/start/munitions_tech,
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
 	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/area/nsv/weapons/fore)
 "cwA" = (
 /obj/structure/table,
 /turf/open/floor/carpet/ship/purple_carpet,
@@ -3500,7 +3531,11 @@
 /turf/open/floor/wood,
 /area/library)
 "cyz" = (
-/obj/machinery/vending/coffee,
+/obj/structure/table/wood,
+/obj/item/storage/fancy/donut_box,
+/obj/item/storage/secure/briefcase,
+/obj/item/clothing/gloves/color/black,
+/obj/effect/spawner/lootdrop/gloves,
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -3522,8 +3557,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "czQ" = (
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/wood,
@@ -3546,8 +3581,8 @@
 	dir = 1
 	},
 /obj/effect/landmark/nuclear_waste_spawner,
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "cAL" = (
 /obj/structure/table,
 /obj/machinery/newscaster/directional/east,
@@ -3601,14 +3636,29 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
 "cDp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/structure/closet/secure_closet/fighter_pilot,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/head/hardhat,
+/obj/item/clothing/head/hardhat,
+/obj/item/radio/headset/heads/captain/alt{
+	desc = "A special headset that protects ears from some loud noises.";
+	keyslot = null;
+	name = "noise cancelling headphones"
 	},
-/turf/open/floor/carpet/ship/blue{
-	color = "#9999DD";
-	name = "nanoweave carpet (bluer)"
+/obj/item/radio/headset/heads/captain/alt{
+	desc = "A special headset that protects ears from some loud noises.";
+	keyslot = null;
+	name = "noise cancelling headphones"
 	},
-/area/bridge)
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/encryptionkey/atc,
+/obj/item/encryptionkey/atc,
+/turf/open/floor/carpet/ship,
+/area/nsv/weapons/port{
+	name = "Weapons Storage"
+	})
 "cDB" = (
 /obj/machinery/ore_silo,
 /turf/open/floor/circuit,
@@ -3801,6 +3851,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/science/explab)
 "cJa" = (
@@ -3921,9 +3972,15 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "cOE" = (
-/obj/machinery/cryopod,
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/carpet/ship,
+/area/nsv/weapons/port{
+	name = "Weapons Storage"
+	})
 "cOU" = (
 /obj/machinery/door/firedoor/window,
 /obj/structure/grille,
@@ -3979,7 +4036,8 @@
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/robotics/lab)
 "cRy" = (
-/turf/closed/wall/mineral/titanium,
+/obj/structure/girder,
+/turf/open/floor/plating,
 /area/maintenance/fore)
 "cRD" = (
 /obj/structure/girder/displaced,
@@ -4008,7 +4066,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "cTw" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
@@ -4059,6 +4117,12 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/bridge/meeting_room/council)
+"cVQ" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "cWN" = (
 /obj/machinery/door/poddoor/ship{
 	id = "launchbay_tube1";
@@ -4112,11 +4176,6 @@
 "cYk" = (
 /obj/structure/chair/office{
 	dir = 8
-	},
-/obj/machinery/door/window{
-	dir = 1;
-	icon_state = "right";
-	req_access_txt = "20"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -4184,6 +4243,10 @@
 /obj/structure/closet/wardrobe/pjs,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"daU" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/science/explab)
 "dbe" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4240,8 +4303,8 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "ddz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -4258,10 +4321,12 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/heads/captain)
 "ddE" = (
-/obj/structure/closet/firecloset/full,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/landmark/start/munitions_tech,
+/turf/open/floor/engine,
+/area/nsv/weapons/fore)
 "deP" = (
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
@@ -4275,6 +4340,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/start/munitions_tech,
 /turf/open/floor/engine,
 /area/nsv/weapons/fore)
 "dfE" = (
@@ -4292,6 +4358,14 @@
 	},
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/mixing/chamber)
+"dhb" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/closet/radiation,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "did" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -4306,7 +4380,7 @@
 /turf/template_noop,
 /area/maintenance/department/science/xenobiology)
 "diA" = (
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/qm)
 "djz" = (
 /obj/structure/cable{
@@ -4324,19 +4398,16 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "djA" = (
-/obj/machinery/cryopod{
-	dir = 4;
-	icon_state = "cryopod-open"
-	},
 /obj/machinery/newscaster/directional/west,
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/obj/structure/frame/machine,
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "djP" = (
 /obj/structure/table,
 /obj/structure/extinguisher_cabinet/east,
 /obj/item/paper_bin,
 /obj/item/pen,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "dks" = (
 /obj/structure/chair/office,
@@ -4376,6 +4447,9 @@
 /area/maintenance/department/science/xenobiology)
 "dlQ" = (
 /obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/engine,
 /area/science/explab)
 "dmr" = (
@@ -4629,13 +4703,18 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "dwt" = (
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable{
-	icon_state = "0-2"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/junction,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/structure/mirror{
+	pixel_x = 27;
+	pixel_y = -2
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/auxiliary)
@@ -4704,15 +4783,12 @@
 /turf/template_noop,
 /area/maintenance/department/science/xenobiology)
 "dzr" = (
-/obj/machinery/cryopod{
-	dir = 4;
-	icon_state = "cryopod-open"
-	},
-/obj/machinery/light{
+/obj/structure/frame/machine,
+/obj/machinery/light/built{
 	dir = 8
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "dzt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -4779,14 +4855,14 @@
 /area/crew_quarters/heads/captain)
 "dAH" = (
 /obj/machinery/vending/wardrobe/cargo_wardrobe,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "dBj" = (
 /obj/structure/closet/l3closet,
 /obj/item/clothing/mask/surgical,
 /obj/item/clothing/gloves/color/latex,
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "dBn" = (
 /obj/item/clipboard,
 /obj/item/stamp{
@@ -4807,7 +4883,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/qm)
 "dBp" = (
 /obj/machinery/airalarm/directional/north,
@@ -4883,9 +4959,6 @@
 /obj/structure/chair/office{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -4914,8 +4987,8 @@
 /obj/structure/frame/machine,
 /obj/item/circuitboard/machine/stasis,
 /obj/item/paper/fluff/vr,
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "dGz" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5132,7 +5205,7 @@
 /area/maintenance/department/science/central)
 "dQa" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "dQe" = (
 /obj/structure/closet/radiation,
@@ -5153,7 +5226,7 @@
 /obj/item/paper{
 	info = "<p>Engineering notice: There are three wire colors used on the Aetherwhisp 6 ship model. White cable is wired to the Stormdrive MK-4 and the supermatter crystal near atmospherics. These lead to their own SMES located nearby. Yellow wires are department distribution wires, which deliver power from the engines SMES to deparment SMES. Red wires deliver power from department SMES to department APCs.</p>"
 	},
-/obj/machinery/airalarm/directional/west,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -5346,14 +5419,16 @@
 "dYW" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/nuclear_waste_spawner,
+/obj/structure/reagent_dispensers/foamtank/hull_repair_juice,
+/obj/item/extinguisher/advanced/hull_repair_juice,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "dZQ" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "ebt" = (
 /obj/effect/turf_decal/delivery/white,
 /obj/item/ship_weapon/ammunition/torpedo/torpedo_casing,
@@ -5363,7 +5438,7 @@
 	},
 /area/nsv/weapons/fore)
 "eci" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/freezer,
@@ -5548,14 +5623,14 @@
 /area/maintenance/fore)
 "ejG" = (
 /obj/structure/frame/machine,
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "ejO" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/structure/sign/poster/random{
 	pixel_x = -32
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/miningoffice)
 "ejU" = (
 /obj/structure/table/glass,
@@ -5645,7 +5720,7 @@
 	dir = 1
 	},
 /obj/machinery/disposal/bin,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "esm" = (
 /obj/structure/disposalpipe/segment{
@@ -5745,6 +5820,9 @@
 	icon_state = "1-2"
 	},
 /obj/item/reagent_containers/food/drinks/flask/gold,
+/obj/machinery/door/window/southleft{
+	req_access_txt = "20"
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "ewJ" = (
@@ -5782,7 +5860,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/air_traffic_controller,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/hanger/deck2/port)
 "exI" = (
 /obj/structure/bookcase/random,
@@ -5828,8 +5906,8 @@
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/glass/fifty,
 /obj/effect/spawner/lootdrop/maintenance/three,
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "ezz" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5886,7 +5964,7 @@
 	id = "disposal_mail";
 	pixel_x = -6
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "eBS" = (
 /obj/machinery/holopad,
@@ -5934,10 +6012,12 @@
 	},
 /area/teleporter)
 "eCT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 10
 	},
-/obj/machinery/airalarm/directional/east,
+/obj/structure/toilet,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/auxiliary)
 "eDn" = (
@@ -5983,11 +6063,13 @@
 "eGc" = (
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump/layer1{
+	dir = 8;
+	on = 1;
+	target_pressure = 2000
 	},
 /obj/machinery/door/airlock/ship/external/glass{
 	name = "External Access Deck 1 Arch";
@@ -6073,6 +6155,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -6134,6 +6219,7 @@
 	pixel_x = -5;
 	pixel_y = 5
 	},
+/obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/robotics/lab)
 "eKz" = (
@@ -6219,7 +6305,7 @@
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "eMQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -6248,7 +6334,9 @@
 /obj/machinery/camera/autoname{
 	dir = 8
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/carpet/ship,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -6286,6 +6374,7 @@
 	dir = 8;
 	name = "emergency shower"
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/engine,
 /area/nsv/hanger)
 "eQz" = (
@@ -6353,10 +6442,6 @@
 	name = "Science Lobby"
 	})
 "eTH" = (
-/obj/machinery/camera/emp_proof/motion{
-	c_tag = "Vault";
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -6464,6 +6549,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"eXR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/machinery/atmospherics/components/binary/pump/layer1{
+	dir = 1;
+	on = 1;
+	target_pressure = 2000
+	},
+/obj/machinery/door/airlock/ship/external/glass{
+	name = "External Access Deck 1 Aft";
+	req_one_access_txt = "13"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "eXZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6552,7 +6653,7 @@
 "faB" = (
 /obj/structure/table,
 /obj/item/papercutter,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "faU" = (
 /obj/structure/disposalpipe/segment,
@@ -6657,8 +6758,8 @@
 /obj/machinery/camera/autoname{
 	dir = 8
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "fcK" = (
 /obj/machinery/atmospherics/pipe/manifold/purple/hidden{
 	dir = 1
@@ -6746,7 +6847,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "fhy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -6759,13 +6860,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "fhB" = (
-/obj/machinery/disposal/deliveryChute{
-	dir = 4;
-	name = "Battle Bridge"
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -6790,7 +6884,7 @@
 /obj/item/hand_labeler_refill,
 /obj/item/computer_hardware/card_slot,
 /obj/item/cartridge/quartermaster,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/qm)
 "fjc" = (
 /obj/machinery/camera/autoname{
@@ -6820,7 +6914,7 @@
 	name = "Mailroom";
 	req_one_access_txt = "31;48;64"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "fkb" = (
 /obj/structure/cable{
@@ -6841,7 +6935,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/air_traffic_controller,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -6867,7 +6961,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -6966,11 +7060,20 @@
 	})
 "fpb" = (
 /obj/machinery/disposal/deliveryChute{
-	dir = 8
+	dir = 8;
+	pixel_x = 5
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/window/westright,
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -6985,27 +7088,17 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/closet{
-	anchored = 1
-	},
 /obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/head/hardhat,
 /obj/item/clothing/head/hardhat,
 /obj/item/radio/headset/heads/captain/alt{
 	desc = "A special headset that protects ears from some loud noises.";
 	keyslot = null;
 	name = "noise cancelling headphones"
 	},
-/obj/item/radio/headset/heads/captain/alt{
-	desc = "A special headset that protects ears from some loud noises.";
-	keyslot = null;
-	name = "noise cancelling headphones"
-	},
-/obj/item/clothing/ears/earmuffs,
 /obj/item/clothing/ears/earmuffs,
 /obj/item/encryptionkey/munitions_tech,
-/obj/item/encryptionkey/munitions_tech,
+/obj/structure/closet/secure_closet/munitions_technician,
+/obj/item/clothing/head/welding,
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
@@ -7123,7 +7216,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 5
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "fsC" = (
 /obj/item/twohanded/required/kirbyplants/random,
@@ -7189,7 +7282,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/hanger/deck2/port)
 "fvN" = (
 /obj/machinery/monkey_recycler,
@@ -7247,8 +7340,10 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "fyO" = (
-/turf/closed/wall/r_wall/ship,
-/area/crew_quarters/cryopods)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "fzd" = (
 /obj/machinery/firealarm{
 	pixel_x = 26;
@@ -7394,8 +7489,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "fHZ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
@@ -7486,11 +7581,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
 "fLx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/machinery/atmospherics/components/binary/pump/layer1{
+	on = 1;
+	target_pressure = 2000
+	},
 /obj/machinery/door/airlock/ship/external/glass{
 	name = "External Access Deck 1 Aft";
 	req_one_access_txt = "13"
@@ -7523,7 +7621,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/miningoffice)
 "fMJ" = (
 /turf/closed/wall/r_wall/ship,
@@ -7679,8 +7777,9 @@
 "fTH" = (
 /obj/structure/table,
 /obj/item/storage/fancy/donut_box,
+/obj/item/clothing/gloves/color/black,
 /obj/item/paper/guides/conveyor,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "fTY" = (
 /obj/machinery/modular_computer/console/preset/command{
@@ -7730,7 +7829,7 @@
 	target_layer = 3
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/visible/layer3,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "fUn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -7839,7 +7938,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -7865,6 +7964,16 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"gbB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/structure/curtain,
+/obj/machinery/shower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/toilet/auxiliary)
 "gbM" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/airalarm/directional/north,
@@ -7906,12 +8015,18 @@
 	pixel_x = 6;
 	pixel_y = -26
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/science/explab)
 "gfY" = (
-/obj/machinery/firealarm/directional/west,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/camera/autoname{
-	dir = 5
+	dir = 1
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/auxiliary)
@@ -8045,7 +8160,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/cargo_technician,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "glw" = (
 /obj/machinery/light/small{
@@ -8093,7 +8208,7 @@
 	name = "Quartermaster Office";
 	req_access_txt = "41"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/qm)
 "gmy" = (
 /obj/structure/closet/firecloset/full,
@@ -8108,7 +8223,7 @@
 /area/science/lab)
 "gmW" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -8164,9 +8279,10 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "gqs" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/structure/closet/bombcloset,
+/obj/item/clothing/gloves/color/black,
 /turf/open/floor/plating,
-/area/crew_quarters/cryopods)
+/area/maintenance/department/cargo)
 "gqO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -8198,7 +8314,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/status_display/evac/west,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "grs" = (
 /obj/structure/cable/yellow{
@@ -8257,7 +8373,7 @@
 /turf/open/floor/wood,
 /area/library)
 "gvQ" = (
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "gwp" = (
 /obj/structure/sign/departments/minsky/supply/janitorial,
@@ -8265,6 +8381,9 @@
 /area/janitor)
 "gxM" = (
 /obj/item/storage/box/snappops,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "gxZ" = (
@@ -8368,7 +8487,7 @@
 	dir = 4;
 	pixel_y = -39
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "gzH" = (
 /obj/structure/sign/solgov_flag/right{
@@ -8386,7 +8505,7 @@
 /area/quartermaster/storage)
 "gAt" = (
 /obj/machinery/mineral/equipment_vendor,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/miningoffice)
 "gBm" = (
 /obj/structure/sign/departments/minsky/supply/mining,
@@ -8591,7 +8710,7 @@
 /obj/machinery/camera/autoname{
 	dir = 8
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/qm)
 "gMf" = (
 /obj/docking_port/stationary{
@@ -8711,7 +8830,7 @@
 	},
 /obj/item/disk/cargo,
 /obj/item/disk/cargo,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "gTr" = (
 /obj/structure/closet/radiation,
@@ -8723,7 +8842,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -8756,6 +8875,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "gVE" = (
@@ -8794,7 +8916,7 @@
 /area/science/xenobiology)
 "gXo" = (
 /obj/structure/table/glass,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/qm)
 "gXt" = (
 /obj/item/electronics/airlock,
@@ -8831,7 +8953,7 @@
 	name = "Flight Leader Office";
 	req_access_txt = "73"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -8853,7 +8975,7 @@
 	dir = 4;
 	id = "warehouse"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "gYH" = (
 /obj/effect/landmark/nuclear_waste_spawner,
@@ -8896,8 +9018,8 @@
 	},
 /obj/structure/extinguisher_cabinet/west,
 /obj/item/radio/intercom/directional/north,
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "haL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -8959,10 +9081,6 @@
 /area/nsv/hanger)
 "hbP" = (
 /obj/structure/table,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -8977,11 +9095,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/airlock/ship/public{
-	name = "Cryostasis Storage"
-	},
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/obj/machinery/door/airlock/ship/public,
+/turf/open/floor/carpet/ship,
+/area/maintenance/department/science/xenobiology)
 "hbT" = (
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -9016,7 +9132,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/qm)
 "heF" = (
 /obj/machinery/door/window/northleft{
@@ -9030,12 +9146,10 @@
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/xenobiology)
 "hfr" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "3;12;69"
-	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
+/obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "hfz" = (
@@ -9073,7 +9187,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -9237,7 +9351,7 @@
 "hlr" = (
 /obj/structure/bed,
 /obj/item/bedsheet/orange,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/hanger/deck2/port)
 "hlA" = (
 /obj/machinery/computer/rdconsole/robotics{
@@ -9370,8 +9484,15 @@
 /turf/open/floor/carpet/ship,
 /area/science/server)
 "hsH" = (
-/turf/closed/wall/ship,
-/area/crew_quarters/cryopods)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "hto" = (
 /obj/structure/displaycase/captain,
 /obj/machinery/firealarm/directional/west,
@@ -9400,7 +9521,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "huI" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -9488,7 +9609,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "hzH" = (
 /obj/structure/cable/yellow{
@@ -9524,6 +9645,9 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/engine,
 /area/science/explab)
 "hAL" = (
@@ -9552,7 +9676,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/qm)
 "hDk" = (
 /obj/structure/grille,
@@ -9687,7 +9811,7 @@
 /area/medical/genetics)
 "hIQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/landmark/start/roboticist,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/engine,
 /area/science/robotics/lab)
 "hJc" = (
@@ -9832,7 +9956,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/office)
 "hQz" = (
 /obj/structure/chair/office{
@@ -9930,7 +10054,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/office)
 "hUM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -9980,6 +10104,8 @@
 /obj/machinery/camera/autoname{
 	dir = 8
 	},
+/obj/item/storage/fancy/cigarettes/cigars,
+/obj/item/lighter,
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
@@ -10258,6 +10384,8 @@
 	name = "External Access Deck 1 Starboard";
 	req_one_access_txt = "13;7"
 	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
 "ikq" = (
@@ -10452,11 +10580,15 @@
 /turf/open/floor/wood,
 /area/library)
 "itS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4;
+	icon_state = "warningline"
+	},
 /turf/open/floor/engine,
 /area/science/robotics/lab)
 "iuJ" = (
 /obj/machinery/light,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "ive" = (
 /obj/machinery/camera/autoname{
@@ -10510,6 +10642,10 @@
 /obj/machinery/computer/cargo/request{
 	dir = 1;
 	icon_state = "computer"
+	},
+/obj/machinery/computer/ship/viewscreen{
+	pixel_x = -32;
+	pixel_y = -6
 	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
@@ -10566,7 +10702,7 @@
 	pixel_x = -2;
 	pixel_y = -2
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "izO" = (
 /obj/item/paper_bin,
@@ -10697,7 +10833,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/hanger/deck2/port)
 "iEp" = (
 /obj/machinery/power/apc/auto_name/west,
@@ -10707,7 +10843,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/qm)
 "iEt" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -10760,7 +10896,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -10942,7 +11078,7 @@
 	name = "Mining Storage";
 	req_access_txt = "48"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/miningoffice)
 "iQG" = (
 /obj/machinery/disposal/bin,
@@ -11044,7 +11180,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/office)
 "iUY" = (
 /obj/machinery/lazylift_button,
@@ -11133,7 +11269,7 @@
 /area/science/lab)
 "jbE" = (
 /obj/effect/landmark/start/cargo_technician,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "jcR" = (
 /obj/structure/table/reinforced,
@@ -11158,7 +11294,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 9
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "jcX" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -11231,7 +11367,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "jdZ" = (
 /obj/structure/closet/firecloset/full,
@@ -11335,7 +11471,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/hanger/deck2/port)
 "jjN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -11359,7 +11495,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "jkw" = (
 /obj/item/beacon,
@@ -11451,7 +11587,7 @@
 /obj/machinery/computer/security/qm{
 	dir = 8
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/qm)
 "jpf" = (
 /obj/structure/closet/crate/medical,
@@ -11704,7 +11840,7 @@
 /obj/machinery/camera/autoname{
 	dir = 5
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/miningoffice)
 "jzo" = (
 /obj/structure/cable{
@@ -11745,6 +11881,9 @@
 "jAZ" = (
 /obj/structure/filingcabinet,
 /obj/item/folder/documents,
+/obj/machinery/camera/emp_proof/motion{
+	c_tag = "Vault"
+	},
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
 "jBD" = (
@@ -11758,8 +11897,8 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "jBX" = (
 /obj/structure/rack,
 /obj/item/storage/briefcase{
@@ -11845,10 +11984,10 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "jFo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/carpet/ship/blue{
@@ -11911,9 +12050,10 @@
 /turf/closed/wall/ship,
 /area/shuttle/turbolift/primary)
 "jHO" = (
-/obj/structure/table,
-/obj/item/storage/fancy/cigarettes/cigars,
-/obj/item/lighter,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
@@ -12027,7 +12167,6 @@
 /area/nsv/hanger)
 "jLE" = (
 /obj/structure/closet/secure_closet/freezer/kitchen/maintenance,
-/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
 /obj/item/kitchen/knife,
 /obj/item/reagent_containers/food/condiment/enzyme,
 /obj/item/reagent_containers/food/condiment/saltshaker,
@@ -12068,11 +12207,14 @@
 	name = "Air Traffic Controller Office";
 	req_access_txt = "72"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/hanger/deck2/port)
 "jNW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "jOc" = (
@@ -12109,7 +12251,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "jPj" = (
 /obj/docking_port/stationary{
@@ -12202,7 +12344,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "jVK" = (
 /obj/structure/bookcase/random/reference,
@@ -12227,7 +12369,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/office)
 "jXq" = (
 /obj/effect/landmark/event_spawn,
@@ -12325,19 +12467,13 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "kbN" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/obj/structure/mirror{
-	pixel_x = 27;
-	pixel_y = -2
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/obj/structure/disposalpipe/junction,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/auxiliary)
 "kcc" = (
@@ -12360,7 +12496,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/office)
 "kcJ" = (
 /obj/structure/cable/yellow{
@@ -12457,7 +12593,7 @@
 /area/science/mixing)
 "kfF" = (
 /obj/machinery/holopad,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/miningoffice)
 "kfK" = (
 /obj/structure/cable{
@@ -12584,6 +12720,7 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
+/obj/effect/landmark/start/munitions_tech,
 /turf/open/floor/carpet/red,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
@@ -12592,11 +12729,11 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
@@ -12649,6 +12786,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/effect/landmark/start/roboticist,
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/robotics/lab)
 "kkQ" = (
@@ -12880,7 +13018,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/office)
 "kuT" = (
 /obj/machinery/computer/ship/tactical{
@@ -12947,11 +13085,20 @@
 "kzF" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 8;
-	name = "Bridge"
+	name = "Bridge";
+	pixel_x = 5
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/window/westright,
 /turf/open/floor/carpet/ship,
 /area/bridge/showroom{
 	name = "Battle Bridge"
@@ -13056,8 +13203,8 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "kDo" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -13085,7 +13232,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "kFP" = (
 /obj/structure/cable{
@@ -13105,7 +13252,7 @@
 /area/science/lab)
 "kGN" = (
 /obj/effect/landmark/start/shaft_miner,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/miningoffice)
 "kHD" = (
 /obj/effect/landmark/start/clown,
@@ -13241,8 +13388,13 @@
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/robotics/lab)
 "kOE" = (
-/obj/machinery/vending/boozeomat,
-/turf/closed/wall/ship,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/airlock/ship/command{
+	name = "Captain Quarters";
+	req_access_txt = "20"
+	},
+/turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "kPd" = (
 /obj/structure/rack,
@@ -13278,7 +13430,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/office)
 "kQE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -13534,7 +13686,7 @@
 	pixel_x = 32;
 	pixel_y = -6
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/qm)
 "leO" = (
 /turf/open/floor/wood,
@@ -13608,7 +13760,7 @@
 	pixel_y = 30
 	},
 /obj/machinery/photocopier,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "lhw" = (
 /obj/structure/cable/yellow{
@@ -13669,7 +13821,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -13704,7 +13856,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -13839,16 +13991,15 @@
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/medical/genetics)
 "lqA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -13877,7 +14028,7 @@
 /turf/open/floor/holofloor/wood,
 /area/bridge/showroom/corporate)
 "lrc" = (
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/miningoffice)
 "lrk" = (
 /obj/structure/cable/yellow{
@@ -13913,6 +14064,7 @@
 /area/library)
 "ltr" = (
 /obj/structure/extinguisher_cabinet/east,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/science/explab)
 "ltx" = (
@@ -13982,6 +14134,7 @@
 "lyQ" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/fyellow,
+/obj/effect/spawner/lootdrop/gloves,
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science{
 	name = "Science Lobby"
@@ -14035,7 +14188,7 @@
 	icon_state = "loadingarea"
 	},
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "lDz" = (
 /obj/structure/cable{
@@ -14100,7 +14253,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/miningoffice)
 "lEu" = (
 /obj/machinery/computer/ship/navigation/astrometrics,
@@ -14173,11 +14326,11 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "lIk" = (
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/airlock/ship/maintenance{
-	name = "Maintenance Access Bathroom";
-	req_one_access_txt = "12"
+	req_one_access_txt = "3;12;69"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
@@ -14286,6 +14439,7 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
+/obj/effect/landmark/start/munitions_tech,
 /turf/open/floor/carpet/red,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
@@ -14316,7 +14470,7 @@
 	pixel_x = 30;
 	pixel_y = 25
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/qm)
 "lKE" = (
 /obj/structure/cable{
@@ -14407,7 +14561,6 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "lTe" = (
@@ -14566,7 +14719,7 @@
 /area/science/lab)
 "lYM" = (
 /obj/machinery/atmospherics/components/binary/pump/layer3,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "lZd" = (
 /turf/closed/wall/r_wall/ship,
@@ -14576,7 +14729,7 @@
 "mav" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/firealarm/directional/north,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/hanger/deck2/port)
 "maU" = (
 /obj/machinery/disposal/bin,
@@ -14605,7 +14758,7 @@
 	pixel_x = 30;
 	pixel_y = 25
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -15001,7 +15154,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "mqX" = (
 /obj/structure/cable{
@@ -15019,7 +15172,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -15030,7 +15183,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "mrH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -15068,8 +15221,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/reagent_dispensers/foamtank/hull_repair_juice,
-/obj/item/extinguisher/advanced/hull_repair_juice,
+/obj/structure/closet/firecloset/full,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "mtn" = (
@@ -15103,7 +15256,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "mtJ" = (
 /obj/structure/chair/comfy{
@@ -15168,7 +15321,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/office)
 "mvd" = (
 /obj/structure/sign/warning/electricshock,
@@ -15236,8 +15389,8 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "myl" = (
 /obj/machinery/washing_machine,
 /obj/structure/cable/yellow{
@@ -15262,8 +15415,7 @@
 	},
 /area/ai_monitored/storage/eva)
 "mzd" = (
-/obj/machinery/recharge_station,
-/obj/effect/landmark/start/cyborg,
+/obj/machinery/vending/coffee,
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -15385,6 +15537,8 @@
 "mCr" = (
 /obj/effect/turf_decal/delivery/white,
 /obj/machinery/status_display/evac/south,
+/obj/structure/closet/bombcloset,
+/obj/item/clothing/gloves/color/black,
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
@@ -15417,7 +15571,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -15584,7 +15738,7 @@
 	dir = 8;
 	sortType = 3
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/office)
 "mKT" = (
 /obj/structure/chair,
@@ -15595,7 +15749,8 @@
 /obj/structure/bookcase/random,
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/light_switch/east,
-/turf/open/floor/carpet/ship/beige_carpet,
+/obj/item/book/manual/wiki/telescience,
+/turf/open/floor/carpet/ship,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -15676,7 +15831,7 @@
 "mOx" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/miningoffice)
 "mPz" = (
 /obj/structure/cable/yellow{
@@ -15776,7 +15931,7 @@
 /area/science/xenobiology)
 "mYa" = (
 /obj/machinery/computer/ship/fighter_controller,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -15818,7 +15973,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "mZf" = (
 /turf/closed/wall/ship,
@@ -15848,7 +16003,7 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/airlock/ship/maintenance{
 	name = "Maintenance Access Robotics Lobby";
-	req_one_access_txt = "12;29"
+	req_one_access_txt = "7;9;29;47"
 	},
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/maintenance/department/science/central)
@@ -16019,13 +16174,11 @@
 /turf/template_noop,
 /area/maintenance/department/science/xenobiology)
 "njl" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/obj/structure/mirror{
-	pixel_x = 27;
-	pixel_y = -2
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/ship/public{
+	name = "Bathroom Cell"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/freezer,
@@ -16114,7 +16267,7 @@
 	},
 /obj/effect/landmark/start/cyborg,
 /turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet/locker)
+/area/crew_quarters/dorms)
 "nmy" = (
 /obj/item/storage/toolbox/emergency,
 /obj/structure/table/glass,
@@ -16252,11 +16405,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/atmospherics/components/binary/pump/layer1{
+	dir = 4;
+	on = 1;
+	target_pressure = 2000
+	},
 /obj/machinery/door/airlock/ship/external/glass{
 	name = "External Access Deck 1 Arch";
 	req_one_access_txt = "46"
@@ -16458,7 +16613,7 @@
 	name = "Maintenance Access Flight Leader Office";
 	req_one_access_txt = "73"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -16572,6 +16727,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "nFQ" = (
@@ -16605,6 +16763,7 @@
 /area/science/lab)
 "nHi" = (
 /obj/machinery/computer/camera_advanced/xenobio,
+/obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/xenobiology)
 "nHr" = (
@@ -16787,8 +16946,8 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "nOF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
@@ -16843,13 +17002,13 @@
 	pixel_x = -32;
 	pixel_y = -6
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "nSn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -16878,12 +17037,13 @@
 /area/maintenance/department/science/central)
 "nTu" = (
 /obj/structure/table/glass,
-/obj/item/stamp/hop,
 /obj/item/pen/fountain,
 /obj/machinery/camera/autoname,
 /obj/machinery/keycard_auth{
 	pixel_y = 24
 	},
+/obj/item/clothing/gloves/color/black,
+/obj/item/stamp/hop,
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -17053,8 +17213,8 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/auto_name/north,
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "nYN" = (
 /obj/machinery/computer/cargo{
 	dir = 4;
@@ -17125,13 +17285,13 @@
 /turf/open/space/basic,
 /area/space)
 "oaa" = (
-/obj/machinery/cryopod,
-/obj/machinery/light{
+/obj/machinery/light_switch/east,
+/obj/structure/frame/machine,
+/obj/machinery/light/built{
 	dir = 4
 	},
-/obj/machinery/light_switch/east,
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "oae" = (
 /obj/structure/closet/radiation,
 /obj/item/clothing/mask/gas,
@@ -17336,14 +17496,14 @@
 /turf/open/floor/engine,
 /area/nsv/hanger)
 "ooJ" = (
-/obj/machinery/recharge_station,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/light/small{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
-/obj/effect/landmark/start/cyborg,
+/obj/structure/curtain,
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/item/soap/nanotrasen,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/auxiliary)
 "ooU" = (
@@ -17438,9 +17598,12 @@
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
 "osE" = (
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/gloves/color/latex,
-/obj/structure/closet/l3closet/janitor,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/airlock/ship/maintenance{
+	name = "Maintenance Access Bathroom";
+	req_one_access_txt = "12"
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "osO" = (
@@ -17455,10 +17618,6 @@
 /area/science/server)
 "otL" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/light{
 	dir = 4
@@ -17519,6 +17678,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/window/reinforced,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "ovW" = (
@@ -17546,7 +17706,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -17571,6 +17731,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/open/floor/engine,
 /area/science/robotics/lab)
 "ozx" = (
@@ -17581,7 +17744,7 @@
 "ozN" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/miningoffice)
 "ozS" = (
 /obj/structure/chair/office{
@@ -17610,8 +17773,14 @@
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/lab)
 "oAC" = (
-/obj/machinery/mecha_part_fabricator,
 /obj/machinery/firealarm/directional/north,
+/obj/structure/frame/machine{
+	desc = "Looks like this used to be a drone dispenser a long time ago"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4;
+	icon_state = "warningline"
+	},
 /turf/open/floor/engine,
 /area/science/robotics/lab)
 "oAH" = (
@@ -17679,7 +17848,7 @@
 /obj/structure/disposalpipe/sorting/wrap/flip{
 	dir = 8
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "oEc" = (
 /obj/structure/disposalpipe/segment{
@@ -17723,7 +17892,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "oFE" = (
 /obj/structure/rack,
@@ -17879,7 +18048,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/miningoffice)
 "oLb" = (
 /obj/structure/cable/yellow{
@@ -17908,7 +18077,7 @@
 	pixel_y = 10
 	},
 /turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet/locker)
+/area/crew_quarters/dorms)
 "oNa" = (
 /obj/machinery/teleport/station,
 /obj/structure/cable/yellow{
@@ -17997,7 +18166,10 @@
 	pixel_x = 27;
 	pixel_y = -2
 	},
-/obj/structure/disposalpipe/junction,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/auxiliary)
 "oRT" = (
@@ -18021,10 +18193,13 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "oTv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/atmospherics/components/binary/pump/layer1{
+	on = 1;
+	target_pressure = 2000
+	},
 /obj/machinery/door/airlock/ship/external/glass{
 	name = "External Access Deck 1 Fore Starboard";
 	req_one_access_txt = "13"
@@ -18114,12 +18289,12 @@
 /turf/template_noop,
 /area/maintenance/department/cargo)
 "oYB" = (
-/obj/machinery/cryopod{
-	dir = 4;
-	icon_state = "cryopod-open"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "oYC" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -18141,7 +18316,7 @@
 	},
 /obj/machinery/computer/ship/viewscreen,
 /obj/machinery/firealarm/directional/west,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -18342,7 +18517,7 @@
 /area/bridge/showroom/corporate)
 "pfn" = (
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -18425,7 +18600,7 @@
 /area/maintenance/fore)
 "pii" = (
 /obj/structure/chair/office,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "pim" = (
 /obj/item/phone{
@@ -18528,14 +18703,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/qm)
 "plQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/ship/cargo{
 	req_one_access_txt = "31;41;48;64;69"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "pmx" = (
 /obj/machinery/light/small{
@@ -18588,13 +18763,10 @@
 /turf/open/floor/holofloor/wood,
 /area/bridge/showroom/corporate)
 "pnP" = (
-/obj/structure/table/wood,
-/obj/machinery/recharger{
-	pixel_x = -7
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
-/obj/machinery/recharger{
-	pixel_x = 7
-	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -18805,7 +18977,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/junction,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 10
+	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/auxiliary)
 "pvn" = (
@@ -18813,7 +18989,7 @@
 	dir = 1
 	},
 /obj/machinery/door/window/southright,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "pvu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
@@ -18859,7 +19035,7 @@
 	})
 "pwr" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "pwR" = (
 /obj/machinery/door/airlock/ship/external/glass{
@@ -18957,7 +19133,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "pCw" = (
 /obj/structure/closet/radiation,
@@ -19168,7 +19344,7 @@
 	name = "Mining Shuttle Docking Pad";
 	req_one_access_txt = "48"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/miningoffice)
 "pKk" = (
 /obj/structure/disposalpipe/segment,
@@ -19211,7 +19387,7 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "pLv" = (
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/office)
 "pLD" = (
 /obj/structure/chair/comfy/shuttle,
@@ -19279,11 +19455,6 @@
 	},
 /area/bridge/meeting_room)
 "pOZ" = (
-/obj/machinery/door/window{
-	dir = 1;
-	icon_state = "right";
-	req_access_txt = "20"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -19312,7 +19483,7 @@
 	},
 /area/bridge/meeting_room/council)
 "pPI" = (
-/obj/effect/decal/cleanable/ash,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/engine,
 /area/science/robotics/lab)
 "pQw" = (
@@ -19398,7 +19569,12 @@
 /area/maintenance/department/cargo)
 "pTQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/atmospherics/components/binary/pump/layer1{
+	on = 1;
+	target_pressure = 2000
+	},
 /obj/machinery/door/airlock/ship/external/glass{
 	name = "External Access Deck 1 Starboard";
 	req_one_access_txt = "13;7"
@@ -19434,14 +19610,9 @@
 /obj/item/coin/gold,
 /obj/item/coin/gold,
 /obj/item/coin/gold,
-/obj/item/stack/sheet/mineral/gold,
-/obj/item/stack/sheet/mineral/gold,
-/obj/item/stack/sheet/mineral/gold,
-/obj/item/stack/sheet/mineral/gold,
-/obj/item/stack/sheet/mineral/gold,
-/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
-/obj/item/disk/holodisk,
-/obj/item/gun/ballistic/revolver,
+/obj/item/stack/sheet/mineral/gold{
+	amount = 5
+	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -19694,7 +19865,7 @@
 /area/crew_quarters/dorms)
 "qhW" = (
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "qip" = (
 /obj/machinery/status_display/ai,
@@ -19750,17 +19921,18 @@
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/xenobiology)
 "qkP" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
 	},
-/turf/closed/wall/ship,
-/area/crew_quarters/cryopods)
+/obj/item/clothing/ears/earmuffs,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "qld" = (
 /obj/structure/ore_box,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/miningoffice)
 "qly" = (
 /obj/structure/table/glass,
@@ -19792,9 +19964,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "qmg" = (
-/obj/structure/closet{
-	anchored = 1
-	},
 /obj/item/encryptionkey/atc,
 /obj/item/clothing/suit/hazardvest,
 /obj/item/clothing/suit/hazardvest,
@@ -19815,10 +19984,19 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/obj/structure/closet/secure_closet/flight_leader,
+/obj/item/encryptionkey/atc,
+/obj/item/encryptionkey/atc,
+/turf/open/floor/carpet/ship,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
+"qmn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/science/explab)
 "qmp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -19840,6 +20018,8 @@
 /turf/open/floor/wood,
 /area/library)
 "qnc" = (
+/obj/structure/closet/bombcloset,
+/obj/item/clothing/gloves/color/black,
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
@@ -19898,7 +20078,7 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "qqW" = (
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -19919,8 +20099,8 @@
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet/east,
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "qrE" = (
 /obj/machinery/computer/scan_consolenew{
 	dir = 1;
@@ -19976,7 +20156,9 @@
 /turf/open/floor/wood,
 /area/maintenance/fore)
 "qvk" = (
-/obj/machinery/light_switch/west,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/auxiliary)
 "qvt" = (
@@ -20032,7 +20214,7 @@
 "qxf" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/window/eastright,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "qxi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -20068,7 +20250,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/office)
 "qyc" = (
 /obj/structure/closet,
@@ -20106,7 +20288,7 @@
 /obj/machinery/camera/autoname{
 	dir = 8
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -20210,7 +20392,7 @@
 	},
 /obj/machinery/computer/lore_terminal,
 /obj/item/key/fighter_tug,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -20271,7 +20453,7 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/structure/table/glass,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/qm)
 "qIo" = (
 /obj/structure/cable{
@@ -20344,8 +20526,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "qNv" = (
 /obj/structure/window/plasma/reinforced{
 	dir = 4;
@@ -20414,6 +20596,15 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"qQx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/toilet/auxiliary)
 "qQS" = (
 /obj/structure/bed/roller,
 /mob/living/carbon/monkey,
@@ -20514,10 +20705,11 @@
 /area/maintenance/fore)
 "qTk" = (
 /obj/structure/table/wood,
-/obj/item/stack/packageWrap,
-/obj/item/destTagger{
-	pixel_x = 4;
-	pixel_y = 3
+/obj/machinery/recharger{
+	pixel_x = -7
+	},
+/obj/machinery/recharger{
+	pixel_x = 7
 	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
@@ -20682,7 +20874,7 @@
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "qYM" = (
 /obj/structure/cable{
@@ -20749,7 +20941,7 @@
 	},
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet/locker)
+/area/crew_quarters/dorms)
 "rae" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/light{
@@ -20820,7 +21012,7 @@
 	name = "Hangar bay";
 	req_one_access_txt = "31;69;72"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/hanger)
 "rdu" = (
 /obj/machinery/suit_storage_unit/standard_unit,
@@ -20901,8 +21093,8 @@
 /area/maintenance/department/science/xenobiology)
 "rfV" = (
 /obj/structure/closet/firecloset/full,
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "rfW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -20989,7 +21181,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "rib" = (
 /obj/structure/cable{
@@ -21005,7 +21197,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "rje" = (
 /obj/structure/table/wood,
@@ -21122,11 +21314,12 @@
 "rpP" = (
 /obj/machinery/airalarm/directional/north,
 /obj/structure/table,
+/obj/effect/spawner/lootdrop/gloves,
+/obj/item/stack/packageWrap,
 /obj/item/destTagger{
 	pixel_x = 4;
 	pixel_y = 3
 	},
-/obj/item/stack/packageWrap,
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
@@ -21140,8 +21333,9 @@
 	name = "Science Lobby"
 	})
 "rqS" = (
-/obj/item/storage/fancy/donut_box,
 /obj/structure/table/glass,
+/obj/item/clothing/gloves/color/black,
+/obj/item/storage/fancy/donut_box,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "rrd" = (
@@ -21269,7 +21463,7 @@
 	pixel_x = 4;
 	pixel_y = 3
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "rwB" = (
 /obj/structure/cable{
@@ -21572,8 +21766,8 @@
 	dir = 4
 	},
 /obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "rJT" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westright{
@@ -21591,7 +21785,7 @@
 	dir = 4;
 	icon_state = "computer"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/qm)
 "rKt" = (
 /obj/structure/frame/computer,
@@ -21623,9 +21817,6 @@
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/science/xenobiology)
 "rLh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -21650,8 +21841,8 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "rMi" = (
 /obj/effect/spawner/lootdrop/gambling,
 /obj/effect/spawner/lootdrop/maintenance/seven,
@@ -21883,7 +22074,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/maintenance/department/cargo)
 "rTM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -21898,8 +22089,8 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "rUh" = (
 /obj/item/storage/fancy/donut_box,
 /obj/structure/window/reinforced,
@@ -21920,7 +22111,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "rUT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -21931,6 +22122,18 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
+"rVi" = (
+/obj/machinery/computer/ship/viewscreen{
+	desc = "It's falling apart!";
+	name = "broken viewscreen";
+	pixel_x = 32;
+	pixel_y = -6
+	},
+/turf/open/floor/carpet/ship/blue{
+	color = "#9999DD";
+	name = "nanoweave carpet (bluer)"
+	},
+/area/bridge)
 "rVj" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -22081,7 +22284,7 @@
 	dir = 4
 	},
 /obj/structure/filingcabinet/chestdrawer/wheeled,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "sae" = (
 /obj/structure/ladder,
@@ -22116,7 +22319,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "scs" = (
 /obj/structure/table/glass,
@@ -22169,6 +22372,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
+/obj/effect/landmark/start/munitions_tech,
 /turf/open/floor/carpet/red,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
@@ -22410,10 +22614,8 @@
 	},
 /area/teleporter)
 "snA" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/carpet/ship/beige_carpet,
+/obj/machinery/suit_storage_unit/pilot,
+/turf/open/floor/carpet/ship,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -22538,7 +22740,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/office)
 "sss" = (
 /obj/structure/munitions_trolley,
@@ -22573,7 +22775,7 @@
 /obj/item/camera,
 /obj/machinery/status_display/evac/north,
 /obj/structure/extinguisher_cabinet/west,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -22592,8 +22794,9 @@
 	pixel_y = -2
 	},
 /obj/structure/extinguisher_cabinet/east,
+/obj/effect/spawner/lootdrop/gloves,
 /obj/item/cane,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/qm)
 "sud" = (
 /obj/structure/closet{
@@ -22686,7 +22889,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "sxZ" = (
 /obj/structure/cable{
@@ -22773,6 +22976,15 @@
 	},
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/lab)
+"szQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/carpet/ship/blue{
+	color = "#9999DD";
+	name = "nanoweave carpet (bluer)"
+	},
+/area/bridge/meeting_room)
 "szX" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -22796,7 +23008,7 @@
 /area/maintenance/department/cargo)
 "sAs" = (
 /obj/item/beacon,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "sAP" = (
 /obj/structure/cable/yellow{
@@ -22829,7 +23041,7 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/airlock/ship/external/glass{
 	name = "Escape Pod Munitions";
-	req_one_access_txt = "72"
+	req_one_access_txt = "3;69;72"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -23033,10 +23245,11 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -23119,8 +23332,8 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "sRO" = (
 /obj/machinery/mecha_part_fabricator,
 /obj/structure/disposalpipe/segment,
@@ -23166,7 +23379,11 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "sUM" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/cleanable/ash,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4;
+	icon_state = "warningline"
+	},
 /turf/open/floor/engine,
 /area/science/robotics/lab)
 "sUU" = (
@@ -23265,7 +23482,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "sYv" = (
 /turf/open/floor/carpet/red,
@@ -23307,7 +23524,7 @@
 "tcd" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/miningoffice)
 "tdz" = (
 /obj/machinery/computer/ship/navigation/public{
@@ -23316,7 +23533,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/hanger/deck2/port)
 "tdZ" = (
 /obj/item/twohanded/required/kirbyplants/random,
@@ -23349,7 +23566,7 @@
 /area/crew_quarters/dorms)
 "tew" = (
 /obj/structure/window/reinforced,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "teU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -23495,7 +23712,7 @@
 /obj/item/pen/fountain,
 /obj/item/key/fighter_tug,
 /obj/machinery/newscaster/directional/west,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -23528,6 +23745,16 @@
 /obj/structure/table/glass,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
+"toN" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/toilet/auxiliary)
 "toO" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible/layer3{
 	dir = 8
@@ -23709,7 +23936,7 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "12;46"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/maintenance/department/science/xenobiology)
 "tva" = (
 /obj/machinery/ship_weapon/energy/beam,
@@ -23736,7 +23963,7 @@
 	pixel_x = 3;
 	pixel_y = 1
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "tvF" = (
 /obj/machinery/meter/atmos/distro_loop{
@@ -23810,7 +24037,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/office)
 "txi" = (
 /obj/item/toy/beach_ball,
@@ -23846,6 +24073,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/machinery/door/window/southright{
+	req_access_txt = "20"
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "tyD" = (
@@ -23879,6 +24109,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
+/obj/structure/window/reinforced,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "tBl" = (
@@ -23924,8 +24155,11 @@
 	})
 "tCy" = (
 /obj/structure/table/wood,
-/obj/item/storage/fancy/donut_box,
-/obj/item/storage/secure/briefcase,
+/obj/item/stack/packageWrap,
+/obj/item/destTagger{
+	pixel_x = 4;
+	pixel_y = 3
+	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -23963,7 +24197,7 @@
 	dir = 8
 	},
 /obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/hanger/deck2/port)
 "tET" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -24050,24 +24284,24 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "tIM" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "tJG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "tJZ" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1;
 	icon_state = "loadingarea"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "tKg" = (
 /obj/structure/cable/yellow{
@@ -24262,17 +24496,10 @@
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/lab)
 "tRx" = (
-/obj/structure/toilet{
-	dir = 4;
-	icon_state = "toilet00"
-	},
-/obj/structure/disposalpipe/trunk{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_y = 10
-	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/auxiliary)
 "tRF" = (
@@ -24338,6 +24565,10 @@
 	name = "nanoweave carpet (bluer)"
 	},
 /area/bridge/meeting_room/council)
+"tTn" = (
+/obj/effect/landmark/start/roboticist,
+/turf/open/floor/carpet/ship/purple_carpet,
+/area/science/robotics/lab)
 "tTN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -24373,12 +24604,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
 "tVQ" = (
-/obj/machinery/cryopod,
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/obj/structure/frame/machine,
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "tWA" = (
 /obj/machinery/atmospherics/components/unary/portables_connector,
 /turf/closed/wall/r_wall/ship,
@@ -24702,7 +24933,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/qm)
 "uhf" = (
 /obj/structure/chair/office,
@@ -24717,6 +24948,7 @@
 	},
 /obj/item/pen/fountain/captain,
 /obj/structure/table/glass,
+/obj/structure/window/reinforced,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "uhz" = (
@@ -24747,7 +24979,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/miningoffice)
 "uin" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
@@ -24873,7 +25105,7 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/airlock/vault/ship{
 	name = "Munitions Weapons Bay";
-	req_one_access_txt = "3;71;72"
+	req_one_access_txt = "3;69;72"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -24881,7 +25113,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -24892,6 +25124,17 @@
 	pixel_x = -12;
 	pixel_y = 2
 	},
+/obj/structure/closet/secure_closet/munitions_technician,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/radio/headset/heads/captain/alt{
+	desc = "A special headset that protects ears from some loud noises.";
+	keyslot = null;
+	name = "noise cancelling headphones"
+	},
+/obj/item/encryptionkey/munitions_tech,
+/obj/item/clothing/head/hardhat,
+/obj/item/clothing/head/welding,
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
@@ -24911,9 +25154,6 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "uom" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -24923,9 +25163,9 @@
 	},
 /area/bridge/meeting_room)
 "uoU" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/crew_quarters/cryopods)
+/obj/structure/disposalpipe/junction,
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/toilet/auxiliary)
 "upu" = (
 /obj/structure/table,
 /obj/item/clothing/mask/gas,
@@ -24962,7 +25202,7 @@
 "uqd" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/photocopier,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/office)
 "uqu" = (
 /obj/structure/cable{
@@ -25039,13 +25279,11 @@
 /turf/closed/wall/ship,
 /area/maintenance/department/science/xenobiology)
 "utH" = (
-/obj/structure/frame/machine{
-	desc = "Looks like this used to be a drone dispenser a long time ago"
-	},
 /obj/structure/sign/solgov_seal,
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/mecha_part_fabricator,
 /turf/open/floor/engine,
 /area/science/robotics/lab)
 "utK" = (
@@ -25115,13 +25353,10 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "uyr" = (
-/obj/machinery/cryopod{
-	dir = 4;
-	icon_state = "cryopod-open"
-	},
 /obj/machinery/firealarm/directional/west,
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/obj/structure/frame/machine,
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "uyI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -25169,11 +25404,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/atmospherics/components/binary/pump/layer1{
+	dir = 4;
+	on = 1;
+	target_pressure = 2000
+	},
 /obj/machinery/door/airlock/ship/external/glass{
 	name = "External Access Deck 1 Fore";
 	req_one_access_txt = "19"
@@ -25380,6 +25617,9 @@
 /obj/item/clothing/ears/earmuffs,
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
+"uKd" = (
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/toilet/auxiliary)
 "uKk" = (
 /obj/structure/chair{
 	dir = 4
@@ -25511,7 +25751,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/carpet/ship/beige_carpet,
+/obj/effect/landmark/start/munitions_tech,
+/turf/open/floor/carpet/ship,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -25615,7 +25856,7 @@
 /area/bridge/meeting_room/council)
 "uTr" = (
 /obj/structure/closet/secure_closet/miner,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/miningoffice)
 "uUk" = (
 /obj/structure/grille,
@@ -25694,7 +25935,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -25718,8 +25959,8 @@
 "uYr" = (
 /obj/structure/closet/emcloset,
 /obj/item/storage/toolbox/emergency,
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "uYy" = (
 /obj/structure/rack,
 /obj/item/folder/red{
@@ -25743,7 +25984,8 @@
 	},
 /obj/machinery/airalarm/directional/west,
 /obj/item/hand_labeler_refill,
-/turf/open/floor/carpet/ship/beige_carpet,
+/obj/item/clothing/gloves/color/black,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "uZa" = (
 /obj/machinery/vending/plasmaresearch,
@@ -25765,7 +26007,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/quartermaster,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/qm)
 "vba" = (
 /obj/structure/cable/yellow{
@@ -25804,6 +26046,7 @@
 /obj/item/pen,
 /obj/item/stamp/captain,
 /obj/structure/table/glass,
+/obj/structure/window/reinforced,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "vdl" = (
@@ -25895,14 +26138,9 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "viL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/obj/item/clothing/ears/earmuffs,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/toilet/auxiliary)
 "viM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
@@ -26006,8 +26244,8 @@
 /area/maintenance/department/science/central)
 "vmY" = (
 /obj/item/beacon,
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "vnw" = (
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
@@ -26019,7 +26257,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/miningoffice)
 "vnA" = (
 /obj/effect/turf_decal/loading_area{
@@ -26027,7 +26265,7 @@
 	icon_state = "loadingarea"
 	},
 /obj/effect/landmark/start/shaft_miner,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/miningoffice)
 "voS" = (
 /obj/machinery/door/window{
@@ -26038,10 +26276,10 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/miningoffice)
 "vpq" = (
-/obj/machinery/airalarm/directional/north,
+/obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/engine,
 /area/nsv/hanger)
 "vqy" = (
@@ -26071,8 +26309,8 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "vsi" = (
 /obj/structure/reagent_dispensers/watertank,
 /mob/living/simple_animal/mouse,
@@ -26182,8 +26420,8 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/layer1{
 	dir = 1
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "vvY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -26198,7 +26436,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "vwI" = (
 /obj/structure/cable{
@@ -26526,7 +26764,7 @@
 	pixel_x = 6;
 	pixel_y = 7
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "vHy" = (
 /obj/structure/cable{
@@ -26782,7 +27020,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "vNG" = (
 /obj/machinery/shower{
@@ -26988,7 +27226,7 @@
 	pixel_x = -1;
 	pixel_y = -2
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/hanger/deck2/port)
 "vWo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -27206,7 +27444,7 @@
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "whR" = (
 /obj/effect/spawner/room/fivexfour,
@@ -27229,14 +27467,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "wim" = (
 /turf/closed/wall/ship,
 /area/maintenance/department/science/xenobiology)
 "wiG" = (
 /obj/machinery/modular_computer/console/preset/civilian,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -27277,7 +27515,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "wju" = (
 /obj/machinery/disposal/bin,
@@ -27343,7 +27581,7 @@
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "wkU" = (
 /obj/structure/disposalpipe/segment{
@@ -27409,7 +27647,7 @@
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/east,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "wpY" = (
 /obj/structure/cable/yellow{
@@ -27419,6 +27657,8 @@
 /area/science/lab)
 "wqr" = (
 /obj/effect/turf_decal/delivery/white,
+/obj/structure/closet/bombcloset,
+/obj/item/clothing/gloves/color/black,
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
@@ -27443,7 +27683,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/vending/snack/random,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/office)
 "wsy" = (
 /obj/effect/turf_decal/stripes/line{
@@ -27475,7 +27715,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/office)
 "wui" = (
 /obj/structure/chair/office,
@@ -27509,7 +27749,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "wvJ" = (
 /obj/structure/cable/yellow{
@@ -27702,7 +27942,10 @@
 	},
 /area/nsv/weapons/fore)
 "wED" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/freezer,
@@ -28032,7 +28275,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -28096,6 +28339,9 @@
 /area/maintenance/department/science/xenobiology)
 "wTi" = (
 /obj/machinery/status_display/ai/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/engine,
 /area/science/explab)
 "wTx" = (
@@ -28151,7 +28397,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/office)
 "wUl" = (
 /obj/machinery/squad_vendor,
@@ -28198,21 +28444,15 @@
 /turf/open/floor/carpet/ship,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "wXQ" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/obj/structure/mirror{
-	pixel_x = 27;
-	pixel_y = -2
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/auxiliary)
@@ -28274,7 +28514,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/miningoffice)
 "xbJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
@@ -28398,7 +28638,12 @@
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/lab)
 "xir" = (
-/obj/effect/landmark/start/roboticist,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/engine,
 /area/science/robotics/lab)
 "xiw" = (
@@ -28465,7 +28710,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/miningoffice)
 "xmk" = (
 /obj/structure/disposalpipe/segment,
@@ -28536,7 +28781,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "xoI" = (
 /turf/open/floor/carpet/ship/purple_carpet,
@@ -28774,7 +29019,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/start/shaft_miner,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "xAR" = (
 /obj/structure/disposalpipe/segment{
@@ -28794,8 +29039,8 @@
 	dir = 8
 	},
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "xDC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
@@ -28833,7 +29078,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/miningoffice)
 "xFN" = (
 /obj/structure/cable{
@@ -28846,7 +29091,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -28905,13 +29150,14 @@
 /area/ai_monitored/storage/eva)
 "xJh" = (
 /obj/structure/table/wood,
-/obj/item/flashlight/lamp,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
+/obj/item/clothing/gloves/color/black,
+/obj/item/flashlight/lamp,
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "xJj" = (
@@ -29300,12 +29546,12 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "xUr" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/cryopods)
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "xVt" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -29329,7 +29575,7 @@
 /area/science/lab)
 "xWt" = (
 /obj/structure/table,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/miningoffice)
 "xWx" = (
 /obj/structure/cable{
@@ -29379,7 +29625,7 @@
 	pixel_y = 38
 	},
 /obj/item/banner/cargo,
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "xXE" = (
 /obj/machinery/rnd/production/techfab,
@@ -29425,6 +29671,9 @@
 /area/science/lab)
 "xZS" = (
 /obj/machinery/aug_manipulator,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/engine,
 /area/science/robotics/lab)
 "yaz" = (
@@ -29480,9 +29729,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
 "ycv" = (
-/obj/structure/closet{
-	anchored = 1
-	},
 /obj/item/encryptionkey/atc,
 /obj/item/clothing/suit/hazardvest,
 /obj/item/clothing/suit/hazardvest,
@@ -29501,7 +29747,9 @@
 /obj/item/clothing/ears/earmuffs,
 /obj/item/clothing/ears/earmuffs,
 /obj/machinery/computer/ship/viewscreen,
-/turf/open/floor/carpet/ship/beige_carpet,
+/obj/structure/closet/secure_closet/atc,
+/obj/item/encryptionkey/atc,
+/turf/open/floor/carpet/ship,
 /area/nsv/hanger/deck2/port)
 "ycz" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -29531,7 +29779,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/qm)
 "ydx" = (
 /obj/structure/closet/secure_closet/personal,
@@ -29631,9 +29879,6 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "yjN" = (
-/obj/structure/closet{
-	anchored = 1
-	},
 /obj/item/encryptionkey/atc,
 /obj/item/clothing/suit/hazardvest,
 /obj/item/clothing/suit/hazardvest,
@@ -29652,7 +29897,10 @@
 /obj/item/clothing/ears/earmuffs,
 /obj/item/clothing/ears/earmuffs,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet/ship/beige_carpet,
+/obj/structure/closet/secure_closet/fighter_pilot,
+/obj/item/encryptionkey/atc,
+/obj/item/encryptionkey/atc,
+/turf/open/floor/carpet/ship,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
 	})
@@ -29685,9 +29933,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "ylI" = (
-/obj/machinery/newscaster/directional/west,
 /obj/structure/table/glass,
-/obj/machinery/computer/ship/viewscreen,
+/obj/machinery/computer/ship/viewscreen{
+	pixel_x = -32;
+	pixel_y = -6
+	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -38303,7 +38554,7 @@ nZT
 nZT
 nZT
 nZT
-nZT
+aEe
 nZT
 nZT
 nZT
@@ -39053,8 +39304,8 @@ nZT
 nZT
 nZT
 nZT
-aEe
-aEe
+nZT
+nZT
 nZT
 nZT
 nZT
@@ -39363,7 +39614,7 @@ nZT
 nZT
 nZT
 nZT
-nZT
+aEe
 nZT
 nZT
 nZT
@@ -39845,7 +40096,7 @@ nZT
 nZT
 nZT
 nZT
-aEe
+nZT
 nZT
 nZT
 nZT
@@ -42114,80 +42365,80 @@ nZT
 nZT
 nZT
 nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
-nZT
 aEe
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
+nZT
 nZT
 nZT
 nZT
@@ -43406,7 +43657,7 @@ nZT
 nZT
 nZT
 nZT
-aEe
+nZT
 nZT
 nZT
 nZT
@@ -43711,7 +43962,7 @@ kxO
 qfE
 rQh
 tvF
-fLx
+eXR
 upQ
 bDm
 xLZ
@@ -46239,7 +46490,7 @@ nZT
 nZT
 oAO
 aee
-aee
+sdP
 iMh
 xqV
 wim
@@ -46495,7 +46746,7 @@ nZT
 nZT
 nZT
 oAO
-aee
+bUF
 aee
 iMh
 jeP
@@ -46557,7 +46808,7 @@ dtC
 xKo
 iMh
 aee
-aee
+bUF
 mpX
 nZT
 nZT
@@ -47283,7 +47534,7 @@ weP
 weP
 weP
 weP
-weP
+hsH
 nFD
 jNW
 gUz
@@ -47782,19 +48033,19 @@ nZT
 oAO
 aee
 aee
-fyO
-oYB
+iMh
+rfK
 dzr
-oYB
-bOA
-oYB
+rfK
+jeP
+rfK
 djA
 uyr
-hsH
+wim
 haq
 rTM
 ano
-hsH
+duZ
 oMg
 sbm
 dyJ
@@ -48039,20 +48290,20 @@ nZT
 oAO
 aee
 owl
-gqs
-bOA
-bOA
+ptx
+jeP
+jeP
 tJG
 aAf
 czG
 bfS
 bfS
 hbS
-bfS
+fyO
 sRD
 dBj
-hsH
-xWZ
+duZ
+duZ
 xWZ
 mOn
 jXi
@@ -48296,19 +48547,19 @@ nZT
 oAO
 aee
 owl
-gqs
-bOA
-bOA
+ptx
+jeP
+jeP
 qNh
 vmY
 xCy
-bOA
+jeP
 cjJ
-cnL
+wim
 dZQ
 rTM
 xUr
-hsH
+duZ
 qZO
 sbm
 oYO
@@ -48367,7 +48618,7 @@ nZT
 nZT
 nZT
 nZT
-nZT
+aEe
 nZT
 nZT
 nZT
@@ -48553,20 +48804,20 @@ nZT
 oAO
 aee
 owl
-gqs
+ptx
+jeP
+jeP
 bOA
-bOA
-bOA
-bOA
-bOA
-bOA
-bOA
-uoU
+cnL
+jeP
+jeP
+jeP
+iAo
 dFZ
 kDd
 uYr
-hsH
-xWZ
+duZ
+duZ
 xWZ
 xpN
 wFc
@@ -48810,19 +49061,19 @@ nZT
 oAO
 aee
 aee
-fyO
-cOE
+iMh
+rfK
 oaa
 tVQ
 fcJ
 tVQ
-cOE
-cOE
-uoU
+rfK
+rfK
+iAo
 ejG
 rTM
 rfV
-hsH
+duZ
 nml
 sbm
 ksa
@@ -49067,20 +49318,20 @@ nZT
 oAO
 aee
 aee
-kJw
-duZ
-duZ
-duZ
-duZ
-duZ
-duZ
-duZ
-hsH
+iMh
+wim
+wim
+wim
+wim
+wim
+wim
+wim
+wim
 ezp
 jBD
 blY
-hsH
-xWZ
+duZ
+duZ
 xWZ
 weN
 jXi
@@ -49132,7 +49383,7 @@ mpX
 nZT
 nZT
 nZT
-aEe
+nZT
 nZT
 nZT
 nZT
@@ -49332,11 +49583,11 @@ duZ
 oCw
 uKv
 ptB
-hsH
+duZ
 vrD
 mye
 blY
-hsH
+duZ
 nml
 sbm
 nEh
@@ -49589,12 +49840,12 @@ duZ
 izO
 iPF
 aJr
-cmO
+hEA
 cAB
 nOi
 ddd
-hsH
-xWZ
+duZ
+duZ
 xWZ
 weN
 lIX
@@ -49846,11 +50097,11 @@ duZ
 vUc
 tgN
 cQA
-hsH
+duZ
 nYz
 rLZ
 vvu
-hsH
+duZ
 oMg
 sbm
 pCF
@@ -50103,11 +50354,11 @@ duZ
 bdA
 teU
 vJs
-hsH
+duZ
 fGQ
 tIH
 qrB
-hsH
+duZ
 duZ
 duZ
 duZ
@@ -50360,11 +50611,11 @@ duZ
 duZ
 bbq
 duZ
-hsH
-qkP
+duZ
+bNv
 rJH
-hsH
-hsH
+duZ
+duZ
 trM
 aXi
 hBL
@@ -52400,7 +52651,7 @@ nZT
 nZT
 nZT
 nZT
-aEe
+nZT
 nZT
 nZT
 nZT
@@ -53990,9 +54241,9 @@ nkW
 pcP
 uUk
 fDk
-wnL
+qmn
 yfh
-wnL
+daU
 huI
 jby
 mzE
@@ -54190,7 +54441,7 @@ nZT
 nZT
 nZT
 nZT
-nZT
+aEe
 nZT
 nZT
 nZT
@@ -54247,9 +54498,9 @@ nkW
 pcP
 rRn
 fDk
-wnL
+qmn
 wBx
-wnL
+daU
 huI
 cBQ
 nTZ
@@ -54506,7 +54757,7 @@ rRn
 fDk
 wTi
 hSN
-wnL
+daU
 huI
 vzQ
 aTJ
@@ -54763,7 +55014,7 @@ rRn
 fDk
 hzI
 jkw
-wnL
+daU
 huI
 nAA
 mzE
@@ -55018,7 +55269,7 @@ nkW
 pcP
 rRn
 fDk
-wnL
+qmn
 wnL
 gfB
 xMO
@@ -55532,7 +55783,7 @@ nkW
 pcP
 rRn
 fDk
-wnL
+qmn
 mzS
 ltr
 xMO
@@ -56836,7 +57087,7 @@ hbT
 nZT
 nZT
 nZT
-aEe
+nZT
 nZT
 nZT
 nZT
@@ -57107,7 +57358,7 @@ nZT
 nZT
 nZT
 nZT
-nZT
+aEe
 nZT
 nZT
 nZT
@@ -61661,7 +61912,7 @@ nZT
 hbT
 nZT
 jQc
-cYB
+cmO
 mot
 qjS
 dCU
@@ -62191,13 +62442,13 @@ ybo
 fDk
 vlP
 bju
-uaY
+tBy
 msW
 pJI
 qrf
 bju
-paT
-pyG
+dhb
+bpc
 nkW
 nVb
 nVb
@@ -62216,7 +62467,7 @@ orC
 nVb
 dOP
 prn
-qXD
+tTn
 prn
 mDf
 dPz
@@ -62450,7 +62701,7 @@ pzy
 bju
 gxM
 pyG
-pyG
+qkP
 pyG
 bju
 paT
@@ -62705,9 +62956,9 @@ eWF
 fDk
 mhY
 kjL
+oYB
 ekU
 ekU
-viL
 ekU
 dkR
 ptR
@@ -62960,13 +63211,13 @@ qCO
 qCO
 ybo
 fDk
-pcP
-vii
-vlP
-osE
-pyG
-tBy
-ddE
+lIk
+nkW
+nkW
+nkW
+nkW
+nkW
+nkW
 mfe
 pAW
 mGQ
@@ -63217,15 +63468,15 @@ qjS
 uiF
 hbD
 fDk
-hfr
+pcP
+nkW
+eCT
+njl
+qvk
+viL
 nkW
 nkW
 nkW
-nkW
-nkW
-nkW
-nkW
-lIk
 jHL
 wyv
 byi
@@ -63449,7 +63700,7 @@ nZT
 nZT
 nZT
 nZT
-aEe
+nZT
 nZT
 nZT
 nZT
@@ -63476,12 +63727,12 @@ mfj
 fDk
 pcP
 nkW
-tRx
+meH
 meH
 tRx
+uKd
 meH
-tRx
-meH
+gbB
 ooJ
 jHL
 hXK
@@ -63732,14 +63983,14 @@ qCO
 ybo
 fDk
 pcP
-nkW
+osE
 bQi
+njl
+uoU
+toN
 meH
-bQi
-meH
-bQi
-meH
-bQi
+qQx
+cdX
 jHL
 wyv
 hXK
@@ -63761,7 +64012,7 @@ kOy
 vKW
 qXD
 qXD
-qXD
+tTn
 fAz
 rlD
 rlD
@@ -63990,13 +64241,13 @@ hbD
 fDk
 pcP
 nkW
-eci
-qvk
+meH
+meH
 eci
 gfY
-eci
+meH
 wED
-eci
+meH
 jHL
 jHL
 jHL
@@ -66036,7 +66287,7 @@ jlU
 bUr
 stV
 tnW
-qqW
+cDp
 uXh
 wRX
 wjT
@@ -66807,7 +67058,7 @@ bej
 jMw
 xFN
 uPA
-uPA
+cOE
 wRu
 mrg
 qyI
@@ -68337,11 +68588,11 @@ nZT
 nZT
 nZT
 nZT
-aEe
+nZT
 nZT
 nZT
 oAO
-aee
+bUF
 hbT
 wjT
 hDk
@@ -68401,7 +68652,7 @@ gSZ
 nCR
 uxC
 hbT
-aee
+bUF
 mpX
 nZT
 nZT
@@ -69658,7 +69909,7 @@ vjC
 rci
 wbJ
 dzW
-mzl
+szQ
 pnP
 eQT
 eQT
@@ -69864,7 +70115,7 @@ nZT
 nZT
 nZT
 nZT
-nZT
+aEe
 nZT
 nZT
 nZT
@@ -70172,7 +70423,7 @@ vjC
 qyG
 xgz
 dzW
-mzl
+oVB
 tCy
 eQT
 aYy
@@ -70417,7 +70668,7 @@ jLE
 suU
 wiQ
 vcH
-cww
+oYb
 rDI
 rqS
 oYb
@@ -70429,7 +70680,7 @@ qYM
 uNA
 wQR
 nZu
-mzl
+oVB
 cyz
 jIw
 wzA
@@ -70674,7 +70925,7 @@ nMw
 xDN
 aAA
 tAS
-cww
+oYb
 rDI
 toh
 hQz
@@ -70686,7 +70937,7 @@ hNg
 lmz
 ozS
 xdA
-mzl
+oVB
 mzd
 eQT
 rWs
@@ -70925,7 +71176,7 @@ lpX
 mCr
 fDk
 nOW
-kJD
+hfr
 fDk
 rbA
 wMe
@@ -70943,7 +71194,7 @@ vjC
 ofC
 vFv
 rIR
-mzl
+oVB
 ixf
 eQT
 pFP
@@ -71181,7 +71432,7 @@ ebt
 lpX
 wqr
 fDk
-uaY
+gqs
 kJD
 fDk
 kAW
@@ -71217,7 +71468,7 @@ oLE
 uvI
 hLG
 obS
-bUF
+uvI
 iOt
 grs
 iOt
@@ -71430,7 +71681,7 @@ hbT
 fMJ
 rNy
 fMJ
-lpX
+cww
 sRk
 mix
 pGe
@@ -71457,7 +71708,7 @@ aJz
 mlm
 xKy
 bjT
-cDp
+oEO
 fhB
 sAm
 tfo
@@ -71691,11 +71942,11 @@ pes
 kOb
 dfp
 bKJ
+ddE
 bKJ
-bKJ
-bKJ
+ddE
 mkK
-bKJ
+ddE
 fmj
 hIh
 fqv
@@ -71722,12 +71973,12 @@ eKq
 bVG
 sWO
 xMP
-cRy
-cRy
-cRy
 uvI
-cRy
-cRy
+uvI
+uvI
+uvI
+uvI
+uvI
 cRy
 wuw
 rCy
@@ -71932,7 +72183,7 @@ nZT
 nZT
 nZT
 nZT
-aEe
+nZT
 nZT
 nZT
 nZT
@@ -71979,10 +72230,10 @@ bUO
 bVG
 sWO
 xMP
-uxC
 uvI
 uvI
-uvI
+cVQ
+cVQ
 uvI
 uvI
 cRy
@@ -72236,7 +72487,7 @@ oRT
 bVG
 sWO
 xMP
-uxC
+uvI
 jEv
 uvI
 uvI
@@ -72493,10 +72744,10 @@ oEO
 bVG
 sWO
 xMP
-uxC
 uvI
 uvI
-uvI
+cVQ
+cVQ
 uvI
 uvI
 cRy
@@ -72750,12 +73001,12 @@ ooi
 bVG
 sWO
 xMP
-cRy
-cRy
-cRy
-cRy
-cRy
-cRy
+uvI
+uvI
+uvI
+uvI
+uvI
+uvI
 cRy
 wuw
 rCy
@@ -73511,7 +73762,7 @@ uXQ
 vWs
 fCk
 oEO
-oEO
+rVi
 oEO
 oae
 eqJ
@@ -76054,7 +76305,7 @@ nZT
 nZT
 nZT
 nZT
-aEe
+nZT
 nZT
 nZT
 nZT
@@ -77360,7 +77611,7 @@ nZT
 nZT
 nZT
 nZT
-aEe
+nZT
 nZT
 nZT
 nZT
@@ -78109,7 +78360,7 @@ nZT
 nZT
 nZT
 nZT
-nZT
+aEe
 nZT
 nZT
 nZT
@@ -78385,7 +78636,7 @@ nZT
 nZT
 nZT
 nZT
-aEe
+nZT
 nZT
 nZT
 nZT

--- a/_maps/map_files/Aetherwhisp/Aetherwhisp2.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp2.dmm
@@ -433,8 +433,7 @@
 /area/science/server)
 "apQ" = (
 /obj/machinery/computer/scan_consolenew{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/medical/genetics)
@@ -519,8 +518,7 @@
 /area/crew_quarters/heads/hop)
 "asv" = (
 /obj/machinery/computer/ship/dradis{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
@@ -1035,8 +1033,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/machinery/door/poddoor/ship/preopen{
 	id = "slimeblastdoors"
@@ -1115,9 +1112,6 @@
 /area/bridge/meeting_room)
 "aMe" = (
 /obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
 /obj/item/storage/toolbox/electrical{
 	pixel_x = 6;
 	pixel_y = 8
@@ -1131,7 +1125,7 @@
 	},
 /obj/structure/table/glass,
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "0-4"
 	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
@@ -1379,9 +1373,11 @@
 	},
 /area/bridge/meeting_room/council)
 "aYy" = (
-/obj/structure/closet/crate,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/structure/sign/solgov_seal,
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/armory_contraband/metastation,
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
 "aYB" = (
@@ -1411,24 +1407,20 @@
 /area/quartermaster/office)
 "baE" = (
 /obj/structure/window/plasma/reinforced{
-	dir = 4;
-	icon_state = "plasmarwindow"
+	dir = 4
 	},
 /obj/structure/window/plasma/reinforced{
-	dir = 8;
-	icon_state = "plasmarwindow"
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrogen_input{
 	dir = 8;
 	id = "n2_in_alt"
 	},
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible/layer1{
-	dir = 1;
-	icon_state = "manifold-1"
+	dir = 1
 	},
 /obj/structure/window/plasma/reinforced{
-	dir = 1;
-	icon_state = "plasmarwindow"
+	dir = 1
 	},
 /turf/open/floor/engine/n2,
 /area/maintenance/fore)
@@ -1530,15 +1522,13 @@
 /area/maintenance/department/science/xenobiology)
 "bdI" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 4;
-	icon_state = "connector_map-2"
+	dir = 4
 	},
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/department/science/xenobiology)
 "bdP" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 6;
-	icon_state = "warningline"
+	dir = 6
 	},
 /turf/open/floor/engine,
 /area/science/robotics/lab)
@@ -1675,8 +1665,7 @@
 /area/quartermaster/storage)
 "biR" = (
 /obj/machinery/modular_computer/console/preset/civilian{
-	dir = 8;
-	icon_state = "console"
+	dir = 8
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -1774,8 +1763,7 @@
 /area/ai_monitored/turret_protected/ai)
 "bnr" = (
 /obj/structure/window/plasma/reinforced{
-	dir = 1;
-	icon_state = "plasmarwindow"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1,
 /obj/machinery/atmospherics/components/trinary/mixer/airmix{
@@ -1830,8 +1818,7 @@
 /area/bridge/showroom/corporate)
 "bpE" = (
 /obj/machinery/computer/shuttle/mining{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /obj/structure/cable,
 /obj/machinery/light{
@@ -1845,6 +1832,9 @@
 /obj/machinery/keycard_auth{
 	pixel_x = 24;
 	pixel_y = 24
+	},
+/mob/living/simple_animal/pet/cat/kitten{
+	name = "Professor Mew"
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
@@ -1899,8 +1889,7 @@
 /area/bridge)
 "bro" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -2083,12 +2072,10 @@
 /area/crew_quarters/heads/hop)
 "bwz" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 4;
-	icon_state = "warningline"
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 8;
-	icon_state = "warningline"
+	dir = 8
 	},
 /obj/machinery/disposal/deliveryChute{
 	dir = 8;
@@ -2205,8 +2192,7 @@
 /area/nsv/weapons/fore)
 "byP" = (
 /obj/structure/shuttle/engine/large{
-	dir = 8;
-	icon_state = "large_engine"
+	dir = 8
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -2280,6 +2266,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
 	id = "courtroom_shutter"
 	},
 /turf/open/floor/plating,
@@ -2309,8 +2296,7 @@
 /area/maintenance/fore)
 "bBc" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -2372,7 +2358,6 @@
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/robotics/lab)
 "bCy" = (
-/obj/structure/closet/crate,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
@@ -2670,8 +2655,7 @@
 	})
 "bRf" = (
 /obj/structure/toilet{
-	dir = 4;
-	icon_state = "toilet00"
+	dir = 4
 	},
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/plasteel/showroomfloor,
@@ -2734,6 +2718,10 @@
 /area/maintenance/department/science/central)
 "bTU" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "qmshutter"
+	},
 /turf/open/floor/plating,
 /area/nsv/hanger)
 "bUr" = (
@@ -2746,8 +2734,7 @@
 /area/space/nearstation)
 "bUO" = (
 /obj/machinery/modular_computer/console/preset/civilian{
-	dir = 1;
-	icon_state = "console"
+	dir = 1
 	},
 /obj/structure/cable,
 /turf/open/floor/carpet/ship/blue{
@@ -2764,8 +2751,7 @@
 /area/bridge)
 "bVM" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/machinery/computer/communications{
 	dir = 8
@@ -2833,6 +2819,9 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	name = "Maintenance Access Captain Quarters";
 	req_one_access_txt = "20"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/captain/private)
@@ -2902,7 +2891,6 @@
 "cbI" = (
 /obj/machinery/computer/atmos_control/tank/oxygen_tank{
 	dir = 1;
-	icon_state = "computer";
 	input_tag = "o2_in_alt";
 	output_tag = "o2_out_alt";
 	sensors = list("o2_sensor_alt" = "Oxygen Tank")
@@ -3127,8 +3115,7 @@
 /area/crew_quarters/heads/captain)
 "ckx" = (
 /obj/machinery/modular_computer/console/preset/civilian{
-	dir = 1;
-	icon_state = "console"
+	dir = 1
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -3184,8 +3171,7 @@
 /area/nsv/hanger)
 "cnq" = (
 /obj/machinery/modular_computer/console/preset/civilian{
-	dir = 8;
-	icon_state = "console"
+	dir = 8
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -3253,8 +3239,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
@@ -3465,10 +3450,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "cvL" = (
-/obj/structure/curtain,
 /obj/machinery/shower{
-	dir = 8
+	dir = 8;
+	layer = 3.5
 	},
+/obj/structure/curtain,
+/obj/item/soap/deluxe,
+/obj/item/bikehorn/rubberducky,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "cww" = (
@@ -3659,7 +3647,6 @@
 	name = "Weapons Storage"
 	})
 "cDB" = (
-/obj/machinery/ore_silo,
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
 "cDE" = (
@@ -3740,8 +3727,7 @@
 /area/teleporter)
 "cGt" = (
 /obj/effect/turf_decal/arrows{
-	dir = 8;
-	icon_state = "arrows"
+	dir = 8
 	},
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
@@ -3899,8 +3885,7 @@
 /obj/structure/lattice,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -4582,25 +4567,20 @@
 /area/maintenance/disposal)
 "dqF" = (
 /obj/structure/disposaloutlet{
-	dir = 8;
-	icon_state = "outlet"
+	dir = 8
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "dqX" = (
-/obj/structure/shuttle/engine/huge{
-	dir = 8;
-	icon_state = "huge_engine"
-	},
+/obj/structure/lattice,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "dsx" = (
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 9
@@ -4701,6 +4681,15 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
+"dvP" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine,
+/area/nsv/weapons/fore)
 "dwt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -5216,8 +5205,7 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "dQg" = (
 /obj/machinery/modular_computer/console/preset/engineering{
-	dir = 4;
-	icon_state = "console"
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -5275,16 +5263,16 @@
 /turf/open/floor/carpet/ship,
 /area/shuttle/turbolift/quaternary)
 "dTn" = (
-/obj/machinery/computer/station_alert{
-	dir = 4;
-	icon_state = "computer"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/machinery/computer/monitor{
+	dir = 4;
+	name = "stormdrive power monitoring console"
+	},
+/obj/structure/cable/white{
+	icon_state = "0-4"
 	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
@@ -5555,8 +5543,7 @@
 /area/maintenance/department/bridge)
 "ehb" = (
 /obj/structure/disposaloutlet{
-	dir = 1;
-	icon_state = "outlet"
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/disposalpipe/trunk,
@@ -5609,8 +5596,7 @@
 /area/janitor)
 "ejy" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
 	dir = 4
@@ -5648,6 +5634,9 @@
 "ele" = (
 /obj/effect/turf_decal/delivery/white,
 /obj/machinery/ship_weapon/torpedo_launcher/east,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
 /turf/open/floor/engine,
 /area/nsv/weapons/fore)
 "elq" = (
@@ -5667,8 +5656,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
@@ -5689,6 +5677,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
 	id = "courtroom_shutter"
 	},
 /turf/open/floor/plating,
@@ -5808,8 +5797,7 @@
 /area/ai_monitored/turret_protected/ai)
 "ewB" = (
 /obj/machinery/computer/upload/borg{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -5928,12 +5916,10 @@
 "ezR" = (
 /obj/structure/window/plasma/reinforced,
 /obj/structure/window/plasma/reinforced{
-	dir = 4;
-	icon_state = "plasmarwindow"
+	dir = 4
 	},
 /obj/structure/window/plasma/reinforced{
-	dir = 8;
-	icon_state = "plasmarwindow"
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/oxygen_output{
 	id_tag = "o2_out_alt"
@@ -6203,8 +6189,7 @@
 /area/crew_quarters/toilet/locker)
 "eKq" = (
 /obj/machinery/computer/bounty{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
@@ -6227,8 +6212,7 @@
 /area/nsv/hanger)
 "eKM" = (
 /obj/structure/chair/comfy{
-	dir = 4;
-	icon_state = "comfychair"
+	dir = 4
 	},
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet,
@@ -6246,8 +6230,7 @@
 /area/science/xenobiology)
 "eLs" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/machinery/door/window/southleft{
 	name = "Containment Pen";
@@ -6310,7 +6293,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
 /turf/open/floor/carpet/ship,
@@ -6661,8 +6644,7 @@
 /area/library)
 "fbh" = (
 /obj/structure/chair/comfy/shuttle{
-	dir = 1;
-	icon_state = "shuttle_chair"
+	dir = 1
 	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
@@ -6888,6 +6870,10 @@
 "fjc" = (
 /obj/machinery/camera/autoname{
 	dir = 1
+	},
+/obj/machinery/squad_vendor{
+	density = 0;
+	pixel_y = -32
 	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
@@ -7353,6 +7339,12 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"fzt" = (
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine,
+/area/nsv/weapons/fore)
 "fAz" = (
 /obj/structure/table,
 /obj/item/hemostat,
@@ -7422,8 +7414,7 @@
 /area/maintenance/department/cargo)
 "fDC" = (
 /obj/structure/chair/comfy/shuttle{
-	dir = 4;
-	icon_state = "shuttle_chair"
+	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/effect/landmark/start/bridge,
@@ -7476,6 +7467,9 @@
 "fGo" = (
 /obj/vehicle/ridden/janicart,
 /obj/item/key/janitor,
+/mob/living/simple_animal/hostile/lizard{
+	name = "Wags-His-Tail"
+	},
 /turf/open/floor/carpet/ship,
 /area/janitor)
 "fGJ" = (
@@ -7519,8 +7513,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/janitorialcart{
-	dir = 4;
-	icon_state = "cart"
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
@@ -7614,8 +7607,7 @@
 /area/quartermaster/storage)
 "fMx" = (
 /obj/machinery/computer/security/mining{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7698,11 +7690,12 @@
 /turf/open/floor/carpet/ship,
 /area/ai_monitored/turret_protected/ai)
 "fQY" = (
-/obj/machinery/modular_computer/console/preset/civilian{
-	dir = 8;
-	icon_state = "console"
+/obj/structure/cable/white{
+	icon_state = "0-2"
 	},
-/obj/structure/cable/yellow,
+/obj/machinery/modular_computer/console/preset/engineering{
+	dir = 8
+	},
 /turf/open/floor/engine,
 /area/nsv/weapons/fore)
 "fRV" = (
@@ -7967,10 +7960,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
-/obj/structure/curtain,
 /obj/machinery/shower{
-	dir = 4
+	dir = 4;
+	layer = 3.5
 	},
+/obj/structure/curtain,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/auxiliary)
 "gbM" = (
@@ -8103,8 +8097,7 @@
 /area/ai_monitored/turret_protected/ai)
 "giw" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5;
-	icon_state = "pipe11-2"
+	dir = 5
 	},
 /turf/open/floor/circuit,
 /area/science/server)
@@ -8182,12 +8175,10 @@
 "glF" = (
 /obj/structure/window/plasma/reinforced,
 /obj/structure/window/plasma/reinforced{
-	dir = 4;
-	icon_state = "plasmarwindow"
+	dir = 4
 	},
 /obj/structure/window/plasma/reinforced{
-	dir = 8;
-	icon_state = "plasmarwindow"
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrogen_output{
 	id_tag = "n2_out_alt"
@@ -8306,8 +8297,7 @@
 /area/maintenance/department/science/xenobiology)
 "gqS" = (
 /obj/machinery/modular_computer/console/preset/civilian{
-	dir = 4;
-	icon_state = "console"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -8704,11 +8694,12 @@
 	},
 /area/bridge/meeting_room)
 "gLU" = (
-/obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/light_switch/east,
 /obj/machinery/camera/autoname{
 	dir = 8
 	},
+/obj/machinery/ore_silo,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/carpet/ship,
 /area/quartermaster/qm)
 "gMf" = (
@@ -8863,9 +8854,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /turf/open/floor/carpet/ship,
 /area/ai_monitored/turret_protected/ai)
 "gUz" = (
@@ -8990,8 +8978,7 @@
 /area/maintenance/department/science/xenobiology)
 "gZR" = (
 /obj/structure/chair/comfy/shuttle{
-	dir = 4;
-	icon_state = "shuttle_chair"
+	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/effect/landmark/start/captain,
@@ -9012,8 +8999,7 @@
 /area/nsv/hanger)
 "haq" = (
 /obj/machinery/computer/crew{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /obj/structure/extinguisher_cabinet/west,
 /obj/item/radio/intercom/directional/north,
@@ -9073,8 +9059,7 @@
 /area/science/robotics/lab)
 "hbD" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 10;
-	icon_state = "warningline"
+	dir = 10
 	},
 /turf/open/floor/plating,
 /area/nsv/hanger)
@@ -9125,8 +9110,7 @@
 /area/maintenance/department/cargo)
 "hdP" = (
 /obj/machinery/computer/bounty{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
@@ -9403,8 +9387,7 @@
 /area/maintenance/department/cargo)
 "hqe" = (
 /obj/machinery/modular_computer/console/preset/civilian{
-	dir = 1;
-	icon_state = "console"
+	dir = 1
 	},
 /obj/structure/cable,
 /turf/open/floor/carpet,
@@ -9438,12 +9421,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "hrb" = (
 /obj/structure/chair/comfy{
-	dir = 4;
-	icon_state = "comfychair"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -9651,8 +9636,7 @@
 /area/science/explab)
 "hAL" = (
 /obj/machinery/modular_computer/console/preset/civilian{
-	dir = 4;
-	icon_state = "console"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -9839,8 +9823,7 @@
 /area/bridge/meeting_room)
 "hJB" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 4;
-	icon_state = "warningline"
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -10089,8 +10072,7 @@
 	})
 "hWv" = (
 /obj/machinery/computer/security/mining{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
@@ -10286,6 +10268,19 @@
 /obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
+"icy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/squad_vendor{
+	density = 0;
+	pixel_y = 26
+	},
+/turf/open/floor/carpet/ship/blue{
+	color = "#9999DD";
+	name = "nanoweave carpet (bluer)"
+	},
+/area/bridge/meeting_room/council)
 "icI" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
@@ -10318,6 +10313,13 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/bridge/meeting_room/council)
+"ifd" = (
+/obj/effect/turf_decal/delivery/white,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine,
+/area/nsv/weapons/fore)
 "igo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10361,8 +10363,7 @@
 "iiB" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector/layer1{
 	dir = 8
@@ -10565,7 +10566,6 @@
 "itN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 4;
-	icon_state = "scrub_map-2";
 	name = "Toxins Combustion Chamber 1"
 	},
 /turf/open/floor/engine,
@@ -10580,8 +10580,7 @@
 /area/library)
 "itS" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 4;
-	icon_state = "warningline"
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/science/robotics/lab)
@@ -10639,8 +10638,7 @@
 /area/ai_monitored/turret_protected/ai)
 "ixT" = (
 /obj/machinery/computer/cargo/request{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /obj/machinery/computer/ship/viewscreen{
 	pixel_x = -32;
@@ -10877,6 +10875,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "iIB" = (
@@ -11106,9 +11107,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
 /turf/open/floor/carpet/ship,
 /area/ai_monitored/turret_protected/ai)
 "iRY" = (
@@ -11215,8 +11213,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
@@ -11322,7 +11319,6 @@
 /obj/machinery/recycler,
 /obj/machinery/conveyor/auto{
 	dir = 4;
-	icon_state = "conveyor_map";
 	id = "disposal-conveyor"
 	},
 /turf/open/floor/plating,
@@ -11534,8 +11530,7 @@
 /area/science/mixing)
 "jmf" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/library)
@@ -11607,8 +11602,7 @@
 /area/nsv/weapons/fore)
 "jqA" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
@@ -11939,6 +11933,9 @@
 	pixel_y = 4
 	},
 /obj/machinery/computer/ship/viewscreen,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -11953,8 +11950,7 @@
 /area/science/xenobiology)
 "jDx" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 8;
-	icon_state = "connector_map-2"
+	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister,
 /obj/structure/sign/solgov_seal,
@@ -12005,11 +12001,7 @@
 /area/maintenance/department/science/central)
 "jGs" = (
 /obj/structure/chair/comfy/shuttle{
-	dir = 8;
-	icon_state = "shuttle_chair"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
+	dir = 8
 	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
@@ -12181,12 +12173,10 @@
 /area/crew_quarters/heads/captain)
 "jLM" = (
 /obj/structure/window/plasma/reinforced{
-	dir = 4;
-	icon_state = "plasmarwindow"
+	dir = 4
 	},
 /obj/structure/window/plasma/reinforced{
-	dir = 8;
-	icon_state = "plasmarwindow"
+	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/air_sensor/atmos/oxygen_tank{
@@ -12403,12 +12393,17 @@
 /obj/structure/sign/warning/vacuum{
 	pixel_y = -32
 	},
+/obj/structure/cable/white{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "jYt" = (
 /obj/effect/turf_decal/arrows{
-	dir = 8;
-	icon_state = "arrows"
+	dir = 8
 	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
@@ -12460,7 +12455,6 @@
 "kbG" = (
 /obj/machinery/conveyor/auto{
 	dir = 4;
-	icon_state = "conveyor_map";
 	id = "disposal-conveyor"
 	},
 /turf/open/floor/plating,
@@ -12791,7 +12785,6 @@
 "kkQ" = (
 /obj/machinery/computer/atmos_control/tank/air_tank{
 	dir = 1;
-	icon_state = "computer";
 	input_tag = "air_in_alt";
 	output_tag = "air_out_alt";
 	sensors = list("air_sensor_alt" = "Air Mix Tank")
@@ -13069,8 +13062,7 @@
 "kxQ" = (
 /obj/structure/window/reinforced,
 /obj/structure/disposaloutlet{
-	dir = 8;
-	icon_state = "outlet"
+	dir = 8
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -13293,12 +13285,10 @@
 /area/nsv/weapons/fore)
 "kJu" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1;
-	icon_state = "warninglinecorner"
+	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 10;
-	icon_state = "warningline"
+	dir = 10
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
@@ -13325,12 +13315,12 @@
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/mixing)
 "kLf" = (
-/mob/living/simple_animal/pet/cat/Proc{
-	name = "Darwin"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
+/mob/living/simple_animal/pet/cat{
+	name = "Darwin"
+	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -13595,7 +13585,6 @@
 "kXh" = (
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank{
 	dir = 1;
-	icon_state = "computer";
 	input_tag = "n2_in_alt";
 	output_tag = "n2_out_alt";
 	sensors = list("n2_sensor_alt" = "Nitrogen Tank")
@@ -13607,8 +13596,7 @@
 /area/maintenance/fore)
 "kXA" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -13649,7 +13637,6 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 8;
-	icon_state = "scrub_map-2";
 	name = "Toxins Combustion Chamber 2"
 	},
 /turf/open/floor/engine,
@@ -13918,9 +13905,6 @@
 /area/maintenance/department/cargo)
 "lpW" = (
 /obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
 	icon_state = "2-8"
 	},
 /obj/structure/cable{
@@ -14183,8 +14167,7 @@
 /area/library)
 "lDf" = (
 /obj/effect/turf_decal/loading_area{
-	dir = 1;
-	icon_state = "loadingarea"
+	dir = 1
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet/ship,
@@ -14331,6 +14314,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "lIn" = (
@@ -14345,15 +14330,13 @@
 /area/maintenance/fore)
 "lIu" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 4;
-	icon_state = "warningline"
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8;
-	icon_state = "warninglinecorner"
+	dir = 8
 	},
 /obj/machinery/disposal/deliveryChute{
 	dir = 8;
@@ -14464,11 +14447,6 @@
 "lKu" = (
 /obj/structure/bed,
 /obj/item/bedsheet/qm,
-/obj/machinery/airalarm/directional/north,
-/obj/item/radio/intercom/directional{
-	pixel_x = 30;
-	pixel_y = 25
-	},
 /turf/open/floor/carpet/ship,
 /area/quartermaster/qm)
 "lKE" = (
@@ -14613,7 +14591,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/mob/living/simple_animal/pet/cat/Proc{
+/mob/living/simple_animal/pet/cat{
 	name = "Magcat"
 	},
 /turf/open/floor/engine,
@@ -14623,11 +14601,12 @@
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/lab)
 "lVB" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/item/radio/intercom/directional{
+	pixel_x = 30;
+	pixel_y = 25
 	},
-/turf/open/floor/engine,
-/area/nsv/weapons/fore)
+/turf/open/floor/carpet/ship,
+/area/quartermaster/qm)
 "lWk" = (
 /obj/machinery/door/poddoor/ship/preopen{
 	id = "slimeblastdoors"
@@ -14742,8 +14721,7 @@
 /area/teleporter)
 "mbN" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 4;
-	icon_state = "connector_map-2"
+	dir = 4
 	},
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/mixing)
@@ -14795,12 +14773,10 @@
 /area/maintenance/department/cargo)
 "mfS" = (
 /obj/machinery/computer/ship/navigation{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
@@ -14843,11 +14819,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "mgG" = (
-/obj/structure/curtain,
-/obj/item/soap/nanotrasen,
 /obj/machinery/shower{
-	dir = 4
+	dir = 4;
+	layer = 3.5
 	},
+/obj/structure/curtain,
+/obj/item/soap/deluxe,
 /obj/item/bikehorn/rubberducky,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/heads/captain)
@@ -14915,6 +14892,10 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/machinery/power/deck_relay,
+/obj/structure/cable/white{
+	icon_state = "0-2"
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "mkr" = (
@@ -14943,8 +14924,7 @@
 "mlg" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector/layer3{
 	dir = 8
@@ -15091,6 +15071,9 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet/east,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -15259,8 +15242,7 @@
 /area/quartermaster/storage)
 "mtJ" = (
 /obj/structure/chair/comfy{
-	dir = 8;
-	icon_state = "comfychair"
+	dir = 8
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -15781,8 +15763,7 @@
 /area/nsv/hanger/deck2/port)
 "mNb" = (
 /obj/structure/chair/comfy/shuttle{
-	dir = 4;
-	icon_state = "shuttle_chair"
+	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/effect/landmark/start/bridge,
@@ -15795,8 +15776,7 @@
 /area/maintenance/fore)
 "mNm" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
 	dir = 4
@@ -15879,8 +15859,7 @@
 /area/maintenance/disposal)
 "mTF" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4;
-	icon_state = "connector_map-2"
+	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plating,
@@ -15986,8 +15965,7 @@
 /area/maintenance/fore)
 "mZX" = (
 /obj/machinery/computer/holodeck{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
@@ -16063,12 +16041,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/machinery/computer/monitor{
-	dir = 8;
-	name = "department distribution monitoring console"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
+/obj/machinery/modular_computer/console/preset/engineering{
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/nsv/weapons/fore)
@@ -16112,8 +16086,7 @@
 /area/maintenance/department/science/central)
 "nin" = (
 /obj/machinery/computer/upload/ai{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -16272,6 +16245,9 @@
 /obj/structure/table/glass,
 /obj/item/flashlight/lamp,
 /obj/machinery/status_display/evac/north,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "nmS" = (
@@ -16367,8 +16343,7 @@
 	pixel_x = 18
 	},
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxins_mixing_input{
-	dir = 1;
-	icon_state = "inje_map-2"
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
@@ -16473,8 +16448,7 @@
 "nvv" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/machinery/door/poddoor/ship/preopen{
 	id = "slimeblastdoors"
@@ -16642,8 +16616,7 @@
 /area/crew_quarters/heads/hop)
 "nCg" = (
 /obj/structure/fighter_launcher{
-	dir = 1;
-	icon_state = "launcher_map"
+	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/layer1{
 	dir = 4
@@ -16740,6 +16713,9 @@
 	dir = 8
 	},
 /obj/machinery/suit_storage_unit/standard_unit,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/blue,
 /area/bridge)
 "nFV" = (
@@ -16774,7 +16750,7 @@
 /turf/open/floor/plating,
 /area/janitor)
 "nIC" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/machinery/blackbox_recorder,
 /turf/open/floor/carpet/ship,
 /area/ai_monitored/turret_protected/ai)
 "nIF" = (
@@ -16833,14 +16809,19 @@
 /area/maintenance/department/cargo)
 "nLy" = (
 /obj/machinery/modular_computer/console/preset/civilian{
-	dir = 8;
-	icon_state = "console"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
+"nLX" = (
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/department/bridge)
 "nLY" = (
 /obj/machinery/bluespace_beacon,
 /obj/structure/cable{
@@ -16987,7 +16968,6 @@
 "nRP" = (
 /obj/machinery/conveyor/auto{
 	dir = 5;
-	icon_state = "conveyor_map";
 	id = "disposal-conveyor"
 	},
 /turf/open/floor/plating,
@@ -17198,6 +17178,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "nXp" = (
@@ -17216,8 +17199,7 @@
 /area/crew_quarters/dorms)
 "nYN" = (
 /obj/machinery/computer/cargo{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/carpet/orange,
@@ -17251,8 +17233,7 @@
 /area/maintenance/fore)
 "nZu" = (
 /obj/machinery/modular_computer/console/preset/command{
-	dir = 4;
-	icon_state = "console"
+	dir = 4
 	},
 /obj/structure/cable,
 /turf/open/floor/carpet/ship/blue{
@@ -17461,16 +17442,13 @@
 /area/maintenance/department/science/xenobiology)
 "oos" = (
 /obj/structure/window/plasma/reinforced{
-	dir = 4;
-	icon_state = "plasmarwindow"
+	dir = 4
 	},
 /obj/structure/window/plasma/reinforced{
-	dir = 8;
-	icon_state = "plasmarwindow"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/oxygen_input{
 	dir = 8;
@@ -17482,8 +17460,7 @@
 	dir = 4
 	},
 /obj/structure/window/plasma/reinforced{
-	dir = 1;
-	icon_state = "plasmarwindow"
+	dir = 1
 	},
 /turf/open/floor/engine/o2,
 /area/maintenance/fore)
@@ -17498,11 +17475,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
-/obj/structure/curtain,
 /obj/machinery/shower{
-	dir = 4
+	dir = 4;
+	layer = 3.5
 	},
-/obj/item/soap/nanotrasen,
+/obj/structure/curtain,
+/obj/item/soap/deluxe,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/auxiliary)
 "ooU" = (
@@ -17681,11 +17659,11 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "ovW" = (
-/obj/structure/curtain,
 /obj/machinery/shower{
-	dir = 8
+	dir = 8;
+	layer = 3.5
 	},
-/obj/item/soap/nanotrasen,
+/obj/structure/curtain,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "owl" = (
@@ -17777,8 +17755,7 @@
 	desc = "Looks like this used to be a drone dispenser a long time ago"
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 4;
-	icon_state = "warningline"
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/science/robotics/lab)
@@ -17814,8 +17791,7 @@
 /area/space/nearstation)
 "oCi" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 8;
-	icon_state = "connector_map-2"
+	dir = 8
 	},
 /turf/closed/wall/r_wall/ship,
 /area/nsv/weapons/fore)
@@ -18068,6 +18044,12 @@
 /obj/item/clothing/glasses/sunglasses/advanced,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"oMa" = (
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/closed/wall/r_wall/ship,
+/area/crew_quarters/heads/captain/private)
 "oMg" = (
 /obj/structure/toilet,
 /obj/structure/disposalpipe/trunk,
@@ -18112,8 +18094,7 @@
 /area/quartermaster/storage)
 "oOV" = (
 /obj/machinery/disposal/deliveryChute{
-	dir = 4;
-	icon_state = "intake"
+	dir = 4
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -18231,8 +18212,7 @@
 /area/bridge/meeting_room)
 "oVG" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 4;
-	icon_state = "warningline"
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -18559,6 +18539,9 @@
 "pgj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -18798,12 +18781,10 @@
 /area/science/lab)
 "ppU" = (
 /obj/structure/window/plasma/reinforced{
-	dir = 4;
-	icon_state = "plasmarwindow"
+	dir = 4
 	},
 /obj/structure/window/plasma/reinforced{
-	dir = 8;
-	icon_state = "plasmarwindow"
+	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1,
@@ -19074,8 +19055,7 @@
 /obj/structure/closet/radiation,
 /obj/item/clothing/mask/gas,
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
@@ -19104,8 +19084,7 @@
 /area/maintenance/department/cargo)
 "pBg" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 8;
-	icon_state = "connector_map-2"
+	dir = 8
 	},
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
@@ -19231,7 +19210,6 @@
 	external_pressure_bound = 120;
 	name = "server vent"
 	},
-/obj/machinery/blackbox_recorder,
 /turf/open/floor/circuit,
 /area/science/server)
 "pFP" = (
@@ -19310,6 +19288,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/item/pet_carrier,
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -19745,12 +19724,10 @@
 /area/maintenance/department/science/xenobiology)
 "qdk" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 10;
-	icon_state = "warningline"
+	dir = 10
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4;
-	icon_state = "warninglinecorner"
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -20055,8 +20032,7 @@
 	})
 "qpG" = (
 /obj/machinery/modular_computer/console/preset/civilian{
-	dir = 4;
-	icon_state = "console"
+	dir = 4
 	},
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/wood,
@@ -20087,8 +20063,7 @@
 /area/maintenance/department/cargo)
 "qru" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 8;
-	icon_state = "connector_map-2"
+	dir = 8
 	},
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/fore)
@@ -20102,8 +20077,7 @@
 /area/crew_quarters/dorms)
 "qrE" = (
 /obj/machinery/computer/scan_consolenew{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
@@ -20116,6 +20090,9 @@
 /area/quartermaster/warehouse)
 "qsp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "qsN" = (
@@ -20140,6 +20117,10 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "qur" = (
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "quw" = (
@@ -20397,8 +20378,7 @@
 	})
 "qCO" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 4;
-	icon_state = "warningline"
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/nsv/hanger)
@@ -20507,6 +20487,9 @@
 /area/crew_quarters/heads/hop)
 "qLS" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "qmshutter"
+	},
 /turf/open/floor/plating,
 /area/quartermaster/qm)
 "qMw" = (
@@ -20529,12 +20512,10 @@
 /area/maintenance/department/science/xenobiology)
 "qNv" = (
 /obj/structure/window/plasma/reinforced{
-	dir = 4;
-	icon_state = "plasmarwindow"
+	dir = 4
 	},
 /obj/structure/window/plasma/reinforced{
-	dir = 8;
-	icon_state = "plasmarwindow"
+	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/air_sensor/atmos/air_tank{
@@ -20563,8 +20544,7 @@
 /area/maintenance/department/science/central)
 "qPe" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -20732,8 +20712,7 @@
 /obj/structure/table/glass,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/item/clothing/ears/earmuffs,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -20796,6 +20775,12 @@
 	name = "nanoweave carpet (bluer)"
 	},
 /area/teleporter)
+"qVT" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/closed/wall/r_wall/ship,
+/area/bridge)
 "qWr" = (
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
@@ -20897,10 +20882,11 @@
 	},
 /area/bridge/meeting_room)
 "qYU" = (
-/obj/structure/curtain,
 /obj/machinery/shower{
-	dir = 4
+	dir = 4;
+	layer = 3.5
 	},
+/obj/structure/curtain,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "qZi" = (
@@ -21280,11 +21266,12 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable,
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	id = "courtroom_shutter"
-	},
 /obj/structure/sign/solgov_seal,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "courtroom_shutter"
+	},
 /turf/open/floor/plating,
 /area/bridge/meeting_room/council)
 "rno" = (
@@ -21429,8 +21416,7 @@
 /area/science/server)
 "rwe" = (
 /obj/effect/turf_decal/stripes/end{
-	dir = 8;
-	icon_state = "warn_end"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -21606,6 +21592,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -21638,8 +21627,7 @@
 /area/bridge/meeting_room)
 "rGV" = (
 /obj/machinery/modular_computer/console/preset/civilian{
-	dir = 4;
-	icon_state = "console"
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -21781,8 +21769,12 @@
 /area/science/lab)
 "rKr" = (
 /obj/machinery/computer/cargo{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "qmshutter";
+	name = "Quartermaster Shutters";
+	pixel_x = -26
 	},
 /turf/open/floor/carpet/ship,
 /area/quartermaster/qm)
@@ -21865,12 +21857,14 @@
 	pixel_y = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/item/clothing/ears/earmuffs,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
+	},
+/obj/structure/cable/white{
+	icon_state = "1-8"
 	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
@@ -21941,8 +21935,7 @@
 	})
 "rPR" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/structure/displaycase/trophy,
 /turf/open/floor/wood,
@@ -21976,8 +21969,7 @@
 	pixel_x = 32
 	},
 /obj/machinery/computer/secure_data{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /obj/machinery/light{
 	dir = 4
@@ -22295,6 +22287,12 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/bridge/meeting_room/council)
+"sba" = (
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/closed/wall/ship,
+/area/maintenance/department/bridge)
 "sbm" = (
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
@@ -22467,8 +22465,7 @@
 /area/medical/genetics)
 "shB" = (
 /obj/machinery/computer/bounty{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /obj/machinery/requests_console{
 	department = "Cargo Bay";
@@ -22510,6 +22507,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"skH" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/ship/blue{
+	color = "#9999DD";
+	name = "nanoweave carpet (bluer)"
+	},
+/area/bridge)
 "skI" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -22870,6 +22876,9 @@
 	pixel_y = 4
 	},
 /obj/item/encryptionkey/atc,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "sxX" = (
@@ -23380,8 +23389,7 @@
 "sUM" = (
 /obj/effect/decal/cleanable/ash,
 /obj/effect/turf_decal/stripes/line{
-	dir = 4;
-	icon_state = "warningline"
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/science/robotics/lab)
@@ -23622,8 +23630,7 @@
 /area/nsv/weapons/fore)
 "thf" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped{
-	dir = 4;
-	icon_state = "filter_off_f"
+	dir = 4
 	},
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/carpet/ship/purple_carpet,
@@ -23767,10 +23774,10 @@
 	name = "Launch tubes 1 and 2"
 	})
 "toW" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -23891,8 +23898,7 @@
 /area/security/checkpoint/supply)
 "ttp" = (
 /obj/machinery/computer/cargo/request{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -24113,13 +24119,12 @@
 /area/crew_quarters/heads/captain)
 "tBl" = (
 /obj/machinery/computer/apc_control{
-	dir = 4;
-	icon_state = "computer"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+	dir = 4
 	},
 /obj/machinery/light_switch/west,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -24166,8 +24171,7 @@
 /area/bridge/meeting_room)
 "tCP" = (
 /obj/structure/window/plasma/reinforced{
-	dir = 1;
-	icon_state = "plasmarwindow"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 5
@@ -24297,8 +24301,7 @@
 /area/maintenance/department/science/xenobiology)
 "tJZ" = (
 /obj/effect/turf_decal/loading_area{
-	dir = 1;
-	icon_state = "loadingarea"
+	dir = 1
 	},
 /turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
@@ -24330,9 +24333,9 @@
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/department/science/central)
 "tKH" = (
-/obj/machinery/squad_vendor,
-/turf/closed/wall/ship,
-/area/shuttle/turbolift/primary)
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/carpet/ship,
+/area/quartermaster/qm)
 "tKZ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -24659,7 +24662,10 @@
 	dir = 6
 	},
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
@@ -24843,11 +24849,12 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
 "ucr" = (
-/obj/structure/curtain,
-/obj/machinery/shower{
-	dir = 4
-	},
 /obj/machinery/airalarm/directional/west,
+/obj/machinery/shower{
+	dir = 4;
+	layer = 3.5
+	},
+/obj/structure/curtain,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "udo" = (
@@ -25068,6 +25075,12 @@
 	},
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/lab)
+"ulC" = (
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "ume" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /turf/open/floor/carpet/ship/purple_carpet,
@@ -25250,8 +25263,7 @@
 /area/maintenance/fore)
 "usF" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	icon_state = "pump_map-2"
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/binary/pump/layer1{
 	dir = 4
@@ -25413,6 +25425,9 @@
 /obj/machinery/door/airlock/ship/external/glass{
 	name = "External Access Deck 1 Fore";
 	req_one_access_txt = "19"
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
@@ -25631,18 +25646,17 @@
 /area/security/checkpoint/science/research)
 "uKq" = (
 /obj/machinery/modular_computer/console/preset/civilian{
-	dir = 8;
-	icon_state = "console"
+	dir = 8
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
@@ -25790,12 +25804,10 @@
 /area/security/checkpoint/science/research)
 "uQA" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 6;
-	icon_state = "warningline"
+	dir = 6
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1;
-	icon_state = "warninglinecorner"
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
@@ -26260,8 +26272,7 @@
 /area/quartermaster/miningoffice)
 "vnA" = (
 /obj/effect/turf_decal/loading_area{
-	dir = 1;
-	icon_state = "loadingarea"
+	dir = 1
 	},
 /obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/carpet/ship,
@@ -26318,12 +26329,10 @@
 "vsq" = (
 /obj/structure/window/plasma/reinforced,
 /obj/structure/window/plasma/reinforced{
-	dir = 4;
-	icon_state = "plasmarwindow"
+	dir = 4
 	},
 /obj/structure/window/plasma/reinforced{
-	dir = 8;
-	icon_state = "plasmarwindow"
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/atmos/air_output{
 	id_tag = "air_out_alt"
@@ -26459,12 +26468,10 @@
 /area/bridge/meeting_room/council)
 "vwZ" = (
 /obj/structure/window/plasma/reinforced{
-	dir = 4;
-	icon_state = "plasmarwindow"
+	dir = 4
 	},
 /obj/structure/window/plasma/reinforced{
-	dir = 8;
-	icon_state = "plasmarwindow"
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/air_input{
 	dir = 8;
@@ -26473,8 +26480,7 @@
 	piping_layer = 1
 	},
 /obj/structure/window/plasma/reinforced{
-	dir = 1;
-	icon_state = "plasmarwindow"
+	dir = 1
 	},
 /turf/open/floor/engine/air,
 /area/maintenance/fore)
@@ -26528,11 +26534,11 @@
 	},
 /area/bridge)
 "vAr" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/structure/cable/white{
+	icon_state = "1-4"
 	},
-/turf/closed/wall/r_wall/ship,
-/area/bridge)
+/turf/open/floor/engine,
+/area/nsv/weapons/fore)
 "vAx" = (
 /obj/machinery/door/poddoor/ship{
 	id = "launchbay_tube1";
@@ -26863,10 +26869,9 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/structure/cable/white{
+	icon_state = "1-4"
 	},
-/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "vKc" = (
@@ -27315,8 +27320,7 @@
 	pixel_x = -4
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/item/reagent_containers/glass/beaker{
 	pixel_x = -5;
@@ -27397,6 +27401,9 @@
 	pixel_x = -6;
 	pixel_y = -6;
 	target_layer = 1
+	},
+/obj/structure/cable/white{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
@@ -27665,8 +27672,7 @@
 /area/nsv/weapons/fore)
 "wqO" = (
 /obj/structure/window/plasma/reinforced{
-	dir = 1;
-	icon_state = "plasmarwindow"
+	dir = 1
 	},
 /obj/machinery/atmospherics/components/binary/pump,
 /turf/open/floor/engine,
@@ -27686,8 +27692,7 @@
 /area/quartermaster/office)
 "wsy" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 10;
-	icon_state = "warningline"
+	dir = 10
 	},
 /obj/structure/reagent_dispensers/foamtank/hull_repair_juice,
 /obj/item/extinguisher/advanced/hull_repair_juice,
@@ -27803,6 +27808,9 @@
 	dir = 1;
 	pixel_y = 1
 	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/blue,
 /area/bridge)
 "wys" = (
@@ -27875,13 +27883,14 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "wBU" = (
-/obj/structure/curtain,
-/obj/machinery/shower{
-	dir = 8
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/shower{
+	dir = 8;
+	layer = 3.5
+	},
+/obj/structure/curtain,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "wBW" = (
@@ -27946,6 +27955,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/airlock/ship/public{
+	name = "Shower"
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/auxiliary)
@@ -28293,16 +28307,14 @@
 /area/crew_quarters/dorms)
 "wSk" = (
 /obj/machinery/computer/ship/helm{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /obj/structure/window/reinforced{
 	dir = 1;
 	pixel_y = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
@@ -28315,6 +28327,9 @@
 /area/maintenance/fore)
 "wSB" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "qmshutter"
+	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "wSM" = (
@@ -28399,9 +28414,11 @@
 /turf/open/floor/carpet/ship,
 /area/quartermaster/office)
 "wUl" = (
-/obj/machinery/squad_vendor,
-/turf/closed/wall/ship,
-/area/shuttle/turbolift/secondary)
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
+/turf/open/floor/engine,
+/area/nsv/weapons/fore)
 "wUp" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -28798,8 +28815,7 @@
 /area/quartermaster/storage)
 "xpd" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 6;
-	icon_state = "warningline"
+	dir = 6
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -28836,13 +28852,14 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "xpP" = (
-/obj/structure/curtain,
-/obj/machinery/shower{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/shower{
+	dir = 4;
+	layer = 3.5
+	},
+/obj/structure/curtain,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "xqV" = (
@@ -29004,8 +29021,7 @@
 /area/maintenance/fore)
 "xyI" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6;
-	icon_state = "pipe11-2"
+	dir = 6
 	},
 /turf/open/floor/circuit,
 /area/science/server)
@@ -29513,6 +29529,9 @@
 	pixel_x = -7
 	},
 /obj/structure/table/glass,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -29703,8 +29722,7 @@
 /area/crew_quarters/heads/captain)
 "ybo" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 6;
-	icon_state = "warningline"
+	dir = 6
 	},
 /turf/open/floor/plating,
 /area/nsv/hanger)
@@ -29772,8 +29790,7 @@
 	pixel_y = 4
 	},
 /obj/machinery/modular_computer/console/preset/command{
-	dir = 4;
-	icon_state = "console"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -29866,7 +29883,6 @@
 "yiU" = (
 /obj/machinery/conveyor/auto{
 	dir = 1;
-	icon_state = "conveyor_map";
 	id = "disposal-conveyor"
 	},
 /turf/open/floor/plating,
@@ -29910,12 +29926,13 @@
 	pixel_y = 8
 	},
 /obj/item/paint/paint_remover,
+/obj/machinery/newscaster/directional/east,
+/obj/item/soap/deluxe,
+/obj/item/mop,
 /obj/item/reagent_containers/glass/bucket{
 	pixel_x = 5;
 	pixel_y = 5
 	},
-/obj/item/mop,
-/obj/machinery/newscaster/directional/east,
 /turf/open/floor/carpet/ship,
 /area/janitor)
 "ykX" = (
@@ -42898,10 +42915,10 @@ nZT
 nZT
 agZ
 agZ
-dqX
+tlV
 agZ
 agZ
-dqX
+tlV
 nZT
 nZT
 nZT
@@ -42909,10 +42926,10 @@ nZT
 nZT
 agZ
 agZ
-dqX
+tlV
 agZ
 agZ
-dqX
+tlV
 nZT
 nZT
 nZT
@@ -44944,7 +44961,7 @@ nZT
 nZT
 nZT
 nZT
-nZT
+dqX
 oAO
 aee
 sdP
@@ -45010,7 +45027,7 @@ iMh
 sdP
 aee
 mpX
-nZT
+dqX
 nZT
 nZT
 nZT
@@ -45715,7 +45732,7 @@ nZT
 nZT
 nZT
 nZT
-nZT
+dqX
 oAO
 aee
 hvg
@@ -45781,7 +45798,7 @@ fCZ
 fMW
 aee
 mpX
-nZT
+dqX
 nZT
 nZT
 nZT
@@ -46486,7 +46503,7 @@ nZT
 nZT
 nZT
 nZT
-nZT
+dqX
 oAO
 aee
 sdP
@@ -46552,7 +46569,7 @@ iMh
 sdP
 aee
 mpX
-nZT
+dqX
 nZT
 nZT
 nZT
@@ -47257,7 +47274,7 @@ nZT
 nZT
 nZT
 nZT
-nZT
+dqX
 oAO
 aee
 aee
@@ -47323,7 +47340,7 @@ iMh
 aee
 aee
 mpX
-nZT
+dqX
 nZT
 nZT
 nZT
@@ -48028,7 +48045,7 @@ nZT
 nZT
 nZT
 nZT
-nZT
+dqX
 oAO
 aee
 aee
@@ -48094,7 +48111,7 @@ iMh
 aee
 aee
 mpX
-nZT
+dqX
 nZT
 nZT
 nZT
@@ -48799,7 +48816,7 @@ nZT
 nZT
 nZT
 nZT
-nZT
+dqX
 oAO
 aee
 owl
@@ -48865,7 +48882,7 @@ iMh
 aee
 aee
 mpX
-nZT
+dqX
 nZT
 nZT
 nZT
@@ -49570,7 +49587,7 @@ nZT
 nZT
 nZT
 nZT
-nZT
+dqX
 oAO
 aee
 aee
@@ -49636,7 +49653,7 @@ oXb
 aee
 aee
 mpX
-nZT
+dqX
 nZT
 nZT
 nZT
@@ -50109,7 +50126,7 @@ xWZ
 wBU
 ovW
 cvL
-cvL
+ovW
 kJw
 uvn
 uvn
@@ -50341,7 +50358,7 @@ nZT
 nZT
 nZT
 nZT
-nZT
+dqX
 oAO
 aee
 aee
@@ -50407,7 +50424,7 @@ iMh
 aee
 aee
 mpX
-nZT
+dqX
 nZT
 nZT
 nZT
@@ -50599,7 +50616,7 @@ nZT
 nZT
 nZT
 nZT
-nZT
+dqX
 oAO
 aee
 kJw
@@ -50663,7 +50680,7 @@ tZs
 iMh
 aee
 mpX
-nZT
+dqX
 nZT
 nZT
 nZT
@@ -51370,7 +51387,7 @@ nZT
 nZT
 nZT
 nZT
-nZT
+dqX
 oAO
 aee
 kJw
@@ -51434,7 +51451,7 @@ fgg
 fgg
 fgg
 mpX
-nZT
+dqX
 nZT
 nZT
 nZT
@@ -52141,7 +52158,7 @@ nZT
 nZT
 nZT
 nZT
-nZT
+dqX
 oAO
 owl
 veo
@@ -52205,7 +52222,7 @@ qAw
 fgg
 uDg
 mpX
-nZT
+dqX
 nZT
 nZT
 nZT
@@ -52912,7 +52929,7 @@ nZT
 nZT
 nZT
 nZT
-nZT
+dqX
 oAO
 aee
 hla
@@ -52976,7 +52993,7 @@ cfH
 fgg
 aee
 mpX
-nZT
+dqX
 nZT
 nZT
 nZT
@@ -59376,7 +59393,7 @@ egj
 egj
 egj
 ewr
-eMQ
+qJR
 bmY
 nsQ
 wZS
@@ -60626,7 +60643,7 @@ hbT
 qLS
 ldc
 joM
-diA
+lVB
 szw
 sVk
 nUD
@@ -61141,7 +61158,7 @@ hbT
 nZT
 son
 gLU
-diA
+tKH
 hBU
 aCe
 sua
@@ -64220,7 +64237,7 @@ nZT
 nZT
 nZT
 nZT
-nZT
+dqX
 oAO
 mDy
 mzQ
@@ -64250,11 +64267,11 @@ meH
 jHL
 jHL
 jHL
-tKH
-vuP
+jHL
+icy
 vHm
 fjc
-wUl
+eoy
 eoy
 eoy
 eoy
@@ -64284,7 +64301,7 @@ frq
 qhB
 aee
 mpX
-nZT
+dqX
 nZT
 nZT
 nZT
@@ -64991,7 +65008,7 @@ nZT
 nZT
 nZT
 nZT
-nZT
+dqX
 reV
 mgr
 mgr
@@ -65055,7 +65072,7 @@ nhj
 qhB
 aee
 mpX
-nZT
+dqX
 nZT
 nZT
 nZT
@@ -65762,7 +65779,7 @@ nZT
 nZT
 nZT
 nZT
-nZT
+dqX
 oAO
 jXx
 sBq
@@ -65826,7 +65843,7 @@ oVJ
 xMP
 aee
 mpX
-nZT
+dqX
 nZT
 nZT
 nZT
@@ -66533,7 +66550,7 @@ nZT
 nZT
 nZT
 nZT
-nZT
+dqX
 oAO
 owl
 wNh
@@ -66597,7 +66614,7 @@ oVJ
 xMP
 aee
 mpX
-nZT
+dqX
 nZT
 nZT
 nZT
@@ -67304,7 +67321,7 @@ nZT
 nZT
 nZT
 nZT
-nZT
+dqX
 oAO
 aee
 wNh
@@ -67368,7 +67385,7 @@ uvI
 xMP
 aee
 mpX
-nZT
+dqX
 nZT
 nZT
 nZT
@@ -68075,7 +68092,7 @@ nZT
 nZT
 nZT
 nZT
-nZT
+dqX
 oAO
 aee
 hbT
@@ -68139,7 +68156,7 @@ xMP
 hbT
 aee
 mpX
-nZT
+dqX
 nZT
 nZT
 nZT
@@ -68846,7 +68863,7 @@ nZT
 nZT
 nZT
 nZT
-nZT
+dqX
 oAO
 aee
 hvg
@@ -68910,7 +68927,7 @@ tlN
 fMW
 aee
 mpX
-nZT
+dqX
 nZT
 nZT
 nZT
@@ -69617,7 +69634,7 @@ nZT
 nZT
 nZT
 nZT
-nZT
+dqX
 oAO
 aee
 hbT
@@ -69681,7 +69698,7 @@ uxC
 hbT
 aee
 mpX
-nZT
+dqX
 nZT
 nZT
 nZT
@@ -70388,7 +70405,7 @@ nZT
 nZT
 nZT
 nZT
-nZT
+dqX
 oAO
 aee
 hbT
@@ -70452,7 +70469,7 @@ uxC
 hbT
 aee
 mpX
-nZT
+dqX
 nZT
 nZT
 nZT
@@ -71159,7 +71176,7 @@ nZT
 nZT
 nZT
 nZT
-nZT
+dqX
 oAO
 aee
 hbT
@@ -71223,7 +71240,7 @@ uxC
 hbT
 aee
 mpX
-nZT
+dqX
 nZT
 nZT
 nZT
@@ -71444,8 +71461,8 @@ oYb
 bVG
 bVG
 bVG
+qVT
 bVG
-vAr
 sVW
 bVG
 bVG
@@ -71957,7 +71974,7 @@ sRS
 qur
 egQ
 aMe
-vAq
+oEO
 jGs
 toW
 lpW
@@ -72197,9 +72214,9 @@ aIV
 xxZ
 uep
 neY
-lVB
-fQY
 aIV
+fQY
+vAr
 byo
 aIV
 pqG
@@ -72209,14 +72226,14 @@ mHQ
 dbe
 dbe
 hqO
-wBL
+dbe
 bXx
 tXj
 cvr
 rNh
 luj
 fnM
-oEO
+skH
 csG
 vAq
 vAq
@@ -72456,18 +72473,18 @@ uHX
 oAM
 xiw
 mUo
-aIV
+wUl
 ele
-aIV
-xxZ
-vJA
-hIh
+fzt
+ifd
+dvP
+oMa
 nmy
-wBL
+ulC
 qsp
 nXi
 sxI
-sRS
+sba
 vKa
 egQ
 ghx
@@ -73240,7 +73257,7 @@ qqk
 xxV
 sRS
 jYl
-egQ
+nLX
 xSx
 moF
 rEp

--- a/_maps/map_files/Aetherwhisp/Aetherwhisp2.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp2.dmm
@@ -9156,7 +9156,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/airlock/ship/public,
+/obj/machinery/door/airlock/ship/public{
+	name = "Unnamed Airlock"
+	},
 /turf/open/floor/carpet/ship,
 /area/maintenance/department/science/xenobiology)
 "hbT" = (

--- a/_maps/map_files/Aetherwhisp/Aetherwhisp2.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp2.dmm
@@ -530,6 +530,7 @@
 	name = "External Access Deck 1 Fore Port";
 	req_one_access_txt = "72"
 	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
@@ -641,6 +642,10 @@
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "ayK" = (
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
@@ -1016,6 +1021,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
+/obj/machinery/vending/coffee,
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -1776,9 +1782,6 @@
 /turf/open/floor/carpet/ship,
 /area/quartermaster/miningoffice)
 "bpU" = (
-/obj/structure/disposalpipe/junction/flip{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -1790,6 +1793,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
@@ -1990,7 +1996,12 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "bvI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
 /turf/open/floor/engine,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
@@ -2752,6 +2763,14 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/atmospherics/components/binary/pump/layer1{
+	dir = 4;
+	on = 1;
+	target_pressure = 2000
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
@@ -3339,8 +3358,8 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "cuz" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/engine,
 /area/nsv/weapons/port{
 	name = "Weapons Storage"
@@ -3395,11 +3414,10 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "cvP" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
 /obj/item/radio/intercom/directional/east,
+/obj/machinery/computer/communications{
+	dir = 8
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "cww" = (
@@ -4218,6 +4236,13 @@
 	name = "nanoweave carpet (puce)"
 	},
 /area/nsv/weapons/fore)
+"deF" = (
+/obj/structure/munitions_trolley,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/engine,
+/area/nsv/weapons/port{
+	name = "Weapons Storage"
+	})
 "deP" = (
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
@@ -4498,6 +4523,10 @@
 "dqX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
+	},
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
@@ -5981,11 +6010,11 @@
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/crew_quarters/heads/hor)
 "eET" = (
-/obj/machinery/modular_computer/console/preset/command{
-	dir = 8
-	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
+	},
+/obj/machinery/computer/ship/dradis{
+	dir = 8
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
@@ -6126,9 +6155,6 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
 	},
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
@@ -9455,7 +9481,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "hpA" = (
@@ -10440,10 +10468,6 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/closet/secure_closet/puce{
-	name = "random puce event";
-	opened = 1
-	},
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/item/radio/headset/heads/captain/alt{
 	desc = "A special headset that protects ears from some loud noises.";
@@ -10451,6 +10475,10 @@
 	name = "noise cancelling headphones"
 	},
 /obj/item/clothing/head/soft/yellow,
+/obj/structure/closet/secure_closet/puce{
+	name = "random puce event";
+	req_access = null
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "igo" = (
@@ -12868,18 +12896,12 @@
 	},
 /area/ai_monitored/turret_protected/aisat_interior)
 "kgC" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/modular_computer/console/preset/command{
-	dir = 8
-	},
-/obj/item/paper{
-	info = "<p>Executive Officer notice: Modular computers are currently experiencing technical difficulties regarding their ID modification hardware. The 'identification card authentication module' supports 2 ID slots, and was previously paired with the 'ID Card Modification' program that also supported 2 IDs. There was recently a software update that removed the need to insert your own ID to authenticate and log in. However, it did not update the hardware, nor does it allow you to remove an ID from the authentication slot anymore.<br><br>To edit IDs with a modular computer without losing your ID, insert the target's ID but NEVER insert your own ID. You will still be able to log in if you are wearing it. Make sure you never put more than 1 ID in the modular computer.<br><br>If you do accidentally lose your own ID and getting a new one without your XO access is borderline impossible, contact Central Command. Politely ask them to remote into the console, then run subroutine '/proc/eject_id'<br><br>Have a secure shift</p>";
-	pixel_x = 4;
-	pixel_y = 4
-	},
 /obj/machinery/airalarm/directional/east,
 /obj/structure/cable/white{
 	icon_state = "0-8"
+	},
+/obj/machinery/modular_computer/console/preset/engineering{
+	dir = 8
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
@@ -13673,6 +13695,15 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
+"kTd" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/nsv/weapons/port{
+	name = "Weapons Storage"
+	})
 "kTT" = (
 /obj/structure/chair{
 	dir = 4
@@ -14392,7 +14423,6 @@
 	},
 /area/teleporter)
 "lDA" = (
-/obj/machinery/power/apc/auto_name/west,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -14405,7 +14435,6 @@
 /obj/machinery/atmospherics/pipe/manifold/purple/hidden{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
@@ -15759,6 +15788,15 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
+"mBe" = (
+/obj/machinery/modular_computer/console/preset/civilian{
+	dir = 1
+	},
+/turf/open/floor/carpet/ship/blue{
+	color = "#9999DD";
+	name = "nanoweave carpet (bluer)"
+	},
+/area/bridge)
 "mBY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -19872,6 +19910,17 @@
 "pNi" = (
 /turf/open/floor/carpet/orange,
 /area/quartermaster/warehouse)
+"pNQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/nsv/weapons/port{
+	name = "Weapons Storage"
+	})
 "pOo" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/atmospherics/components/unary/portables_connector/layer3{
@@ -20236,6 +20285,9 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
@@ -21587,11 +21639,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "rgf" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/light_switch/east,
-/obj/machinery/computer/communications{
-	dir = 8
-	},
 /obj/machinery/button/door{
 	desc = "A remote control switch for the captain's front door.";
 	id = "CaptainFoyer";
@@ -21602,6 +21650,14 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/machinery/modular_computer/console/preset/command{
+	dir = 8
+	},
+/obj/item/paper{
+	info = "<p>Executive Officer notice: Modular computers are currently experiencing technical difficulties regarding their ID modification hardware. The 'identification card authentication module' supports 2 ID slots, and was previously paired with the 'ID Card Modification' program that also supported 2 IDs. There was recently a software update that removed the need to insert your own ID to authenticate and log in. However, it did not update the hardware, nor does it allow you to remove an ID from the authentication slot anymore.<br><br>To edit IDs with a modular computer without losing your ID, insert the target's ID but NEVER insert your own ID. You will still be able to log in if you are wearing it. Make sure you never put more than 1 ID in the modular computer.<br><br>If you do accidentally lose your own ID and getting a new one without your XO access is borderline impossible, contact Central Command. Politely ask them to remote into the console, then run subroutine '/proc/eject_id'<br><br>Have a secure shift</p>";
+	pixel_x = 4;
+	pixel_y = 4
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
@@ -24050,6 +24106,17 @@
 	},
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/science/xenobiology)
+"sZs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/nsv/weapons/port{
+	name = "Weapons Storage"
+	})
 "sZC" = (
 /obj/machinery/atmospherics/pipe/manifold/purple/hidden{
 	dir = 4
@@ -25621,10 +25688,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/twohanded/required/kirbyplants/random,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
+/obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "unh" = (
@@ -26759,6 +26826,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/ship,
 /area/maintenance/department/cargo)
+"vlD" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "vlP" = (
 /obj/structure/closet/radiation,
 /obj/item/clothing/mask/gas,
@@ -69328,7 +69402,7 @@ oAO
 owl
 wjT
 hWj
-nNJ
+pNQ
 cAg
 wjT
 lDM
@@ -69584,8 +69658,8 @@ sdP
 oAO
 owl
 wjT
-hWj
-nNJ
+deF
+kTd
 cAg
 wjT
 sdb
@@ -69842,7 +69916,7 @@ oAO
 owl
 wjT
 nNJ
-nNJ
+pNQ
 cAg
 wjT
 lJg
@@ -70356,7 +70430,7 @@ oAO
 aee
 asv
 ayK
-ayK
+sZs
 cHv
 wjT
 ila
@@ -73473,7 +73547,7 @@ xJO
 fum
 vix
 oEO
-oEO
+mBe
 bVG
 sWO
 xMP
@@ -73710,7 +73784,7 @@ fDk
 fDk
 rQB
 fDk
-wBL
+vlD
 wqW
 wBL
 hdn

--- a/_maps/map_files/Aetherwhisp/job_changes.dm
+++ b/_maps/map_files/Aetherwhisp/job_changes.dm
@@ -1,4 +1,4 @@
-/datum/job/munitions_technician/New()
+/datum/job/munitions_tech/New()
 	..()
 	MAP_JOB_CHECK
 	total_positions = 1

--- a/_maps/map_files/Aetherwhisp/job_changes.dm
+++ b/_maps/map_files/Aetherwhisp/job_changes.dm
@@ -1,0 +1,7 @@
+/datum/job/munitions_technician/New()
+	..()
+	MAP_JOB_CHECK
+	total_positions = 1
+	spawn_positions = 1
+
+#undef JOB_MODIFICATION_MAP_NAME

--- a/code/modules/jobs/map_changes/map_changes.dm
+++ b/code/modules/jobs/map_changes/map_changes.dm
@@ -5,3 +5,6 @@
 
 #define JOB_MODIFICATION_MAP_NAME "NSV Jeppison"
 #include "..\..\..\..\_maps\map_files\Jeppison\job_changes.dm"
+
+#define JOB_MODIFICATION_MAP_NAME "SGV Aetherwhisp"
+#include "..\..\..\..\_maps\map_files\Aetherwhisp\job_changes.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

Get ready for a bucketload of fixes! 

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

- Reduce carp spawns, compare with other ships and match their frequency. And space them out more, so they can potentially be avoided sometimes
- Telecomms needs more than one server 
- Munitions techs spawned on rocci mining ship 
- Access mismatch in munitions storage, airlocks
- Master at arms locker, ATC, munitions tech, fighter pilot and fighter leader lockers, add current contents into it 
- Check flight leader has a suit storage unit 
- Master at arms add bomb disposal locker 
- Safe has a max capacity and there's 2 too many in the vault 
- Remove badminka in captains office, that should be in the vault 
-  Check that all fighters are prebuilt
- Add more viewscreens in various departments where they're lacking 
- Cargo elevator is very broken and causes injury from falling. Try remaking that elevator to see if that fixes it 
- Too many complaints about carpet that looks like skin. Replace all beige carpet with grey carpet 
- Job slots, reduce munitions tech to 1. 1 tech plus 1 master at arms. It will be up to the XO or captain to determine tech staffing changes
- Move bar jukebox so it's visible to more people 
- Replace bottom deck bathroom with cryostorage, so it's much more centralized than it is currently 
- Remove top deck cryostorage
- Add storage consoles for medical patient rooms, and one in permabrig
- Rearrange councilroom bathroom to have a shower and 3 stalls, to compensate for losing bottom deck bathroom which had a shower
- CE's power control console can only be access by jumping into disposals and getting out, which is mostly an inconvenience.
- the pre-built shuttle below bridge can't be used as the shuttle designator complains it can't use things attached to the station
- and the building probe can't go outside the station so you can't really use it
- Add ladders to 4 armor panels on both decks, to connect them and allow repairing more easily
- Move bridge-to-engineering disposal inlet on the bridge, and add windoors and window protection to both sides
- Add 2 more Seegson overmap viewscreens to engineering
- Add a few stethescopes to the contraband lockers in security. They're only used to break into the vault, make it some effort to get it 
- Add a few more valuable secrets to the vault safe. Add a floor vault
- Add black gloves throughout the ship. One in maintenance, one in tool storage, several in maintenance, and random gloves spawners in personal lockers 
- Add two birthday cake hats
- Move digital valve on stormdrive input so it takes less time to drain. Move the emergency water vapor connector after the digital valve, and replace water vapor with carbon dioxide 
- Move igniter on top of gas sensor to help save space 
- Add munitions wiki book on a table
- There are duplicate atmospheric meters on certain pipes
- Add all-in-one reagents grinder to virology 
- Science break room needs to be science front door access, same with maint airlock
- Move engineering breakroom table to the other side of room, 2 tiles way from left airlock
- Move south engine airlock to be inline with monitoring room
- Expand stormdrive central chamber to 5x5
- Move particle accelerator down 2 tiles 
- Move scrubber loop inside atmospherics to save space, and allow more custom pipe layering
- Add fire alarm to stormdrive core /area 
- Add wikibook for stormdrive, if it exists
- Add gas pump valves to all external airlocks to act as a supply buffer, in case the supply loop is emptied. Set to 2000kpa for ~1-3 pipes-worth of content
- Captain cannot open his desk windoor in the office
- Move motion-sensitve camera in the vault so it isn't accidentally tripped
- Permabrig has wrong library console, "book management console"
- Full telecomms machinery, instead of birdstation variant
- Copy kitchen coldroom layout from Tycoon, seems they've sorted out all the issues
- Botanists able to access sec equipment in their room

Deck 2 top deck 
![deck2](https://user-images.githubusercontent.com/22532898/89708267-a949ce00-d932-11ea-8993-432538a7bdd9.png)

Deck 1 bottom deck 
![deck1](https://user-images.githubusercontent.com/22532898/89708269-ad75eb80-d932-11ea-99e9-63c97ec4997a.png)


## Why It's Good For The Game

<!- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
