### PR TITLE
Jolly Sausage, various engineering-related fixes

### DIFF
--- a/_maps/map_files/jollysausage/todger.dmm
+++ b/_maps/map_files/jollysausage/todger.dmm
@@ -111,7 +111,6 @@
 	dir = 8;
 	dwidth = 3;
 	height = 14;
-	icon_state = "pinonfar";
 	id = "arrivals_stationary";
 	name = "Sausage Arrivals";
 	roundstart_template = /datum/map_template/shuttle/arrival/kilo;
@@ -154,26 +153,22 @@
 /area/ai_monitored/turret_protected/ai)
 "aaG" = (
 /turf/open/floor/plasteel/chapel{
-	dir = 9;
-	icon_state = "chapel"
+	dir = 9
 	},
 /area/chapel/main)
 "aaH" = (
 /turf/open/floor/plasteel/chapel{
-	dir = 5;
-	icon_state = "chapel"
+	dir = 5
 	},
 /area/chapel/main)
 "aaI" = (
 /turf/open/floor/plasteel/chapel{
-	dir = 1;
-	icon_state = "chapel"
+	dir = 1
 	},
 /area/chapel/main)
 "aaJ" = (
 /turf/open/floor/plasteel/chapel{
-	dir = 4;
-	icon_state = "chapel"
+	dir = 4
 	},
 /area/chapel/main)
 "aaK" = (
@@ -223,38 +218,31 @@
 /area/chapel/office)
 "aaT" = (
 /obj/structure/chair/pew/left{
-	dir = 1;
-	icon_state = "pewend_left"
+	dir = 1
 	},
 /turf/open/floor/plasteel/chapel{
-	dir = 10;
-	icon_state = "chapel"
+	dir = 10
 	},
 /area/chapel/main)
 "aaU" = (
 /obj/structure/chair/pew/right{
-	dir = 1;
-	icon_state = "pewend_right"
+	dir = 1
 	},
 /turf/open/floor/plasteel/chapel{
-	dir = 6;
-	icon_state = "chapel"
+	dir = 6
 	},
 /area/chapel/main)
 "aaV" = (
 /obj/structure/chair/pew/left{
-	dir = 1;
-	icon_state = "pewend_left"
+	dir = 1
 	},
 /turf/open/floor/plasteel/chapel{
-	dir = 8;
-	icon_state = "chapel"
+	dir = 8
 	},
 /area/chapel/main)
 "aaW" = (
 /obj/structure/chair/pew/right{
-	dir = 1;
-	icon_state = "pewend_right"
+	dir = 1
 	},
 /turf/open/floor/plasteel/chapel,
 /area/chapel/main)
@@ -330,8 +318,7 @@
 /area/hydroponics)
 "abg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 4;
-	icon_state = "scrub_map_on-1"
+	dir = 4
 	},
 /turf/open/floor/monotile,
 /area/nsv/hanger)
@@ -462,8 +449,7 @@
 /area/maintenance/department/crew_quarters/bar)
 "abE" = (
 /obj/effect/turf_decal/stripes/white/line{
-	dir = 4;
-	icon_state = "warningline_white"
+	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -579,8 +565,7 @@
 /area/nsv/hanger)
 "abV" = (
 /obj/structure/disposalpipe/trunk{
-	dir = 1;
-	icon_state = "pipe-t"
+	dir = 1
 	},
 /obj/machinery/disposal/bin,
 /turf/open/floor/carpet/green,
@@ -597,8 +582,7 @@
 /area/nsv/hanger)
 "abZ" = (
 /obj/effect/turf_decal/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/nsv/hanger)
@@ -615,8 +599,7 @@
 "acc" = (
 /obj/machinery/computer/ship/viewscreen,
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -634,8 +617,7 @@
 /area/nsv/hanger)
 "ace" = (
 /obj/effect/turf_decal/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
+	dir = 8
 	},
 /turf/open/floor/monotile,
 /area/nsv/hanger)
@@ -696,7 +678,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 10;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/keycard_auth{
@@ -810,8 +791,7 @@
 	req_access_txt = "68"
 	},
 /obj/effect/mapping_helpers/airlock/unres{
-	dir = 1;
-	icon_state = "airlock_unres_helper"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -831,8 +811,7 @@
 	req_access_txt = "68"
 	},
 /obj/effect/mapping_helpers/airlock/unres{
-	dir = 1;
-	icon_state = "airlock_unres_helper"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
@@ -856,7 +835,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -866,15 +844,13 @@
 	icon_state = "2-6"
 	},
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/stripes/red/line{
-	dir = 1;
-	icon_state = "warningline_red"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "2-10"
@@ -883,8 +859,7 @@
 /area/tcommsat/computer)
 "acT" = (
 /obj/structure/fighter_launcher{
-	dir = 1;
-	icon_state = "launcher_map"
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger)
@@ -917,8 +892,7 @@
 /area/medical/genetics/cloning)
 "acZ" = (
 /obj/machinery/camera/autoname{
-	dir = 5;
-	icon_state = "camera"
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -926,8 +900,7 @@
 /area/hallway/secondary/entry)
 "adb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 4;
-	icon_state = "scrub_map_on-1"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -958,7 +931,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/effect/landmark/event_spawn,
@@ -970,8 +942,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
@@ -1000,7 +971,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -1030,7 +1000,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/structure/disposalpipe/segment{
@@ -1051,12 +1020,9 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plasteel/chapel{
-	dir = 4;
-	icon_state = "chapel"
+	dir = 4
 	},
 /area/chapel/main)
 "ads" = (
@@ -1087,7 +1053,6 @@
 	},
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 8;
-	icon_state = "pipe-j1s";
 	name = "chief engineer sorting disposal pipe";
 	sortType = 5
 	},
@@ -1095,8 +1060,7 @@
 /area/engine/engineering)
 "adz" = (
 /obj/effect/turf_decal/stripes/white/line{
-	dir = 4;
-	icon_state = "warningline_white"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -1114,12 +1078,10 @@
 /area/hallway/secondary/entry)
 "adA" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/structure/chair,
 /obj/structure/cable{
@@ -1166,8 +1128,7 @@
 	req_access_txt = "61"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1;
-	icon_state = "airlock_cyclelink_helper"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -1175,8 +1136,7 @@
 /area/tcommsat/computer)
 "adI" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -1217,8 +1177,7 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -1226,7 +1185,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/effect/landmark/start/emt,
@@ -1286,8 +1244,7 @@
 "adY" = (
 /obj/machinery/clonepod/prefilled,
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/item/reagent_containers/food/drinks/bottle/synthflesh,
 /turf/open/floor/engine,
@@ -1328,8 +1285,7 @@
 /area/medical/surgery)
 "aef" = (
 /obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
+	dir = 4
 	},
 /obj/structure/window/reinforced,
 /obj/machinery/door/window/eastleft,
@@ -1369,9 +1325,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "ael" = (
@@ -1379,8 +1333,7 @@
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/stripes/red/corner{
-	dir = 1;
-	icon_state = "warninglinecorner_red"
+	dir = 1
 	},
 /obj/machinery/power/apc/auto_name/west{
 	pixel_x = -24
@@ -1423,8 +1376,7 @@
 "aes" = (
 /obj/machinery/dna_scannernew,
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -1493,17 +1445,14 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /obj/machinery/light{
@@ -1532,7 +1481,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/structure/extinguisher_cabinet/south,
@@ -1574,7 +1522,6 @@
 	},
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8;
-	icon_state = "pipe-j2s";
 	name = "chem sorting disposal pipe";
 	sortType = 11
 	},
@@ -1584,7 +1531,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 6;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/carpet/green,
@@ -1672,9 +1618,7 @@
 /obj/structure/cable{
 	icon_state = "0-6"
 	},
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 4
@@ -1714,13 +1658,11 @@
 /area/hallway/primary/aft)
 "aeV" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/machinery/computer/arcade,
 /turf/open/floor/plasteel,
@@ -1776,16 +1718,13 @@
 /area/hallway/primary/fore)
 "afd" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/structure/chair{
-	dir = 4;
-	icon_state = "chair"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -1802,12 +1741,10 @@
 "afg" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/machinery/computer/arcade,
 /turf/open/floor/plasteel,
@@ -1815,7 +1752,6 @@
 "afh" = (
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 4;
-	icon_state = "pipe-j1s";
 	name = "research sorting disposal pipe";
 	sortType = "12;13;14;24;25;28"
 	},
@@ -1855,12 +1791,10 @@
 "afo" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/structure/chair{
-	dir = 8;
-	icon_state = "chair"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -1872,8 +1806,7 @@
 /area/science/robotics/mechbay)
 "afq" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 1;
-	icon_state = "warningline"
+	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/mech_bay_recharge_floor,
@@ -1910,16 +1843,14 @@
 /area/security/warden)
 "afv" = (
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "afw" = (
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -1939,7 +1870,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/requests_console{
@@ -1985,8 +1915,7 @@
 	icon_state = "8-10"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 8;
-	icon_state = "scrub_map_on-1"
+	dir = 8
 	},
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/green{
@@ -2036,16 +1965,14 @@
 "afI" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "afJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer1{
-	dir = 1;
-	icon_state = "dpvent_map-1"
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
@@ -2057,16 +1984,13 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/plasteel,
@@ -2095,19 +2019,16 @@
 /area/nsv/weapons/port)
 "afP" = (
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "afQ" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -2129,15 +2050,13 @@
 "afV" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/structure/disposalpipe/segment{
@@ -2151,8 +2070,7 @@
 	icon_state = "5-10"
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -2178,12 +2096,10 @@
 /area/medical/medbay)
 "afY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 4;
-	icon_state = "scrub_map_on-1"
+	dir = 4
 	},
 /obj/structure/chair{
-	dir = 8;
-	icon_state = "chair"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -2219,7 +2135,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 10;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/structure/chair/office,
@@ -2304,8 +2219,7 @@
 "agt" = (
 /obj/structure/table/reinforced,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 8;
-	icon_state = "vent_map_on-3"
+	dir = 8
 	},
 /obj/machinery/button/door{
 	id = "magcat_in";
@@ -2356,8 +2270,7 @@
 /area/tcommsat/server)
 "agB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 4;
-	icon_state = "scrub_map_on-1"
+	dir = 4
 	},
 /obj/effect/spawner/lootdrop/techstorage/AI,
 /obj/structure/rack,
@@ -2375,8 +2288,6 @@
 /area/medical/genetics/cloning)
 "agE" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 2;
-	icon_state = "closed";
 	name = "Chapel"
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -2385,8 +2296,7 @@
 /area/chapel/main)
 "agF" = (
 /obj/machinery/camera/autoname{
-	dir = 8;
-	icon_state = "camera"
+	dir = 8
 	},
 /turf/open/floor/plating/airless,
 /area/nsv/weapons/gauss)
@@ -2412,7 +2322,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
@@ -2429,8 +2338,7 @@
 /area/nsv/weapons/gauss)
 "agN" = (
 /obj/structure/chair/pew/right{
-	dir = 1;
-	icon_state = "pewend_right"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-10"
@@ -2477,8 +2385,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/chair/office{
-	dir = 4;
-	icon_state = "officechair_dark"
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -2528,8 +2435,7 @@
 /area/crew_quarters/dorms)
 "ahb" = (
 /obj/structure/chair{
-	dir = 4;
-	icon_state = "chair"
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -2546,8 +2452,7 @@
 /area/nsv/hanger)
 "ahe" = (
 /obj/structure/chair{
-	dir = 1;
-	icon_state = "chair"
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -2595,14 +2500,14 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/shower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/machinery/airalarm/directional/north,
+/obj/structure/extinguisher_cabinet/west,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aho" = (
@@ -2645,7 +2550,6 @@
 	},
 /obj/machinery/door/poddoor/shutters/ship/preopen{
 	dir = 8;
-	icon_state = "open";
 	id = "xo_line"
 	},
 /obj/machinery/door/firedoor/window,
@@ -2660,8 +2564,7 @@
 /area/hallway/primary/aft)
 "ahx" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 8;
-	icon_state = "scrub_map_on-1"
+	dir = 8
 	},
 /obj/machinery/camera/emp_proof/motion{
 	c_tag = "AI Core Mantrap"
@@ -2706,15 +2609,13 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/closed/wall/steel,
 /area/engine/engineering)
 "ahF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 8;
-	icon_state = "vent_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
@@ -2773,13 +2674,11 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/unres{
-	dir = 8;
-	icon_state = "airlock_unres_helper"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/door/firedoor/border_only/directional/west,
@@ -2815,8 +2714,6 @@
 /area/nsv/weapons/port)
 "ahV" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 2;
-	icon_state = "closed";
 	name = "Hydroponics Hallway"
 	},
 /obj/structure/disposalpipe/segment{
@@ -2840,8 +2737,6 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "ahZ" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 2;
-	icon_state = "closed";
 	name = "Hydroponics Hallway"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -2867,8 +2762,7 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "aib" = (
 /obj/structure/transit_tube/horizontal{
-	dir = 2;
-	icon_state = "straight"
+	dir = 2
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -2887,8 +2781,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/chapel{
-	dir = 1;
-	icon_state = "chapel"
+	dir = 1
 	},
 /area/chapel/main)
 "aif" = (
@@ -3050,13 +2943,11 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/unres{
-	dir = 8;
-	icon_state = "airlock_unres_helper"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -3077,8 +2968,7 @@
 /area/hallway/primary/central)
 "aiz" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer1{
-	dir = 8;
-	icon_state = "dpvent_map-1"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -3190,8 +3080,6 @@
 /area/hallway/secondary/service)
 "aiI" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 2;
-	icon_state = "closed";
 	name = "Research Lobby"
 	},
 /obj/machinery/door/firedoor,
@@ -3239,7 +3127,6 @@
 /obj/structure/plasticflaps,
 /obj/machinery/conveyor{
 	dir = 1;
-	icon_state = "conveyor_map";
 	id = "cargo_shuttle"
 	},
 /obj/machinery/door/firedoor/window,
@@ -3304,8 +3191,7 @@
 	dir = 8
 	},
 /obj/machinery/computer/ship/navigation{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -3356,7 +3242,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 6;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/freezer,
@@ -3445,7 +3330,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 5;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/wood,
@@ -3545,8 +3429,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -3554,7 +3437,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/light{
@@ -3573,21 +3455,18 @@
 /area/maintenance/department/security/brig)
 "ajz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8;
-	icon_state = "vent_map_on-2"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 9;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
 "ajA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1;
-	icon_state = "scrub_map_on-1"
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security)
@@ -3599,7 +3478,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -3618,15 +3496,13 @@
 /area/maintenance/department/security/brig)
 "ajE" = (
 /obj/structure/chair/pew/left{
-	dir = 1;
-	icon_state = "pewend_left"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/chapel{
-	dir = 8;
-	icon_state = "chapel"
+	dir = 8
 	},
 /area/chapel/main)
 "ajF" = (
@@ -3648,8 +3524,7 @@
 	icon_state = "5-10"
 	},
 /obj/machinery/camera/autoname{
-	dir = 5;
-	icon_state = "camera"
+	dir = 5
 	},
 /obj/structure/table/wood,
 /obj/machinery/microwave,
@@ -3703,7 +3578,6 @@
 	},
 /obj/machinery/door/poddoor/shutters/ship/preopen{
 	dir = 8;
-	icon_state = "open";
 	id = "xo_line"
 	},
 /turf/open/floor/plating,
@@ -3726,12 +3600,10 @@
 /area/chapel/office)
 "ajP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 4;
-	icon_state = "scrub_map_on-1"
+	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	dir = 5;
-	icon_state = "camera"
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -3740,8 +3612,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/chapel{
-	dir = 9;
-	icon_state = "chapel"
+	dir = 9
 	},
 /area/chapel/main)
 "ajR" = (
@@ -3749,8 +3620,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/chapel{
-	dir = 5;
-	icon_state = "chapel"
+	dir = 5
 	},
 /area/chapel/main)
 "ajS" = (
@@ -3779,8 +3649,7 @@
 	icon_state = "1-5"
 	},
 /turf/open/floor/plasteel/chapel{
-	dir = 1;
-	icon_state = "chapel"
+	dir = 1
 	},
 /area/chapel/main)
 "ajV" = (
@@ -3829,16 +3698,14 @@
 /area/janitor)
 "ajZ" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/plasteel/white,
@@ -3848,8 +3715,7 @@
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -3909,7 +3775,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -3955,7 +3820,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 10;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/item/radio/intercom/directional/north,
@@ -3971,8 +3835,7 @@
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/camera/autoname{
-	dir = 8;
-	icon_state = "camera"
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -3980,8 +3843,7 @@
 /obj/structure/table/wood/fancy/royalblack,
 /obj/item/storage/fancy/candle_box,
 /turf/open/floor/plasteel/chapel{
-	dir = 4;
-	icon_state = "chapel"
+	dir = 4
 	},
 /area/chapel/main)
 "akm" = (
@@ -4031,7 +3893,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 6;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/wood,
@@ -4105,7 +3966,6 @@
 	},
 /obj/machinery/door/poddoor/ship/preopen{
 	dir = 10;
-	icon_state = "open";
 	id = "fbridge_spaceshield"
 	},
 /turf/open/floor/plating,
@@ -4115,8 +3975,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/camera/autoname,
 /obj/effect/turf_decal/tile/blue{
@@ -4126,8 +3985,7 @@
 /area/bridge)
 "akz" = (
 /obj/structure/chair{
-	dir = 8;
-	icon_state = "chair"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "5-10"
@@ -4140,8 +3998,7 @@
 /area/crew_quarters/heads/hop)
 "akB" = (
 /obj/structure/chair{
-	dir = 1;
-	icon_state = "chair"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "5-10"
@@ -4252,8 +4109,7 @@
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
-	dir = 8;
-	icon_state = "pipe-t"
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/library)
@@ -4312,8 +4168,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/camera/autoname{
-	dir = 10;
-	icon_state = "camera"
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -4343,8 +4198,7 @@
 /area/crew_quarters/heads/cmo)
 "akX" = (
 /obj/effect/turf_decal/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 9
@@ -4385,16 +4239,14 @@
 /area/hallway/primary/central)
 "alb" = (
 /obj/effect/turf_decal/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /turf/open/floor/monotile,
 /area/nsv/hanger)
 "alc" = (
 /obj/effect/turf_decal/arrows/red{
-	dir = 1;
-	icon_state = "arrows_red"
+	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /turf/open/floor/monotile,
@@ -4450,15 +4302,13 @@
 "alj" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/item/radio/intercom/directional/north{
 	name = "prison intra ship intercom";
@@ -4468,8 +4318,7 @@
 /area/security/prison)
 "alk" = (
 /obj/structure/transit_tube/curved{
-	dir = 1;
-	icon_state = "curved0"
+	dir = 1
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -4500,7 +4349,6 @@
 /area/security/warden)
 "aln" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/door/window/brigdoor/security/cell/northright{
 	id = "stationbrigcell_1";
 	name = "cell 1 door"
@@ -4514,8 +4362,7 @@
 /area/hallway/secondary/entry)
 "alp" = (
 /obj/machinery/computer/crew{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/carpet/red,
@@ -4553,8 +4400,7 @@
 	dir = 1
 	},
 /obj/structure/chair{
-	dir = 4;
-	icon_state = "chair"
+	dir = 4
 	},
 /obj/structure/sign/poster/official/obey{
 	pixel_x = -32
@@ -4585,7 +4431,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 9;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/dark,
@@ -4641,8 +4486,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/item/radio/intercom/directional/north,
 /obj/structure/closet/toolcloset,
@@ -4844,7 +4688,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 6;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/monotile,
@@ -4889,7 +4732,6 @@
 "alW" = (
 /obj/machinery/computer/card{
 	dir = 1;
-	icon_state = "computer";
 	name = "backup identification console"
 	},
 /obj/machinery/requests_console{
@@ -4918,7 +4760,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/item/tape/random,
@@ -4974,8 +4815,7 @@
 /area/security/brig)
 "amd" = (
 /obj/machinery/computer/card/minor/cmo{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
@@ -4989,7 +4829,6 @@
 	},
 /obj/structure/transit_tube/station/reverse/flipped{
 	dir = 1;
-	icon_state = "closed_terminus1";
 	name = "Telecom Access Conduit"
 	},
 /obj/machinery/camera/autoname,
@@ -5008,7 +4847,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/wood,
@@ -5051,8 +4889,7 @@
 /area/medical/medbay/lobby)
 "amm" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -5068,8 +4905,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/unres{
-	dir = 8;
-	icon_state = "airlock_unres_helper"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -5080,8 +4916,7 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -5092,8 +4927,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -5105,8 +4939,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -5116,8 +4949,7 @@
 "amr" = (
 /obj/machinery/computer/ship/viewscreen,
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -5135,8 +4967,7 @@
 "amt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -5144,7 +4975,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 5;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -5176,8 +5006,7 @@
 /area/hydroponics)
 "amw" = (
 /obj/structure/chair/office{
-	dir = 1;
-	icon_state = "officechair_dark"
+	dir = 1
 	},
 /obj/effect/landmark/start/virologist,
 /turf/open/floor/plasteel/white,
@@ -5185,8 +5014,7 @@
 "amx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -5206,8 +5034,7 @@
 	},
 /obj/structure/extinguisher_cabinet/south,
 /obj/machinery/camera/autoname{
-	dir = 8;
-	icon_state = "camera"
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -5226,8 +5053,7 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/unres{
-	dir = 8;
-	icon_state = "airlock_unres_helper"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
@@ -5238,13 +5064,11 @@
 	icon_state = "5-10"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 8;
-	icon_state = "scrub_map_on-1"
+	dir = 8
 	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
-	dir = 8;
-	icon_state = "pipe-t"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -5260,8 +5084,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -5269,7 +5092,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/firealarm/directional/north,
@@ -5291,7 +5113,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/monotile,
@@ -5318,12 +5139,10 @@
 /area/bridge)
 "amN" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -5342,8 +5161,7 @@
 /area/science/lab)
 "amO" = (
 /obj/structure/chair/office{
-	dir = 4;
-	icon_state = "officechair_dark"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "2-5"
@@ -5391,7 +5209,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/light{
@@ -5450,8 +5267,7 @@
 "anb" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -5463,8 +5279,7 @@
 /area/crew_quarters/heads/cmo)
 "and" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	icon_state = "propulsion"
+	dir = 8
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -5491,8 +5306,7 @@
 	pixel_y = 24
 	},
 /obj/machinery/camera/autoname{
-	dir = 5;
-	icon_state = "camera"
+	dir = 5
 	},
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/plasteel/dark,
@@ -5505,18 +5319,14 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "anh" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 2;
-	icon_state = "closed";
 	name = "Aft Primary Hallway"
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -5528,15 +5338,13 @@
 /area/hallway/primary/aft)
 "ani" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 4;
-	icon_state = "scrub_map_on-1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "anj" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 5
@@ -5544,7 +5352,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 10;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -5566,8 +5373,7 @@
 /area/nsv/weapons/port)
 "anm" = (
 /obj/structure/chair/office{
-	dir = 1;
-	icon_state = "officechair_dark"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/blue{
@@ -5636,7 +5442,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 10;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/structure/extinguisher_cabinet/north,
@@ -5687,8 +5492,7 @@
 /area/nsv/weapons/port)
 "anA" = (
 /obj/structure/transit_tube/curved{
-	dir = 8;
-	icon_state = "curved0"
+	dir = 8
 	},
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -5724,7 +5528,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -5754,8 +5557,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1;
-	icon_state = "scrub_map_on-1"
+	dir = 1
 	},
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/tile/green,
@@ -5775,7 +5577,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 6;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -5784,7 +5585,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -5797,8 +5597,7 @@
 /area/crew_quarters/lounge)
 "anN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 8;
-	icon_state = "scrub_map_on-1"
+	dir = 8
 	},
 /obj/machinery/vending/wardrobe/chem_wardrobe,
 /obj/structure/disposalpipe/segment{
@@ -5844,7 +5643,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#f00";
 	dir = 4;
-	icon_state = "pipe";
 	name = "to-space disposal pipe"
 	},
 /turf/open/floor/plating,
@@ -5860,14 +5658,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/status_display/evac/north,
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 10;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/light{
@@ -5877,16 +5673,13 @@
 /area/medical/medbay/lobby)
 "anU" = (
 /obj/structure/chair{
-	dir = 4;
-	icon_state = "chair"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel,
@@ -5925,9 +5718,7 @@
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
 "anY" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
 	icon_state = "0-10"
 	},
@@ -5938,8 +5729,7 @@
 	pixel_y = -24
 	},
 /obj/machinery/computer/crew{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /turf/open/floor/carpet/green,
 /area/crew_quarters/heads/cmo)
@@ -5967,7 +5757,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/vending/wardrobe/viro_wardrobe,
@@ -5984,7 +5773,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 10;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -6015,8 +5803,7 @@
 /area/nsv/hanger)
 "aoh" = (
 /obj/effect/turf_decal/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -6043,8 +5830,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -6053,8 +5839,7 @@
 	dir = 6
 	},
 /obj/structure/disposalpipe/trunk{
-	dir = 4;
-	icon_state = "pipe-t"
+	dir = 4
 	},
 /obj/machinery/disposal/bin,
 /turf/open/floor/monotile/dark,
@@ -6067,8 +5852,7 @@
 /area/nsv/crew_quarters/heads/maa)
 "aom" = (
 /obj/machinery/modular_computer/console/preset/command{
-	dir = 1;
-	icon_state = "console"
+	dir = 1
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
@@ -6094,7 +5878,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#f00";
 	dir = 10;
-	icon_state = "pipe";
 	name = "to-space disposal pipe"
 	},
 /obj/item/storage/box/syringes,
@@ -6126,8 +5909,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -6135,7 +5917,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -6153,8 +5934,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -6164,12 +5944,10 @@
 /area/nsv/crew_quarters/heads/maa)
 "aox" = (
 /obj/machinery/camera/autoname{
-	dir = 8;
-	icon_state = "camera"
+	dir = 8
 	},
 /turf/open/floor/plasteel/chapel{
-	dir = 4;
-	icon_state = "chapel"
+	dir = 4
 	},
 /area/chapel/main)
 "aoy" = (
@@ -6194,22 +5972,19 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 10;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/port)
 "aoD" = (
 /obj/machinery/computer/ship/dradis/minor{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/nsv/crew_quarters/heads/maa)
 "aoE" = (
 /obj/machinery/computer/ship/dradis{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/wood,
@@ -6251,8 +6026,7 @@
 /area/nsv/hanger)
 "aoK" = (
 /obj/effect/turf_decal/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -6264,8 +6038,7 @@
 /area/nsv/hanger)
 "aoL" = (
 /obj/effect/turf_decal/arrows/red{
-	dir = 1;
-	icon_state = "arrows_red"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-6"
@@ -6298,8 +6071,7 @@
 	req_access_txt = "19"
 	},
 /obj/effect/mapping_helpers/airlock/unres{
-	dir = 1;
-	icon_state = "airlock_unres_helper"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
@@ -6331,8 +6103,7 @@
 /area/bridge)
 "aoP" = (
 /obj/machinery/camera/autoname{
-	dir = 5;
-	icon_state = "camera"
+	dir = 5
 	},
 /turf/open/floor/plating/airless,
 /area/nsv/weapons/gauss)
@@ -6445,7 +6216,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 6;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/monotile/dark,
@@ -6500,7 +6270,6 @@
 	},
 /obj/machinery/door/poddoor/shutters/ship/preopen{
 	dir = 8;
-	icon_state = "open";
 	id = "chefbar";
 	name = "Quik-Service shutter"
 	},
@@ -6514,8 +6283,7 @@
 "apg" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /obj/machinery/camera/autoname{
-	dir = 8;
-	icon_state = "camera"
+	dir = 8
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
@@ -6574,14 +6342,12 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/ship/preopen{
 	dir = 8;
-	icon_state = "open";
 	id = "chefbar";
 	name = "Quik-Service shutter"
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/door/firedoor/window,
@@ -6596,8 +6362,7 @@
 	icon_state = "5-10"
 	},
 /obj/machinery/computer/ship/tactical{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -6622,8 +6387,7 @@
 	dir = 4
 	},
 /obj/structure/chair/office{
-	dir = 4;
-	icon_state = "officechair_dark"
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -6635,8 +6399,7 @@
 	icon_state = "6-10"
 	},
 /obj/machinery/computer/ship/dradis{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -6657,8 +6420,7 @@
 	icon_state = "2-5"
 	},
 /obj/machinery/camera/autoname{
-	dir = 5;
-	icon_state = "camera"
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
@@ -6674,12 +6436,10 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/computer/ship/helm{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -6690,7 +6450,6 @@
 	},
 /obj/machinery/door/poddoor/ship/preopen{
 	dir = 5;
-	icon_state = "open";
 	id = "fbridge_spaceshield"
 	},
 /turf/open/floor/plating,
@@ -6709,12 +6468,10 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 1;
-	icon_state = "vent_map_on-3"
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -6723,8 +6480,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "6-9"
@@ -6791,12 +6547,10 @@
 /area/hallway/primary/fore)
 "apD" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "4-5"
@@ -6804,7 +6558,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/structure/disposalpipe/segment{
@@ -6818,8 +6571,7 @@
 /area/science)
 "apE" = (
 /obj/machinery/camera/autoname{
-	dir = 10;
-	icon_state = "camera"
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
@@ -6834,12 +6586,9 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 2;
-	icon_state = "closed";
 	name = "Aft Primary Hallway"
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -6865,7 +6614,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -6907,15 +6655,13 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "apO" = (
 /obj/effect/turf_decal/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -6947,7 +6693,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -6989,7 +6734,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -7013,8 +6757,7 @@
 /area/hallway/secondary/command)
 "apY" = (
 /obj/structure/chair/office{
-	dir = 4;
-	icon_state = "officechair_dark"
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -7023,8 +6766,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/status_display/evac/north,
@@ -7079,9 +6821,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
 	icon_state = "0-10"
 	},
@@ -7089,8 +6829,7 @@
 /area/bridge)
 "aqh" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -7198,8 +6937,7 @@
 "aqs" = (
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/plasteel/chapel{
-	dir = 9;
-	icon_state = "chapel"
+	dir = 9
 	},
 /area/chapel/main)
 "aqt" = (
@@ -7226,8 +6964,7 @@
 	dir = 4
 	},
 /obj/machinery/computer/warrant{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/security)
@@ -7283,16 +7020,13 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "aqB" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
 	icon_state = "0-9"
 	},
@@ -7307,7 +7041,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -7329,8 +7062,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/camera/autoname,
@@ -7364,8 +7096,7 @@
 /area/security/brig)
 "aqI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 4;
-	icon_state = "scrub_map_on-1"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -7375,8 +7106,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	dir = 5;
-	icon_state = "camera"
+	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -7468,7 +7198,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 6;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -7476,7 +7205,6 @@
 "aqR" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	name = "Service Cupboard Maintenance";
-	req_access_txt = "0";
 	req_one_access_txt = "25;26;28;35"
 	},
 /obj/machinery/door/firedoor/border_only/directional/north,
@@ -7496,7 +7224,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -7552,7 +7279,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 6;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -7666,7 +7392,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -7699,8 +7424,7 @@
 /area/medical/genetics)
 "ark" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -7744,8 +7468,7 @@
 	dir = 4
 	},
 /obj/structure/chair{
-	dir = 4;
-	icon_state = "chair"
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -7827,8 +7550,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/structure/chair{
-	dir = 4;
-	icon_state = "chair"
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -7907,8 +7629,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	dir = 10;
-	icon_state = "camera"
+	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/nsv/officerquarters)
@@ -7919,7 +7640,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 6;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -7998,7 +7718,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plating,
@@ -8017,8 +7736,7 @@
 /area/hallway/primary/fore)
 "arP" = (
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -8039,8 +7757,7 @@
 /area/security/prison)
 "arS" = (
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -8053,8 +7770,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -8064,8 +7780,7 @@
 "arV" = (
 /obj/effect/landmark/start/lawyer,
 /obj/structure/chair/office{
-	dir = 4;
-	icon_state = "officechair_dark"
+	dir = 4
 	},
 /turf/open/floor/carpet/blue,
 /area/security/detectives_office/combined)
@@ -8095,7 +7810,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/holopad,
@@ -8108,8 +7822,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -8154,8 +7867,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -8187,8 +7899,7 @@
 "ask" = (
 /obj/effect/landmark/start/detective,
 /obj/structure/chair/office{
-	dir = 4;
-	icon_state = "officechair_dark"
+	dir = 4
 	},
 /turf/open/floor/carpet/red,
 /area/security/detectives_office/combined)
@@ -8201,15 +7912,13 @@
 /area/security/prison)
 "asn" = (
 /obj/machinery/computer/secure_data{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /turf/open/floor/carpet/red,
 /area/security/detectives_office/combined)
 "aso" = (
 /obj/machinery/computer/security{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /turf/open/floor/carpet/red,
 /area/security/detectives_office/combined)
@@ -8227,7 +7936,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -8246,8 +7954,7 @@
 /area/hydroponics)
 "asr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 8;
-	icon_state = "scrub_map_on-1"
+	dir = 8
 	},
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/plasteel/grimy,
@@ -8307,7 +8014,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -8347,7 +8053,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -8369,16 +8074,14 @@
 /area/ai_monitored/security/armory)
 "asB" = (
 /obj/machinery/sleeper{
-	dir = 1;
-	icon_state = "sleeper"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -8420,7 +8123,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -8433,7 +8135,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -8446,8 +8147,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -8458,7 +8158,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -8505,7 +8204,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -8534,12 +8232,10 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/camera/autoname{
-	dir = 10;
-	icon_state = "camera"
+	dir = 10
 	},
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/wood,
@@ -8655,8 +8351,6 @@
 /area/security/brig)
 "atb" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 2;
-	icon_state = "closed";
 	name = "Research Lobby"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -8685,8 +8379,7 @@
 /area/science/storage)
 "atf" = (
 /obj/effect/turf_decal/box/corners{
-	dir = 8;
-	icon_state = "box_corners"
+	dir = 8
 	},
 /turf/open/floor/plating/airless,
 /area/nsv/weapons/gauss)
@@ -8710,7 +8403,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 5;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -8729,8 +8421,7 @@
 	name = "Arrivals Dock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1;
-	icon_state = "airlock_cyclelink_helper"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -8738,8 +8429,7 @@
 /area/hallway/secondary/entry)
 "atA" = (
 /obj/effect/turf_decal/arrows/red{
-	dir = 4;
-	icon_state = "arrows_red"
+	dir = 4
 	},
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/light/small{
@@ -8770,8 +8460,7 @@
 	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
-	dir = 4;
-	icon_state = "pipe-t"
+	dir = 4
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -8793,8 +8482,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -8802,7 +8490,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -8824,7 +8511,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -8858,8 +8544,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plasteel/white,
@@ -8871,8 +8556,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/effect/turf_decal/stripes/red/line{
-	dir = 8;
-	icon_state = "warningline_red"
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
@@ -8893,8 +8577,7 @@
 "atU" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -8914,7 +8597,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -8930,7 +8612,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#f00";
 	dir = 5;
-	icon_state = "pipe";
 	name = "to-space disposal pipe"
 	},
 /obj/machinery/newscaster/directional/west,
@@ -8942,8 +8623,7 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/tank/air,
 /obj/machinery/status_display/evac/north,
@@ -8951,8 +8631,7 @@
 /area/medical/medbay)
 "aua" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 4;
-	icon_state = "scrub_map_on-1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
@@ -8973,8 +8652,7 @@
 /area/quartermaster/storage)
 "auc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 8;
-	icon_state = "vent_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
@@ -8989,7 +8667,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/firealarm/directional/north,
@@ -9007,8 +8684,7 @@
 /area/science/mixing)
 "auh" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 1;
-	icon_state = "inje_map-2"
+	dir = 1
 	},
 /turf/open/floor/engine/vacuum,
 /area/science/mixing)
@@ -9024,8 +8700,7 @@
 /obj/machinery/computer/ship/viewscreen,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -9059,16 +8734,13 @@
 "auo" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/item/stack/sheet/glass,
@@ -9090,7 +8762,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/firealarm/directional/north,
@@ -9104,8 +8775,6 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 2;
-	icon_state = "closed";
 	name = "Aft Primary Hallway"
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -9133,8 +8802,7 @@
 /obj/machinery/computer/scan_consolenew,
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -9173,7 +8841,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -9207,9 +8874,7 @@
 /obj/structure/cable{
 	icon_state = "0-6"
 	},
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /turf/open/floor/plasteel/dark,
@@ -9274,8 +8939,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -9283,7 +8947,6 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 8;
-	icon_state = "pipe-j1s";
 	name = "genetic sorting disposal pipe";
 	sortType = 23
 	},
@@ -9294,8 +8957,7 @@
 	icon_state = "0-10"
 	},
 /obj/machinery/power/terminal{
-	dir = 4;
-	icon_state = "term"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -9383,8 +9045,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -9396,7 +9057,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
@@ -9405,16 +9065,13 @@
 /area/engine/engineering)
 "auW" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -9444,18 +9101,15 @@
 /area/maintenance/department/crew_quarters/bar)
 "ava" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/newscaster/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 4;
-	icon_state = "scrub_map_on-1"
+	dir = 4
 	},
 /obj/structure/closet/crate/science{
 	name = "Xenobiology crate"
@@ -9477,8 +9131,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/newscaster/directional/north,
@@ -9509,8 +9162,7 @@
 /area/nsv/hanger)
 "avh" = (
 /obj/machinery/camera/autoname{
-	dir = 5;
-	icon_state = "camera"
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -9530,7 +9182,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -9587,7 +9238,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -9603,7 +9253,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -9631,7 +9280,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/squad_vendor{
@@ -9669,8 +9317,7 @@
 "avy" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
-	dir = 8;
-	icon_state = "pipe-t"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plating,
@@ -9762,7 +9409,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/wood,
@@ -9806,7 +9452,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/light/small,
@@ -9842,7 +9487,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -9851,12 +9495,10 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/effect/turf_decal/tile/bar{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -9867,12 +9509,10 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/effect/turf_decal/tile/bar{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -9904,12 +9544,10 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/effect/turf_decal/tile/bar{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -9923,8 +9561,7 @@
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/camera/autoname{
-	dir = 5;
-	icon_state = "camera"
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
@@ -9947,41 +9584,34 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/modular_computer/console/preset/engineering{
-	dir = 8;
-	icon_state = "console"
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "avY" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science)
 "avZ" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science)
 "awa" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/structure/chair{
@@ -10008,12 +9638,10 @@
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/disposal/bin,
@@ -10022,8 +9650,7 @@
 /area/science/robotics)
 "awd" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 6
@@ -10035,13 +9662,11 @@
 /area/science)
 "awe" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -10058,19 +9683,16 @@
 /area/science/robotics/mechbay)
 "awg" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science)
 "awh" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/structure/chair{
@@ -10080,8 +9702,7 @@
 /area/science)
 "awi" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -10097,8 +9718,7 @@
 	},
 /obj/effect/turf_decal/tile/green,
 /obj/machinery/camera/autoname{
-	dir = 8;
-	icon_state = "camera"
+	dir = 8
 	},
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel,
@@ -10106,33 +9726,27 @@
 "awk" = (
 /obj/machinery/vending/modularpc,
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science)
 "awl" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/structure/chair{
 	dir = 4
@@ -10145,8 +9759,7 @@
 /area/storage/tech)
 "awn" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
@@ -10185,19 +9798,16 @@
 /area/science/robotics/mechbay)
 "awt" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science)
 "awu" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
@@ -10207,13 +9817,11 @@
 /area/science/robotics)
 "awv" = (
 /obj/structure/chair/pew/left{
-	dir = 1;
-	icon_state = "pewend_left"
+	dir = 1
 	},
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/plasteel/chapel{
-	dir = 10;
-	icon_state = "chapel"
+	dir = 10
 	},
 /area/chapel/main)
 "aww" = (
@@ -10330,18 +9938,15 @@
 /area/medical/medbay)
 "awH" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 5;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/structure/cable{
@@ -10369,15 +9974,13 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	dir = 5;
-	icon_state = "camera"
+	dir = 5
 	},
 /obj/structure/sign/warning/nosmoking/circle{
 	pixel_x = -32
 	},
 /obj/structure/sign/directions/plaque/munitions{
 	dir = 1;
-	icon_state = "minskydirection_munitions";
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
@@ -10395,8 +9998,7 @@
 /obj/item/barcodescanner,
 /obj/item/radio/intercom/directional/east,
 /obj/machinery/camera/autoname{
-	dir = 8;
-	icon_state = "camera"
+	dir = 8
 	},
 /obj/structure/extinguisher_cabinet/south,
 /obj/machinery/libraryscanner,
@@ -10425,7 +10027,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -10476,7 +10077,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -10501,12 +10101,10 @@
 	},
 /obj/structure/sign/directions/engineering{
 	dir = 8;
-	icon_state = "direction_eng";
 	pixel_y = 32
 	},
 /obj/structure/sign/directions/command{
 	dir = 4;
-	icon_state = "direction_bridge";
 	pixel_y = 40
 	},
 /turf/open/floor/plasteel,
@@ -10514,7 +10112,6 @@
 "awW" = (
 /obj/machinery/conveyor{
 	dir = 1;
-	icon_state = "conveyor_map";
 	id = "cargo_shuttle"
 	},
 /turf/open/floor/plating,
@@ -10562,8 +10159,7 @@
 /area/crew_quarters/heads/hop)
 "axe" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 8;
-	icon_state = "vent_map_on-3"
+	dir = 8
 	},
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/plasteel/dark,
@@ -10572,17 +10168,14 @@
 /obj/structure/closet/firecloset,
 /obj/structure/sign/directions/security{
 	dir = 4;
-	icon_state = "direction_sec";
 	pixel_y = 40
 	},
 /obj/structure/sign/directions/supply{
 	dir = 8;
-	icon_state = "direction_supply";
 	pixel_y = 32
 	},
 /obj/structure/sign/directions/medical{
 	dir = 8;
-	icon_state = "direction_med";
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel,
@@ -10592,7 +10185,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -10604,7 +10196,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -10618,8 +10209,7 @@
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -10630,7 +10220,6 @@
 	},
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 8;
-	icon_state = "pipe-j1s";
 	name = "virology isolation sorting disposal pipe";
 	sortType = 27
 	},
@@ -10660,12 +10249,10 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -10733,12 +10320,10 @@
 /area/storage/tech)
 "axv" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/power/apc/auto_name/north{
 	pixel_y = 24
@@ -10759,7 +10344,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -10769,8 +10353,7 @@
 	pixel_x = -32
 	},
 /obj/structure/chair{
-	dir = 4;
-	icon_state = "chair"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -10808,8 +10391,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel/dark,
@@ -10844,8 +10426,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
@@ -10886,8 +10467,7 @@
 /area/crew_quarters/lounge)
 "axL" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
@@ -10895,9 +10475,7 @@
 /obj/machinery/conveyor{
 	id = "mailsort"
 	},
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
 	icon_state = "0-10"
 	},
@@ -10946,12 +10524,10 @@
 /area/nsv/hanger)
 "axS" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -11005,8 +10581,7 @@
 	},
 /obj/machinery/rnd/production/circuit_imprinter/department/science,
 /obj/effect/turf_decal/tile/bar{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -11036,8 +10611,7 @@
 /area/science/robotics)
 "axZ" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/structure/disposalpipe/segment{
@@ -11048,8 +10622,7 @@
 /area/science)
 "aya" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 8;
-	icon_state = "scrub_map_on-1"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics)
@@ -11081,12 +10654,10 @@
 /area/maintenance/department/cargo)
 "ayd" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -11101,15 +10672,13 @@
 /area/hallway/secondary/exit/departure_lounge)
 "ayf" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/airalarm/directional/south,
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/structure/cable{
@@ -11126,8 +10695,7 @@
 	},
 /obj/effect/landmark/start/scientist,
 /obj/effect/turf_decal/tile/bar{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -11138,8 +10706,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
@@ -11183,7 +10750,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 6;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -11206,8 +10772,6 @@
 /area/maintenance/department/chapel)
 "ayq" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 2;
-	icon_state = "closed";
 	name = "Library"
 	},
 /obj/machinery/door/firedoor/border_only/directional/north,
@@ -11216,12 +10780,10 @@
 /area/library)
 "ayr" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -11314,7 +10876,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -11324,8 +10885,6 @@
 	icon_state = "2-9"
 	},
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 2;
-	icon_state = "closed";
 	name = "Library"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -11349,13 +10908,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -11437,13 +10994,11 @@
 /area/hallway/secondary/entry)
 "ayO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1;
-	icon_state = "scrub_map_on-1"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/structure/disposalpipe/segment{
@@ -11463,8 +11018,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/structure/noticeboard/hop{
 	pixel_y = 32
@@ -11472,7 +11026,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -11496,8 +11049,7 @@
 /area/maintenance/department/crew_quarters/bar)
 "ayS" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -11517,8 +11069,7 @@
 /area/medical/medbay)
 "ayT" = (
 /obj/machinery/camera/autoname{
-	dir = 10;
-	icon_state = "camera"
+	dir = 10
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -11535,13 +11086,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -11615,15 +11164,13 @@
 /area/hydroponics)
 "aze" = (
 /obj/effect/turf_decal/stripes/white/line{
-	dir = 9;
-	icon_state = "warningline_white"
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 6
 	},
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
-	icon_state = "pump_on_map-2";
 	level = 1;
 	name = "Coldroom Air Supply"
 	},
@@ -11639,13 +11186,11 @@
 /area/hallway/primary/central)
 "azg" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -11676,7 +11221,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/wood,
@@ -11685,7 +11229,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 10;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/wood,
@@ -11701,7 +11244,6 @@
 	},
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 1;
-	icon_state = "pipe-j1s";
 	name = "bar sorting disposal pipe";
 	sortType = 19
 	},
@@ -11711,8 +11253,7 @@
 /obj/machinery/airalarm/directional/south,
 /obj/structure/closet/l3closet/janitor,
 /obj/machinery/camera/autoname{
-	dir = 8;
-	icon_state = "camera"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
@@ -11720,7 +11261,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 9;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/firealarm/partyalarm{
@@ -11737,7 +11277,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -11747,7 +11286,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -11766,8 +11304,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/junction/flip{
-	dir = 4;
-	icon_state = "pipe-j2"
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/port)
@@ -11824,7 +11361,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -11882,7 +11418,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 10;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -11892,8 +11427,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/disposalpipe/segment{
@@ -11916,8 +11450,7 @@
 	icon_state = "6-10"
 	},
 /obj/structure/disposalpipe/junction/flip{
-	dir = 8;
-	icon_state = "pipe-j2"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -11958,7 +11491,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/door/firedoor/border_only/directional/west,
@@ -11977,8 +11509,7 @@
 /area/crew_quarters/heads/hop)
 "azR" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -12038,7 +11569,6 @@
 	},
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4;
-	icon_state = "pipe-j2s";
 	name = "weapons bay sorting disposal pipe";
 	sortType = 33
 	},
@@ -12150,7 +11680,6 @@
 	},
 /obj/machinery/door/poddoor/shutters/ship/preopen{
 	dir = 8;
-	icon_state = "open";
 	id = "xo_line"
 	},
 /turf/open/floor/plating,
@@ -12172,9 +11701,7 @@
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
 "aAk" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
 	icon_state = "0-10"
 	},
@@ -12239,13 +11766,11 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -12270,7 +11795,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -12336,7 +11860,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/light/small{
@@ -12367,7 +11890,6 @@
 	},
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1;
-	icon_state = "pipe-j2s";
 	name = "engineering branch sorting disposal pipe";
 	sortType = "4;5;6"
 	},
@@ -12412,8 +11934,10 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 10;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
+	},
+/obj/machinery/camera/autoname{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -12424,7 +11948,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/monotile/dark,
@@ -12495,17 +12018,14 @@
 /area/quartermaster/miningdock)
 "aAM" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
@@ -12555,7 +12075,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plating,
@@ -12639,12 +12158,10 @@
 /area/maintenance/department/bridge)
 "aBc" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4;
-	icon_state = "pipe-j2s";
 	name = "robotics sorting disposal pipe";
 	sortType = 14
 	},
@@ -12732,7 +12249,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/dark,
@@ -12741,7 +12257,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/structure/extinguisher_cabinet/north,
@@ -12769,8 +12284,7 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -12832,8 +12346,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -12847,7 +12360,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/dark,
@@ -12866,7 +12378,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/dark,
@@ -12884,7 +12395,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -12918,7 +12428,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 9;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/dark,
@@ -12928,8 +12437,6 @@
 	icon_state = "2-5"
 	},
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 2;
-	icon_state = "closed";
 	name = "Chapel"
 	},
 /obj/machinery/door/firedoor/border_only/directional/south,
@@ -12938,8 +12445,7 @@
 /area/chapel/main)
 "aBO" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/brown,
 /obj/structure/sign/poster/official/random{
@@ -12948,7 +12454,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -12961,15 +12466,14 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 10;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 5;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
+/obj/structure/extinguisher_cabinet/east,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aBU" = (
@@ -13023,9 +12527,7 @@
 /area/quartermaster/storage)
 "aCa" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -13034,8 +12536,7 @@
 /area/quartermaster/storage)
 "aCb" = (
 /obj/machinery/camera/autoname{
-	dir = 5;
-	icon_state = "camera"
+	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
@@ -13065,7 +12566,6 @@
 "aCf" = (
 /obj/machinery/conveyor{
 	dir = 8;
-	icon_state = "conveyor_map";
 	id = "cargo_shuttle"
 	},
 /turf/open/floor/plating,
@@ -13120,7 +12620,6 @@
 "aCm" = (
 /obj/machinery/conveyor/inverted{
 	dir = 5;
-	icon_state = "conveyor_map_inverted";
 	id = "cargo_shuttle"
 	},
 /turf/open/floor/plating,
@@ -13132,7 +12631,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 6;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -13147,7 +12645,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -13162,7 +12659,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -13188,7 +12684,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -13218,13 +12713,11 @@
 /area/quartermaster/miningdock)
 "aCA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 1;
-	icon_state = "vent_map_on-3"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/effect/turf_decal/tile/purple,
@@ -13274,23 +12767,20 @@
 	name = "Escape Shuttle Dock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1;
-	icon_state = "airlock_cyclelink_helper"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "aCG" = (
 /obj/machinery/computer/ship/fighter_launcher{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /turf/open/floor/monotile,
 /area/nsv/hanger)
 "aCH" = (
 /obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
+	dir = 4
 	},
 /obj/structure/curtain,
 /turf/open/floor/plasteel/showroomfloor,
@@ -13313,16 +12803,13 @@
 /area/crew_quarters/dorms)
 "aCL" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
@@ -13362,8 +12849,7 @@
 	req_access_txt = "13"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1;
-	icon_state = "airlock_cyclelink_helper"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
@@ -13380,9 +12866,7 @@
 	dir = 8
 	},
 /obj/structure/table/reinforced,
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "aCV" = (
@@ -13410,8 +12894,7 @@
 /area/chapel/main)
 "aCY" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/structure/sign/warning/explosives/alt{
 	pixel_y = 32
@@ -13515,9 +12998,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
 	icon_state = "5-8"
 	},
@@ -13527,7 +13008,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 9;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/requests_console{
@@ -13581,8 +13061,6 @@
 	icon_state = "2-10"
 	},
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 2;
-	icon_state = "closed";
 	name = "Chapel"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -13611,17 +13089,14 @@
 /area/maintenance/department/security/brig)
 "aDo" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 6;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -13629,8 +13104,7 @@
 "aDr" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on/coldroom,
 /obj/machinery/camera/autoname{
-	dir = 8;
-	icon_state = "camera"
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/service)
@@ -13648,8 +13122,7 @@
 /area/hallway/primary/fore)
 "aDt" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 4;
-	icon_state = "scrub_map_on-1"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green,
@@ -13683,12 +13156,10 @@
 /area/crew_quarters/heads/chief)
 "aDv" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/structure/noticeboard/rd{
 	pixel_y = 32
@@ -13696,7 +13167,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -13709,8 +13179,7 @@
 /area/science)
 "aDy" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -13720,24 +13189,20 @@
 /area/science)
 "aDz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 1;
-	icon_state = "vent_map_on-3"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/computer/med_data{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /obj/machinery/camera/autoname{
-	dir = 5;
-	icon_state = "camera"
+	dir = 5
 	},
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/plasteel/white,
@@ -13779,8 +13244,7 @@
 /area/maintenance/department/crew_quarters/dorms)
 "aDG" = (
 /obj/machinery/gateway{
-	dir = 10;
-	icon_state = "off"
+	dir = 10
 	},
 /obj/effect/spawner/lootdrop/gloves,
 /turf/open/floor/plating,
@@ -13817,8 +13281,7 @@
 /area/quartermaster/storage)
 "aDL" = (
 /obj/effect/turf_decal/stripes/red/line{
-	dir = 1;
-	icon_state = "warningline_red"
+	dir = 1
 	},
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/light_switch/west,
@@ -13857,7 +13320,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 9;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/newscaster/directional/south,
@@ -13866,12 +13328,10 @@
 /area/hallway/primary/fore)
 "aDQ" = (
 /obj/effect/turf_decal/tile/neutral{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/machinery/airalarm/directional/north,
 /obj/item/twohanded/required/kirbyplants/random,
@@ -13929,8 +13389,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -13942,8 +13401,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -13951,7 +13409,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
@@ -13972,8 +13429,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -13988,8 +13444,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -14005,8 +13460,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -14018,8 +13472,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -14028,15 +13481,13 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aEk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 4;
-	icon_state = "scrub_map_on-1"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -14046,12 +13497,10 @@
 "aEl" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -16
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -14070,15 +13519,13 @@
 "aEn" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aEo" = (
 /obj/machinery/computer/secure_data{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /obj/machinery/newscaster/security_unit/north,
 /turf/open/floor/plasteel/dark,
@@ -14088,8 +13535,7 @@
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -14142,8 +13588,7 @@
 /obj/machinery/biogenerator,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -14157,8 +13602,7 @@
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -14167,8 +13611,7 @@
 	icon_state = "6-9"
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -14183,8 +13626,7 @@
 /obj/machinery/computer/arcade,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -14198,8 +13640,7 @@
 /obj/machinery/computer/arcade,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -14209,16 +13650,14 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aEC" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -14291,12 +13730,10 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -14333,20 +13770,17 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "aEO" = (
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 1;
-	icon_state = "vent_map_on-3"
+	dir = 1
 	},
 /obj/item/ship_weapon/ammunition/torpedo/freight,
 /turf/open/floor/plasteel/dark,
@@ -14356,20 +13790,17 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "aEQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1;
-	icon_state = "scrub_map_on-1"
+	dir = 1
 	},
 /obj/structure/disposalpipe/junction/flip{
-	dir = 8;
-	icon_state = "pipe-j2"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -14379,8 +13810,7 @@
 "aES" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/machinery/cryopod,
 /turf/open/floor/plasteel,
@@ -14390,16 +13820,14 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/camera/autoname{
-	dir = 5;
-	icon_state = "camera"
+	dir = 5
 	},
 /obj/machinery/newscaster/security_unit/west,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hos)
 "aEU" = (
 /obj/machinery/computer/security{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/security)
@@ -14431,8 +13859,7 @@
 	icon_state = "5-10"
 	},
 /obj/structure/disposalpipe/junction/flip{
-	dir = 8;
-	icon_state = "pipe-j2"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -14441,20 +13868,17 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "aFb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1;
-	icon_state = "scrub_map_on-1"
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/nsv/hanger)
@@ -14473,12 +13897,10 @@
 /area/maintenance/nsv/bridge)
 "aFf" = (
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 8
@@ -14505,8 +13927,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 4;
-	icon_state = "scrub_map_on-1"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -14520,8 +13941,7 @@
 /area/hydroponics)
 "aFj" = (
 /obj/machinery/camera/autoname{
-	dir = 10;
-	icon_state = "camera"
+	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
@@ -14559,12 +13979,10 @@
 	},
 /obj/machinery/ore_silo,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 4;
-	icon_state = "vent_map_on-3"
+	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	dir = 5;
-	icon_state = "camera"
+	dir = 5
 	},
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/plasteel,
@@ -14590,7 +14008,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -14648,8 +14065,7 @@
 "aFw" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1;
-	icon_state = "scrub_map_on-1"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -14744,9 +14160,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
@@ -14766,7 +14180,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/structure/cable{
@@ -14804,12 +14217,10 @@
 /area/quartermaster/storage)
 "aFL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 8;
-	icon_state = "vent_map_on-3"
+	dir = 8
 	},
 /obj/structure/chair{
-	dir = 4;
-	icon_state = "chair"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -14853,7 +14264,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
@@ -14872,7 +14282,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/item/radio/intercom/directional/north,
@@ -14880,8 +14289,7 @@
 /area/medical/chemistry)
 "aFV" = (
 /obj/structure/chair{
-	dir = 8;
-	icon_state = "chair"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -14889,12 +14297,10 @@
 /obj/structure/closet/radiation,
 /obj/item/shovel,
 /obj/machinery/camera/autoname{
-	dir = 8;
-	icon_state = "camera"
+	dir = 8
 	},
 /obj/structure/sign/directions/science{
 	dir = 4;
-	icon_state = "direction_sci";
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
@@ -14957,8 +14363,7 @@
 /area/science/robotics/mechbay)
 "aGn" = (
 /obj/structure/chair{
-	dir = 4;
-	icon_state = "chair"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -14971,7 +14376,6 @@
 	dir = 2;
 	dwidth = 4;
 	height = 9;
-	icon_state = "pinonfar";
 	id = "supply_home";
 	name = "Supply Dock";
 	width = 16
@@ -14997,8 +14401,7 @@
 /area/security/brig)
 "aGr" = (
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
@@ -15010,8 +14413,7 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
-	dir = 1;
-	icon_state = "pipe-t"
+	dir = 1
 	},
 /obj/machinery/requests_console{
 	department = "Medical Bay";
@@ -15023,12 +14425,10 @@
 /area/medical/medbay)
 "aGt" = (
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/structure/chair,
 /turf/open/floor/plasteel,
@@ -15046,12 +14446,10 @@
 "aGv" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/structure/table,
 /obj/item/toner,
@@ -15067,12 +14465,9 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 2;
-	icon_state = "closed";
 	name = "Central Primary Hallway"
 	},
 /obj/machinery/door/firedoor/border_only/directional/west,
@@ -15126,7 +14521,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -15172,7 +14566,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/light{
@@ -15218,20 +14611,17 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/chapel{
-	dir = 9;
-	icon_state = "chapel"
+	dir = 9
 	},
 /area/chapel/main)
 "aHb" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -15240,7 +14630,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/light{
@@ -15269,12 +14658,10 @@
 /area/crew_quarters/heads/chief)
 "aHo" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -15282,7 +14669,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -15301,12 +14687,9 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 2;
-	icon_state = "closed";
 	name = "Fore Primary Hallway"
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -15319,13 +14702,11 @@
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -15334,7 +14715,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -15373,9 +14753,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
@@ -15408,7 +14786,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/wood,
@@ -15440,8 +14817,7 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -15458,7 +14834,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -15538,21 +14913,18 @@
 /area/hallway/primary/fore)
 "aHE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1;
-	icon_state = "scrub_map_on-1"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHF" = (
 /obj/structure/disposalpipe/junction/flip{
-	dir = 8;
-	icon_state = "pipe-j2"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -15593,7 +14965,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/effect/turf_decal/tile/purple,
@@ -15627,7 +14998,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -15671,19 +15041,15 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 9
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 8;
-	icon_state = "scrub_map_on-1"
+	dir = 8
 	},
 /obj/structure/disposalpipe/trunk{
-	dir = 8;
-	icon_state = "pipe-t"
+	dir = 8
 	},
 /obj/machinery/disposal/bin,
 /obj/machinery/newscaster/directional/south,
@@ -15721,14 +15087,12 @@
 /area/hallway/primary/central)
 "aHU" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -15746,7 +15110,6 @@
 "aHW" = (
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 4;
-	icon_state = "pipe-j1s";
 	name = "dorm branch sorting disposal pipe";
 	sortType = "26;29;30"
 	},
@@ -15754,8 +15117,7 @@
 /area/hallway/primary/fore)
 "aHX" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/structure/cable{
@@ -15766,36 +15128,30 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHY" = (
 /obj/effect/turf_decal/stripes/end{
-	dir = 4;
-	icon_state = "warn_end"
+	dir = 4
 	},
 /obj/machinery/computer/mech_bay_power_console{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	dir = 10;
-	icon_state = "camera"
+	dir = 10
 	},
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
 "aHZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1;
-	icon_state = "scrub_map_on-1"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/effect/turf_decal/tile/purple,
@@ -15803,12 +15159,10 @@
 /area/hallway/primary/central)
 "aIa" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -15817,7 +15171,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -15847,7 +15200,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -15926,27 +15278,23 @@
 /area/tcommsat/computer)
 "aIj" = (
 /obj/machinery/computer/security{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /turf/open/floor/carpet/red,
 /area/security/warden)
 "aIk" = (
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "aIl" = (
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/vending/cigarette,
@@ -15954,16 +15302,13 @@
 /area/hallway/secondary/exit/departure_lounge)
 "aIm" = (
 /obj/structure/chair{
-	dir = 4;
-	icon_state = "chair"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/firealarm/directional/west,
@@ -15975,31 +15320,26 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "aIo" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "aIp" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow"
+	dir = 1
 	},
 /obj/structure/chair,
 /obj/machinery/door/firedoor/border_only/directional/north,
@@ -16014,25 +15354,21 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/chapel{
-	dir = 5;
-	icon_state = "chapel"
+	dir = 5
 	},
 /area/chapel/main)
 "aIr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 8;
-	icon_state = "vent_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics)
 "aIs" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -16041,7 +15377,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -16053,7 +15388,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -16075,7 +15409,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -16107,12 +15440,10 @@
 /area/crew_quarters/heads/hos)
 "aIy" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/power/apc/auto_name/north{
 	pixel_y = 24
@@ -16126,15 +15457,13 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
 /area/science)
 "aIz" = (
 /obj/machinery/computer/robotics{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/dark/hidden{
 	dir = 5
@@ -16144,8 +15473,7 @@
 /area/crew_quarters/heads/hor)
 "aIA" = (
 /obj/structure/disposalpipe/junction/flip{
-	dir = 4;
-	icon_state = "pipe-j2"
+	dir = 4
 	},
 /obj/effect/landmark/start/scientist,
 /obj/machinery/atmospherics/pipe/simple/dark/hidden{
@@ -16160,8 +15488,7 @@
 /area/crew_quarters/heads/hor)
 "aIC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1;
-	icon_state = "scrub_map_on-1"
+	dir = 1
 	},
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
@@ -16174,8 +15501,7 @@
 	},
 /obj/effect/turf_decal/tile/brown,
 /obj/machinery/computer/cargo{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /obj/machinery/requests_console{
 	department = "Cargo Bay";
@@ -16188,26 +15514,22 @@
 /area/quartermaster/sorting)
 "aIE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1;
-	icon_state = "scrub_map_on-1"
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science)
 "aIF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 1;
-	icon_state = "vent_map_on-3"
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science)
 "aIG" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -16222,21 +15544,18 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
 /area/science)
 "aIH" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
@@ -16247,12 +15566,10 @@
 /area/science)
 "aII" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
@@ -16261,7 +15578,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/structure/disposalpipe/segment{
@@ -16291,21 +15607,17 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 8;
-	icon_state = "vent_map_on-3"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -16339,37 +15651,31 @@
 /area/science/mixing)
 "aIO" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/item/radio/intercom/directional/north,
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
 /area/science)
 "aIP" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 9;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -16386,7 +15692,6 @@
 	},
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 4;
-	icon_state = "pipe-j1s";
 	name = "research head sorting disposal pipe";
 	sortType = 13
 	},
@@ -16404,7 +15709,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 5;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/light_switch/west,
@@ -16475,7 +15779,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/structure/disposalpipe/segment{
@@ -16502,7 +15805,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/effect/landmark/event_spawn,
@@ -16518,7 +15820,6 @@
 	},
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1;
-	icon_state = "pipe-j2s";
 	name = "chef sorting disposal pipe";
 	sortType = 20
 	},
@@ -16568,7 +15869,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/wood,
@@ -16621,8 +15921,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1;
-	icon_state = "scrub_map_on-1"
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -16679,8 +15978,7 @@
 	icon_state = "9-10"
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -16692,8 +15990,7 @@
 /area/security/prison)
 "aJo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 4;
-	icon_state = "scrub_map_on-1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -16705,8 +16002,7 @@
 /area/security/prison)
 "aJq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 4;
-	icon_state = "vent_map_on-3"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -16716,12 +16012,10 @@
 "aJr" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/structure/chair{
-	dir = 8;
-	icon_state = "chair"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 10
@@ -16734,8 +16028,7 @@
 "aJs" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/machinery/status_display/evac/south,
 /obj/item/twohanded/required/kirbyplants/random,
@@ -16743,25 +16036,21 @@
 /area/hallway/secondary/exit/departure_lounge)
 "aJt" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 8;
-	icon_state = "scrub_map_on-1"
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aJu" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	dir = 10;
-	icon_state = "camera"
+	dir = 10
 	},
 /obj/machinery/firealarm/directional/south,
 /obj/structure/chair{
-	dir = 1;
-	icon_state = "chair"
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -16773,8 +16062,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 8;
-	icon_state = "vent_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -16803,8 +16091,7 @@
 /obj/structure/table/wood/fancy/royalblack,
 /obj/item/storage/book/bible,
 /turf/open/floor/plasteel/chapel{
-	dir = 10;
-	icon_state = "chapel"
+	dir = 10
 	},
 /area/chapel/main)
 "aJz" = (
@@ -16834,8 +16121,7 @@
 	icon_state = "4-9"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 8;
-	icon_state = "vent_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -16860,8 +16146,7 @@
 	icon_state = "4-9"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 8;
-	icon_state = "scrub_map_on-1"
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -16918,15 +16203,13 @@
 "aJH" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 1;
-	icon_state = "vent_map_on-3"
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aJI" = (
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/item/ship_weapon/ammunition/torpedo/freight,
@@ -16952,8 +16235,7 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/chair/office{
-	dir = 4;
-	icon_state = "officechair_dark"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "6-10"
@@ -16988,8 +16270,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 1;
-	icon_state = "vent_map_on-3"
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -17015,8 +16296,7 @@
 "aJQ" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -17065,8 +16345,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -17080,12 +16359,9 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
@@ -17104,8 +16380,7 @@
 	pixel_y = 3
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1;
-	icon_state = "scrub_map_on-1"
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -17114,12 +16389,10 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1;
-	icon_state = "scrub_map_on-1"
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -17161,8 +16434,7 @@
 /area/crew_quarters/heads/hop)
 "aKb" = (
 /obj/effect/turf_decal/arrows/red{
-	dir = 1;
-	icon_state = "arrows_red"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "2-9"
@@ -17171,8 +16443,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1;
-	icon_state = "scrub_map_on-1"
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/hallway/primary/fore)
@@ -17194,8 +16465,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1;
-	icon_state = "scrub_map_on-1"
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/hallway/primary/fore)
@@ -17230,7 +16500,6 @@
 	},
 /obj/machinery/door/poddoor/shutters/ship/preopen{
 	dir = 8;
-	icon_state = "open";
 	id = "xo_line"
 	},
 /turf/open/floor/plating,
@@ -17242,7 +16511,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/machinery/holopad,
@@ -17277,7 +16545,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/structure/disposalpipe/segment{
@@ -17295,7 +16562,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/structure/disposalpipe/segment{
@@ -17309,7 +16575,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -17323,8 +16588,7 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -17345,7 +16609,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/door/firedoor/border_only/directional/west,
@@ -17358,7 +16621,6 @@
 	},
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1;
-	icon_state = "pipe-j2s";
 	name = "hydro sorting disposal pipe";
 	sortType = 21
 	},
@@ -17383,8 +16645,7 @@
 "aKr" = (
 /obj/item/radio/intercom/directional/south,
 /obj/machinery/camera/autoname{
-	dir = 10;
-	icon_state = "camera"
+	dir = 10
 	},
 /turf/open/floor/monotile,
 /area/nsv/hanger)
@@ -17393,7 +16654,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/effect/turf_decal/tile/purple,
@@ -17401,12 +16661,10 @@
 /area/hallway/primary/central)
 "aKt" = (
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -17416,9 +16674,7 @@
 /obj/structure/cable{
 	icon_state = "2-9"
 	},
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
 	icon_state = "0-6"
 	},
@@ -17436,8 +16692,6 @@
 /area/maintenance/department/crew_quarters/bar)
 "aKv" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 2;
-	icon_state = "closed";
 	name = "Central Primary Hallway"
 	},
 /obj/structure/cable{
@@ -17460,7 +16714,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -17475,7 +16728,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/machinery/holopad,
@@ -17487,8 +16739,7 @@
 /area/security/detectives_office/combined)
 "aKz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 4;
-	icon_state = "vent_map_on-3"
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/security/detectives_office/combined)
@@ -17550,8 +16801,7 @@
 	icon_state = "Executive Officer"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1;
-	icon_state = "scrub_map_on-1"
+	dir = 1
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
@@ -17566,7 +16816,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -17583,7 +16832,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -17593,8 +16841,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/dark,
@@ -17604,7 +16851,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -17616,7 +16862,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -17628,20 +16873,17 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aKS" = (
 /obj/structure/disposalpipe/junction/flip{
-	dir = 8;
-	icon_state = "pipe-j2"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -17656,8 +16898,7 @@
 /area/bridge)
 "aKU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 8;
-	icon_state = "scrub_map_on-1"
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -17668,7 +16909,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/machinery/camera/autoname,
@@ -17686,7 +16926,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/monotile/dark,
@@ -17713,8 +16952,7 @@
 	icon_state = "6-9"
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -17722,7 +16960,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -17804,8 +17041,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -17835,19 +17071,16 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 8;
-	icon_state = "scrub_map_on-1"
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "aLk" = (
 /obj/structure/chair{
-	dir = 8;
-	icon_state = "chair"
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1;
-	icon_state = "scrub_map_on-1"
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -17856,16 +17089,14 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j1"
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -17885,12 +17116,10 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -17900,8 +17129,7 @@
 	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
-	dir = 8;
-	icon_state = "pipe-t"
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -17936,15 +17164,13 @@
 /area/bridge)
 "aLs" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 1;
-	icon_state = "vent_map_on-3"
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/nsv/officerquarters)
 "aLt" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1;
-	icon_state = "scrub_map_on-1"
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/nsv/officerquarters)
@@ -17960,7 +17186,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/structure/disposalpipe/segment{
@@ -17976,7 +17201,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -17998,13 +17222,11 @@
 /area/bridge)
 "aLx" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1;
-	icon_state = "scrub_map_on-1"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -18017,7 +17239,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/machinery/light,
@@ -18052,15 +17273,13 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "aLE" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/plasteel/dark,
@@ -18071,12 +17290,10 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/computer/card{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -18091,8 +17308,7 @@
 /area/crew_quarters/nsv/officerquarters)
 "aLH" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -18101,7 +17317,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/dark,
@@ -18119,7 +17334,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 10;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/dark,
@@ -18176,16 +17390,13 @@
 /area/hallway/primary/aft)
 "aLP" = (
 /obj/effect/turf_decal/tile/neutral{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 8;
-	icon_state = "vent_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -18196,8 +17407,7 @@
 /area/bridge)
 "aLR" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -18215,16 +17425,14 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/junction/flip{
-	dir = 1;
-	icon_state = "pipe-j2"
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "aLS" = (
 /obj/structure/closet/secure_closet/master_at_arms,
 /obj/machinery/camera/autoname{
-	dir = 8;
-	icon_state = "camera"
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/nsv/crew_quarters/heads/maa)
@@ -18254,7 +17462,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/machinery/light{
@@ -18278,7 +17485,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 10;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -18316,23 +17522,19 @@
 /area/hallway/primary/central)
 "aMa" = (
 /obj/effect/turf_decal/tile/neutral{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 8;
-	icon_state = "scrub_map_on-1"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aMc" = (
 /obj/machinery/computer/security/hos{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
@@ -18361,8 +17563,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/junction/flip{
-	dir = 1;
-	icon_state = "pipe-j2"
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
@@ -18426,7 +17627,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/dark,
@@ -18434,12 +17634,10 @@
 "aMk" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/structure/chair{
-	dir = 1;
-	icon_state = "chair"
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -18454,8 +17652,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "aMm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 8;
-	icon_state = "vent_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -18546,7 +17743,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/dark,
@@ -18599,15 +17795,13 @@
 	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
-	dir = 1;
-	icon_state = "pipe-t"
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "aMy" = (
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -18624,14 +17818,12 @@
 /area/science/lab)
 "aMA" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/status_display/evac/north,
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/machinery/light{
@@ -18646,7 +17838,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 5;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -18699,17 +17890,14 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/structure/chair/office{
-	dir = 1;
-	icon_state = "officechair_dark"
+	dir = 1
 	},
 /obj/machinery/button/door{
 	id = "mechbay_desk";
@@ -18739,7 +17927,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 5;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -18750,12 +17937,10 @@
 /area/medical/medbay)
 "aML" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -18771,7 +17956,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/camera/autoname,
@@ -18802,8 +17986,6 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 2;
-	icon_state = "closed";
 	name = "Central Primary Hallway"
 	},
 /obj/machinery/door/firedoor/border_only/directional/west,
@@ -18812,14 +17994,12 @@
 /area/hallway/primary/central)
 "aMP" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
-	dir = 1;
-	icon_state = "pipe-t"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -18847,13 +18027,11 @@
 /area/security/warden)
 "aMS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 1;
-	icon_state = "vent_map_on-3"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/machinery/light,
@@ -18920,8 +18098,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 4;
-	icon_state = "vent_map_on-3"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -18965,7 +18142,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -18977,7 +18153,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -19014,12 +18189,10 @@
 "aNj" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/structure/chair{
-	dir = 8;
-	icon_state = "chair"
+	dir = 8
 	},
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/plasteel,
@@ -19033,8 +18206,7 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -19067,30 +18239,25 @@
 /area/quartermaster/storage)
 "aNo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 1;
-	icon_state = "vent_map_on-3"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aNp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1;
-	icon_state = "scrub_map_on-1"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/effect/turf_decal/tile/red,
@@ -19099,32 +18266,27 @@
 "aNq" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/machinery/status_display/evac/south,
 /obj/structure/chair{
-	dir = 1;
-	icon_state = "chair"
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "aNr" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 8;
-	icon_state = "vent_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "aNs" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -19140,7 +18302,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/structure/disposalpipe/segment{
@@ -19156,7 +18317,6 @@
 "aNv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 4;
-	icon_state = "scrub_map-2";
 	id_tag = "aft_tox_burn";
 	name = "Aft Burn Filter"
 	},
@@ -19171,15 +18331,13 @@
 /area/nsv/weapons/port)
 "aNx" = (
 /obj/machinery/camera/autoname{
-	dir = 10;
-	icon_state = "camera"
+	dir = 10
 	},
 /turf/open/floor/monotile,
 /area/nsv/hanger)
 "aNy" = (
 /obj/machinery/modular_computer/console/preset/research{
-	dir = 4;
-	icon_state = "console"
+	dir = 4
 	},
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/carpet/purple,
@@ -19191,16 +18349,13 @@
 /area/hallway/secondary/exit/departure_lounge)
 "aNA" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/structure/chair{
-	dir = 4;
-	icon_state = "chair"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 6
@@ -19227,8 +18382,7 @@
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
@@ -19236,12 +18390,10 @@
 "aND" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -19257,20 +18409,17 @@
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "aNF" = (
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/airalarm/directional/south,
@@ -19298,7 +18447,6 @@
 "aNJ" = (
 /obj/machinery/conveyor{
 	dir = 8;
-	icon_state = "conveyor_map";
 	id = "cargo_shuttle"
 	},
 /obj/machinery/airalarm/directional/south,
@@ -19332,8 +18480,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 4;
-	icon_state = "vent_map_on-3"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -19349,8 +18496,7 @@
 /area/hallway/primary/central)
 "aNQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 8;
-	icon_state = "vent_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/kitchen)
@@ -19368,8 +18514,7 @@
 /area/chapel/office)
 "aNT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 4;
-	icon_state = "vent_map_on-3"
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
@@ -19387,8 +18532,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 8;
-	icon_state = "scrub_map_on-1"
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
@@ -19396,7 +18540,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/grass,
@@ -19408,12 +18551,10 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1;
-	icon_state = "scrub_map_on-1"
+	dir = 1
 	},
 /obj/machinery/hydroponics/soil,
 /turf/open/floor/grass,
@@ -19433,8 +18574,6 @@
 /area/chapel/main)
 "aOa" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 2;
-	icon_state = "closed";
 	name = "Lounge"
 	},
 /obj/machinery/door/firedoor/border_only/directional/north,
@@ -19447,8 +18586,7 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/open/floor/plasteel/chapel{
-	dir = 6;
-	icon_state = "chapel"
+	dir = 6
 	},
 /area/chapel/main)
 "aOd" = (
@@ -19471,8 +18609,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 2;
-	icon_state = "closed";
 	name = "Lounge"
 	},
 /obj/structure/cable{
@@ -19493,7 +18629,6 @@
 "aOk" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4;
-	icon_state = "pipe-j2s";
 	name = "munitions branch sorting disposal pipe";
 	sortType = "32;33"
 	},
@@ -19526,8 +18661,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/computer/ship/viewscreen,
 /obj/machinery/light/small{
@@ -19549,8 +18683,6 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 2;
-	icon_state = "closed";
 	name = "Fore Primary Hallway"
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -19575,16 +18707,13 @@
 "aOu" = (
 /obj/machinery/vending/robotics,
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
@@ -19592,63 +18721,52 @@
 "aOv" = (
 /obj/machinery/mecha_part_fabricator,
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
 /area/science/robotics)
 "aOw" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics)
 "aOy" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics)
 "aOz" = (
 /obj/effect/landmark/start/roboticist,
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/bot_red,
 /turf/open/floor/plasteel,
 /area/science/robotics)
 "aOA" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/bot_red,
 /turf/open/floor/plasteel,
@@ -19673,8 +18791,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 2;
-	icon_state = "closed";
 	name = "Security Lobby"
 	},
 /obj/structure/disposalpipe/segment{
@@ -19690,8 +18806,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
@@ -19702,12 +18817,10 @@
 	},
 /obj/machinery/rnd/production/circuit_imprinter/department/science,
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics)
@@ -19738,13 +18851,11 @@
 /area/science/robotics)
 "aOK" = (
 /obj/structure/chair/pew/right{
-	dir = 1;
-	icon_state = "pewend_right"
+	dir = 1
 	},
 /obj/item/radio/intercom/directional/east,
 /obj/machinery/camera/autoname{
-	dir = 8;
-	icon_state = "camera"
+	dir = 8
 	},
 /turf/open/floor/plasteel/chapel,
 /area/chapel/main)
@@ -19754,36 +18865,30 @@
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics)
 "aOO" = (
 /obj/machinery/vending/wardrobe/robo_wardrobe,
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics)
 "aOP" = (
 /obj/effect/turf_decal/stripes/red/corner{
-	dir = 8;
-	icon_state = "warninglinecorner_red"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -19792,12 +18897,10 @@
 /area/science/robotics/mechbay)
 "aOQ" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/aug_manipulator,
 /turf/open/floor/plasteel,
@@ -19821,12 +18924,10 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/bar{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j1"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -19838,13 +18939,11 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/bar{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/structure/disposalpipe/segment{
@@ -19901,8 +19000,7 @@
 /area/crew_quarters/lounge)
 "aPb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 1;
-	icon_state = "vent_map_on-3"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "5-10"
@@ -19910,7 +19008,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -19926,7 +19023,6 @@
 	},
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4;
-	icon_state = "pipe-j2s";
 	name = "food service sorting disposal pipe";
 	sortType = "19;20;21"
 	},
@@ -19950,8 +19046,7 @@
 /area/hallway/primary/central)
 "aPf" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -19960,7 +19055,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 5;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -20014,7 +19108,6 @@
 	},
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 4;
-	icon_state = "pipe-j1s";
 	name = "shitcurity sorting disposal pipe";
 	sortType = "7;8"
 	},
@@ -20033,8 +19126,7 @@
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks,
 /obj/structure/window/reinforced/tinted/frosted{
-	dir = 1;
-	icon_state = "fwindow"
+	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
 /area/hallway/secondary/service)
@@ -20082,7 +19174,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 5;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/dark,
@@ -20117,7 +19208,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 10;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/dark,
@@ -20148,8 +19238,7 @@
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer,
 /obj/structure/window/reinforced/tinted/frosted{
-	dir = 1;
-	icon_state = "fwindow"
+	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
 /area/hallway/secondary/service)
@@ -20195,22 +19284,18 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aPC" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/machinery/camera/autoname{
-	dir = 8;
-	icon_state = "camera"
+	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
@@ -20308,7 +19393,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 6;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plating,
@@ -20323,7 +19407,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plating,
@@ -20341,7 +19424,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 9;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plating,
@@ -20392,7 +19474,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/structure/disposalpipe/segment{
@@ -20408,7 +19489,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -20446,8 +19526,7 @@
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/camera/autoname{
-	dir = 5;
-	icon_state = "camera"
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -20468,8 +19547,7 @@
 /area/security/brig)
 "aPY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 8;
-	icon_state = "vent_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/port)
@@ -20522,15 +19600,13 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/port)
 "aQg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 8;
-	icon_state = "scrub_map_on-1"
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/nsv/crew_quarters/heads/maa)
@@ -20538,25 +19614,21 @@
 /obj/machinery/ship_weapon/torpedo_launcher/east,
 /obj/effect/turf_decal/delivery/white,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1;
-	icon_state = "scrub_map_on-1"
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/nsv/weapons/port)
 "aQi" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/computer/ship/navigation/astrometrics{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
@@ -20593,12 +19665,10 @@
 /area/space/nearstation)
 "aQm" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/light{
 	dir = 1
@@ -20614,7 +19684,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plating,
@@ -20635,7 +19704,6 @@
 	},
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 4;
-	icon_state = "pipe-j1s";
 	name = "antonio sorting disposal pipe";
 	sortType = 32
 	},
@@ -20646,8 +19714,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
@@ -20662,20 +19729,17 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aQs" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 1;
-	icon_state = "vent_map_on-3"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -20686,8 +19750,7 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j1"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -20704,30 +19767,25 @@
 "aQv" = (
 /obj/effect/landmark/start/master_at_arms,
 /obj/structure/chair/office{
-	dir = 4;
-	icon_state = "officechair_dark"
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 8;
-	icon_state = "vent_map_on-3"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/wood,
 /area/nsv/crew_quarters/heads/maa)
 "aQw" = (
 /obj/machinery/computer/ship/fighter_controller{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/wood,
@@ -20737,7 +19795,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plating,
@@ -20749,7 +19806,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/monotile,
@@ -20760,13 +19816,11 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 1;
-	icon_state = "vent_map_on-3"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 10;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/monotile,
@@ -20790,12 +19844,10 @@
 /area/library)
 "aQC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1;
-	icon_state = "scrub_map_on-1"
+	dir = 1
 	},
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4;
-	icon_state = "pipe-j2s";
 	name = "hangar sorting disposal pipe";
 	sortType = 31
 	},
@@ -20821,7 +19873,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 10;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -20830,7 +19881,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 5;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/closed/wall/r_wall,
@@ -20844,7 +19894,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/structure/disposalpipe/segment{
@@ -20867,8 +19916,7 @@
 	name = "Arrivals Dock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1;
-	icon_state = "airlock_cyclelink_helper"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -20876,8 +19924,7 @@
 /area/hallway/secondary/entry)
 "aQJ" = (
 /obj/effect/turf_decal/stripes/red/line{
-	dir = 8;
-	icon_state = "warningline_red"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
@@ -20925,7 +19972,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 10;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -20960,8 +20006,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1;
-	icon_state = "scrub_map_on-1"
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -20993,8 +20038,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 4;
-	icon_state = "scrub_map_on-1"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -21010,8 +20054,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 4;
-	icon_state = "vent_map_on-3"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -21067,15 +20110,12 @@
 /area/maintenance/department/cargo)
 "aRe" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 2;
-	icon_state = "closed";
 	name = "Central Primary Hallway"
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -21105,8 +20145,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/camera/autoname{
-	dir = 10;
-	icon_state = "camera"
+	dir = 10
 	},
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/plasteel,
@@ -21132,16 +20171,13 @@
 "aRm" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -16
 	},
 /obj/structure/chair/office{
-	dir = 1;
-	icon_state = "officechair_dark"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -21170,12 +20206,10 @@
 /area/hallway/secondary/exit/departure_lounge)
 "aRr" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/structure/extinguisher_cabinet/south,
@@ -21191,12 +20225,9 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 2;
-	icon_state = "closed";
 	name = "Central Primary Hallway"
 	},
 /obj/machinery/door/firedoor/border_only/directional/west,
@@ -21254,8 +20285,7 @@
 /area/storage/tech)
 "aRD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 8;
-	icon_state = "vent_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
@@ -21263,9 +20293,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
 /turf/open/floor/plating,
 /area/storage/tech)
@@ -21428,12 +20456,10 @@
 /area/engine/gravity_generator)
 "aRW" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/newscaster/directional/east,
@@ -21468,8 +20494,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/newscaster/directional/east,
@@ -21533,8 +20558,7 @@
 /area/engine/gravity_generator)
 "aSf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1;
-	icon_state = "scrub_map_on-1"
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
@@ -21627,8 +20651,7 @@
 /area/hallway/secondary/entry)
 "aSq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 4;
-	icon_state = "vent_map_on-3"
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
@@ -21643,15 +20666,13 @@
 /area/engine/gravity_generator)
 "aSs" = (
 /obj/structure/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/item/reagent_containers/spray/cleaner,
@@ -21666,8 +20687,7 @@
 /area/maintenance/department/chapel)
 "aSu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 1;
-	icon_state = "vent_map_on-3"
+	dir = 1
 	},
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/plasteel/dark,
@@ -21713,8 +20733,7 @@
 /area/chapel/office)
 "aSD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 1;
-	icon_state = "vent_map_on-3"
+	dir = 1
 	},
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -21754,8 +20773,7 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "aSI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 4;
-	icon_state = "scrub_map_on-1"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "0-6"
@@ -21786,8 +20804,7 @@
 /area/engine/gravity_generator)
 "aSK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 8;
-	icon_state = "vent_map_on-3"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "0-10"
@@ -21810,8 +20827,7 @@
 /area/engine/gravity_generator)
 "aSM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 4;
-	icon_state = "scrub_map_on-1"
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
@@ -21835,8 +20851,7 @@
 "aSQ" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
-	dir = 1;
-	icon_state = "pipe-t"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 5
@@ -21861,8 +20876,7 @@
 	icon_state = "5-10"
 	},
 /obj/machinery/computer/card/minor/hos{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
@@ -21881,12 +20895,10 @@
 /area/security/brig)
 "aSV" = (
 /obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j1"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -21929,8 +20941,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/arrows{
-	dir = 1;
-	icon_state = "arrows"
+	dir = 1
 	},
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel/dark,
@@ -21941,8 +20952,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/arrows{
-	dir = 1;
-	icon_state = "arrows"
+	dir = 1
 	},
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel/dark,
@@ -21958,13 +20968,11 @@
 /area/crew_quarters/dorms)
 "aTc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1;
-	icon_state = "scrub_map_on-1"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/light,
@@ -22006,8 +21014,7 @@
 "aTg" = (
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/computer/crew/console{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -22047,7 +21054,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
@@ -22084,8 +21090,7 @@
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -22107,7 +21112,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -22144,18 +21148,14 @@
 /area/medical/genetics)
 "aTr" = (
 /obj/effect/turf_decal/tile/bar{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 2;
-	icon_state = "closed";
 	name = "Central Primary Hallway"
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -22175,7 +21175,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 6;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/computer/ship/viewscreen,
@@ -22201,7 +21200,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -22209,12 +21207,10 @@
 "aTu" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 10
@@ -22238,7 +21234,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 9;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/effect/landmark/event_spawn,
@@ -22247,12 +21242,10 @@
 "aTw" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 1;
-	icon_state = "vent_map_on-3"
+	dir = 1
 	},
 /obj/machinery/requests_console{
 	department = "Research";
@@ -22267,13 +21260,11 @@
 "aTx" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/item/radio/intercom/directional/east,
 /obj/machinery/camera/autoname{
-	dir = 8;
-	icon_state = "camera"
+	dir = 8
 	},
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/plasteel/white,
@@ -22298,7 +21289,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -22320,7 +21310,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -22337,7 +21326,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -22356,7 +21344,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -22373,8 +21360,7 @@
 	},
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -22382,27 +21368,23 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
 "aTD" = (
 /obj/machinery/sleeper{
-	dir = 1;
-	icon_state = "sleeper"
+	dir = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -22421,8 +21403,6 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 2;
-	icon_state = "closed";
 	name = "Security Lobby"
 	},
 /obj/machinery/door/firedoor/border_only/directional/north,
@@ -22436,7 +21416,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -22479,8 +21458,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -22488,7 +21466,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -22502,8 +21479,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -22511,7 +21487,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -22527,8 +21502,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -22536,15 +21510,13 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
 "aTL" = (
 /obj/effect/turf_decal/stripes/end{
-	dir = 8;
-	icon_state = "warn_end"
+	dir = 8
 	},
 /obj/machinery/mech_bay_recharge_port,
 /obj/structure/extinguisher_cabinet/west,
@@ -22558,13 +21530,11 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -22577,7 +21547,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -22634,8 +21603,6 @@
 /area/science/lab)
 "aTT" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 2;
-	icon_state = "closed";
 	name = "Fore Primary Hallway"
 	},
 /obj/structure/cable{
@@ -22644,7 +21611,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/machinery/door/firedoor/border_only/directional/west,
@@ -22654,7 +21620,6 @@
 "aTU" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 16
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -22672,8 +21637,7 @@
 "aTV" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/machinery/firealarm/directional/south,
 /obj/effect/landmark/start/roboticist,
@@ -22682,16 +21646,14 @@
 "aTW" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/landmark/start/roboticist,
 /turf/open/floor/plasteel,
 /area/science/robotics)
 "aTX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 4;
-	icon_state = "vent_map_on-3"
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
@@ -22703,12 +21665,9 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 2;
-	icon_state = "closed";
 	name = "Fore Primary Hallway"
 	},
 /obj/machinery/door/firedoor/border_only/directional/west,
@@ -22722,7 +21681,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 5;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/newscaster/directional/south,
@@ -22732,7 +21690,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#f00";
 	dir = 4;
-	icon_state = "pipe";
 	name = "to-space disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -22750,8 +21707,7 @@
 "aUc" = (
 /obj/structure/table/glass,
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/item/storage/firstaid/regular,
 /obj/item/storage/firstaid/regular,
@@ -22766,20 +21722,17 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
 "aUd" = (
 /obj/structure/table/glass,
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
+	dir = 8
 	},
 /obj/item/storage/firstaid/brute,
 /obj/item/storage/firstaid/brute,
@@ -22816,7 +21769,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -22825,12 +21777,9 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 2;
-	icon_state = "closed";
 	name = "Fore Primary Hallway"
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -22860,7 +21809,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/machinery/newscaster/directional/south,
@@ -22903,8 +21851,7 @@
 	},
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/camera/autoname{
-	dir = 8;
-	icon_state = "camera"
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
@@ -22937,8 +21884,7 @@
 /area/medical/medbay)
 "aUt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 1;
-	icon_state = "vent_map_on-3"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -22961,7 +21907,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 6;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -22976,7 +21921,6 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 8;
-	icon_state = "pipe-j1s";
 	name = "medbay sorting disposal pipe";
 	sortType = 9
 	},
@@ -22991,7 +21935,6 @@
 	},
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 8;
-	icon_state = "pipe-j1s";
 	name = "virology sorting disposal pipe";
 	sortType = 27
 	},
@@ -23003,7 +21946,6 @@
 	},
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 8;
-	icon_state = "pipe-j1s";
 	name = "chief medical sorting disposal pipe";
 	sortType = 10
 	},
@@ -23043,7 +21985,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/camera/autoname,
@@ -23052,12 +21993,10 @@
 "aUD" = (
 /obj/structure/table/glass,
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
+	dir = 8
 	},
 /obj/item/storage/firstaid/fire,
 /obj/item/storage/firstaid/fire,
@@ -23078,7 +22017,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 6;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/item/storage/box/beakers,
@@ -23167,7 +22105,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/structure/extinguisher_cabinet/south,
@@ -23203,8 +22140,7 @@
 /area/security/warden)
 "aVa" = (
 /obj/machinery/computer/prisoner{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /turf/open/floor/carpet/red,
 /area/security/warden)
@@ -23254,7 +22190,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 6;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/wood,
@@ -23262,8 +22197,7 @@
 "aVh" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/machinery/requests_console{
 	department = "Research";
@@ -23279,16 +22213,13 @@
 "aVj" = (
 /obj/machinery/mecha_part_fabricator,
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/computer/ship/viewscreen,
@@ -23296,20 +22227,16 @@
 /area/science/robotics)
 "aVk" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 8;
-	icon_state = "scrub_map_on-1"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -23318,9 +22245,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "aVm" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -23332,8 +22257,7 @@
 "aVn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/chair/office{
-	dir = 4;
-	icon_state = "officechair_dark"
+	dir = 4
 	},
 /obj/effect/landmark/start/warden,
 /turf/open/floor/carpet/red,
@@ -23352,12 +22276,10 @@
 /area/bridge)
 "aVq" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/structure/chair{
@@ -23368,12 +22290,10 @@
 /area/science)
 "aVr" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -23421,7 +22341,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -23483,8 +22402,7 @@
 	dir = 4
 	},
 /obj/machinery/computer/mecha{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -23499,12 +22417,10 @@
 "aVD" = (
 /obj/structure/table/glass,
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
+	dir = 8
 	},
 /obj/item/storage/firstaid/o2,
 /obj/item/storage/firstaid/o2,
@@ -23545,8 +22461,7 @@
 "aVG" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/camera/autoname{
-	dir = 10;
-	icon_state = "camera"
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -23564,7 +22479,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 6;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -23598,8 +22512,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
@@ -23621,8 +22534,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -23637,8 +22549,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -23647,8 +22558,7 @@
 /area/medical/medbay/lobby)
 "aVQ" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -23660,8 +22570,7 @@
 /area/medical/medbay)
 "aVR" = (
 /obj/structure/chair/office{
-	dir = 1;
-	icon_state = "officechair_dark"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 5
@@ -23674,8 +22583,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
@@ -23690,8 +22598,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -23747,8 +22654,7 @@
 	dir = 4
 	},
 /obj/machinery/computer/crew{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
@@ -23781,13 +22687,11 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/machinery/shower{
@@ -23801,15 +22705,13 @@
 /area/engine/engineering)
 "aWb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 4;
-	icon_state = "vent_map_on-3"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
 	},
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1;
-	icon_state = "pipe-j2s";
 	name = "cargo sorting disposal pipe";
 	sortType = "2;3"
 	},
@@ -23818,8 +22720,7 @@
 "aWc" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
-	dir = 1;
-	icon_state = "pipe-t"
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -23841,7 +22742,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plating,
@@ -23865,7 +22765,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -23876,8 +22775,7 @@
 	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
-	dir = 8;
-	icon_state = "pipe-t"
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hos)
@@ -23908,8 +22806,7 @@
 /area/maintenance/department/science)
 "aWj" = (
 /obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j1"
+	dir = 8
 	},
 /obj/machinery/light,
 /obj/structure/extinguisher_cabinet/south,
@@ -23918,8 +22815,7 @@
 "aWk" = (
 /obj/machinery/stasis,
 /obj/structure/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -23950,8 +22846,7 @@
 "aWm" = (
 /obj/machinery/stasis,
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -24002,8 +22897,7 @@
 	dir = 1
 	},
 /obj/structure/chair{
-	dir = 4;
-	icon_state = "chair"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/sign/poster/official/obey{
@@ -24024,8 +22918,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 4;
-	icon_state = "scrub_map_on-1"
+	dir = 4
 	},
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
@@ -24063,8 +22956,7 @@
 "aWv" = (
 /obj/structure/curtain,
 /obj/machinery/shower{
-	dir = 8;
-	icon_state = "shower"
+	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/heads/captain/private)
@@ -24087,9 +22979,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/toilet)
 "aWy" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
 	icon_state = "0-6"
 	},
@@ -24210,7 +23100,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 6;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/dark,
@@ -24307,8 +23196,7 @@
 "aWO" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/structure/table/glass,
 /obj/item/stack/sheet/iron/fifty,
@@ -24389,27 +23277,23 @@
 /area/security/brig)
 "aXc" = (
 /obj/effect/turf_decal/stripes/red/line{
-	dir = 8;
-	icon_state = "warningline_red"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "aXd" = (
 /obj/effect/turf_decal/stripes/end{
-	dir = 8;
-	icon_state = "warn_end"
+	dir = 8
 	},
 /obj/machinery/mech_bay_recharge_port,
 /turf/open/floor/circuit/green/anim,
 /area/science/robotics/mechbay)
 "aXe" = (
 /obj/effect/turf_decal/stripes/end{
-	dir = 4;
-	icon_state = "warn_end"
+	dir = 4
 	},
 /obj/machinery/computer/mech_bay_power_console{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
@@ -24452,7 +23336,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -24507,7 +23390,6 @@
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
-	icon_state = "pump_on_map-2";
 	level = 1;
 	name = "Server Air Supply"
 	},
@@ -24556,8 +23438,7 @@
 	dir = 1
 	},
 /obj/structure/chair{
-	dir = 4;
-	icon_state = "chair"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 6
@@ -24684,7 +23565,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/machinery/door/firedoor/border_only/directional/west,
@@ -24700,8 +23580,7 @@
 /area/crew_quarters/lounge)
 "aXD" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -24717,8 +23596,7 @@
 "aXF" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -24732,8 +23610,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 8
@@ -24762,7 +23639,6 @@
 /obj/machinery/camera/emp_proof/motion{
 	c_tag = "Armory Exterior Fore";
 	dir = 5;
-	icon_state = "camera";
 	tag = "Armory Exterior"
 	},
 /turf/open/floor/plating/airless,
@@ -24814,7 +23690,6 @@
 	},
 /obj/machinery/door/poddoor/ship/preopen{
 	dir = 4;
-	icon_state = "open";
 	id = "fbridge_spaceshield"
 	},
 /turf/open/floor/plating,
@@ -24823,7 +23698,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/ship/preopen{
 	dir = 4;
-	icon_state = "open";
 	id = "fbridge_spaceshield"
 	},
 /turf/open/floor/plating,
@@ -24835,7 +23709,6 @@
 	},
 /obj/machinery/door/poddoor/ship/preopen{
 	dir = 4;
-	icon_state = "open";
 	id = "fbridge_spaceshield"
 	},
 /turf/open/floor/plating,
@@ -24847,7 +23720,6 @@
 	},
 /obj/machinery/door/poddoor/ship/preopen{
 	dir = 9;
-	icon_state = "open";
 	id = "fbridge_spaceshield"
 	},
 /turf/open/floor/plating,
@@ -24859,7 +23731,6 @@
 	},
 /obj/machinery/door/poddoor/ship/preopen{
 	dir = 6;
-	icon_state = "open";
 	id = "fbridge_spaceshield"
 	},
 /turf/open/floor/plating,
@@ -24869,8 +23740,7 @@
 	icon_state = "1-10"
 	},
 /obj/structure/chair/office{
-	dir = 4;
-	icon_state = "officechair_dark"
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -24952,12 +23822,10 @@
 	dir = 4
 	},
 /obj/machinery/computer/robotics{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	dir = 8;
-	icon_state = "camera"
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -24970,8 +23838,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "5-10"
@@ -24980,8 +23847,7 @@
 	icon_state = "6-9"
 	},
 /obj/machinery/computer/cargo/request{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -24994,15 +23860,13 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "9-10"
 	},
 /obj/machinery/computer/crew{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -25026,7 +23890,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/machinery/camera/autoname,
@@ -25086,13 +23949,11 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/structure/closet/toolcloset,
 /obj/machinery/camera/autoname{
-	dir = 10;
-	icon_state = "camera"
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 9
@@ -25114,7 +23975,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 5;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/firealarm/directional/south,
@@ -25284,7 +24144,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 5;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/light{
@@ -25383,8 +24242,7 @@
 "aZc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/transit_tube/horizontal{
-	dir = 2;
-	icon_state = "straight"
+	dir = 2
 	},
 /obj/structure/cable{
 	icon_state = "0-9"
@@ -25408,7 +24266,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#f00";
 	dir = 6;
-	icon_state = "pipe";
 	name = "to-space disposal pipe"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -25424,8 +24281,7 @@
 /area/space/nearstation)
 "aZh" = (
 /obj/structure/transit_tube/curved{
-	dir = 4;
-	icon_state = "curved0"
+	dir = 4
 	},
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -25459,23 +24315,19 @@
 /area/space/nearstation)
 "aZm" = (
 /obj/structure/disposaloutlet{
-	dir = 8;
-	icon_state = "outlet"
+	dir = 8
 	},
 /obj/structure/disposalpipe/trunk{
-	dir = 1;
-	icon_state = "pipe-t"
+	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 1;
-	icon_state = "inje_map-2"
+	dir = 1
 	},
 /turf/open/floor/plating/airless,
 /area/medical/virology)
 "aZn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 1;
-	icon_state = "vent_map_on-3"
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
@@ -25494,8 +24346,7 @@
 /area/maintenance/department/crew_quarters/bar)
 "aZq" = (
 /obj/structure/shuttle/engine/huge{
-	dir = 8;
-	icon_state = "huge_engine"
+	dir = 8
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -25567,8 +24418,7 @@
 /area/tcommsat/computer)
 "aZA" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/vending/wardrobe/science_wardrobe,
@@ -25579,8 +24429,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer1{
-	dir = 1;
-	icon_state = "dpvent_map-1"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "2-9"
@@ -25626,7 +24475,6 @@
 "aZG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 4;
-	icon_state = "scrub_map-2";
 	id_tag = "fore_tox_burn";
 	name = "Fore Burn Filter"
 	},
@@ -25640,8 +24488,7 @@
 /area/science/storage)
 "aZJ" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 1;
-	icon_state = "inje_map-2"
+	dir = 1
 	},
 /turf/open/floor/plating/airless,
 /area/science/mixing)
@@ -25661,8 +24508,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 4;
-	icon_state = "scrub_map_on-1"
+	dir = 4
 	},
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/plasteel,
@@ -25747,7 +24593,6 @@
 "aZX" = (
 /obj/machinery/mass_driver{
 	dir = 1;
-	icon_state = "mass_driver";
 	id = "holy_driver";
 	name = "chapel mass driver"
 	},
@@ -25763,8 +24608,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/effect/turf_decal/stripes/red/line{
-	dir = 8;
-	icon_state = "warningline_red"
+	dir = 8
 	},
 /obj/item/paper{
 	info = "Okay. Screw this. I have no idea what you people want, just build it yourself. <br> -<i>Titanworks Design Staff</i>";
@@ -25776,8 +24620,7 @@
 /obj/machinery/rnd/production/protolathe/department/science,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -25797,8 +24640,7 @@
 "bad" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 8;
-	icon_state = "vent_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -25828,8 +24670,7 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/stripes/red/line{
-	dir = 8;
-	icon_state = "warningline_red"
+	dir = 8
 	},
 /obj/machinery/button/ignition{
 	id = "toxin_right";
@@ -25845,8 +24686,7 @@
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/camera/autoname{
-	dir = 5;
-	icon_state = "camera"
+	dir = 5
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/port)
@@ -25864,8 +24704,7 @@
 /obj/machinery/vending/cola/random,
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/camera/autoname{
-	dir = 10;
-	icon_state = "camera"
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -25898,8 +24737,7 @@
 /area/science/robotics/mechbay)
 "bap" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
@@ -25911,7 +24749,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -25939,12 +24776,10 @@
 /area/crew_quarters/heads/hos)
 "bas" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/structure/closet/bombcloset/white,
@@ -25952,8 +24787,7 @@
 /area/science)
 "bat" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -25964,7 +24798,6 @@
 	},
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 4;
-	icon_state = "pipe-j1s";
 	name = "toxins disposal pipe";
 	sortType = "24;25"
 	},
@@ -26001,7 +24834,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -26064,7 +24896,6 @@
 	},
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4;
-	icon_state = "pipe-j2s";
 	name = "janitorial sorting disposal pipe";
 	sortType = 22
 	},
@@ -26076,8 +24907,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/machinery/vending/sustenance,
 /turf/open/floor/plasteel,
@@ -26118,8 +24948,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 4;
-	icon_state = "scrub_map_on-1"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "6-10"
@@ -26130,7 +24959,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 6;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/closed/wall/steel,
@@ -26151,7 +24979,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/wood,
@@ -26200,8 +25027,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "6-10"
@@ -26217,8 +25043,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1;
-	icon_state = "scrub_map_on-1"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "6-10"
@@ -26247,8 +25072,7 @@
 	icon_state = "6-9"
 	},
 /obj/structure/chair/office{
-	dir = 4;
-	icon_state = "officechair_dark"
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -26322,12 +25146,10 @@
 /area/maintenance/department/chapel)
 "bba" = (
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
@@ -26339,7 +25161,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/effect/turf_decal/tile/bar{
@@ -26364,8 +25185,6 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 2;
-	icon_state = "closed";
 	name = "Central Primary Hallway"
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -26374,15 +25193,13 @@
 /area/hallway/primary/central)
 "bbd" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4;
-	icon_state = "pipe-j2s";
 	name = "med sorting disposal pipe";
 	sortType = "9;10;11;23;27"
 	},
@@ -26470,8 +25287,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/cable{
@@ -26518,8 +25334,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 2;
-	icon_state = "closed";
 	name = "Fore Primary Hallway"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -26582,7 +25396,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plating,
@@ -26597,7 +25410,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -26610,7 +25422,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -26629,7 +25440,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -26648,8 +25458,6 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 2;
-	icon_state = "closed";
 	name = "Fore Primary Hallway"
 	},
 /obj/machinery/door/firedoor/border_only/directional/west,
@@ -26658,8 +25466,7 @@
 /area/hallway/primary/fore)
 "bbB" = (
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/disposalpipe/segment{
@@ -26684,8 +25491,7 @@
 /area/crew_quarters/dorms)
 "bbD" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -26694,15 +25500,13 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 6;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/nsv/officerquarters)
 "bbE" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -26713,15 +25517,13 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/nsv/officerquarters)
 "bbF" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -26736,15 +25538,13 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/nsv/officerquarters)
 "bbG" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -26759,15 +25559,13 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/nsv/officerquarters)
 "bbH" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -26781,7 +25579,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/dark,
@@ -26789,8 +25586,7 @@
 "bbI" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -26810,7 +25606,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/dark,
@@ -26821,8 +25616,7 @@
 	},
 /obj/effect/turf_decal/tile/brown,
 /obj/machinery/computer/bounty{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
@@ -26862,8 +25656,7 @@
 /area/crew_quarters/nsv/officerquarters)
 "bbO" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -26880,12 +25673,10 @@
 /area/bridge)
 "bbP" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-10"
@@ -26905,8 +25696,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -26933,8 +25723,7 @@
 /area/quartermaster/sorting)
 "bbS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1;
-	icon_state = "scrub_map_on-1"
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
@@ -26987,7 +25776,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/item/pen/fountain/captain,
@@ -27005,12 +25793,10 @@
 /area/quartermaster/sorting)
 "bbY" = (
 /obj/structure/chair{
-	dir = 8;
-	icon_state = "chair"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/landmark/start/assistant,
@@ -27055,7 +25841,6 @@
 	},
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 8;
-	icon_state = "pipe-j1s";
 	name = "justice team sorting disposal pipe";
 	sortType = "29;30"
 	},
@@ -27126,9 +25911,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "bcj" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -27140,8 +25923,7 @@
 /area/crew_quarters/dorms)
 "bck" = (
 /obj/effect/turf_decal/stripes/red/line{
-	dir = 8;
-	icon_state = "warningline_red"
+	dir = 8
 	},
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/plasteel,
@@ -27177,7 +25959,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/wood,
@@ -27198,7 +25979,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/wood,
@@ -27210,13 +25990,10 @@
 /obj/structure/cable{
 	icon_state = "0-5"
 	},
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
-	dir = 1;
-	icon_state = "pipe-t"
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain/private)
@@ -27237,7 +26014,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -27266,7 +26042,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/dark,
@@ -27281,7 +26056,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 9;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/machinery/firealarm/directional/south,
@@ -27314,19 +26088,16 @@
 /obj/structure/disposalpipe/segment{
 	color = "#f00";
 	dir = 10;
-	icon_state = "pipe";
 	name = "to-space disposal pipe"
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "bcx" = (
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 4;
-	icon_state = "scrub_map_on-1"
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
@@ -27337,8 +26108,7 @@
 "bcy" = (
 /obj/structure/table/reinforced,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 8;
-	icon_state = "scrub_map_on-1"
+	dir = 8
 	},
 /obj/item/storage/firstaid,
 /turf/open/floor/plasteel/dark,
@@ -27348,7 +26118,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 5;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -27358,7 +26127,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -27366,13 +26134,11 @@
 "bcB" = (
 /obj/effect/turf_decal/bot_red,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1;
-	icon_state = "scrub_map_on-1"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 9;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -27441,7 +26207,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 6;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/wood,
@@ -27456,7 +26221,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 6;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/wood,
@@ -27478,7 +26242,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/machinery/door/firedoor/border_only/directional/west,
@@ -27490,9 +26253,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 9
 	},
@@ -27502,7 +26263,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 9;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/wood,
@@ -27510,7 +26270,6 @@
 "bcL" = (
 /obj/machinery/conveyor{
 	dir = 8;
-	icon_state = "conveyor_map";
 	id = "cargo_shuttle"
 	},
 /obj/structure/disposalpipe/segment{
@@ -27529,7 +26288,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -27553,7 +26311,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/structure/disposalpipe/segment{
@@ -27573,7 +26330,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 9;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/wood,
@@ -27612,12 +26368,10 @@
 /area/crew_quarters/dorms)
 "bcT" = (
 /obj/effect/turf_decal/tile/neutral{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 6
@@ -27643,31 +26397,26 @@
 /area/space/nearstation)
 "bcW" = (
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 5;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "bcX" = (
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/disposalpipe/trunk{
-	dir = 8;
-	icon_state = "pipe-t"
+	dir = 8
 	},
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel,
@@ -27718,29 +26467,24 @@
 /area/security/detectives_office/combined)
 "bdd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 4;
-	icon_state = "scrub_map_on-1"
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 5;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/wood,
 /area/security/detectives_office/combined)
 "bde" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 9
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 9;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/wood,
@@ -27766,7 +26510,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/effect/turf_decal/tile/bar{
@@ -27776,8 +26519,7 @@
 /area/hallway/primary/central)
 "bdj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 1;
-	icon_state = "vent_map_on-3"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "6-8"
@@ -27824,8 +26566,7 @@
 /area/crew_quarters/dorms)
 "bdp" = (
 /obj/machinery/disposal/deliveryChute{
-	dir = 1;
-	icon_state = "intake"
+	dir = 1
 	},
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/door/firedoor/border_only/directional/north,
@@ -27844,7 +26585,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 5;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -27863,12 +26603,10 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 5;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/structure/disposalpipe/trunk{
-	dir = 8;
-	icon_state = "pipe-t"
+	dir = 8
 	},
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel,
@@ -27877,7 +26615,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/structure/extinguisher_cabinet/south,
@@ -27892,8 +26629,7 @@
 /area/medical/chemistry)
 "bdv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 1;
-	icon_state = "vent_map_on-3"
+	dir = 1
 	},
 /obj/structure/sign/poster/official/moth7{
 	pixel_y = -32
@@ -27905,7 +26641,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 9;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -27917,8 +26652,7 @@
 /obj/structure/cable,
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
-	dir = 1;
-	icon_state = "pipe-t"
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -27932,7 +26666,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 10;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -27942,7 +26675,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/structure/disposalpipe/segment{
@@ -27956,7 +26688,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 5;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -27972,17 +26703,14 @@
 /area/science/lab)
 "bdC" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/structure/table/glass,
 /obj/item/stack/sheet/glass/fifty,
@@ -28027,7 +26755,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/structure/disposalpipe/segment{
@@ -28042,8 +26769,7 @@
 	},
 /obj/effect/turf_decal/tile/brown,
 /obj/structure/disposalpipe/junction/flip{
-	dir = 4;
-	icon_state = "pipe-j2"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -28052,21 +26778,17 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 4;
-	icon_state = "vent_map_on-3"
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 8;
-	icon_state = "connector_map-2"
+	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "bdI" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/effect/turf_decal/tile/green,
@@ -28079,15 +26801,13 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 9;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bdJ" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -28099,15 +26819,13 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
 /area/science)
 "bdK" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
@@ -28119,15 +26837,13 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
 /area/science)
 "bdL" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/structure/cable{
@@ -28140,7 +26856,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -28158,15 +26873,13 @@
 /area/science/mixing)
 "bdN" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 9;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -28176,8 +26889,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 4;
-	icon_state = "vent_map_on-3"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-10"
@@ -28220,8 +26932,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 8;
-	icon_state = "connector_map-2"
+	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plating,
@@ -28243,7 +26954,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 5;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -28254,8 +26964,7 @@
 	},
 /obj/machinery/computer/ship/viewscreen,
 /obj/structure/disposalpipe/trunk{
-	dir = 8;
-	icon_state = "pipe-t"
+	dir = 8
 	},
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/white,
@@ -28273,8 +26982,7 @@
 	name = "mail trunk disposal pipe"
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/atmospherics/pipe/simple/dark/hidden,
@@ -28297,16 +27005,13 @@
 "bdY" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/item/stock_parts/matter_bin,
@@ -28315,8 +27020,7 @@
 /area/science)
 "bdZ" = (
 /obj/machinery/camera/autoname{
-	dir = 10;
-	icon_state = "camera"
+	dir = 10
 	},
 /obj/machinery/newscaster/directional/south,
 /obj/effect/landmark/start/chemist,
@@ -28348,8 +27052,7 @@
 	req_access_txt = "71"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1;
-	icon_state = "airlock_cyclelink_helper"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/disposalpipe/segment{
@@ -28363,8 +27066,7 @@
 "bed" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
-	dir = 1;
-	icon_state = "pipe-t"
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/nsv/crew_quarters/heads/maa)
@@ -28373,8 +27075,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/disposalpipe/segment{
@@ -28401,7 +27102,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/structure/disposalpipe/segment{
@@ -28412,15 +27112,13 @@
 /area/hallway/primary/fore)
 "beh" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j1"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -28457,15 +27155,13 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hos)
 "bek" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -28482,7 +27178,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 6;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/dark,
@@ -28492,7 +27187,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/dark,
@@ -28511,7 +27205,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/dark,
@@ -28532,7 +27225,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/dark,
@@ -28550,7 +27242,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/dark,
@@ -28569,7 +27260,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /mob/living/simple_animal/bot/secbot/beepsky,
@@ -28592,7 +27282,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/dark,
@@ -28613,7 +27302,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/dark,
@@ -28631,7 +27319,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/dark,
@@ -28648,7 +27335,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/dark,
@@ -28738,7 +27424,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/dark,
@@ -28759,7 +27444,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/dark,
@@ -28779,7 +27463,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/dark,
@@ -28797,7 +27480,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/dark,
@@ -28808,7 +27490,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/dark,
@@ -28823,7 +27504,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/dark,
@@ -28836,8 +27516,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -28848,7 +27527,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/effect/landmark/event_spawn,
@@ -28871,7 +27549,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 5;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/dark,
@@ -28880,7 +27557,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/dark,
@@ -28889,7 +27565,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 9;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/dark,
@@ -28903,8 +27578,7 @@
 	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
-	dir = 8;
-	icon_state = "pipe-t"
+	dir = 8
 	},
 /obj/machinery/requests_console{
 	department = "Research Director";
@@ -28930,8 +27604,7 @@
 "beN" = (
 /obj/effect/landmark/start/chaplain,
 /obj/structure/chair/office{
-	dir = 4;
-	icon_state = "officechair_dark"
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
@@ -28942,16 +27615,13 @@
 "beO" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/item/gps/science,
@@ -28973,12 +27643,9 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 2;
-	icon_state = "closed";
 	name = "Central Primary Hallway"
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -28988,7 +27655,6 @@
 "beR" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4;
-	icon_state = "pipe-j2s";
 	name = "library theatre sorting disposal pipe";
 	sortType = "16;18"
 	},
@@ -29000,7 +27666,6 @@
 	},
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4;
-	icon_state = "pipe-j2s";
 	name = "holy sorting disposal pipe";
 	sortType = 17
 	},
@@ -29010,7 +27675,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/item/radio/intercom/directional/south,
@@ -29026,7 +27690,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#f00";
 	dir = 5;
-	icon_state = "pipe";
 	name = "to-space disposal pipe"
 	},
 /turf/open/floor/plating/airless,
@@ -29034,8 +27697,7 @@
 "beW" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
-	dir = 8;
-	icon_state = "pipe-t"
+	dir = 8
 	},
 /turf/open/floor/plating/airless,
 /area/quartermaster/storage)
@@ -29049,8 +27711,7 @@
 "beY" = (
 /obj/machinery/camera/emp_proof/motion{
 	c_tag = "Vault";
-	dir = 8;
-	icon_state = "camera"
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/nuke_storage)
@@ -29063,8 +27724,7 @@
 	id = "mailsort"
 	},
 /obj/machinery/camera/autoname{
-	dir = 8;
-	icon_state = "camera"
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
@@ -29085,7 +27745,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/effect/landmark/event_spawn,
@@ -29153,8 +27812,7 @@
 /area/maintenance/department/security/brig)
 "bfp" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 1;
-	icon_state = "inje_map-2"
+	dir = 1
 	},
 /turf/open/floor/plating/airless,
 /area/tcommsat/computer)
@@ -29164,8 +27822,7 @@
 	req_access_txt = "61"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1;
-	icon_state = "airlock_cyclelink_helper"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -29203,8 +27860,7 @@
 /area/maintenance/department/security/brig)
 "bfw" = (
 /obj/machinery/gateway{
-	dir = 9;
-	icon_state = "off"
+	dir = 9
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
@@ -29222,15 +27878,13 @@
 "bfy" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/gateway{
-	dir = 5;
-	icon_state = "off"
+	dir = 5
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "bfz" = (
 /obj/machinery/gateway{
-	dir = 8;
-	icon_state = "off"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "5-9"
@@ -29239,8 +27893,7 @@
 /area/maintenance/department/security/brig)
 "bfA" = (
 /obj/machinery/gateway{
-	dir = 1;
-	icon_state = "off"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "2-10"
@@ -29249,8 +27902,7 @@
 /area/maintenance/department/security/brig)
 "bfB" = (
 /obj/machinery/gateway{
-	dir = 4;
-	icon_state = "off"
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
@@ -29273,8 +27925,7 @@
 /area/nsv/weapons/port)
 "bfH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 1;
-	icon_state = "vent_map_on-3"
+	dir = 1
 	},
 /obj/machinery/suit_storage_unit/captain,
 /turf/open/floor/wood,
@@ -29286,8 +27937,7 @@
 /area/bridge)
 "bfJ" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -29299,7 +27949,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/light,
@@ -29329,16 +27978,14 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bfN" = (
 /obj/machinery/camera/autoname{
-	dir = 10;
-	icon_state = "camera"
+	dir = 10
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/port)
@@ -29347,8 +27994,7 @@
 	dir = 8
 	},
 /obj/structure/chair/office{
-	dir = 4;
-	icon_state = "officechair_dark"
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -29367,8 +28013,7 @@
 	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
-	dir = 1;
-	icon_state = "pipe-t"
+	dir = 1
 	},
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/plasteel/dark,
@@ -29391,12 +28036,10 @@
 "bfS" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/structure/chair{
-	dir = 8;
-	icon_state = "chair"
+	dir = 8
 	},
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/plasteel,
@@ -29422,8 +28065,7 @@
 /area/science/storage)
 "bfW" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -29443,8 +28085,7 @@
 /area/quartermaster/storage)
 "bfY" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/requests_console{
@@ -29474,12 +28115,10 @@
 /area/crew_quarters/heads/captain/private)
 "bgb" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -29494,8 +28133,7 @@
 /area/crew_quarters/dorms)
 "bgd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 4;
-	icon_state = "vent_map_on-3"
+	dir = 4
 	},
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/plasteel/showroomfloor,
@@ -29514,8 +28152,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/item/radio/intercom/directional/north{
 	name = "prison intra ship intercom";
@@ -29629,13 +28266,11 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 1;
-	icon_state = "vent_map_on-3"
+	dir = 1
 	},
 /obj/item/radio/intercom/directional/south,
 /obj/machinery/camera/autoname{
-	dir = 10;
-	icon_state = "camera"
+	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -29657,8 +28292,7 @@
 /obj/structure/table/wood/fancy/royalblack,
 /obj/item/reagent_containers/food/snacks/grown/poppy,
 /turf/open/floor/plasteel/chapel{
-	dir = 8;
-	icon_state = "chapel"
+	dir = 8
 	},
 /area/chapel/main)
 "bgu" = (
@@ -29672,12 +28306,10 @@
 /area/crew_quarters/nsv/officerquarters)
 "bgv" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/light{
 	dir = 8
@@ -29690,8 +28322,7 @@
 	req_access_txt = "71"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1;
-	icon_state = "airlock_cyclelink_helper"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/door/firedoor/border_only/directional/south,
@@ -29715,7 +28346,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/item/reagent_containers/food/condiment/saltshaker,
@@ -29733,7 +28363,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/structure/table/reinforced,
@@ -29790,7 +28419,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/item/toy/cards/deck,
@@ -29815,7 +28443,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 10;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/machinery/computer/security/telescreen/entertainment{
@@ -29881,8 +28508,7 @@
 	icon_state = "5-10"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 8;
-	icon_state = "vent_map_on-3"
+	dir = 8
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -29891,16 +28517,13 @@
 /area/bridge)
 "bgR" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/structure/chair{
-	dir = 4;
-	icon_state = "chair"
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 8
@@ -29975,8 +28598,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/effect/turf_decal/stripes/red/line{
-	dir = 8;
-	icon_state = "warningline_red"
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
@@ -29991,13 +28613,11 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 4;
-	icon_state = "scrub_map_on-1"
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 5;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -30012,7 +28632,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/machinery/light/small,
@@ -30020,8 +28639,7 @@
 /area/crew_quarters/toilet)
 "bhc" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/landmark/event_spawn,
@@ -30033,20 +28651,16 @@
 /area/crew_quarters/toilet)
 "bhe" = (
 /obj/structure/chair{
-	dir = 4;
-	icon_state = "chair"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/plasteel,
@@ -30067,15 +28681,13 @@
 	dir = 8
 	},
 /obj/machinery/computer/mecha{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
 "bhj" = (
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -30101,8 +28713,7 @@
 /obj/item/seeds/tobacco,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -30135,8 +28746,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/machinery/light,
 /turf/open/floor/plasteel,
@@ -30144,12 +28754,10 @@
 "bhr" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/plasteel,
@@ -30235,12 +28843,10 @@
 "bhy" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/structure/chair{
-	dir = 8;
-	icon_state = "chair"
+	dir = 8
 	},
 /obj/machinery/light{
 	dir = 4
@@ -30278,8 +28884,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 8;
-	icon_state = "vent_map_on-3"
+	dir = 8
 	},
 /obj/machinery/light{
 	dir = 1
@@ -30295,8 +28900,7 @@
 /area/quartermaster/storage)
 "bhC" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/firealarm/directional/south,
@@ -30309,8 +28913,7 @@
 /area/science)
 "bhD" = (
 /obj/effect/turf_decal/stripes/red/line{
-	dir = 8;
-	icon_state = "warningline_red"
+	dir = 8
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
@@ -30322,14 +28925,12 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	dir = 8;
-	icon_state = "camera"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/effect/turf_decal/stripes/red/line{
-	dir = 8;
-	icon_state = "warningline_red"
+	dir = 8
 	},
 /obj/machinery/requests_console{
 	department = "Research";
@@ -30384,9 +28985,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -30432,8 +29031,7 @@
 	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
-	dir = 8;
-	icon_state = "pipe-t"
+	dir = 8
 	},
 /obj/machinery/light,
 /turf/open/floor/monotile,
@@ -30529,12 +29127,10 @@
 /area/science/robotics/mechbay)
 "bic" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -30543,7 +29139,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/camera/autoname,
@@ -30569,7 +29164,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/structure/disposalpipe/segment{
@@ -30577,8 +29171,7 @@
 	name = "return trunk disposal pipe"
 	},
 /obj/machinery/computer/cargo/request{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -30624,7 +29217,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 10;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/computer/bank_machine,
@@ -30640,8 +29232,7 @@
 	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
-	dir = 4;
-	icon_state = "pipe-t"
+	dir = 4
 	},
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = -32
@@ -30665,7 +29256,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 9;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/structure/reagent_dispensers/water_cooler,
@@ -30689,18 +29279,15 @@
 "bim" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 4;
-	icon_state = "scrub_map_on-1"
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/structure/chair/office{
-	dir = 4;
-	icon_state = "officechair_dark"
+	dir = 4
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
@@ -30728,7 +29315,6 @@
 "biq" = (
 /obj/structure/transit_tube/station/reverse/flipped{
 	dir = 4;
-	icon_state = "closed_terminus1";
 	name = "Secure Hallway Access Conduit"
 	},
 /obj/structure/transit_tube_pod,
@@ -30782,12 +29368,10 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/structure/sign/directions/plaque/hangar{
 	dir = 1;
-	icon_state = "minskydirection_hangar";
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
@@ -30824,7 +29408,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/machinery/camera/autoname,
@@ -30834,7 +29417,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/structure/extinguisher_cabinet/north,
@@ -30850,7 +29432,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -30880,13 +29461,11 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 5;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/light,
 /obj/machinery/camera/autoname{
-	dir = 10;
-	icon_state = "camera"
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -30918,8 +29497,7 @@
 /obj/effect/turf_decal/bot_white,
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/machinery/camera/autoname{
-	dir = 10;
-	icon_state = "camera"
+	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/storage)
@@ -30937,8 +29515,7 @@
 /area/science/mixing)
 "biN" = (
 /obj/machinery/camera/preset/toxins{
-	dir = 1;
-	icon_state = "camera"
+	dir = 1
 	},
 /turf/open/indestructible/airblock,
 /area/space/nearstation)
@@ -30951,12 +29528,10 @@
 	icon_state = "1-2"
 	},
 /obj/structure/chair/office{
-	dir = 4;
-	icon_state = "officechair_dark"
+	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	dir = 5;
-	icon_state = "camera"
+	dir = 5
 	},
 /obj/machinery/light_switch/west,
 /turf/open/floor/plasteel/dark,
@@ -30967,8 +29542,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 8;
-	icon_state = "scrub_map_on-1"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -30985,28 +29559,23 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/camera/autoname{
-	dir = 5;
-	icon_state = "camera"
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/security)
 "biS" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/structure/table,
 /obj/machinery/camera/autoname{
-	dir = 5;
-	icon_state = "camera"
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -31024,8 +29593,7 @@
 	dir = 5
 	},
 /obj/machinery/camera/autoname{
-	dir = 5;
-	icon_state = "camera"
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -31063,8 +29631,7 @@
 /area/quartermaster/miningdock)
 "biX" = (
 /obj/machinery/camera/autoname{
-	dir = 5;
-	icon_state = "camera"
+	dir = 5
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
@@ -31092,8 +29659,7 @@
 "biZ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/camera/autoname{
-	dir = 10;
-	icon_state = "camera"
+	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -31137,8 +29703,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
 /obj/machinery/camera/autoname{
-	dir = 10;
-	icon_state = "camera"
+	dir = 10
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
@@ -31149,12 +29714,9 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 2;
-	icon_state = "closed";
 	name = "Fore Primary Hallway"
 	},
 /obj/machinery/door/firedoor/border_only/directional/west,
@@ -31168,8 +29730,7 @@
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/camera/autoname{
-	dir = 10;
-	icon_state = "camera"
+	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -31193,8 +29754,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/item/radio/intercom/directional/north{
 	name = "prison intra ship intercom";
@@ -31224,7 +29784,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/firealarm/directional/north,
@@ -31233,8 +29792,7 @@
 "bjl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 1;
-	icon_state = "vent_map_on-3"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/dark/hidden{
 	dir = 4
@@ -31315,8 +29873,7 @@
 /area/crew_quarters/heads/hor)
 "bjC" = (
 /obj/machinery/gateway{
-	dir = 6;
-	icon_state = "off"
+	dir = 6
 	},
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
@@ -31399,12 +29956,10 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/structure/noticeboard/captain{
 	dir = 4;
-	icon_state = "nboard00";
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -31435,8 +29990,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/cable{
@@ -31498,8 +30052,7 @@
 /area/quartermaster/miningdock)
 "bjW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1;
-	icon_state = "scrub_map_on-1"
+	dir = 1
 	},
 /obj/effect/landmark/start/munitions_tech,
 /turf/open/floor/monotile/dark,
@@ -31507,8 +30060,7 @@
 "bjX" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/camera/autoname{
-	dir = 10;
-	icon_state = "camera"
+	dir = 10
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/port)
@@ -31523,8 +30075,7 @@
 "bkb" = (
 /obj/structure/table/glass,
 /obj/structure/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
+	dir = 8
 	},
 /obj/item/storage/firstaid/toxin,
 /obj/item/storage/firstaid/toxin,
@@ -31560,7 +30111,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/effect/landmark/start/scientist,
@@ -31588,17 +30138,14 @@
 /obj/structure/table/glass,
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/item/storage/belt/utility,
 /obj/item/multitool,
@@ -31624,8 +30171,7 @@
 /area/security/detectives_office/combined)
 "bkm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 4;
-	icon_state = "scrub_map_on-1"
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
@@ -31647,21 +30193,17 @@
 "bkq" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/camera/autoname{
-	dir = 5;
-	icon_state = "camera"
+	dir = 5
 	},
 /obj/item/stock_parts/micro_laser,
 /obj/item/stack/sheet/glass,
@@ -31670,16 +30212,13 @@
 "bkr" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/item/stock_parts/matter_bin,
@@ -31687,32 +30226,26 @@
 /area/science)
 "bks" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/computer/rdconsole/robotics{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics)
 "bkt" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/camera/autoname{
-	dir = 10;
-	icon_state = "camera"
+	dir = 10
 	},
 /obj/machinery/light_switch/south,
 /obj/structure/rack,
@@ -31742,25 +30275,21 @@
 "bky" = (
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/computer/rdconsole/core{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/lab)
 "bkz" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
@@ -31786,16 +30315,13 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bkD" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/structure/chair{
-	dir = 4;
-	icon_state = "chair"
+	dir = 4
 	},
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/plasteel,
@@ -31810,7 +30336,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/effect/turf_decal/tile/bar{
@@ -31826,7 +30351,6 @@
 "bkG" = (
 /obj/machinery/conveyor{
 	dir = 8;
-	icon_state = "conveyor_map";
 	id = "cargo_shuttle"
 	},
 /obj/machinery/newscaster/directional/south,
@@ -31847,8 +30371,7 @@
 /area/crew_quarters/toilet)
 "bkI" = (
 /obj/structure/toilet{
-	dir = 1;
-	icon_state = "toilet00"
+	dir = 1
 	},
 /obj/machinery/button/door{
 	id = "toilet_2";
@@ -31863,8 +30386,7 @@
 /area/crew_quarters/toilet)
 "bkJ" = (
 /obj/structure/toilet{
-	dir = 1;
-	icon_state = "toilet00"
+	dir = 1
 	},
 /obj/machinery/button/door{
 	id = "toilet_1";
@@ -31895,13 +30417,11 @@
 /area/science/mixing)
 "bkM" = (
 /obj/machinery/computer/card{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 6;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/machinery/newscaster/directional/west,
@@ -31946,12 +30466,10 @@
 /area/security/brig)
 "bkR" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -31962,7 +30480,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel/white,
@@ -31971,7 +30488,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/structure/extinguisher_cabinet/north,
@@ -32032,7 +30548,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/vending/wardrobe/cargo_wardrobe,
@@ -32048,7 +30563,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/machinery/newscaster/directional/south,
@@ -32085,7 +30599,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/firealarm/directional/south,
@@ -32112,8 +30625,7 @@
 /area/ai_monitored/turret_protected/ai)
 "bli" = (
 /obj/machinery/power/terminal{
-	dir = 8;
-	icon_state = "term"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "0-6"
@@ -32135,26 +30647,21 @@
 /area/ai_monitored/turret_protected/ai)
 "bll" = (
 /obj/effect/turf_decal/stripes/red/line{
-	dir = 1;
-	icon_state = "warningline_red"
+	dir = 1
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "blm" = (
 /obj/effect/turf_decal/stripes/red/line{
-	dir = 1;
-	icon_state = "warningline_red"
+	dir = 1
 	},
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "bln" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 4;
-	icon_state = "scrub_map_on-1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
@@ -32195,8 +30702,7 @@
 /area/ai_monitored/turret_protected/ai)
 "blv" = (
 /obj/machinery/computer/card/minor/rd{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 5
@@ -32241,8 +30747,7 @@
 /area/crew_quarters/heads/cmo)
 "blD" = (
 /obj/structure/transit_tube/curved/flipped{
-	dir = 8;
-	icon_state = "curved1"
+	dir = 8
 	},
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -32253,8 +30758,7 @@
 /area/space/nearstation)
 "blE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 8;
-	icon_state = "vent_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
@@ -32273,9 +30777,7 @@
 /obj/structure/cable{
 	icon_state = "0-10"
 	},
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/table/glass,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/storage/backpack/duffelbag/med/surgery{
@@ -32335,8 +30837,7 @@
 	icon_state = "1-10"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 4;
-	icon_state = "vent_map_on-3"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -32356,7 +30857,6 @@
 /obj/machinery/camera/emp_proof/motion{
 	c_tag = "Vault Exterior Aft";
 	dir = 8;
-	icon_state = "camera";
 	tag = "Armory Exterior"
 	},
 /turf/open/space/basic,
@@ -32372,7 +30872,6 @@
 "blU" = (
 /obj/machinery/computer/communications/console{
 	dir = 1;
-	icon_state = "computer_end";
 	name = "emergency communications console"
 	},
 /obj/machinery/requests_console{
@@ -32389,8 +30888,7 @@
 /area/nsv/hanger)
 "blW" = (
 /obj/machinery/computer/communications{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -32412,8 +30910,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/arrows{
-	dir = 1;
-	icon_state = "arrows"
+	dir = 1
 	},
 /obj/effect/landmark/start/security_officer,
 /obj/machinery/light/small,
@@ -32424,7 +30921,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/structure/extinguisher_cabinet/south,
@@ -32470,13 +30966,11 @@
 /area/quartermaster/storage)
 "bmh" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -32490,13 +30984,11 @@
 	},
 /obj/effect/turf_decal/tile/brown,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 8;
-	icon_state = "vent_map_on-3"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 9;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -32574,8 +31066,7 @@
 	},
 /obj/machinery/rnd/server,
 /obj/effect/turf_decal/stripes/red/line{
-	dir = 1;
-	icon_state = "warningline_red"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/dark/hidden{
 	dir = 5
@@ -32584,16 +31075,13 @@
 /area/crew_quarters/heads/hor)
 "bmr" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/structure/chair{
-	dir = 4;
-	icon_state = "chair"
+	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/firealarm/directional/west,
@@ -32607,12 +31095,10 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bmt" = (
 /obj/structure/chair{
-	dir = 8;
-	icon_state = "chair"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/landmark/start/assistant,
@@ -32692,16 +31178,13 @@
 /area/quartermaster/storage)
 "bmC" = (
 /obj/structure/chair{
-	dir = 4;
-	icon_state = "chair"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/landmark/start/assistant,
 /obj/machinery/door/firedoor/border_only/directional/north,
@@ -32940,7 +31423,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/light/small,
@@ -32951,7 +31433,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/item/ship_weapon/ammunition/torpedo,
@@ -32992,12 +31473,10 @@
 "bng" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/machinery/light{
 	dir = 8
@@ -33022,8 +31501,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 4;
-	icon_state = "vent_map_on-3"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -33036,8 +31514,7 @@
 /area/hallway/secondary/entry)
 "bnk" = (
 /obj/effect/turf_decal/stripes/red/line{
-	dir = 8;
-	icon_state = "warningline_red"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 1
@@ -33079,8 +31556,7 @@
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer1{
-	dir = 1;
-	icon_state = "dpvent_map-1"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plating,
@@ -33090,8 +31566,7 @@
 	name = "Escape Shuttle Dock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1;
-	icon_state = "airlock_cyclelink_helper"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
@@ -33156,8 +31631,7 @@
 /area/quartermaster/storage)
 "bnx" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer1{
-	dir = 1;
-	icon_state = "dpvent_map-1"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/advanced_airlock_controller/directional/east{
@@ -33170,8 +31644,7 @@
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer1{
-	dir = 1;
-	icon_state = "dpvent_map-1"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plating,
@@ -33195,8 +31668,7 @@
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 1;
-	icon_state = "vent_map_on-3"
+	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
@@ -33209,8 +31681,7 @@
 	dir = 8
 	},
 /obj/machinery/computer/shuttle/mining{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -33220,8 +31691,7 @@
 	req_access_txt = "31"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1;
-	icon_state = "airlock_cyclelink_helper"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
@@ -33248,16 +31718,13 @@
 "bnN" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/red{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/structure/chair{
-	dir = 8;
-	icon_state = "chair"
+	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	dir = 8;
-	icon_state = "camera"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
@@ -33265,8 +31732,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bnO" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -33304,8 +31770,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/red/line{
-	dir = 1;
-	icon_state = "warningline_red"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/dark/hidden,
 /turf/open/floor/circuit/airless,
@@ -33360,7 +31825,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/machinery/firealarm/directional/south,
@@ -33370,7 +31834,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/machinery/firealarm/directional/north,
@@ -33388,7 +31851,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/firealarm/directional/south,
@@ -33411,21 +31873,17 @@
 /area/crew_quarters/dorms)
 "bob" = (
 /obj/effect/turf_decal/tile/neutral{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
-	dir = 8;
-	icon_state = "pipe-t"
+	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	dir = 10;
-	icon_state = "camera"
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 9
@@ -33465,8 +31923,7 @@
 "boh" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/machinery/computer/monitor{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/bridge)
@@ -33495,8 +31952,7 @@
 /area/maintenance/nsv/bridge)
 "bom" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1;
-	icon_state = "scrub_map_on-1"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 5
@@ -33513,9 +31969,7 @@
 "boo" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/maintenance/seven,
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
 	icon_state = "0-10"
 	},
@@ -33544,8 +31998,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/cable{
@@ -33661,8 +32114,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer1{
-	dir = 1;
-	icon_state = "dpvent_map-1"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/advanced_airlock_controller/directional/west{
@@ -33676,8 +32128,7 @@
 /area/maintenance/department/bridge)
 "boD" = (
 /obj/structure/chair/office{
-	dir = 4;
-	icon_state = "officechair_dark"
+	dir = 4
 	},
 /obj/structure/extinguisher_cabinet/west,
 /turf/open/floor/plasteel,
@@ -33687,7 +32138,6 @@
 /obj/machinery/camera/emp_proof/motion{
 	c_tag = "Armory Exterior Starboard";
 	dir = 1;
-	icon_state = "camera";
 	tag = "Armory Exterior"
 	},
 /turf/open/floor/plating/airless,
@@ -33730,7 +32180,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/newscaster/directional/north,
@@ -33974,8 +32423,7 @@
 "bpo" = (
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/camera/autoname{
-	dir = 10;
-	icon_state = "camera"
+	dir = 10
 	},
 /obj/machinery/pdapainter,
 /turf/open/floor/carpet/blue,
@@ -33996,12 +32444,10 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -34012,7 +32458,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/structure/disposalpipe/segment{
@@ -34020,8 +32465,7 @@
 	name = "mail trunk disposal pipe"
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -34044,8 +32488,7 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -34054,24 +32497,21 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bpy" = (
 /obj/machinery/status_display/evac/south,
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bpz" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -34080,7 +32520,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/light,
@@ -34089,13 +32528,11 @@
 /area/hallway/primary/central)
 "bpB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 1;
-	icon_state = "vent_map_on-3"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/effect/turf_decal/tile/red,
@@ -34103,14 +32540,11 @@
 /area/hallway/primary/central)
 "bpC" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 2;
-	icon_state = "closed";
 	name = "Fore Primary Hallway"
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/door/firedoor/border_only/directional/west,
@@ -34124,7 +32558,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -34136,44 +32569,36 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/structure/sign/directions/medical{
 	dir = 8;
-	icon_state = "direction_med";
 	pixel_y = 24
 	},
 /obj/structure/sign/directions/evac{
 	dir = 1;
-	icon_state = "direction_evac";
 	pixel_y = 32
 	},
 /obj/structure/sign/directions/engineering{
 	dir = 8;
-	icon_state = "direction_eng";
 	pixel_y = 40
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bpF" = (
 /obj/structure/disposalpipe/junction/flip{
-	dir = 8;
-	icon_state = "pipe-j2"
+	dir = 8
 	},
 /obj/structure/sign/directions/science{
 	dir = 8;
-	icon_state = "direction_sci";
 	pixel_y = 40
 	},
 /obj/structure/sign/directions/supply{
 	dir = 8;
-	icon_state = "direction_supply";
 	pixel_y = 32
 	},
 /obj/structure/sign/directions/command{
 	dir = 4;
-	icon_state = "direction_bridge";
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel,
@@ -34183,18 +32608,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/sign/directions/command{
 	dir = 4;
-	icon_state = "direction_bridge";
 	pixel_x = 32
 	},
 /obj/structure/sign/directions/engineering{
 	dir = 8;
-	icon_state = "direction_eng";
 	pixel_x = 32;
 	pixel_y = 8
 	},
 /obj/structure/sign/directions/science{
 	dir = 4;
-	icon_state = "direction_sci";
 	pixel_x = 32;
 	pixel_y = -8
 	},
@@ -34227,14 +32649,11 @@
 /area/space/nearstation)
 "bpK" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 2;
-	icon_state = "closed";
 	name = "Central Primary Hallway"
 	},
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -34344,7 +32763,6 @@
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/poddoor/ship/preopen{
 	dir = 4;
-	icon_state = "open";
 	id = "rd_toxburn"
 	},
 /turf/open/floor/plating,
@@ -34399,8 +32817,7 @@
 /area/maintenance/department/bridge)
 "bqh" = (
 /obj/machinery/camera/autoname{
-	dir = 10;
-	icon_state = "camera"
+	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics)
@@ -34413,12 +32830,10 @@
 	dir = 8
 	},
 /obj/machinery/computer/shuttle/mining{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /obj/machinery/camera/autoname{
-	dir = 10;
-	icon_state = "camera"
+	dir = 10
 	},
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/plasteel,
@@ -34429,8 +32844,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/camera/autoname{
-	dir = 10;
-	icon_state = "camera"
+	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -34443,8 +32857,7 @@
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
-	dir = 5;
-	icon_state = "camera"
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -34509,12 +32922,10 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 5;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 1;
-	icon_state = "vent_map_on-3"
+	dir = 1
 	},
 /obj/structure/table/reinforced,
 /obj/item/cultivator,
@@ -34533,7 +32944,6 @@
 "bqx" = (
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 4;
-	icon_state = "pipe-j1s";
 	name = "research shared sorting disposal pipe";
 	sortType = "12;28"
 	},
@@ -34593,8 +33003,7 @@
 /area/nsv/weapons/port)
 "bqC" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -34612,7 +33021,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/machinery/squad_vendor{
@@ -34628,7 +33036,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/machinery/squad_vendor{
@@ -34652,8 +33059,7 @@
 /area/quartermaster/storage)
 "bqI" = (
 /obj/effect/turf_decal/tile/red{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -34676,7 +33082,6 @@
 "bqL" = (
 /obj/machinery/airalarm/unlocked{
 	dir = 1;
-	icon_state = "alarm0";
 	name = "unlocked air alarm";
 	pixel_y = -24
 	},
@@ -34686,12 +33091,10 @@
 /area/science/mixing)
 "bqM" = (
 /obj/effect/turf_decal/tile/neutral{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
@@ -34913,8 +33316,7 @@
 "brx" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/components/binary/valve/on{
-	dir = 4;
-	icon_state = "mvalve_map-2"
+	dir = 4
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -34937,7 +33339,6 @@
 /obj/machinery/computer/rdservercontrol,
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
-	icon_state = "pump_on_map-2";
 	level = 1;
 	name = "Server Air Supply"
 	},
@@ -34957,8 +33358,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/red/line{
-	dir = 1;
-	icon_state = "warningline_red"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/dark/hidden{
 	dir = 4
@@ -34980,8 +33380,7 @@
 	name = "R&D Server"
 	},
 /obj/effect/turf_decal/stripes/red/line{
-	dir = 1;
-	icon_state = "warningline_red"
+	dir = 1
 	},
 /turf/open/floor/circuit/airless,
 /area/crew_quarters/heads/hor)
@@ -35000,8 +33399,7 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/stripes/red/line{
-	dir = 1;
-	icon_state = "warningline_red"
+	dir = 1
 	},
 /turf/open/floor/circuit/airless,
 /area/crew_quarters/heads/hor)
@@ -35012,8 +33410,7 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/rnd/server,
 /obj/effect/turf_decal/stripes/red/line{
-	dir = 1;
-	icon_state = "warningline_red"
+	dir = 1
 	},
 /turf/open/floor/circuit/airless,
 /area/crew_quarters/heads/hor)
@@ -35022,8 +33419,7 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -35031,11 +33427,10 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "byi" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos{
-	dir = 1;
-	icon_state = "inje_map-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/general/visible/layer3,
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/air_input{
+	dir = 1
+	},
 /turf/open/floor/engine/air,
 /area/engine/atmos)
 "byK" = (
@@ -35046,15 +33441,13 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 6;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
 /area/engine/storage)
 "byT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/atmos/air_output{
-	dir = 1;
-	icon_state = "vent_map_siphon_on-2"
+	dir = 1
 	},
 /turf/open/floor/engine/air,
 /area/engine/atmos)
@@ -35074,8 +33467,7 @@
 	dir = 10
 	},
 /obj/structure/particle_accelerator/particle_emitter/center{
-	dir = 8;
-	icon_state = "emitter_center"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
@@ -35112,8 +33504,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -35129,8 +33520,7 @@
 /area/maintenance/department/electrical)
 "bMW" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -35143,8 +33533,7 @@
 /area/engine/storage)
 "bQH" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/oxygen_input{
-	dir = 1;
-	icon_state = "inje_map-2"
+	dir = 1
 	},
 /turf/open/floor/engine/o2,
 /area/engine/atmos)
@@ -35157,8 +33546,7 @@
 /area/engine/atmos)
 "bWi" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2{
-	dir = 4;
-	icon_state = "filter_on_f"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible/layer3,
 /turf/open/floor/plasteel,
@@ -35181,8 +33569,7 @@
 /obj/structure/girder,
 /obj/structure/grille,
 /obj/structure/window/reinforced/tinted/frosted{
-	dir = 4;
-	icon_state = "fwindow"
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -35195,13 +33582,10 @@
 "cep" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
-	icon_state = "pump_on_map-2";
-	level = 2;
 	name = "Reactor Mix to Reactor"
 	},
 /obj/effect/turf_decal/ship/shutoff{
-	dir = 1;
-	icon_state = "shutoff"
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
@@ -35211,27 +33595,23 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ckG" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/bar{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
 "coY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1;
-	icon_state = "scrub_map_on-1"
+	dir = 1
 	},
 /obj/structure/chair/office,
 /obj/effect/landmark/start/chief_engineer,
@@ -35249,8 +33629,7 @@
 /area/engine/atmos)
 "cuC" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -35258,7 +33637,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 5;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/door/firedoor/window,
@@ -35269,26 +33647,22 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 10;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
 /area/engine/storage)
 "cxU" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/bar{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
@@ -35297,15 +33671,13 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 8;
-	icon_state = "scrub_map_on-1"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "cHq" = (
 /obj/machinery/atmospherics/components/binary/pump/on/layer3{
 	dir = 1;
-	icon_state = "pump_on_map-3";
 	name = "O2 to Airmix"
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -35316,8 +33688,7 @@
 /area/engine/atmos)
 "cMY" = (
 /obj/effect/turf_decal/stripes/red/line{
-	dir = 5;
-	icon_state = "warningline_red"
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
@@ -35329,6 +33700,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "dac" = (
@@ -35336,8 +33710,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -35379,16 +33752,14 @@
 /area/engine/atmos)
 "dlL" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/computer/monitor,
 /obj/structure/cable{
 	icon_state = "0-6"
 	},
 /obj/effect/turf_decal/tile/bar{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/north{
 	pixel_y = 24
@@ -35397,8 +33768,7 @@
 /area/engine/engine_room)
 "doG" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrogen_input{
-	dir = 1;
-	icon_state = "inje_map-2"
+	dir = 1
 	},
 /turf/open/floor/engine/n2,
 /area/engine/atmos)
@@ -35407,14 +33777,12 @@
 	icon_state = "5-10"
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/structure/table/reinforced,
 /obj/item/analyzer,
 /obj/effect/turf_decal/tile/bar{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
@@ -35424,8 +33792,7 @@
 "dzX" = (
 /obj/machinery/vending/wardrobe/atmos_wardrobe,
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/yellow{
@@ -35455,7 +33822,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/structure/extinguisher_cabinet/south,
@@ -35475,8 +33841,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -35484,7 +33849,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
@@ -35547,18 +33911,36 @@
 /obj/item/stack/cable_coil/random/five,
 /obj/item/stack/sheet/plastic/five,
 /obj/item/storage/backpack/duffelbag/engineering,
+/obj/machinery/requests_console{
+	department = "Engineering";
+	departmentType = 3;
+	name = "Engineering RC";
+	pixel_x = 30
+	},
 /turf/open/floor/plasteel,
 /area/engine/storage)
 "dTa" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible/layer1,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/bar{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"dTO" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	dir = 5
+	},
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "dXh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 8
@@ -35574,19 +33956,18 @@
 /area/engine/atmos)
 "ebX" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/bar{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/machinery/power/port_gen/pacman,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/bot_red,
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
 "enY" = (
@@ -35609,8 +33990,7 @@
 /obj/structure/girder,
 /obj/structure/grille,
 /obj/structure/window/reinforced/tinted/frosted{
-	dir = 8;
-	icon_state = "fwindow"
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -35620,8 +34000,7 @@
 	},
 /obj/effect/turf_decal/ship/techfloor/corner,
 /obj/effect/turf_decal/ship/techfloor/corner{
-	dir = 4;
-	icon_state = "techfloor_corners"
+	dir = 4
 	},
 /turf/open/floor/engine/vacuum/light,
 /area/engine/engine_room)
@@ -35632,7 +34011,6 @@
 "exA" = (
 /obj/machinery/atmospherics/components/binary/volume_pump{
 	dir = 4;
-	icon_state = "volpump_map-2";
 	name = "Purge Mixline"
 	},
 /turf/open/floor/plasteel,
@@ -35647,7 +34025,6 @@
 "eyX" = (
 /obj/machinery/atmospherics/components/binary/pump/layer3{
 	dir = 1;
-	icon_state = "pump_map-3";
 	name = "TOX to Constriction"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer1{
@@ -35661,12 +34038,10 @@
 /area/engine/atmos)
 "eBS" = (
 /obj/effect/turf_decal/ship/techfloor/grey{
-	dir = 1;
-	icon_state = "techfloor_grey"
+	dir = 1
 	},
 /obj/effect/turf_decal/ship/techfloor/grey{
-	dir = 4;
-	icon_state = "techfloor_grey"
+	dir = 4
 	},
 /obj/effect/turf_decal/ship/borderfloor,
 /turf/open/floor/plasteel/dark,
@@ -35684,7 +34059,6 @@
 "eKX" = (
 /obj/machinery/atmospherics/components/binary/pump/on/layer3{
 	dir = 1;
-	icon_state = "pump_on_map-3";
 	name = "N2 to Airmix"
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -35695,8 +34069,7 @@
 /area/engine/atmos)
 "eLh" = (
 /obj/effect/turf_decal/tile/bar{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
@@ -35706,8 +34079,7 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -35725,7 +34097,6 @@
 "eTR" = (
 /obj/machinery/atmospherics/components/binary/volume_pump/layer3{
 	dir = 4;
-	icon_state = "volpump_map-3";
 	name = "Reactor Mix Input Purge"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -35735,8 +34106,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -35749,8 +34119,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -35763,8 +34132,7 @@
 "fhH" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -35782,7 +34150,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -35809,16 +34176,15 @@
 "frb" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/bar{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
 "fwg" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/visible,
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -35830,7 +34196,6 @@
 	name = "Atmospherics External airlock";
 	req_access_txt = "24"
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold/visible,
 /obj/machinery/atmospherics/pipe/layer_manifold/visible,
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -35845,8 +34210,7 @@
 /area/engine/atmos)
 "fKg" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/yellow{
@@ -35872,8 +34236,7 @@
 /area/engine/atmos)
 "fOV" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -35894,27 +34257,24 @@
 "fQu" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/bar{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
+/obj/structure/extinguisher_cabinet/east,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
 "fQT" = (
 /obj/machinery/atmospherics/components/binary/pump/layer3{
 	dir = 1;
-	icon_state = "pump_map-3";
 	name = "N2O to Mixline"
 	},
 /obj/effect/turf_decal/caution/red{
-	dir = 4;
-	icon_state = "caution_red"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -35930,25 +34290,22 @@
 /area/engine/engine_room)
 "fUz" = (
 /obj/effect/turf_decal/stripes/red/line{
-	dir = 8;
-	icon_state = "warningline_red"
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "fXi" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/bar{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/machinery/computer/ship/ftl_computer/preset{
-	dir = 4;
-	icon_state = "ftl_off"
+	dir = 4
 	},
+/obj/structure/extinguisher_cabinet/east,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
 "fXR" = (
@@ -35956,8 +34313,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -35966,7 +34322,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/structure/cable{
@@ -35982,8 +34337,7 @@
 /area/engine/engineering)
 "fYb" = (
 /obj/machinery/computer/atmos_control/tank/toxin_tank{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible/layer3,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -35998,8 +34352,7 @@
 /area/engine/atmos)
 "gcr" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -36025,15 +34378,13 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/item/storage/belt/utility,
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 5;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -36046,24 +34397,20 @@
 /area/engine/engine_room)
 "gkS" = (
 /obj/structure/particle_accelerator/power_box{
-	dir = 8;
-	icon_state = "power_box"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
 "gme" = (
 /obj/effect/turf_decal/tile/bar{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/computer/atmos_control/tank/air_tank{
 	dir = 1;
-	icon_state = "computer";
 	input_tag = "sdmix_in";
 	name = "Reactor Mix Control";
 	output_tag = "sdmix_out";
@@ -36088,15 +34435,13 @@
 "gug" = (
 /obj/machinery/atmospherics/components/binary/pump/on/layer3{
 	dir = 1;
-	icon_state = "pump_on_map-3";
 	name = "Pure to Distribution Loop"
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "guZ" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxin_input{
-	dir = 1;
-	icon_state = "inje_map-2"
+	dir = 1
 	},
 /turf/open/floor/engine/plasma,
 /area/engine/atmos)
@@ -36108,8 +34453,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -36123,8 +34467,7 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/bar{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
@@ -36155,8 +34498,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -36164,7 +34506,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
@@ -36235,8 +34576,7 @@
 /area/engine/atmos)
 "gWa" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/carbon_output{
-	dir = 1;
-	icon_state = "vent_map_siphon_on-2"
+	dir = 1
 	},
 /obj/structure/sign/poster/official/wtf_is_co2{
 	pixel_y = -32
@@ -36245,8 +34585,7 @@
 /area/engine/atmos)
 "gXr" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -36265,8 +34604,7 @@
 /area/engine/storage)
 "hbv" = (
 /obj/effect/turf_decal/stripes/red/line{
-	dir = 8;
-	icon_state = "warningline_red"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
 	dir = 4
@@ -36278,8 +34616,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -36287,7 +34624,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
@@ -36296,6 +34632,16 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"hkb" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/west,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "hkT" = (
 /turf/closed/wall/r_wall,
 /area/engine/storage)
@@ -36310,8 +34656,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -36334,7 +34679,6 @@
 "hzP" = (
 /obj/machinery/atmospherics/components/binary/pump/on/layer1{
 	dir = 1;
-	icon_state = "pump_on_map-1";
 	name = "Airmix to Pure"
 	},
 /turf/open/floor/plasteel,
@@ -36343,15 +34687,13 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 10;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
 "hDi" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrous_input{
-	dir = 1;
-	icon_state = "inje_map-2"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible/layer3,
 /turf/open/floor/engine/n2o,
@@ -36364,8 +34706,7 @@
 /area/engine/engine_room)
 "hHE" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -36383,23 +34724,20 @@
 /area/engine/atmos)
 "hOb" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 4;
-	icon_state = "vent_map_on-3"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "ihv" = (
 /obj/structure/window/reinforced/tinted/frosted{
-	dir = 1;
-	icon_state = "fwindow"
+	dir = 1
 	},
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable{
@@ -36409,8 +34747,7 @@
 /area/engine/engine_room)
 "ipI" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -36422,29 +34759,24 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/ship/techfloor/grid{
-	dir = 8;
-	icon_state = "techfloor_grid"
+	dir = 8
 	},
 /obj/effect/turf_decal/ship/techfloor/grey,
 /obj/effect/turf_decal/ship/techfloor/grey{
-	dir = 1;
-	icon_state = "techfloor_grey"
+	dir = 1
 	},
 /obj/effect/turf_decal/ship/borderfloor/gunmetal/corner{
-	dir = 4;
-	icon_state = "borderfloorcorner_white"
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
 "iCH" = (
 /obj/machinery/atmospherics/components/binary/pump/layer3{
 	dir = 1;
-	icon_state = "pump_map-3";
 	name = "TOX to Mixline"
 	},
 /obj/machinery/atmospherics/components/binary/pump/layer1{
 	dir = 4;
-	icon_state = "pump_map-1";
 	name = "Mixtank to Pure"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible/layer3{
@@ -36483,15 +34815,13 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
 "iQq" = (
 /obj/effect/turf_decal/tile/bar{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
@@ -36504,8 +34834,7 @@
 	name = "Distribution Loop Purge"
 	},
 /obj/effect/turf_decal/caution/white{
-	dir = 8;
-	icon_state = "caution_white"
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
@@ -36551,7 +34880,6 @@
 "jgT" = (
 /obj/machinery/atmospherics/components/binary/pump/on/layer1{
 	dir = 4;
-	icon_state = "pump_on_map-1";
 	name = "Reactor Waste to Wasteline"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer1,
@@ -36584,6 +34912,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"jwc" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/extinguisher_cabinet/west,
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "jyz" = (
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -36611,8 +34950,7 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/bar{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/plasteel,
@@ -36645,14 +34983,37 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engine_room)
+"jOh" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	color = "#afa";
+	dir = 4;
+	name = "mail trunk disposal pipe"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "jOp" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/full,
 /obj/machinery/atmospherics/components/unary/portables_connector/layer1{
-	dir = 4;
-	icon_state = "connector_map-1"
+	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/plasteel/dark,
@@ -36667,8 +35028,7 @@
 /area/engine/atmos)
 "jOT" = (
 /obj/structure/bodycontainer/morgue{
-	dir = 1;
-	icon_state = "morgue1"
+	dir = 1
 	},
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/dark,
@@ -36697,8 +35057,7 @@
 /area/engine/atmos)
 "kgN" = (
 /obj/effect/turf_decal/stripes/red/line{
-	dir = 8;
-	icon_state = "warningline_red"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/layer_manifold/visible{
 	dir = 4
@@ -36719,21 +35078,17 @@
 	},
 /obj/machinery/atmospherics/components/binary/volume_pump/layer3{
 	dir = 8;
-	icon_state = "volpump_map-3";
 	name = "Purge Reactor Inlet"
 	},
 /obj/effect/turf_decal/ship/techfloor/grid,
 /obj/effect/turf_decal/ship/techfloor/grey{
-	dir = 8;
-	icon_state = "techfloor_grey"
+	dir = 8
 	},
 /obj/effect/turf_decal/ship/techfloor/grey{
-	dir = 4;
-	icon_state = "techfloor_grey"
+	dir = 4
 	},
 /obj/effect/turf_decal/ship/borderfloor/gunmetal/corner{
-	dir = 1;
-	icon_state = "borderfloorcorner_white"
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
@@ -36751,8 +35106,7 @@
 /area/engine/storage)
 "kyT" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-10"
@@ -36761,35 +35115,29 @@
 /area/engine/engine_room)
 "kyX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrogen_output{
-	dir = 1;
-	icon_state = "vent_map_siphon_on-2"
+	dir = 1
 	},
 /turf/open/floor/engine/n2,
 /area/engine/atmos)
 "kzK" = (
 /obj/effect/turf_decal/ship/techfloor/grid{
-	dir = 1;
-	icon_state = "techfloor_grid"
+	dir = 1
 	},
 /obj/effect/turf_decal/ship/techfloor/grey{
-	dir = 4;
-	icon_state = "techfloor_grey"
+	dir = 4
 	},
 /obj/effect/turf_decal/ship/techfloor/grey{
-	dir = 8;
-	icon_state = "techfloor_grey"
+	dir = 8
 	},
 /obj/effect/turf_decal/ship/borderfloor/gunmetal/corner,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
 "kAv" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/bar{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
@@ -36807,8 +35155,7 @@
 /area/engine/atmos)
 "kVf" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -36823,15 +35170,13 @@
 	icon_state = "5-10"
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/wrench,
 /obj/effect/turf_decal/tile/bar{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
@@ -36903,7 +35248,6 @@
 	dir = 2;
 	dwidth = 3;
 	height = 5;
-	icon_state = "pinonfar";
 	id = "mining_home";
 	name = "Mainship Mining Dock";
 	roundstart_template = /datum/map_template/shuttle/mining/kilo;
@@ -36932,8 +35276,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel,
@@ -36943,24 +35286,21 @@
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1{
-	dir = 1;
-	icon_state = "dpvent_map-1"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "lLk" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2{
-	dir = 4;
-	icon_state = "filter_on_f"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible/layer3,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "lME" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -36996,7 +35336,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 10;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -37008,12 +35347,10 @@
 "mfH" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/bar{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/ship/techfloor/grey{
-	dir = 8;
-	icon_state = "techfloor_grey"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
@@ -37031,19 +35368,18 @@
 /obj/structure/cable{
 	icon_state = "8-9"
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
 "mww" = (
 /obj/structure/bodycontainer/morgue{
-	dir = 1;
-	icon_state = "morgue1"
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "mMv" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/brown{
@@ -37064,8 +35400,7 @@
 	icon_state = "1-6"
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -37073,7 +35408,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 6;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -37083,15 +35417,13 @@
 "mQX" = (
 /obj/machinery/atmospherics/components/binary/pump/layer3{
 	dir = 1;
-	icon_state = "pump_map-3";
 	name = "N2 to Mixline"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "mTO" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/brown{
@@ -37103,8 +35435,7 @@
 "mVD" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/bar{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/structure/reagent_dispensers/foamtank,
 /turf/open/floor/plasteel,
@@ -37117,8 +35448,7 @@
 /area/engine/engine_room)
 "ndu" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1;
-	icon_state = "connector_map-2"
+	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel,
@@ -37159,8 +35489,7 @@
 "ntm" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -37181,8 +35510,7 @@
 /area/engine/atmos)
 "nxP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1;
-	icon_state = "scrub_map_on-1"
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
@@ -37197,8 +35525,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -37232,15 +35559,13 @@
 /area/engine/atmos)
 "nMe" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrous_output{
-	dir = 1;
-	icon_state = "vent_map_siphon_on-2"
+	dir = 1
 	},
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
 "nRc" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2o{
-	dir = 4;
-	icon_state = "filter_on_f"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible/layer3,
 /turf/open/floor/plasteel,
@@ -37275,13 +35600,13 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/structure/extinguisher_cabinet/west,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "nXN" = (
@@ -37296,8 +35621,7 @@
 "nYf" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater,
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -37313,7 +35637,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -37330,13 +35653,11 @@
 /area/engine/engine_room)
 "ogI" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/bar{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
@@ -37348,15 +35669,13 @@
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/bar{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
 "olz" = (
 /obj/machinery/atmospherics/components/binary/pump/layer3{
 	dir = 1;
-	icon_state = "pump_map-3";
 	name = "O2 to Mixline"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -37369,15 +35688,13 @@
 /area/engine/engine_room)
 "oqu" = (
 /obj/structure/particle_accelerator/fuel_chamber{
-	dir = 8;
-	icon_state = "fuel_chamber"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
 "ord" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/mix_output{
-	dir = 1;
-	icon_state = "vent_map_siphon_on-2"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible/layer3{
 	dir = 9
@@ -37402,9 +35719,7 @@
 	dir = 8
 	},
 /obj/machinery/vending/engivend,
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -37417,8 +35732,7 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/yellow{
@@ -37467,8 +35781,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/bar{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -37480,20 +35793,19 @@
 /area/engine/engine_room)
 "oVW" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
 /obj/structure/reagent_dispensers/watertank/high,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/plasteel,
 /area/engine/storage)
 "oWV" = (
 /obj/machinery/suit_storage_unit/atmos,
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -37508,8 +35820,7 @@
 	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
-	dir = 4;
-	icon_state = "pipe-t"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
@@ -37531,8 +35842,7 @@
 /area/engine/atmos)
 "oYu" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/mix_input{
-	dir = 1;
-	icon_state = "inje_map-2"
+	dir = 1
 	},
 /turf/open/floor/engine/vacuum/light,
 /area/engine/atmos)
@@ -37566,7 +35876,6 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /obj/machinery/atmospherics/components/binary/volume_pump/layer1{
 	dir = 4;
-	icon_state = "volpump_map-1";
 	name = "Constriction Output Purge"
 	},
 /turf/open/floor/plasteel,
@@ -37580,8 +35889,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -37604,8 +35912,7 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plasteel,
@@ -37623,12 +35930,10 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible/layer1,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/bar{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/structure/particle_accelerator/particle_emitter/right{
-	dir = 8;
-	icon_state = "emitter_right"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
@@ -37652,8 +35957,7 @@
 /area/engine/atmos)
 "pVn" = (
 /obj/machinery/computer/atmos_control/tank/oxygen_tank{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible/layer3,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -37665,8 +35969,7 @@
 /area/engine/atmos)
 "pWw" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/computer/station_alert,
 /obj/machinery/light{
@@ -37674,8 +35977,7 @@
 	},
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/bar{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
@@ -37710,18 +36012,15 @@
 /area/maintenance/department/electrical)
 "qOE" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/electrical,
 /obj/effect/turf_decal/tile/bar{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
@@ -37787,25 +36086,21 @@
 	icon_state = "5-10"
 	},
 /obj/effect/turf_decal/ship/techfloor/grid{
-	dir = 4;
-	icon_state = "techfloor_grid"
+	dir = 4
 	},
 /obj/effect/turf_decal/ship/techfloor/grey{
-	dir = 1;
-	icon_state = "techfloor_grey"
+	dir = 1
 	},
 /obj/effect/turf_decal/ship/techfloor/grey,
 /obj/effect/turf_decal/ship/borderfloor/gunmetal/corner{
-	dir = 8;
-	icon_state = "borderfloorcorner_white"
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
 "rHr" = (
 /obj/structure/tank_dispenser,
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -37813,6 +36108,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "rHK" = (
@@ -37830,16 +36126,14 @@
 /area/engine/engine_room)
 "rQJ" = (
 /obj/effect/turf_decal/ship/techfloor/grey{
-	dir = 4;
-	icon_state = "techfloor_grey"
+	dir = 4
 	},
 /obj/effect/turf_decal/ship/techfloor/grey,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
 "rRP" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 1;
-	icon_state = "inje_map-2"
+	dir = 1
 	},
 /turf/open/floor/plating/airless,
 /area/engine/atmos)
@@ -37854,12 +36148,10 @@
 "scl" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/bar{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/ship/techfloor/grey{
-	dir = 4;
-	icon_state = "techfloor_grey"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
@@ -37877,8 +36169,7 @@
 	},
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1;
-	icon_state = "airlock_cyclelink_helper"
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
@@ -37903,15 +36194,13 @@
 /area/quartermaster/miningdock)
 "snj" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/bar{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
@@ -37923,8 +36212,7 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector/layer1{
-	dir = 4;
-	icon_state = "connector_map-1"
+	dir = 4
 	},
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/plasteel/dark,
@@ -37968,13 +36256,13 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/structure/extinguisher_cabinet/west,
 /turf/open/floor/plasteel,
 /area/engine/storage)
 "sNE" = (
@@ -37984,7 +36272,6 @@
 	},
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1;
-	icon_state = "pipe-j2s";
 	name = "engmos sorting disposal pipe";
 	sortType = "4;6"
 	},
@@ -38018,7 +36305,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -38026,7 +36312,6 @@
 "tao" = (
 /obj/machinery/atmospherics/components/binary/pump/layer3{
 	dir = 1;
-	icon_state = "pump_map-3";
 	name = "CO2 to Mixline"
 	},
 /turf/open/floor/plasteel,
@@ -38037,7 +36322,6 @@
 "tlH" = (
 /obj/machinery/atmospherics/components/binary/pump/layer3{
 	dir = 1;
-	icon_state = "pump_map-3";
 	name = "Airmix to Mixline"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -38050,8 +36334,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -38059,7 +36342,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/firealarm/directional/north,
@@ -38077,19 +36359,16 @@
 	},
 /obj/effect/turf_decal/ship/techfloor/grey,
 /obj/effect/turf_decal/ship/techfloor/grey{
-	dir = 8;
-	icon_state = "techfloor_grey"
+	dir = 8
 	},
 /obj/effect/turf_decal/ship/borderfloor{
-	dir = 1;
-	icon_state = "borderfloor"
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
 "tAQ" = (
 /obj/machinery/computer/atmos_control/tank/nitrous_tank{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible/layer3,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -38107,8 +36386,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -38138,15 +36416,13 @@
 	},
 /obj/machinery/atmospherics/components/binary/volume_pump/layer1{
 	dir = 4;
-	icon_state = "volpump_map-1";
 	name = "Pure Purge"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "tZU" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/plasma{
-	dir = 4;
-	icon_state = "filter_on_f"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
@@ -38166,8 +36442,7 @@
 /area/engine/atmos)
 "uaC" = (
 /obj/effect/turf_decal/ship/techfloor/grey{
-	dir = 4;
-	icon_state = "techfloor_grey"
+	dir = 4
 	},
 /obj/effect/turf_decal/ship/techfloor/grey,
 /obj/structure/chair/office{
@@ -38178,8 +36453,7 @@
 /area/engine/engine_room)
 "uaX" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -38200,8 +36474,7 @@
 /area/engine/engine_room)
 "ulE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/oxygen_output{
-	dir = 1;
-	icon_state = "vent_map_siphon_on-2"
+	dir = 1
 	},
 /turf/open/floor/engine/o2,
 /area/engine/atmos)
@@ -38217,8 +36490,7 @@
 /area/engine/storage)
 "uwo" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2{
-	dir = 4;
-	icon_state = "filter_on_f"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible/layer3,
 /turf/open/floor/plasteel,
@@ -38238,8 +36510,7 @@
 /area/crew_quarters/heads/chief)
 "uCX" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -38247,6 +36518,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high/plus,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/plasteel,
 /area/engine/storage)
 "uDx" = (
@@ -38259,7 +36531,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 5;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
@@ -38279,8 +36550,7 @@
 	icon_state = "1-5"
 	},
 /obj/effect/turf_decal/tile/bar{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
@@ -38293,7 +36563,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#faa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "return trunk disposal pipe"
 	},
 /turf/open/floor/plasteel,
@@ -38304,6 +36573,9 @@
 	dir = 4
 	},
 /obj/structure/closet/secure_closet/engineering_electrical,
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/storage)
 "uPI" = (
@@ -38319,8 +36591,7 @@
 /area/engine/atmos)
 "uWu" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -38330,8 +36601,7 @@
 /area/medical/medbay)
 "uWI" = (
 /obj/machinery/computer/atmos_control/tank/carbon_tank{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible/layer3,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -38342,17 +36612,14 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "uYP" = (
-/obj/machinery/computer/atmos_control/tank/air_tank{
-	dir = 1;
-	icon_state = "computer";
-	name = "Reactor Mix Control";
-	sensors = list("sdmix_sensor" = "Reactor Mix Tank")
-	},
 /obj/machinery/atmospherics/pipe/simple/general/visible/layer3,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
+	},
+/obj/machinery/computer/atmos_control/tank/air_tank{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -38363,16 +36630,13 @@
 "vdk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos{
 	dir = 1;
-	icon_state = "vent_map_siphon_on-2";
 	id_tag = "sdmix_out"
 	},
 /obj/effect/turf_decal/ship/techfloor/corner{
-	dir = 1;
-	icon_state = "techfloor_corners"
+	dir = 1
 	},
 /obj/effect/turf_decal/ship/techfloor/corner{
-	dir = 8;
-	icon_state = "techfloor_corners"
+	dir = 8
 	},
 /turf/open/floor/engine/vacuum/light,
 /area/engine/engine_room)
@@ -38384,19 +36648,16 @@
 /area/maintenance/department/electrical)
 "vir" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/bar{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/plasteel,
@@ -38418,8 +36679,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -38448,12 +36708,10 @@
 	},
 /obj/machinery/atmospherics/components/binary/volume_pump/layer1{
 	dir = 4;
-	icon_state = "volpump_map-1";
 	name = "Constriction Input Purge"
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -38466,8 +36724,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/bar{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
@@ -38476,8 +36733,7 @@
 /area/engine/atmos)
 "vHA" = (
 /obj/structure/particle_accelerator/particle_emitter/left{
-	dir = 8;
-	icon_state = "emitter_left"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
@@ -38487,22 +36743,19 @@
 	},
 /obj/machinery/atmospherics/components/binary/volume_pump/layer3{
 	dir = 4;
-	icon_state = "volpump_map-3";
 	name = "Mixtank Output Purge"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "vKD" = (
 /obj/machinery/atmospherics/components/trinary/mixer/airmix{
-	dir = 4;
-	icon_state = "mixer_on"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "vOC" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
-	icon_state = "pump_map-2";
 	name = "Constriction Output to Mixline"
 	},
 /turf/open/floor/plasteel,
@@ -38529,14 +36782,21 @@
 /area/engine/atmos)
 "wbb" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"wgY" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "wig" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	name = "Morgue Maintenance";
@@ -38557,8 +36817,7 @@
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer1{
-	dir = 1;
-	icon_state = "dpvent_map-1"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plating,
@@ -38568,8 +36827,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -38583,13 +36841,11 @@
 /area/engine/atmos)
 "wBi" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/machinery/computer/atmos_alert,
 /obj/effect/turf_decal/tile/bar{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/plasteel,
@@ -38603,30 +36859,42 @@
 /area/engine/atmos)
 "wGI" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/structure/sign/poster/contraband/power{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/tile/bar{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
-/obj/machinery/computer/ship/reactor_control_computer,
+/obj/machinery/computer/ship/reactor_control_computer{
+	reactor_id = 1
+	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
 "wLv" = (
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"wLE" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "wMF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/turf_decal/tile/blue,
@@ -38641,12 +36909,10 @@
 /area/engine/atmos)
 "wQF" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1;
-	icon_state = "connector_map-2"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -38662,19 +36928,16 @@
 /area/engine/atmos)
 "wTH" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/bar{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
 "wWr" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 2;
-	icon_state = "morgue1";
 	name = "isolation morgue"
 	},
 /turf/open/floor/plasteel/dark,
@@ -38687,12 +36950,10 @@
 /area/engine/atmos)
 "xaJ" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/bar{
-	dir = 4;
-	icon_state = "tile_corner"
+	dir = 4
 	},
 /obj/structure/tank_dispenser/plasma,
 /obj/machinery/computer/ship/viewscreen,
@@ -38730,15 +36991,13 @@
 /obj/structure/girder/reinforced,
 /obj/structure/grille,
 /obj/structure/window/reinforced/tinted/frosted{
-	dir = 1;
-	icon_state = "fwindow"
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "xlq" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/carbon_input{
-	dir = 1;
-	icon_state = "inje_map-2"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible/layer3,
 /turf/open/floor/engine/co2,
@@ -38752,8 +37011,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/structure/window/spawner/north,
@@ -38783,8 +37041,7 @@
 /area/engine/engine_room)
 "xuW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/toxin_output{
-	dir = 1;
-	icon_state = "vent_map_siphon_on-2"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible/layer3{
 	dir = 9
@@ -38813,8 +37070,7 @@
 "xAD" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible/layer1,
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -38824,8 +37080,7 @@
 /area/engine/atmos)
 "xBp" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/structure/table/reinforced,
 /obj/item/pipe_dispenser,
@@ -38834,12 +37089,10 @@
 /area/engine/engine_room)
 "xEl" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/bar{
-	dir = 8;
-	icon_state = "tile_corner"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 6
@@ -38851,8 +37104,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -38862,8 +37114,7 @@
 /area/engine/atmos)
 "xFU" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -38901,8 +37152,7 @@
 	icon_state = "6-8"
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1;
-	icon_state = "tile_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -38910,7 +37160,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 10;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
@@ -38927,8 +37176,7 @@
 /area/engine/storage)
 "xQX" = (
 /obj/structure/particle_accelerator/end_cap{
-	dir = 8;
-	icon_state = "end_cap"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
@@ -38943,7 +37191,6 @@
 /obj/structure/disposalpipe/segment{
 	color = "#afa";
 	dir = 4;
-	icon_state = "pipe";
 	name = "mail trunk disposal pipe"
 	},
 /obj/structure/disposalpipe/segment{
@@ -38956,8 +37203,7 @@
 /area/engine/storage)
 "xWu" = (
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible/layer3,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -38969,8 +37215,7 @@
 /area/engine/atmos)
 "yeQ" = (
 /obj/machinery/computer/atmos_control/tank/mix_tank{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer1{
 	dir = 5
@@ -49654,14 +47899,14 @@ onE
 cxU
 xEl
 ckG
-ckG
+jwc
 ckG
 kAv
 lEc
 fOV
 ipI
-ipI
-ipI
+hkb
+dTO
 ipI
 fKg
 ran
@@ -53248,12 +51493,12 @@ bJD
 ihv
 fQu
 vDb
-vDb
+wLE
 oVV
 uKw
 mfH
 frb
-frb
+wgY
 fXi
 lEc
 wvx
@@ -56076,7 +54321,7 @@ aez
 aeS
 aMF
 agU
-gDQ
+jOh
 ajB
 lEc
 oYn


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request


Fixed mixed air tank console is a reactor tank console 
Fixed no cameras in engineering. 
Added more fire extinguishers, newscasters, intercoms and a request console to engineering 
Removed distribution loop doublepipe on tile X136, Y127
Removed layer manifold doublepipe on tile X43, Y122
Fixed reactor console does not start linked 

Also strongdmm accidentally sanitized a bunch of redundant var declarations, where a custom var was the same as the default var. Hope that's okay 

## Why It's Good For The Game

Grug 

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
