### PR TITLE
Constructable Flak mounts

### DIFF
--- a/nsv13/code/modules/munitions/ship_weapons/ship_weapon_parts.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ship_weapon_parts.dm
@@ -6,17 +6,58 @@
 	build_path = /obj/machinery/computer/ship/munitions_computer
 
 /**
- * PDC mount circuitboard
+ * PDC/Flak mount circuitboard
  */
 /obj/item/circuitboard/machine/pdc_mount
 	name = "circuit board (pdc mount)"
-	build_path = /obj/machinery/ship_weapon/pdc_mount
+	desc = "You can use a screwdriver to switch between PDC and flak."
 	req_components = list(
 		/obj/item/stock_parts/manipulator = 4,
 		/obj/item/stock_parts/capacitor = 2,
 		/obj/item/stock_parts/matter_bin = 3,
 		/obj/item/ship_weapon/parts/firing_electronics = 1
 	)
+
+#define PATH_PDC /obj/machinery/ship_weapon/pdc_mount
+#define PATH_FLAK  /obj/machinery/ship_weapon/pdc_mount/flak
+
+/obj/item/circuitboard/machine/pdc_mount/Initialize()
+	. = ..()
+	if(!build_path)
+		if(prob(50))
+			name = "PDC Loading Rack (Machine Board)"
+			build_path = PATH_PDC
+		else
+			name = "Flak Loading Rack (Machine Board)"
+			build_path = PATH_FLAK
+
+/obj/item/circuitboard/machine/pdc_mount/attackby(obj/item/I, mob/user, params)
+	if(I.tool_behaviour == TOOL_SCREWDRIVER)
+		var/obj/item/circuitboard/new_type
+		var/new_setting
+		switch(build_path)
+			if(PATH_PDC)
+				new_type = /obj/item/circuitboard/machine/pdc_mount/flak
+				new_setting = "Flak"
+			if(PATH_FLAK)
+				new_type = /obj/item/circuitboard/machine/pdc_mount/
+				new_setting = "PDC"
+		name = initial(new_type.name)
+		build_path = initial(new_type.build_path)
+		I.play_tool_sound(src)
+		to_chat(user, "<span class='notice'>You change the circuitboard setting to \"[new_setting]\".</span>")
+		return
+		
+/obj/item/circuitboard/machine/pdc_mount
+	name = "PDC Mount (Machine Board)"
+	build_path = PATH_PDC
+
+/obj/item/circuitboard/machine/pdc_mount/flak
+	name = "Flak Loading Rack (Machine Board)"
+	build_path = PATH_FLAK
+
+#undef PATH_PDC
+#undef PATH_FLAK
 
 /**
  * Firing electronics - used for pdcs, torp tubes, and railguns

--- a/nsv13/code/modules/munitions/ship_weapons/ship_weapon_research.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ship_weapon_research.dm
@@ -17,8 +17,8 @@
 	export_price = 8000
 
 /datum/design/board/pdc_mount_circuit
-	name = "Machine Design (PDC Mount)"
-	desc = "Allows for the construction of a PDC mount."
+	name = "Machine Design (PDC/Flak Mount)"
+	desc = "Allows for the construction of a PDC or Flak mount."
 	id = "pdc_mount_circuit"
 	materials = list(/datum/material/glass = 2000, /datum/material/copper = 200, /datum/material/gold = 500)
 	build_path = /obj/item/circuitboard/machine/pdc_mount


### PR DESCRIPTION
## About The Pull Request

You can now screwdriver PDC circuit boards to turn them into flak circuit boards, Allowing for the construction of more flak racks during a round.

## Why It's Good For The Game

More ship weapon construction is good, I'll try and do the same for MAC Cannons after I wrap my head around it

## Changelog
:cl:
tweak: You can now create additional flak loading racks.
/:cl: