### PR TITLE
Fix traitor steal objective by moving Winona to the HoS locker

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -116,6 +116,7 @@
 	new /obj/item/shield/riot/tele(src)
 	new /obj/item/storage/belt/security/full(src)
 	new /obj/item/ammo_box/c9mm/rubber(src)
+	new /obj/item/gun/ballistic/automatic/pistol/glock/command/hos
 	new /obj/item/flashlight/seclite(src)
 	new /obj/item/pinpointer/nuke(src)
 	new /obj/item/circuitboard/machine/techfab/department/security(src)

--- a/code/modules/jobs/job_types/head_of_security.dm
+++ b/code/modules/jobs/job_types/head_of_security.dm
@@ -46,7 +46,6 @@
 	gloves = /obj/item/clothing/gloves/color/black/hos
 	head = /obj/item/clothing/head/HoS/beret
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
-	suit_store = /obj/item/gun/ballistic/automatic/pistol/glock/command/hos
 	r_pocket = /obj/item/assembly/flash/handheld
 	l_pocket = /obj/item/restraints/handcuffs
 	backpack_contents = list(/obj/item/melee/baton/loaded=1, /obj/item/ammo_box/magazine/pistolm9mm/glock, /obj/item/gun/ballistic/tazer,  /obj/item/ammo_box/magazine/tazer_cartridge_storage=1, /obj/item/book/granter/martial/jujitsu, /obj/item/club=1)


### PR DESCRIPTION
Traitors can have the objective to steal the HoS's glock, Winona, but the objective is impossible if nobody has signed up as HoS during the round. This PR moves Winona to the HoS locker so that every traitor with this steal objective has a chance to complete it.

:cl:
tweak: The HoS's glock now spawns in their locker.
/:cl: