### PR TITLE
Overhauls the SSV Hammurabi to be Monstermos compliant and makes declaring war ops work.

### DIFF
--- a/_maps/map_files/PVP/Hammurabi.dmm
+++ b/_maps/map_files/PVP/Hammurabi.dmm
@@ -5,12 +5,6 @@
 "ab" = (
 /turf/closed/wall/ship,
 /area/hammurabi/maintenance)
-"ac" = (
-/obj/structure/closet/crate,
-/obj/item/storage/belt/utility/full,
-/obj/item/storage/belt/utility/full,
-/turf/open/floor/plating,
-/area/hammurabi/maintenance)
 "ad" = (
 /obj/structure/sign/poster/contraband/c20r{
 	pixel_y = -6
@@ -42,64 +36,12 @@
 	},
 /turf/closed/wall/ship,
 /area/hammurabi/tcomms)
-"ak" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/monotile/dark,
-/area/hammurabi/tcomms)
-"al" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/lore_terminal{
-	pixel_x = 1;
-	pixel_y = 2
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/monotile/dark,
-/area/hammurabi/tcomms)
-"am" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/monotile/dark,
-/area/hammurabi/tcomms)
 "an" = (
 /turf/closed/wall/ship,
-/area/hammurabi)
-"ao" = (
-/obj/machinery/door/airlock/ship/maintenance,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/hammurabi)
-"ap" = (
-/obj/structure/window/reinforced/fulltile/ship/interior,
-/obj/structure/grille,
-/turf/open/floor/monotile/dark,
 /area/hammurabi)
 "aq" = (
 /turf/closed/wall/ship,
 /area/hammurabi/medbay)
-"ar" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/monotile/dark,
-/area/hammurabi/tcomms)
-"as" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/monotile,
-/area/hammurabi/tcomms)
-"at" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/monotile/dark,
-/area/hammurabi/tcomms)
 "au" = (
 /turf/closed/wall/r_wall/ship,
 /area/hammurabi/hangar)
@@ -142,13 +84,6 @@
 	},
 /turf/open/floor/plating,
 /area/hammurabi/hangar)
-"aC" = (
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/hammurabi/maintenance)
 "aD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -162,15 +97,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
 /area/hammurabi/hangar)
-"aF" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi/bridge)
 "aG" = (
 /turf/closed/wall/r_wall/ship,
 /area/hammurabi/maintenance)
@@ -180,20 +106,12 @@
 	},
 /turf/open/floor/plating,
 /area/hammurabi/hangar)
-"aI" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plasteel/dark,
-/area/hammurabi/hangar)
 "aJ" = (
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/hangar)
 "aK" = (
 /turf/open/floor/plating,
 /area/hammurabi/maintenance)
-"aL" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/carpet/red,
-/area/hammurabi)
 "aM" = (
 /obj/machinery/computer/ship/fighter_launcher{
 	req_access = null;
@@ -212,7 +130,9 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/hangar)
 "aP" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -239,11 +159,6 @@
 "aS" = (
 /turf/open/floor/monotile/dark,
 /area/hammurabi)
-"aT" = (
-/obj/machinery/computer/ship/viewscreen,
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/floor/monotile/dark,
-/area/hammurabi)
 "aU" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -255,10 +170,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
-"aW" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
 "aX" = (
 /turf/open/floor/plasteel/tech/grid,
@@ -275,35 +186,11 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/hangar)
-"ba" = (
-/obj/machinery/door/airlock/ship{
-	name = "TE/LE/COM core"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/monotile,
-/area/hammurabi/tcomms)
 "bb" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 8
 	},
 /turf/closed/wall/ship,
-/area/hammurabi)
-"bc" = (
-/obj/machinery/computer/ship/viewscreen,
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/machinery/computer/monitor,
-/turf/open/floor/carpet/red,
-/area/hammurabi)
-"bd" = (
-/obj/machinery/computer/ship/reactor_control_computer{
-	reactor_id = 3;
-	req_access = null;
-	req_one_access_txt = "150"
-	},
-/turf/open/floor/carpet/red,
 /area/hammurabi)
 "be" = (
 /turf/open/floor/carpet/red,
@@ -340,11 +227,10 @@
 /turf/open/floor/plasteel/dark,
 /area/hammurabi/hangar)
 "bl" = (
-/obj/machinery/door/airlock/ship{
-	name = "Engineering"
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/armoury)
 "bm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -402,20 +288,6 @@
 	},
 /turf/open/floor/plating,
 /area/hammurabi/hangar)
-"bw" = (
-/obj/structure/table/reinforced,
-/obj/machinery/button/door{
-	id = "syndie_interior_l";
-	name = "Left interior doors"
-	},
-/obj/machinery/button/door{
-	id = "syndie_exterior_l";
-	name = "Left launch bay doors";
-	pixel_y = 7;
-	pixel_z = 1
-	},
-/turf/open/floor/plasteel/ship,
-/area/hammurabi/hangar)
 "bx" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -437,14 +309,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hammurabi/hangar)
-"bz" = (
-/obj/machinery/door/airlock/ship/hatch{
-	name = "Launch tubes";
-	req_one_access_txt = "150"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/monotile/dark,
-/area/hammurabi/hangar)
 "bA" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/poddoor/ship{
@@ -455,26 +319,10 @@
 "bB" = (
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/hangar)
-"bC" = (
-/obj/structure/window/reinforced/fulltile/ship/interior,
-/obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/carpet/red,
-/area/hammurabi)
 "bD" = (
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
-"bE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4;
-	icon_state = "pipe11-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi/hangar)
 "bF" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
@@ -482,33 +330,15 @@
 	},
 /turf/open/floor/plating,
 /area/hammurabi/maintenance)
-"bG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/monotile,
-/area/hammurabi/tcomms)
-"bH" = (
-/obj/machinery/door/airlock/ship/maintenance,
-/turf/open/floor/plating,
-/area/hammurabi/tcomms)
 "bI" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/carpet/red,
 /area/hammurabi)
-"bJ" = (
-/obj/machinery/door/airlock/ship/engineering{
-	name = "Reactor monitoring"
-	},
-/turf/open/floor/plating,
-/area/hammurabi)
 "bK" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 6;
-	icon_state = "pipe11-2"
+	dir = 6
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -517,8 +347,7 @@
 /area/hammurabi)
 "bL" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -527,8 +356,7 @@
 /area/hammurabi)
 "bM" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 10;
-	icon_state = "pipe11-2"
+	dir = 10
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -539,35 +367,9 @@
 /obj/machinery/computer/cryopod,
 /turf/closed/wall/ship,
 /area/hammurabi)
-"bO" = (
-/obj/machinery/door/airlock/glass_large/ship{
-	name = "cryostasis"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
 "bP" = (
 /turf/closed/wall/r_wall/ship,
 /area/hammurabi/armoury)
-"bQ" = (
-/obj/structure/fluff/bleepypanel{
-	dir = 4
-	},
-/turf/closed/wall/ship,
-/area/hammurabi)
-"bR" = (
-/obj/machinery/door/airlock/ship{
-	name = "Aft frame"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
-"bS" = (
-/obj/machinery/door/airlock/ship{
-	name = "Marine suit storage";
-	req_one_access_txt = "150"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi)
 "bT" = (
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
@@ -575,26 +377,6 @@
 /obj/machinery/suit_storage_unit/syndicate/odst,
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/armoury)
-"bV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/armoury)
-"bW" = (
-/obj/machinery/door/airlock/ship{
-	name = "TE/LE/COM core"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/monotile,
-/area/hammurabi/tcomms)
 "bX" = (
 /turf/closed/wall/ship,
 /area/hammurabi/bridge)
@@ -605,20 +387,9 @@
 /obj/item/storage/box/donkpockets,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
-"bZ" = (
-/obj/machinery/door/airlock/ship/maintenance,
-/turf/open/floor/plating,
-/area/hammurabi/maintenance)
 "ca" = (
 /turf/closed/wall/r_wall/ship,
 /area/hammurabi)
-"cb" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi/hangar)
 "cc" = (
 /obj/structure/rack,
 /obj/item/gun/ballistic/automatic/c20r/unrestricted{
@@ -634,8 +405,11 @@
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/armoury)
 "cd" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/engine,
+/obj/machinery/shower{
+	dir = 8;
+	name = "emergency shower"
+	},
+/turf/open/floor/plasteel/grid/techfloor/grid,
 /area/hammurabi)
 "ce" = (
 /obj/effect/turf_decal/stripes/line{
@@ -657,23 +431,10 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/armoury)
-"cg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/armoury)
 "ch" = (
 /obj/structure/sink{
 	pixel_y = 32
 	},
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi)
-"ci" = (
-/obj/structure/table/reinforced,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
 "cj" = (
@@ -684,18 +445,6 @@
 /obj/machinery/microwave,
 /obj/structure/table/reinforced,
 /turf/open/floor/mineral/plastitanium,
-/area/hammurabi)
-"cl" = (
-/obj/machinery/door/airlock/ship{
-	name = "Kitchen"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi)
-"cm" = (
-/obj/machinery/door/airlock/ship{
-	name = "Canteen"
-	},
-/turf/open/floor/carpet/red,
 /area/hammurabi)
 "cn" = (
 /obj/structure/window/reinforced/fulltile/ship/interior,
@@ -713,30 +462,12 @@
 /obj/effect/landmark/start/nukeop/syndi_crew,
 /turf/open/floor/monotile/dark,
 /area/hammurabi)
-"cr" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/engine,
-/area/hammurabi)
-"cs" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/monotile/dark,
-/area/hammurabi/hangar)
 "ct" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/hangar)
-"cu" = (
-/obj/machinery/door/airlock/ship{
-	name = "Bridge frame";
-	req_one_access_txt = "150"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi)
 "cv" = (
 /obj/structure/chair{
 	dir = 8
@@ -748,16 +479,12 @@
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
 "cw" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	name = "Armoury";
-	req_one_access_txt = "150"
-	},
-/turf/open/floor/plating,
-/area/hammurabi/armoury)
+/obj/structure/sign/poster/contraband/free_key,
+/turf/closed/wall/ship,
+/area/hammurabi/tcomms)
 "cx" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 6;
-	icon_state = "pipe11-2"
+	dir = 6
 	},
 /turf/closed/wall/r_wall/ship,
 /area/hammurabi)
@@ -769,8 +496,7 @@
 /area/hammurabi/hangar)
 "cz" = (
 /obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	dir = 4;
-	icon_state = "manifold-2"
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -795,12 +521,6 @@
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi/medbay)
-"cE" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi/armoury)
 "cF" = (
 /obj/machinery/shower{
 	dir = 8
@@ -820,10 +540,6 @@
 "cH" = (
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/bridge)
-"cI" = (
-/obj/structure/table/optable,
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi/medbay)
 "cJ" = (
 /turf/open/floor/monotile/dark,
 /area/hammurabi/medbay)
@@ -859,10 +575,6 @@
 	},
 /turf/open/floor/plating,
 /area/hammurabi/maintenance)
-"cP" = (
-/obj/machinery/computer/ship/viewscreen,
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi/bridge)
 "cQ" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/dna_scannernew,
@@ -884,35 +596,12 @@
 "cT" = (
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/bridge)
-"cU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi/bridge)
-"cV" = (
-/turf/open/floor/plasteel/stairs/medium{
-	dir = 8;
-	icon_state = "stairs-m"
-	},
-/area/hammurabi/bridge)
 "cW" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
 	},
 /turf/open/floor/monotile/dark,
 /area/hammurabi/medbay)
-"cX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/computer/ship/viewscreen,
-/obj/machinery/computer{
-	dir = 8;
-	icon_state = "computer"
-	},
-/turf/open/floor/plating,
-/area/hammurabi/bridge)
 "cY" = (
 /obj/machinery/sleeper/syndie{
 	dir = 8;
@@ -929,14 +618,15 @@
 /obj/item/wrench,
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi/medbay)
-"da" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/plating,
-/area/hammurabi/bridge)
 "db" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/belt/utility/full,
+/obj/item/storage/belt/utility/full,
 /turf/open/floor/mineral/plastitanium,
-/area/hammurabi/bridge)
+/area/hammurabi/maintenance)
 "dc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -959,8 +649,11 @@
 /turf/open/floor/engine,
 /area/hammurabi)
 "df" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 9
+	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/plating,
 /area/hammurabi)
 "dg" = (
@@ -980,22 +673,16 @@
 /turf/open/floor/plating,
 /area/hammurabi/maintenance)
 "di" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/machinery/door/airlock/ship{
+	name = "TE/LE/COM core"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1;
-	icon_state = "manifold-2"
-	},
-/turf/open/floor/monotile/dark,
-/area/hammurabi)
-"dj" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/floor/plating,
-/area/hammurabi)
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/monotile,
+/area/hammurabi/tcomms)
 "dk" = (
 /obj/machinery/cryopod{
 	dir = 4
@@ -1008,22 +695,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/hammurabi)
-"dm" = (
-/obj/machinery/door/airlock/ship{
-	name = "Central frame"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
-"dn" = (
-/obj/machinery/door/airlock/ship{
-	name = "Bridge frame";
-	req_one_access_txt = "150"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/bridge)
-"do" = (
-/turf/open/floor/carpet/red,
-/area/hammurabi/bridge)
 "dp" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/mineral/plastitanium/red,
@@ -1045,39 +716,11 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hammurabi)
-"ds" = (
-/obj/structure/chair/comfy/shuttle{
-	color = "#696969";
-	dir = 4;
-	icon_state = "shuttle_chair";
-	name = "bridge chair"
-	},
-/obj/effect/landmark/start/nukeop/syndi_crew,
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi/bridge)
-"dt" = (
-/obj/machinery/computer/ship/tactical{
-	dir = 8;
-	req_access = null;
-	req_one_access_txt = "150"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/hammurabi/bridge)
 "du" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 8;
-	icon_state = "pipe11-2"
+	dir = 8
 	},
 /turf/closed/wall/r_wall/ship,
-/area/hammurabi)
-"dv" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/carpet/red,
 /area/hammurabi)
 "dw" = (
 /obj/structure/lattice/catwalk,
@@ -1088,22 +731,13 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 8;
-	icon_state = "pipe11-2"
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/hammurabi)
-"dy" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/hammurabi)
 "dz" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -1134,8 +768,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 8;
-	icon_state = "pipe11-2"
+	dir = 8
 	},
 /obj/machinery/light{
 	dir = 8
@@ -1146,22 +779,13 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi/bridge)
-"dE" = (
-/obj/machinery/computer/communications{
-	dir = 8;
-	req_access = null;
-	req_one_access_txt = "151"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating,
 /area/hammurabi/bridge)
 "dF" = (
 /obj/structure/railing{
@@ -1192,10 +816,6 @@
 	},
 /turf/open/floor/engine,
 /area/hammurabi)
-"dK" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/hammurabi)
 "dL" = (
 /obj/machinery/atmospherics/components/binary/magnetic_constrictor{
 	dir = 1
@@ -1219,50 +839,11 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/bridge)
-"dO" = (
-/obj/machinery/computer/ship/helm{
-	dir = 8;
-	req_access = null;
-	req_one_access_txt = "150"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/hammurabi/bridge)
-"dP" = (
-/obj/machinery/door/airlock/ship/engineering{
-	dir = 2;
-	icon_state = "closed";
-	name = "Reactor core";
-	req_one_access_txt = null
-	},
-/turf/open/floor/plating,
-/area/hammurabi)
-"dQ" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 5;
-	icon_state = "pipe11-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/hammurabi)
 "dR" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/hammurabi)
-"dS" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 9;
-	icon_state = "pipe11-2"
-	},
 /turf/open/floor/plating,
 /area/hammurabi)
 "dT" = (
@@ -1275,26 +856,6 @@
 	icon_state = "railgun_platform"
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi)
-"dV" = (
-/obj/structure/closet/radiation,
-/obj/item/clothing/mask/gas,
-/obj/item/tank/internals/oxygen,
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/bridge)
-"dW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/machinery/computer/ship/navigation{
-	dir = 8;
-	icon_state = "computer"
-	},
-/turf/open/floor/plating,
-/area/hammurabi/bridge)
-"dX" = (
-/obj/structure/closet/radiation,
-/turf/open/floor/plating,
 /area/hammurabi)
 "dY" = (
 /obj/structure/hull_plate/end{
@@ -1339,13 +900,6 @@
 	},
 /turf/open/space/basic,
 /area/hammurabi/maintenance/exterior)
-"eg" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/hammurabi/maintenance)
 "eh" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/monotile/dark,
@@ -1371,10 +925,17 @@
 /turf/open/floor/plating,
 /area/hammurabi/maintenance)
 "em" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/obj/item/folder/syndicate{
+	name = "folder"
+	},
+/turf/open/floor/carpet/red,
 /area/hammurabi)
 "en" = (
 /obj/structure/hull_plate/end{
@@ -1407,10 +968,10 @@
 /turf/open/floor/plating,
 /area/hammurabi/maintenance)
 "er" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	name = "Gravity generator"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
 "es" = (
 /obj/structure/shuttle/engine/heater{
@@ -1418,42 +979,29 @@
 	},
 /turf/closed/wall/ship,
 /area/hammurabi/maintenance)
-"et" = (
-/obj/structure/fluff/bleepypanel{
-	dir = 8
-	},
-/turf/closed/wall/ship,
-/area/hammurabi/maintenance)
 "eu" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	name = "Armoury";
-	req_one_access_txt = "150"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/hammurabi/armoury)
-"ev" = (
-/obj/machinery/door/airlock/ship/external/glass,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/hammurabi)
-"ew" = (
-/obj/machinery/door/airlock/ship/external/glass,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/hammurabi)
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/hangar)
 "ex" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/door/airlock/ship{
+	name = "TE/LE/COM core"
 	},
-/turf/open/floor/monotile/dark,
-/area/hammurabi)
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/monotile,
+/area/hammurabi/tcomms)
 "ey" = (
 /obj/item/ship_weapon/ammunition/missile,
 /obj/effect/turf_decal/delivery,
@@ -1469,13 +1017,10 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi)
 "eB" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 1;
-	icon_state = "pipe11-2"
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi)
+/obj/structure/girder/reinforced,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
 "eC" = (
 /obj/machinery/suit_storage_unit/syndicate,
 /obj/effect/turf_decal/box,
@@ -1483,17 +1028,6 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/armoury)
 "eD" = (
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/armoury)
-"eE" = (
-/obj/machinery/door/airlock/ship{
-	name = "Elite boarding team";
-	req_one_access_txt = "151"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4;
-	icon_state = "pipe11-2"
-	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/armoury)
 "eF" = (
@@ -1509,9 +1043,9 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/armoury)
 "eI" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi/medbay)
+/obj/machinery/computer/atmos_alert,
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
 "eJ" = (
 /obj/machinery/suit_storage_unit/syndicate/odst,
 /obj/effect/turf_decal/box,
@@ -1523,13 +1057,6 @@
 /obj/machinery/suit_storage_unit/syndicate/odst,
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/armoury)
-"eL" = (
-/obj/machinery/shower{
-	dir = 8;
-	name = "emergency shower"
-	},
-/turf/open/floor/plating,
-/area/hammurabi)
 "eM" = (
 /obj/structure/particle_accelerator/particle_emitter/left{
 	dir = 8;
@@ -1543,25 +1070,9 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hammurabi)
-"eN" = (
-/obj/machinery/door/airlock/ship/external/glass,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
-/area/hammurabi/maintenance)
 "eO" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
-"eP" = (
-/obj/machinery/door/airlock/ship{
-	name = "Munitions";
-	req_one_access_txt = "150"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 1;
-	icon_state = "pipe11-2"
-	},
-/turf/open/floor/plasteel/stairs/medium,
 /area/hammurabi)
 "eQ" = (
 /obj/effect/turf_decal/stripes/line{
@@ -1575,22 +1086,9 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/bridge)
-"eS" = (
-/obj/machinery/door/airlock/ship{
-	name = "Torpedo rack"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi)
 "eT" = (
 /obj/structure/fluff/bleepypanel,
 /turf/closed/wall/ship,
-/area/hammurabi)
-"eU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 1;
-	icon_state = "pipe11-2"
-	},
-/turf/open/floor/plasteel/stairs/old,
 /area/hammurabi)
 "eV" = (
 /obj/effect/turf_decal/stripes/line,
@@ -1645,13 +1143,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
-"fa" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi)
 "fb" = (
 /obj/machinery/ship_weapon/pdc_mount/north,
 /obj/effect/turf_decal/delivery,
@@ -1698,35 +1189,9 @@
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
-"fj" = (
-/obj/machinery/door/airlock/glass_large/ship{
-	name = "Armoury"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/armoury)
-"fk" = (
-/obj/machinery/door/airlock/ship/external/glass,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/hammurabi/maintenance)
 "fl" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/mineral/plastitanium,
-/area/hammurabi)
-"fm" = (
-/obj/machinery/door/airlock/ship{
-	name = "Storage junction"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi)
-"fn" = (
-/obj/machinery/door/airlock/ship{
-	name = "Missile tubes"
-	},
-/turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
 "fo" = (
 /obj/machinery/ship_weapon/torpedo_launcher/east,
@@ -1758,19 +1223,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/armoury)
-"fr" = (
-/obj/structure/table/reinforced,
-/obj/item/gun/ballistic/automatic/c20r/toy/unrestricted/riot,
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/armoury)
-"fs" = (
-/obj/structure/window/reinforced/fulltile/ship/interior,
-/obj/structure/grille,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
 "ft" = (
 /obj/structure/table/reinforced,
 /obj/item/ship_weapon/ammunition/railgun_ammo,
@@ -1814,51 +1266,6 @@
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
-"fA" = (
-/obj/item/gun/ballistic/automatic/c20r/toy/unrestricted/riot,
-/obj/structure/table/reinforced,
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/armoury)
-"fB" = (
-/obj/structure/table/reinforced,
-/obj/item/ship_weapon/parts/torpedo/propulsion_system,
-/obj/item/ship_weapon/parts/torpedo/propulsion_system,
-/obj/item/ship_weapon/parts/torpedo/propulsion_system,
-/obj/item/ship_weapon/parts/torpedo/propulsion_system,
-/obj/item/ship_weapon/parts/torpedo/warhead,
-/obj/item/ship_weapon/parts/torpedo/warhead,
-/obj/item/ship_weapon/parts/torpedo/warhead/decoy,
-/obj/item/ship_weapon/parts/torpedo/warhead/decoy,
-/obj/item/ship_weapon/parts/torpedo/warhead/decoy,
-/obj/item/ship_weapon/parts/torpedo/warhead,
-/obj/item/ship_weapon/parts/torpedo/warhead,
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi)
-"fC" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/cable_coil,
-/obj/item/ship_weapon/parts/torpedo/guidance_system,
-/obj/item/ship_weapon/parts/torpedo/guidance_system,
-/obj/item/ship_weapon/parts/torpedo/guidance_system,
-/obj/item/ship_weapon/parts/torpedo/guidance_system,
-/obj/item/ship_weapon/parts/torpedo/iff_card,
-/obj/item/ship_weapon/parts/torpedo/iff_card,
-/obj/item/ship_weapon/parts/torpedo/iff_card,
-/obj/item/ship_weapon/parts/torpedo/iff_card,
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi)
-"fD" = (
-/obj/machinery/door/airlock/ship{
-	name = "Small ammunition"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi)
-"fE" = (
-/obj/machinery/door/airlock/ship{
-	name = "Ammo rack"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
 "fF" = (
 /obj/item/ship_weapon/ammunition/torpedo/nuke,
 /obj/effect/turf_decal/delivery,
@@ -1872,7 +1279,9 @@
 "fH" = (
 /obj/machinery/suit_storage_unit/syndicate/odst,
 /obj/effect/turf_decal/box,
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -1908,10 +1317,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/hammurabi)
-"fN" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi/hangar)
 "fO" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/belt/utility/full,
@@ -1936,30 +1341,13 @@
 /obj/structure/reagent_dispensers/fueltank/aviation_fuel,
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/hangar)
-"fS" = (
-/obj/machinery/door/airlock/ship/maintenance,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/hammurabi/maintenance)
-"fT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4;
-	icon_state = "pipe11-2"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi/hangar)
 "fU" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi/hangar)
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/turf/open/floor/wood,
+/area/hammurabi/maintenance)
 "fV" = (
 /obj/machinery/computer/ship/viewscreen,
 /obj/machinery/light{
@@ -1977,18 +1365,12 @@
 "fX" = (
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi/medbay)
-"fY" = (
-/obj/structure/window/reinforced/fulltile/ship/interior,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/hammurabi)
 "fZ" = (
-/obj/machinery/door/airlock/ship{
-	name = "Sickbay"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi/medbay)
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
 "ga" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/machinery/light{
@@ -2019,15 +1401,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
-"ge" = (
-/obj/machinery/suit_storage_unit/syndicate,
-/obj/effect/turf_decal/box,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi/armoury)
 "gf" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light{
@@ -2041,12 +1414,6 @@
 /obj/machinery/light,
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/armoury)
-"gh" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/monotile/dark,
-/area/hammurabi)
 "gi" = (
 /obj/machinery/light{
 	dir = 8
@@ -2059,13 +1426,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi)
-"gk" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/armoury)
 "gl" = (
 /obj/structure/rack,
 /obj/item/ammo_box/c45,
@@ -2083,12 +1443,6 @@
 /obj/machinery/light,
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/armoury)
-"gn" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi/bridge)
 "go" = (
 /obj/machinery/light{
 	dir = 4
@@ -2132,20 +1486,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi)
-"gu" = (
-/obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	dir = 4;
-	icon_state = "manifold-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/meter,
-/turf/open/floor/plating,
-/area/hammurabi)
 "gv" = (
 /obj/structure/particle_accelerator/end_cap{
 	dir = 8;
@@ -2156,19 +1496,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/monotile/dark,
-/area/hammurabi)
-"gw" = (
-/obj/structure/closet/radiation,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/hammurabi)
-"gx" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating,
 /area/hammurabi)
 "gy" = (
 /obj/machinery/light/small,
@@ -2198,14 +1525,12 @@
 /turf/open/floor/monotile/dark,
 /area/hammurabi)
 "gC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/armoury)
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi)
 "gD" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
@@ -2213,15 +1538,6 @@
 	},
 /turf/open/floor/plating,
 /area/hammurabi/maintenance)
-"gE" = (
-/obj/machinery/recharge_station,
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/obj/machinery/power/apc/auto_name/north,
-/turf/open/floor/monotile/dark,
-/area/hammurabi/tcomms)
 "gF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -2240,13 +1556,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/armoury)
-"gH" = (
-/obj/machinery/door/airlock/ship/maintenance,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/hammurabi/maintenance)
 "gI" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable{
@@ -2274,22 +1583,10 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/monotile/dark,
 /area/hammurabi)
-"gM" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/hammurabi/maintenance)
 "gN" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5;
-	icon_state = "pipe11-2"
-	},
+/obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/monotile/dark,
-/area/hammurabi)
+/area/hammurabi/medbay)
 "gO" = (
 /obj/effect/turf_decal/box,
 /obj/structure/closet/firecloset,
@@ -2308,10 +1605,6 @@
 	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi)
-"gQ" = (
-/obj/machinery/light,
-/turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
 "gR" = (
 /obj/machinery/button/door{
@@ -2335,13 +1628,6 @@
 	},
 /turf/open/floor/plating,
 /area/hammurabi/maintenance)
-"gT" = (
-/obj/machinery/door/airlock/ship/maintenance,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/hammurabi/maintenance)
 "gU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -2354,7 +1640,9 @@
 "gV" = (
 /obj/structure/table/glass,
 /obj/item/storage/backpack/duffelbag/syndie/surgery,
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -2385,7 +1673,9 @@
 /turf/open/floor/plating,
 /area/hammurabi/maintenance)
 "gZ" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -2508,29 +1798,22 @@
 /turf/open/floor/monotile/dark,
 /area/hammurabi)
 "hn" = (
-/obj/machinery/door/airlock/ship{
-	name = "Engineering"
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4;
-	icon_state = "pipe11-2"
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi)
-"ho" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 1;
-	icon_state = "pipe11-2"
-	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi/hangar)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/turf/open/floor/carpet/red,
+/area/hammurabi)
+"ho" = (
+/obj/structure/table/reinforced,
+/obj/item/toy/figure/syndie,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
 "hp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -2559,22 +1842,9 @@
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/armoury)
 "ht" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/mineral/plastitanium,
-/area/hammurabi/armoury)
-"hu" = (
-/obj/machinery/door/airlock/glass_large/ship{
-	name = "Ammunition storage"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/armoury)
+/area/hammurabi)
 "hv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -2618,12 +1888,12 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
 "hA" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/hammurabi/maintenance)
+/obj/structure/window/reinforced/fulltile/ship/interior,
+/obj/structure/grille,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/carpet/red,
+/area/hammurabi)
 "hB" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -2632,8 +1902,7 @@
 /area/hammurabi/maintenance)
 "hC" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
@@ -2649,15 +1918,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hammurabi)
-"hE" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/hammurabi/maintenance)
 "hF" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -2682,15 +1942,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/hammurabi/maintenance)
-"hI" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
 /area/hammurabi/maintenance)
@@ -2729,37 +1980,9 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hammurabi)
-"hO" = (
-/obj/machinery/door/airlock/ship{
-	name = "Execution chamber"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi)
-"hP" = (
-/obj/structure/window/reinforced/fulltile/ship/interior,
-/obj/structure/grille,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
 "hQ" = (
 /obj/structure/chair{
 	dir = 8
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
-"hR" = (
-/obj/machinery/door/poddoor/ship{
-	dir = 4;
-	id = "syndicell1"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
@@ -2768,41 +1991,6 @@
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
-/area/hammurabi)
-"hT" = (
-/obj/structure/window/reinforced/fulltile/ship/interior,
-/obj/structure/grille,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
-"hU" = (
-/obj/structure/window/reinforced/fulltile/ship/interior,
-/obj/structure/grille,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
-"hV" = (
-/obj/machinery/door/poddoor/ship{
-	dir = 4;
-	id = "syndicell2"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
 "hW" = (
 /obj/effect/turf_decal/stripes/line{
@@ -2833,15 +2021,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/hammurabi)
-"hZ" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/carpet/red,
-/area/hammurabi)
 "ia" = (
 /obj/machinery/computer/ship/ftl_computer/syndicate,
 /turf/open/floor/carpet/red,
@@ -2860,10 +2039,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/hangar)
-"id" = (
-/obj/structure/fluff/bleepypanel,
-/turf/closed/wall/ship,
-/area/hammurabi/maintenance)
 "ie" = (
 /obj/effect/turf_decal/delivery,
 /obj/item/ship_weapon/ammunition/missile,
@@ -2879,8 +2054,7 @@
 /area/hammurabi)
 "ig" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/landmark/start/nukeop/syndi_crew,
@@ -2894,27 +2068,12 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/hammurabi/maintenance)
-"ij" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	name = "Munitions";
-	req_one_access_txt = "150"
-	},
-/turf/open/floor/plating,
-/area/hammurabi/maintenance)
 "ik" = (
 /obj/structure/sign/warning/explosives/alt{
 	pixel_y = 26
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/hangar)
-"il" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/hammurabi/maintenance)
 "im" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -2925,19 +2084,8 @@
 /turf/open/floor/plating,
 /area/hammurabi/maintenance)
 "in" = (
-/obj/machinery/door/airlock/ship/maintenance,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/hammurabi)
-"io" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/monotile/dark,
-/area/hammurabi)
+/turf/open/floor/carpet/red,
+/area/hammurabi/bridge)
 "ip" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -2961,14 +2109,9 @@
 /turf/open/floor/plating,
 /area/hammurabi/maintenance)
 "ir" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating,
-/area/hammurabi/maintenance)
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
 "is" = (
 /obj/structure/sign/poster/contraband/rebels_unite{
 	pixel_y = -5
@@ -2976,25 +2119,14 @@
 /turf/closed/wall/r_wall/ship,
 /area/hammurabi/armoury)
 "it" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
 	},
-/obj/machinery/door/airlock/ship/maintenance{
-	name = "Bridge maintenance";
-	req_one_access_txt = "150"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
 	},
-/turf/open/floor/plating,
-/area/hammurabi/maintenance)
-"iu" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	name = "Bridge maintenance";
-	req_one_access_txt = "150"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/hammurabi/maintenance)
+/turf/open/floor/carpet/red,
+/area/hammurabi/bridge)
 "iv" = (
 /obj/structure/bed/dogbed,
 /obj/machinery/nuclearbomb/syndicate,
@@ -3014,13 +2146,6 @@
 /obj/machinery/porta_turret/syndicate/shuttle,
 /turf/open/floor/plating/airless,
 /area/hammurabi/maintenance/exterior)
-"iy" = (
-/obj/structure/cable/yellow,
-/obj/machinery/atmospherics/components/binary/stormdrive_reactor/syndicate{
-	reactor_id = 3
-	},
-/turf/open/floor/engine,
-/area/hammurabi)
 "iz" = (
 /obj/structure/hull_plate/end{
 	dir = 4;
@@ -3039,125 +2164,19 @@
 /obj/machinery/porta_turret/syndicate/pod,
 /turf/open/floor/plating/airless,
 /area/hammurabi/maintenance/exterior)
-"iC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 1;
-	icon_state = "pipe11-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/stairs/medium{
-	dir = 1;
-	icon_state = "stairs-m"
-	},
-/area/hammurabi/hangar)
-"iD" = (
-/obj/machinery/door/airlock/ship{
-	name = "Hangar bay"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/stairs/medium,
-/area/hammurabi)
-"iE" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4;
-	icon_state = "pipe11-2"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi)
-"iF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4;
-	icon_state = "pipe11-2"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi)
-"iG" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi)
-"iH" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi)
-"iI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10;
-	icon_state = "pipe11-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
-"iJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 1;
-	icon_state = "pipe11-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi)
-"iK" = (
-/obj/machinery/door/airlock/ship{
-	name = "Aft frame"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
 "iL" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4;
-	icon_state = "manifold-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi)
-"iM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
-"iN" = (
+/obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 1;
-	icon_state = "pipe11-2"
+	dir = 6
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
 	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi)
+/obj/item/folder/syndicate/red{
+	pixel_x = 12
+	},
+/turf/open/floor/carpet/red,
+/area/hammurabi/bridge)
 "iO" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3168,13 +2187,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/bridge)
-"iP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
 "iQ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3184,25 +2196,6 @@
 "iR" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi)
-"iS" = (
-/obj/machinery/door/airlock/ship{
-	name = "Central frame"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
-"iT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 1;
-	icon_state = "pipe11-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi)
@@ -3223,54 +2216,172 @@
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/hangar)
 "iW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/vehicle/sealed/car/realistic/fighter_tug,
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/hangar)
+/obj/item/flashlight/lantern/syndicate,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
 "iX" = (
 /obj/vehicle/sealed/car/realistic/fighter_tug,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/hangar)
-"jh" = (
+"iY" = (
+/obj/structure/window/reinforced/fulltile/ship/interior,
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"jf" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 1;
-	icon_state = "pipe11-2"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
 	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plating,
 /area/hammurabi)
 "jk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4;
-	icon_state = "pipe11-2"
+	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi)
+"jm" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
+"jo" = (
+/obj/machinery/door/airlock/ship{
+	name = "Bridge frame";
+	req_one_access_txt = "150"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
 "jq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	icon_state = "pipe11-2"
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/hangar)
-"jE" = (
-/obj/effect/landmark/nuclear_waste_spawner,
+"jz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi)
+"jA" = (
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/plating,
+/area/hammurabi)
+"jB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/bridge)
-"jM" = (
-/obj/machinery/door/airlock/ship{
-	name = "Central frame"
+"jD" = (
+/obj/item/extinguisher/advanced/hull_repair_juice,
+/obj/structure/reagent_dispensers/foamtank/hull_repair_juice,
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
+"jI" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/carpet/red,
+/area/hammurabi/bridge)
+"jJ" = (
+/obj/machinery/door/airlock/ship/external/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4;
-	icon_state = "pipe11-2"
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hammurabi)
+"jK" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi/hangar)
+"jP" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
+"jQ" = (
+/obj/machinery/door/airlock/ship{
+	name = "Canteen"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/carpet/red,
+/area/hammurabi)
+"jT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi)
+"kz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/airalarm/directional/west{
+	req_access = null;
+	req_one_access_txt = "150"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/armoury)
+"kA" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/ship/interior,
 /turf/open/floor/plasteel/tech/grid,
+/area/hammurabi/maintenance)
+"kG" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi)
 "kL" = (
 /obj/machinery/door/poddoor/ship{
@@ -3281,44 +2392,194 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4;
-	icon_state = "pipe11-2"
+	dir = 4
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
-"kP" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/ship,
-/area/hammurabi/hangar)
-"lw" = (
-/obj/machinery/airalarm/directional/west{
-	req_access = null;
+"kU" = (
+/obj/machinery/door/airlock/ship{
+	name = "Munitions";
 	req_one_access_txt = "150"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel/stairs/medium,
+/area/hammurabi)
+"li" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/landmark/start/nukeop/syndi_crew,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/red,
+/area/hammurabi)
+"ll" = (
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
+"lo" = (
+/obj/machinery/door/airlock/glass_large/ship{
+	name = "Armoury"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/armoury)
+"lq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
+"lr" = (
+/obj/structure/window/reinforced/fulltile/ship/interior,
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/landmark/nuclear_waste_spawner,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"lG" = (
+/obj/machinery/computer/ship/viewscreen,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/bridge)
 "lI" = (
+/obj/machinery/door/airlock/ship{
+	name = "Torpedo rack"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
+"lJ" = (
+/obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/turf/open/floor/wood{
+	broken = 1
+	},
+/area/hammurabi/maintenance)
+"lS" = (
+/obj/structure/extinguisher_cabinet/north,
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi/hangar)
+"mn" = (
+/obj/machinery/door/firedoor/window,
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/bridge)
+"mo" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/armoury)
+"mr" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
+"mu" = (
+/obj/machinery/recharge_station,
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/extinguisher_cabinet/west,
+/turf/open/floor/monotile/dark,
+/area/hammurabi/tcomms)
+"mv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10;
-	icon_state = "pipe11-2"
+	dir = 10
+	},
+/obj/structure/extinguisher_cabinet/north,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/armoury)
+"mB" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
+"mC" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
+"mG" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/binary/valve/on,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
+"mJ" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/engine,
+/area/hammurabi)
+"mT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi)
+"nc" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/armoury)
-"me" = (
-/obj/machinery/door/airlock/ship{
-	name = "Bridge frame";
-	req_one_access_txt = "150"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4;
-	icon_state = "pipe11-2"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/bridge)
-"mh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/carpet/red,
-/area/hammurabi/bridge)
 "np" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -3333,31 +2594,157 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
-"nF" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4;
-	icon_state = "manifold-2"
+"nt" = (
+/obj/machinery/door/airlock/ship/external/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
 	},
-/turf/open/floor/mineral/plastitanium/red,
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hammurabi)
+"nv" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/bridge)
+"nw" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/ballistic/automatic/c20r/toy/unrestricted/riot,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/mineral/plastitanium,
 /area/hammurabi/armoury)
-"nX" = (
-/obj/machinery/light{
+"nC" = (
+/obj/machinery/door/airlock/ship/engineering{
+	name = "Reactor monitoring"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/hammurabi)
+"nE" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
-"oK" = (
+"nU" = (
+/obj/machinery/door/airlock/ship{
+	name = "Bridge frame";
+	req_one_access_txt = "150"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/bridge)
+"od" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/armoury)
+"of" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
-/area/hammurabi/hangar)
-"oX" = (
-/obj/effect/landmark/nuclear_waste_spawner,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4;
-	icon_state = "manifold-2"
+/area/hammurabi/maintenance)
+"oq" = (
+/mob/living/simple_animal/pet/cat/space{
+	name = "Syndicat"
 	},
 /turf/open/floor/carpet/red,
+/area/hammurabi/bridge)
+"oO" = (
+/obj/machinery/door/airlock/ship/maintenance,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
 /area/hammurabi)
+"oQ" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/hammurabi)
+"oV" = (
+/obj/structure/table/reinforced,
+/obj/item/ship_weapon/parts/torpedo/propulsion_system,
+/obj/item/ship_weapon/parts/torpedo/propulsion_system,
+/obj/item/ship_weapon/parts/torpedo/propulsion_system,
+/obj/item/ship_weapon/parts/torpedo/propulsion_system,
+/obj/item/ship_weapon/parts/torpedo/warhead,
+/obj/item/ship_weapon/parts/torpedo/warhead,
+/obj/item/ship_weapon/parts/torpedo/warhead/decoy,
+/obj/item/ship_weapon/parts/torpedo/warhead/decoy,
+/obj/item/ship_weapon/parts/torpedo/warhead/decoy,
+/obj/item/ship_weapon/parts/torpedo/warhead,
+/obj/item/ship_weapon/parts/torpedo/warhead,
+/obj/item/ship_weapon/parts/torpedo/propulsion_system,
+/obj/item/ship_weapon/parts/torpedo/propulsion_system,
+/obj/item/ship_weapon/parts/torpedo/propulsion_system,
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi)
+"oW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi/hangar)
+"pg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi)
+"pj" = (
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/closet/radiation,
+/obj/item/shovel,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
 "pl" = (
 /obj/machinery/airalarm/directional/north{
 	req_access = null;
@@ -3365,38 +2752,146 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/hangar)
-"pK" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4;
-	icon_state = "manifold-2"
+"ps" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/computer/ship/navigation{
+	dir = 8;
+	icon_state = "computer"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/bridge)
+"pA" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
+"pC" = (
+/obj/structure/extinguisher_cabinet/south,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/hangar)
+"pH" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi)
-"pL" = (
-/obj/structure/chair{
-	dir = 4
+"pI" = (
+/obj/structure/extinguisher_cabinet/south,
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
+"pJ" = (
+/obj/structure/window/reinforced/fulltile/ship/interior,
+/obj/structure/grille,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
+"pO" = (
+/obj/machinery/suit_storage_unit/syndicate,
+/obj/effect/turf_decal/box,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/effect/landmark/start/nukeop/syndi_crew,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4;
-	icon_state = "pipe11-2"
+	icon_state = "vent_map_on-2"
 	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi/armoury)
+"pT" = (
+/obj/structure/chair/office,
+/turf/open/floor/carpet/red,
+/area/hammurabi/bridge)
+"pW" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/carpet/red,
 /area/hammurabi)
-"pQ" = (
+"pX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi/armoury)
+"qj" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	name = "Armoury";
+	req_one_access_txt = "150"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/hammurabi/armoury)
+"qk" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
+"qF" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"qI" = (
+/obj/machinery/door/airlock/ship{
+	name = "Storage junction"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
+"qO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"qR" = (
+/obj/structure/bed,
+/obj/item/bedsheet/syndie,
+/obj/item/toy/plush/nukeplushie,
+/obj/item/toy/figure/syndie,
+/turf/open/floor/carpet/red,
+/area/hammurabi/bridge)
+"rh" = (
+/obj/item/chair/stool/bar,
+/turf/open/floor/wood{
+	broken = 1
+	},
+/area/hammurabi/maintenance)
+"rj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4;
-	icon_state = "manifold-2"
+/obj/structure/table/reinforced,
+/obj/item/radio/intercom{
+	freerange = 1
 	},
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/armoury)
-"rc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/armoury)
+/turf/open/floor/monotile/dark,
+/area/hammurabi/tcomms)
+"ro" = (
+/obj/structure/table/optable,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi/medbay)
 "rr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1;
@@ -3404,14 +2899,39 @@
 	},
 /turf/open/floor/carpet/red,
 /area/hammurabi)
-"rV" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4;
-	icon_state = "pipe11-2"
+"ru" = (
+/obj/machinery/door/airlock/ship/maintenance,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
+"rD" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
 	},
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/armoury)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
+"rE" = (
+/obj/machinery/computer/ship/reactor_control_computer{
+	req_access = null;
+	req_one_access_txt = "150"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/carpet/red,
+/area/hammurabi)
+"rK" = (
+/obj/structure/window/reinforced/fulltile/ship/interior,
+/obj/structure/grille,
+/obj/machinery/door/firedoor/window,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hammurabi)
 "sb" = (
 /obj/machinery/door/poddoor/ship{
 	dir = 4;
@@ -3421,23 +2941,56 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4;
-	icon_state = "pipe11-2"
+	dir = 4
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
+"sc" = (
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/armoury)
 "si" = (
 /obj/machinery/door/airlock/ship/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/hammurabi/hangar)
-"ss" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4;
-	icon_state = "pipe11-2"
+"sk" = (
+/obj/machinery/vending/boozeomat/syndicate_access,
+/turf/closed/wall/r_wall/ship,
+/area/hammurabi/bridge)
+"sl" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
+/obj/machinery/computer/ship/viewscreen,
+/obj/machinery/computer{
+	dir = 8;
+	icon_state = "computer"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/mineral/plastitanium,
-/area/hammurabi/hangar)
+/area/hammurabi/bridge)
+"sp" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
+"sx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"sD" = (
+/obj/item/storage/toolbox/syndicate,
+/obj/structure/table/reinforced,
+/obj/machinery/airalarm/directional/south{
+	req_access = null;
+	req_one_access_txt = "150"
+	},
+/turf/open/floor/plating,
+/area/hammurabi)
 "sM" = (
 /obj/machinery/light{
 	dir = 1
@@ -3448,34 +3001,98 @@
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
+"sO" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/armoury)
 "sR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/monotile/dark,
 /area/hammurabi/medbay)
-"ta" = (
-/obj/machinery/door/airlock/ship{
-	name = "Plasma Storage"
+"sZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
+"tf" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/dark,
 /area/hammurabi)
-"tb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	icon_state = "pipe11-2"
+"tm" = (
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
-"td" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6;
-	icon_state = "pipe11-2"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi)
-"tJ" = (
-/obj/effect/landmark/nuclear_waste_spawner,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
 /turf/open/floor/carpet/red,
 /area/hammurabi)
+"tw" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/glass{
+	amount = 15
+	},
+/obj/item/stack/sheet/iron/twenty,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/maintenance)
+"tx" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/landmark/start/nukeop/syndi_crew,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
+/area/hammurabi)
+"tD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/hangar)
+"tU" = (
+/obj/machinery/door/airlock/ship/maintenance,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plating,
+/area/hammurabi)
+"tZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
+"ub" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/armoury)
 "ud" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3483,129 +3100,760 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/armoury)
-"ue" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4;
-	icon_state = "vent_map_on-2"
+"uh" = (
+/obj/machinery/door/airlock/ship{
+	name = "Kitchen"
 	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi)
-"vy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/mineral/plastitanium,
-/area/hammurabi/bridge)
-"vz" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/monotile/dark,
 /area/hammurabi)
-"vE" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1;
-	icon_state = "manifold-2"
+"ui" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/carpet/red,
-/area/hammurabi)
-"vJ" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 9;
-	icon_state = "pipe11-2"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/hammurabi)
-"wa" = (
-/obj/machinery/ship_weapon/mac{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi)
-"wF" = (
-/obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	dir = 8;
-	icon_state = "manifold-2"
+/area/hammurabi/armoury)
+"uk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
 	},
-/turf/open/floor/monotile/dark,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi)
-"wT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/mineral/plastitanium,
+"uu" = (
+/obj/machinery/door/airlock/ship/maintenance,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
+"uw" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1;
+	icon_state = "vent_map_on-2"
+	},
+/turf/open/floor/carpet/red,
+/area/hammurabi/bridge)
+"uA" = (
+/obj/structure/closet/radiation,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/shovel,
+/turf/open/floor/plating,
 /area/hammurabi)
-"yl" = (
+"uK" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi/bridge)
+"uN" = (
+/obj/structure/table/reinforced,
+/obj/item/poster/random_contraband,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
+"uQ" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plasteel/dark,
+/area/hammurabi/hangar)
+"uX" = (
+/obj/machinery/door/poddoor/ship{
+	dir = 4;
+	id = "syndicell2"
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"uZ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/armoury)
+"vq" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/hammurabi)
+"vJ" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/hammurabi)
+"vL" = (
+/turf/open/floor/wood{
+	broken = 1
+	},
+/area/hammurabi/maintenance)
+"vS" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
+"vU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi/medbay)
+"vV" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
+"vX" = (
+/obj/machinery/door/airlock/ship/engineering{
+	dir = 2;
+	icon_state = "closed";
+	name = "Reactor core";
+	req_one_access_txt = null
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/hammurabi)
+"wb" = (
+/obj/structure/window/reinforced/fulltile/ship/interior,
+/obj/structure/grille,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/hammurabi)
+"wj" = (
+/obj/machinery/computer/ship/tactical{
+	dir = 8;
+	req_access = null;
+	req_one_access_txt = "150"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/bridge)
+"wr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi/hangar)
+"wz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/turf/open/floor/carpet/red,
+/area/hammurabi)
+"wC" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
+"wF" = (
+/obj/machinery/atmospherics/pipe/manifold/orange/visible{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
+"wG" = (
+/obj/item/ship_weapon/ammunition/torpedo/torpedo_casing,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"wI" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi)
+"wL" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
+"wM" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
+"wN" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/armoury)
+"wP" = (
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
+"wQ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/carpet/red,
+/area/hammurabi)
+"wR" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/monotile,
+/area/hammurabi/tcomms)
+"wY" = (
+/obj/machinery/door/poddoor/ship{
+	dir = 4;
+	id = "syndicell1"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"xb" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/hangar)
+"xf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/carpet/red,
+/area/hammurabi)
+"xi" = (
+/obj/structure/table/reinforced,
+/obj/item/radio/intercom{
+	freqlock = 1;
+	frequency = 1213;
+	syndie = 1
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi/bridge)
+"xk" = (
+/obj/machinery/door/airlock/ship{
+	name = "Aft frame"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"xv" = (
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
+"xC" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/armoury)
+"xH" = (
+/obj/machinery/computer/ship/helm{
+	dir = 8;
+	req_access = null;
+	req_one_access_txt = "150"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/bridge)
+"xM" = (
+/obj/structure/table/reinforced,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
+"xP" = (
+/obj/structure/sign/poster/contraband/syndiemoth,
+/turf/closed/wall/ship,
+/area/hammurabi)
+"xU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"xY" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/armoury)
+"yb" = (
+/obj/machinery/door/airlock/ship{
+	name = "Execution chamber"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi)
+"ye" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/turf/open/floor/carpet/red,
+/area/hammurabi/bridge)
+"yg" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi)
+"yo" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/south,
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi/bridge)
 "yr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/carpet/red,
 /area/hammurabi)
-"yD" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/carpet/red,
-/area/hammurabi/bridge)
-"zq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4;
-	icon_state = "pipe11-2"
+"yu" = (
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi/hangar)
-"zu" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/hangar)
-"zI" = (
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
+"yv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
-"zV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4;
-	icon_state = "pipe11-2"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
 	},
 /turf/open/floor/carpet/red,
-/area/hammurabi/bridge)
-"AJ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
-"Bp" = (
-/obj/machinery/door/airlock/ship{
-	name = "Storage junction"
-	},
+"yx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4;
-	icon_state = "pipe11-2"
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
-"Br" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5;
-	icon_state = "pipe11-2"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/armoury)
-"Bt" = (
-/obj/machinery/door/airlock/ship{
-	name = "Small ammunition"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi)
-"BM" = (
+"yF" = (
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
+"yH" = (
 /obj/machinery/door/airlock/ship{
 	name = "Torpedo rack"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
-"Cd" = (
+"yN" = (
+/obj/structure/displaycase{
+	req_access = list(151);
+	start_showpiece_type = /obj/item/gun/ballistic/automatic/pistol/deagle/gold
+	},
+/turf/open/floor/carpet/red,
+/area/hammurabi/bridge)
+"yQ" = (
+/obj/machinery/atmospherics/pipe/manifold4w/orange/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/meter,
+/turf/open/floor/plating,
+/area/hammurabi)
+"yW" = (
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
+"yX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"zf" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/armoury)
+"zj" = (
+/obj/structure/extinguisher_cabinet/north,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"zn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
+"zD" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
+"zH" = (
+/obj/structure/extinguisher_cabinet/north,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi)
+"zK" = (
+/obj/structure/closet/secure_closet{
+	icon_state = "hos";
+	name = "Captain's Locker";
+	req_one_access_txt = "151"
+	},
+/obj/item/pet_carrier,
+/obj/item/clothing/head/HoS/beret/syndicate,
+/obj/item/clothing/head/HoS/syndicate,
+/obj/item/clothing/suit/armor/vest/capcarapace/syndicate,
+/obj/item/clothing/under/syndicate,
+/obj/item/clothing/under/syndicate/sniper,
+/obj/item/radio/headset/syndicate/alt/leader,
+/obj/item/clothing/mask/balaclava,
+/obj/item/clothing/head/beret,
+/obj/item/clothing/suit/pirate/captain,
+/obj/item/clothing/neck/cloak/syndcap,
+/obj/item/clothing/head/pirate/captain,
+/obj/item/clothing/accessory/medal/gold/heroism,
+/obj/item/clothing/shoes/combat,
+/turf/open/floor/carpet/red,
+/area/hammurabi/bridge)
+"zL" = (
+/obj/machinery/door/airlock/ship/external/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
+"zM" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
 /area/hammurabi/hangar)
+"zV" = (
+/obj/structure/extinguisher_cabinet/north,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
+"Af" = (
+/obj/machinery/door/airlock/ship{
+	name = "Plasma Storage"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
+"Aj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
+"Am" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4;
+	icon_state = "vent_map_on-2"
+	},
+/turf/open/floor/monotile/dark,
+/area/hammurabi/tcomms)
+"Ao" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
+"As" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "syndie_interior_l";
+	name = "Left interior doors"
+	},
+/obj/machinery/button/door{
+	id = "syndie_exterior_l";
+	name = "Left launch bay doors";
+	pixel_y = 7;
+	pixel_z = 1
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/plasteel/ship,
+/area/hammurabi/hangar)
+"Av" = (
+/obj/machinery/airalarm/directional/north{
+	req_access = null;
+	req_one_access_txt = "150"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/carpet/red,
+/area/hammurabi/bridge)
+"AB" = (
+/obj/item/ship_weapon/parts/torpedo/warhead/bunker_buster,
+/obj/structure/table/reinforced,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
+"AR" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
+"AT" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet/west,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/armoury)
+"AX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump,
+/obj/machinery/advanced_airlock_controller/directional/east{
+	pixel_y = 24
+	},
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
+"Bh" = (
+/obj/structure/table/reinforced,
+/obj/item/toy/cards/deck/syndicate,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
+"Bm" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"Bq" = (
+/obj/structure/chair/comfy/shuttle{
+	color = "#696969";
+	dir = 4;
+	icon_state = "shuttle_chair";
+	name = "bridge chair"
+	},
+/obj/effect/landmark/start/nukeop/syndi_crew,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi/bridge)
+"Bs" = (
+/obj/machinery/door/airlock/ship{
+	name = "Elite boarding team";
+	req_one_access_txt = "151"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/armoury)
+"BE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/armoury)
+"BI" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/computer/monitor,
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
+"BJ" = (
+/obj/machinery/airalarm/directional/north{
+	req_access = null;
+	req_one_access_txt = "150"
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
+"BN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/armoury)
+"BP" = (
+/obj/machinery/door/airlock/ship{
+	name = "Bridge frame";
+	req_one_access_txt = "150"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
+"BW" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/armoury)
+"BY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
 "Ct" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8;
@@ -3613,19 +3861,475 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
-"Cu" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/effect/landmark/nuclear_waste_spawner,
-/turf/open/floor/monotile/dark,
-/area/hammurabi/medbay)
-"CD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+"Cx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/carpet/red,
+/area/hammurabi/bridge)
+"CG" = (
+/obj/machinery/door/airlock/ship{
+	name = "Hangar bay"
 	},
-/obj/machinery/atmospherics/pipe/manifold/orange/visible,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel/stairs/medium,
+/area/hammurabi)
+"CI" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/monotile/dark,
+/area/hammurabi/tcomms)
+"CM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"CP" = (
+/obj/machinery/door/airlock/ship{
+	name = "Missile tubes"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"Db" = (
+/obj/machinery/door/airlock/ship{
+	name = "Marine suit storage";
+	req_one_access_txt = "150"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
+"Dr" = (
+/obj/machinery/door/airlock/ship{
+	name = "Small ammunition"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
+"Du" = (
+/obj/machinery/door/airlock/ship/hatch{
+	name = "Launch tubes";
+	req_one_access_txt = "150"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/monotile/dark,
+/area/hammurabi/hangar)
+"Dv" = (
+/obj/machinery/airalarm/directional/south{
+	req_access = null;
+	req_one_access_txt = "150"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"DH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
+"DN" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/plasteel/dark,
+/area/hammurabi/hangar)
+"DQ" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4;
+	icon_state = "vent_map_on-2"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
+"DR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/armoury)
+"DV" = (
+/obj/machinery/light/small,
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
+"DW" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi)
+"Ec" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/nuclear,
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi/hangar)
+"Ef" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/computer/lore_terminal{
+	pixel_x = 1;
+	pixel_y = 2
+	},
+/turf/open/floor/monotile/dark,
+/area/hammurabi/tcomms)
+"Eg" = (
+/obj/item/storage/toolbox/electrical{
+	icon_state = "syndicate"
+	},
+/obj/structure/table/reinforced,
+/obj/item/pipe_dispenser,
 /turf/open/floor/plating,
 /area/hammurabi)
-"CT" = (
+"Ek" = (
+/obj/machinery/door/airlock/ship/external/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold/visible,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
+"El" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi/hangar)
+"Em" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
+"Ep" = (
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
+"EC" = (
+/obj/machinery/computer/ship/viewscreen,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/machinery/computer/monitor,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/carpet/red,
+/area/hammurabi)
+"ED" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	name = "Munitions";
+	req_one_access_txt = "150"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
+"EF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/carpet/red,
+/area/hammurabi)
+"EK" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi/hangar)
+"ES" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/hangar)
+"EW" = (
+/obj/item/shovel,
+/obj/structure/closet/radiation,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
+"Fb" = (
+/obj/machinery/door/airlock/ship/maintenance,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/bridge)
+"Fd" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/extinguisher_cabinet/south,
+/turf/open/floor/plating,
+/area/hammurabi)
+"Fi" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"Fn" = (
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/carpet/red,
+/area/hammurabi/bridge)
+"Fp" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1;
+	icon_state = "vent_map_on-2"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"Fq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/hangar)
+"Fr" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
+"Fu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/vehicle/sealed/car/realistic/fighter_tug,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/hangar)
+"Fy" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer3,
+/turf/open/space/basic,
+/area/hammurabi/maintenance/exterior)
+"FC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi/hangar)
+"FM" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi/bridge)
+"FS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
+"FX" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/open/floor/plating,
+/area/hammurabi)
+"Gd" = (
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"Gh" = (
+/obj/machinery/door/airlock/ship{
+	name = "Plasma Storage"
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
+"Gy" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi/medbay)
+"GN" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
+"GP" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi)
+"GQ" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/airalarm/directional/west{
+	req_access = null;
+	req_one_access_txt = "150"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
+"GV" = (
+/obj/machinery/door/airlock/ship{
+	name = "Aft frame"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"GW" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/machinery/meter,
+/turf/open/floor/plating,
+/area/hammurabi)
+"GX" = (
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/airlock/ship{
+	name = "Bridge frame";
+	req_one_access_txt = "150"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/bridge)
+"Hc" = (
+/obj/structure/rack,
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/sheet/iron/fifty,
+/obj/machinery/computer/ship/viewscreen,
+/obj/item/clothing/head/welding,
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
+"Hl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/armoury)
+"Hs" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel/ship,
+/area/hammurabi/hangar)
+"HB" = (
+/obj/structure/closet/radiation,
+/obj/item/clothing/mask/gas,
+/obj/item/tank/internals/oxygen,
+/obj/item/shovel,
+/obj/item/storage/toolbox/emergency,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/bridge)
+"HM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/carpet/red,
+/area/hammurabi)
+"HQ" = (
+/obj/structure/extinguisher_cabinet/east,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"HR" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	name = "Bridge maintenance";
+	req_one_access_txt = "150"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
+"Id" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
+"Ih" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/monotile,
+/area/hammurabi/tcomms)
+"Ij" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi/hangar)
+"In" = (
+/obj/structure/chair/stool/bar,
+/turf/open/floor/wood,
+/area/hammurabi/maintenance)
+"Io" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/hammurabi)
+"IK" = (
 /obj/structure/window/reinforced/fulltile/ship/interior,
 /obj/structure/grille,
 /obj/structure/cable{
@@ -3637,70 +4341,101 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/landmark/nuclear_waste_spawner,
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
-"EF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/carpet/red,
-/area/hammurabi)
-"EK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi/hangar)
-"Fx" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8;
-	icon_state = "manifold-2"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
-"FX" = (
-/obj/machinery/door/airlock/ship{
-	name = "Bridge frame";
+"IL" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	name = "Armoury";
 	req_one_access_txt = "150"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4;
-	icon_state = "pipe11-2"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi)
-"GW" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/machinery/meter,
-/turf/open/floor/plating,
-/area/hammurabi)
-"Hb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/hangar)
-"HU" = (
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5;
-	icon_state = "pipe11-2"
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hammurabi/armoury)
+"IO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/hammurabi/armoury)
-"IT" = (
+/area/hammurabi)
+"IY" = (
+/obj/machinery/light/small,
+/obj/structure/table/wood/poker,
+/obj/item/stack/spacecash/c200{
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 7
+	},
+/turf/open/floor/wood,
+/area/hammurabi/maintenance)
+"Jp" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi)
-"Jd" = (
-/obj/machinery/atmospherics/components/unary/portables_connector,
-/turf/open/floor/monotile/dark,
-/area/hammurabi)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/hangar)
 "Jr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
-"Ki" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+"Js" = (
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
+"Jw" = (
+/obj/machinery/door/airlock/glass_large/ship{
+	name = "cryostasis"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"Jy" = (
+/obj/machinery/vending/cola/sodie,
+/turf/open/floor/carpet/red,
+/area/hammurabi)
+"JG" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
+"JN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
+"Kl" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
 "Kp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4;
@@ -3708,66 +4443,298 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/hangar)
-"Ln" = (
-/obj/machinery/door/airlock/ship{
-	name = "Marine suit storage";
-	req_one_access_txt = "150"
+"KG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/turf/closed/wall/ship,
+/area/hammurabi/maintenance)
+"KL" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
+"KM" = (
+/obj/machinery/light{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/armoury)
+"KP" = (
+/obj/structure/window/reinforced/fulltile/ship/interior,
+/obj/structure/grille,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"KT" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/turf/open/floor/carpet/red,
+/area/hammurabi)
+"KU" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
+"Lh" = (
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi/bridge)
+"Lr" = (
+/turf/open/floor/plasteel/stairs/medium{
+	dir = 4;
+	icon_state = "stairs-m"
+	},
+/area/hammurabi/bridge)
+"Lt" = (
+/obj/effect/landmark/nuclear_waste_spawner,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/carpet/red,
+/area/hammurabi)
+"LD" = (
+/obj/structure/grille,
+/obj/structure/table_frame,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
+"LF" = (
+/obj/item/gun/ballistic/automatic/c20r/toy/unrestricted/riot,
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/armoury)
+"LN" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi/bridge)
+"Ms" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/monotile/dark,
+/area/hammurabi/hangar)
+"Mw" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/turf/open/floor/carpet/red,
+/area/hammurabi/bridge)
+"Mx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
-"LF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi/medbay)
-"Mt" = (
+"MS" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
+"MY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4;
-	icon_state = "pipe11-2"
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi/armoury)
-"Nj" = (
-/obj/effect/turf_decal/delivery,
-/obj/effect/landmark/nuclear_waste_spawner,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4;
-	icon_state = "vent_map_on-2"
+/area/hammurabi/hangar)
+"Nd" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi)
-"Ny" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4;
-	icon_state = "pipe11-2"
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/bridge)
+"Nv" = (
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi/maintenance)
+"Ny" = (
+/obj/machinery/autolathe,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/maintenance)
+"NC" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/iron/fifty,
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi)
+"NI" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
 "NK" = (
 /obj/structure/sign/warning/vacuum/external,
 /turf/closed/wall/ship,
 /area/hammurabi/maintenance)
-"NS" = (
+"NQ" = (
+/obj/machinery/door/airlock/ship{
+	name = "Engineering"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4;
-	icon_state = "pipe11-2"
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi)
-"NZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10;
-	icon_state = "pipe11-2"
+"NS" = (
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi/hangar)
-"Oh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/structure/reagent_dispensers/foamtank/hull_repair_juice,
+/obj/item/extinguisher/advanced/hull_repair_juice,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
+"Ob" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/armoury)
+"Og" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
+"Oi" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"Om" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hammurabi)
+"Oq" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi/hangar)
+"Os" = (
+/obj/structure/closet/radiation,
+/obj/item/clothing/mask/gas,
+/obj/item/tank/internals/oxygen,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/obj/item/shovel,
+/obj/item/storage/toolbox/emergency,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/bridge)
+"Ou" = (
+/obj/machinery/suit_storage_unit/syndicate{
+	helmet_type = /obj/item/clothing/head/helmet/space/syndicate/black/orange;
+	storage_type = /obj/item/clothing/shoes/magboots/syndie;
+	suit_type = /obj/item/clothing/suit/space/syndicate/black/orange
+	},
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
+"OD" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi/bridge)
+"OK" = (
+/obj/machinery/door/airlock/ship/maintenance,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
+"OP" = (
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"OS" = (
+/obj/machinery/door/airlock/ship{
+	name = "Ammo rack"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"OU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/hammurabi/tcomms)
 "OX" = (
 /obj/machinery/light{
 	dir = 1
@@ -3779,34 +4746,95 @@
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
 "Pc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 1;
-	icon_state = "pipe11-2"
+/obj/machinery/door/airlock/ship{
+	name = "Marine suit storage";
+	req_one_access_txt = "150"
 	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
-"Pe" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4;
-	icon_state = "manifold-2"
+"Pd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
 	},
-/turf/open/floor/monotile/dark,
-/area/hammurabi)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel/stairs/medium{
+	dir = 1;
+	icon_state = "stairs-m"
+	},
+/area/hammurabi/hangar)
 "Pi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi)
-"Pk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4;
-	icon_state = "pipe11-2"
-	},
-/turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
 "Pp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/hangar)
+"Py" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"PA" = (
+/obj/machinery/door/airlock/ship{
+	name = "Sickbay"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi/medbay)
+"PC" = (
+/obj/structure/cable/yellow,
+/obj/machinery/atmospherics/components/binary/stormdrive_reactor/syndicate,
+/turf/open/floor/engine,
+/area/hammurabi)
+"PD" = (
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi/armoury)
+"PN" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi/armoury)
+"PT" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/armoury)
+"PX" = (
+/obj/machinery/door/airlock/ship/maintenance,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
 "PZ" = (
 /obj/machinery/door/airlock/ship/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -3814,14 +4842,171 @@
 	},
 /turf/open/floor/plating,
 /area/hammurabi/hangar)
+"Qf" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
+"Qj" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi)
+"Qm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi)
 "Qo" = (
 /obj/effect/landmark/nuclear_waste_spawner,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi)
+"Qq" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
 "Qv" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/cable_coil,
+/obj/item/ship_weapon/parts/torpedo/guidance_system,
+/obj/item/ship_weapon/parts/torpedo/guidance_system,
+/obj/item/ship_weapon/parts/torpedo/guidance_system,
+/obj/item/ship_weapon/parts/torpedo/guidance_system,
+/obj/item/ship_weapon/parts/torpedo/iff_card,
+/obj/item/ship_weapon/parts/torpedo/iff_card,
+/obj/item/ship_weapon/parts/torpedo/iff_card,
+/obj/item/ship_weapon/parts/torpedo/iff_card,
+/obj/item/ship_weapon/parts/torpedo/iff_card,
+/obj/item/ship_weapon/parts/torpedo/iff_card,
+/obj/item/ship_weapon/parts/torpedo/iff_card,
+/obj/item/ship_weapon/parts/torpedo/guidance_system,
+/obj/item/ship_weapon/parts/torpedo/guidance_system,
+/obj/item/ship_weapon/parts/torpedo/guidance_system,
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi)
+"Qw" = (
+/obj/structure/closet/radiation,
+/obj/item/shovel,
+/turf/open/floor/plating,
+/area/hammurabi)
+"QD" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi)
+"QF" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/airalarm/directional/west{
+	req_access = null;
+	req_one_access_txt = "150"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/armoury)
+"QJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
+"QM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"QN" = (
+/obj/machinery/door/airlock/glass_large/ship{
+	name = "Ammunition storage"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/armoury)
+"QO" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/monotile/dark,
+/area/hammurabi)
+"QZ" = (
+/obj/machinery/door/airlock/ship{
+	name = "Small ammunition"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
+"Rb" = (
+/obj/machinery/door/airlock/ship{
+	name = "Central frame"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"Ri" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"Rm" = (
+/obj/structure/window/reinforced/fulltile/ship/interior,
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
 "Rq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -3830,6 +5015,39 @@
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
+"Rr" = (
+/obj/machinery/door/airlock/ship{
+	name = "Missile tubes"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"Rt" = (
+/obj/structure/extinguisher_cabinet/north,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"Rv" = (
+/obj/machinery/computer/communications{
+	dir = 8;
+	req_access = null;
+	req_one_access_txt = "151"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/bridge)
+"RB" = (
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi/hangar)
 "RI" = (
 /obj/machinery/airalarm/directional/north{
 	req_access = null;
@@ -3837,39 +5055,121 @@
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
-"Sf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4;
-	icon_state = "pipe11-2"
+"RN" = (
+/obj/machinery/door/airlock/ship/maintenance,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/mineral/plastitanium,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
+"RT" = (
+/obj/structure/window/reinforced/fulltile/ship/interior,
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
-"Sm" = (
-/obj/machinery/airalarm/directional/north{
-	req_access = null;
-	req_one_access_txt = "150"
+"RZ" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/hammurabi/bridge)
+/area/hammurabi/armoury)
+"Sa" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
+"Sh" = (
+/obj/item/organ/wings/moth,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
+"Sn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi)
 "Sv" = (
 /obj/structure/sign/warning/vacuum/external,
 /turf/closed/wall/ship,
 /area/hammurabi/hangar)
 "Sx" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi)
-"Ts" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4;
-	icon_state = "manifold-2"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/plasteel/tech/grid,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/wood{
+	broken = 1
+	},
+/area/hammurabi/maintenance)
+"SA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/closet/syndicate{
+	name = "equipment closet"
+	},
+/obj/item/clothing/mask/chameleon,
+/obj/machinery/airalarm/directional/south{
+	req_access = null;
+	req_one_access_txt = "150"
+	},
+/turf/open/floor/monotile,
+/area/hammurabi/tcomms)
+"SC" = (
+/obj/structure/table/wood,
+/obj/item/phone{
+	anchored = 1;
+	pixel_x = -2
+	},
+/obj/item/toy/redbutton{
+	anchored = 1;
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/turf/open/floor/carpet/red,
+/area/hammurabi/bridge)
+"SD" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/red,
+/area/hammurabi/bridge)
+"SV" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
 /area/hammurabi)
+"SY" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
 "Tu" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -3880,6 +5180,13 @@
 	},
 /turf/open/floor/plating,
 /area/hammurabi)
+"Tv" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hammurabi/hangar)
 "Tz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1;
@@ -3887,17 +5194,25 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
-"TS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 1;
-	icon_state = "pipe11-2"
+"TH" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/mineral/plastitanium/red,
+/turf/open/floor/wood{
+	broken = 1
+	},
+/area/hammurabi/maintenance)
+"TP" = (
+/obj/machinery/atmospherics/components/binary/valve,
+/turf/open/floor/plating,
 /area/hammurabi)
-"Uf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5;
-	icon_state = "pipe11-2"
+"Ur" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/hangar)
@@ -3905,27 +5220,218 @@
 /obj/effect/landmark/nuclear_waste_spawner,
 /turf/closed/wall/ship,
 /area/hammurabi/hangar)
-"VW" = (
+"UE" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi)
+"UN" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
+"UP" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet/west,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
+"UR" = (
+/obj/machinery/door/airlock/ship{
+	name = "Engineering"
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4;
-	icon_state = "pipe11-2"
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi)
+"UY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
+"Vq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi)
+"Vr" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/east{
+	req_access = null;
+	req_one_access_txt = "150"
 	},
 /turf/open/floor/monotile/dark,
 /area/hammurabi)
-"Wq" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4;
-	icon_state = "vent_map_on-2"
+"Vt" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
+"Vv" = (
+/obj/machinery/door/airlock/ship{
+	name = "Central frame"
 	},
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/armoury)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"Vx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel/stairs/old,
+/area/hammurabi)
+"Vz" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
+"VD" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/item/pen/fountain/captain,
+/turf/open/floor/carpet/red,
+/area/hammurabi/bridge)
+"VE" = (
+/obj/structure/table/wood/poker,
+/obj/item/dice/d6{
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/obj/item/dice/d6{
+	pixel_x = -4;
+	pixel_y = -2
+	},
+/turf/open/floor/wood{
+	broken = 1
+	},
+/area/hammurabi/maintenance)
+"VN" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"Wn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/turf/closed/wall/ship,
+/area/hammurabi/maintenance)
+"Wr" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
 "Wu" = (
 /obj/machinery/atmospherics/components/unary/tank/oxygen,
 /turf/open/floor/plating,
 /area/hammurabi/maintenance)
+"Wx" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
+"WH" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/engine,
+/area/hammurabi)
+"WU" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
+/area/hammurabi/bridge)
+"WY" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/turf/open/floor/carpet/red,
+/area/hammurabi)
+"Xa" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi/hangar)
+"Xb" = (
+/obj/machinery/airalarm/directional/south{
+	req_access = null;
+	req_one_access_txt = "150"
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi/bridge)
 "Xr" = (
 /obj/machinery/light{
 	dir = 1
@@ -3936,26 +5442,122 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/hangar)
-"Xs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/hangar)
-"YA" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/carpet/red,
+"Xw" = (
+/obj/structure/extinguisher_cabinet/south,
+/obj/item/ship_weapon/ammunition/torpedo/torpedo_casing,
+/turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
-"YD" = (
-/obj/effect/landmark/nuclear_waste_spawner,
+"Xy" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	name = "Gravity generator"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/hammurabi)
+"XB" = (
+/obj/structure/fluff/bleepypanel,
+/turf/closed/wall/ship,
+/area/hammurabi/bridge)
+"XF" = (
+/obj/machinery/iv_drip,
+/obj/structure/extinguisher_cabinet/east,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi/medbay)
+"XI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/carpet/red,
+/area/hammurabi/bridge)
+"XT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"XU" = (
+/obj/structure/closet/radiation,
+/obj/item/shovel,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/maintenance)
+"Yd" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 1;
-	icon_state = "pipe11-2"
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi)
-"YI" = (
-/obj/machinery/space_heater,
+"Yi" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood,
+/area/hammurabi/maintenance)
+"Ym" = (
+/obj/effect/landmark/nuclear_waste_spawner,
+/obj/machinery/holopad,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/bridge)
+"Yq" = (
+/obj/machinery/door/airlock/ship{
+	name = "Storage junction"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
+"Ys" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/armoury)
+"Yy" = (
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/airlock/ship{
+	name = "Central frame"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi/maintenance)
+"Yz" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/monotile/dark,
 /area/hammurabi)
+"YA" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/reagent_dispensers/foamtank/hull_repair_juice,
+/obj/item/extinguisher/advanced/hull_repair_juice,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
 "YL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1;
@@ -3963,22 +5565,83 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hammurabi)
-"ZM" = (
+"YQ" = (
 /obj/machinery/door/airlock/ship{
-	name = "Plasma Storage"
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
-	},
-/turf/open/floor/monotile/dark,
-/area/hammurabi)
-"ZV" = (
-/obj/machinery/airalarm/directional/north{
-	req_access = null;
+	name = "Bridge frame";
 	req_one_access_txt = "150"
 	},
-/turf/open/floor/monotile/dark,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/bridge)
+"YR" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
+"YU" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/bridge)
+"YV" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/armoury)
+"Zb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi/hangar)
+"Zc" = (
+/obj/structure/closet/radiation,
+/obj/item/clothing/mask/gas,
+/obj/item/tank/internals/oxygen,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1;
+	icon_state = "vent_map_on-2"
+	},
+/obj/item/shovel,
+/obj/item/storage/toolbox/emergency,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/bridge)
+"Zi" = (
+/obj/machinery/door/airlock/ship/maintenance,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
+"Zl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
 
 (1,1,1) = {"
@@ -24410,8 +26073,8 @@ cp
 cp
 cp
 cp
-cp
-ab
+Fy
+KG
 es
 ab
 aK
@@ -24668,26 +26331,26 @@ cp
 cp
 cp
 ef
-ab
-aK
-aK
-aK
-eg
-in
+Wn
+UY
+UY
+UY
+Id
+oO
 ip
 hY
 be
-cd
+WH
 dc
 dC
 dH
 ca
-dX
-gw
-dX
+Qw
+uA
+Qw
 ab
 bt
-gX
+Kl
 gX
 hq
 ab
@@ -24929,19 +26592,19 @@ ab
 aK
 ab
 ab
-gH
+Zi
 an
-bc
-hZ
+EC
+hn
 bI
-cr
+mJ
 dd
-iy
+PC
 dI
-dP
+vX
 dZ
 dZ
-dZ
+jA
 ab
 cC
 ab
@@ -25186,19 +26849,19 @@ ab
 aK
 ab
 ii
-gM
+SY
 an
-bd
-dv
+rE
+tm
 be
-cd
+WH
 de
 dx
 dJ
 ca
 ea
-em
-dZ
+jf
+sD
 ab
 cC
 ii
@@ -25443,22 +27106,22 @@ an
 aK
 ab
 iq
-ir
+Wx
 an
-fY
-fY
-bJ
+wb
+rK
+nC
 cx
-df
-dy
-dK
+Io
+vq
+SV
 ca
 ca
-ev
+nt
 ca
 ab
-cC
-aK
+Yi
+lJ
 ab
 cC
 ab
@@ -25700,23 +27363,23 @@ an
 aK
 ab
 iq
-ir
+Wx
 an
-vz
-gh
+BI
+KU
 bK
 cz
 dg
-gu
+yQ
 dL
-dQ
+FX
 ca
-gx
-eL
+Om
+cd
 ab
-cC
-aK
-ab
+fU
+vL
+yW
 cC
 ab
 cp
@@ -25957,22 +27620,22 @@ an
 aK
 ab
 aK
-gM
+SY
 an
-aT
-aS
+eI
+Og
 bL
 aS
 aS
+KL
 aS
-aS
-dR
+Fd
 ca
-ew
+jJ
 ca
 ab
-cC
-aK
+TH
+In
 ab
 cC
 ab
@@ -26210,26 +27873,26 @@ aS
 eh
 ej
 aX
-er
+Xy
 gy
 ab
 cO
-gM
+SY
 an
-ZV
-Jd
-CD
+BJ
+Yz
+oQ
 aS
 aS
 aS
 aS
 dR
 aS
-ex
-aS
+jP
+jD
 ab
-cC
-aK
+Yi
+VE
 ab
 cC
 ab
@@ -26471,10 +28134,10 @@ an
 aK
 ab
 Wu
-il
-ao
-io
-gN
+mG
+tU
+tf
+vV
 dz
 dM
 eM
@@ -26482,11 +28145,11 @@ gB
 hl
 hC
 dM
-dM
+JG
 hD
-gT
-hE
-gy
+OK
+Sx
+IY
 ab
 hF
 ab
@@ -26723,7 +28386,7 @@ aX
 aX
 aX
 aX
-aX
+HQ
 an
 aK
 ab
@@ -26731,7 +28394,7 @@ aU
 im
 an
 gZ
-di
+Vz
 Tu
 aS
 hm
@@ -26739,11 +28402,11 @@ dA
 aS
 dR
 aS
-aS
+FS
 aS
 ab
-aK
-aK
+rh
+vL
 ab
 cC
 ab
@@ -26987,8 +28650,8 @@ ab
 dh
 dh
 an
-YI
-VW
+Hc
+Ao
 bL
 cq
 gA
@@ -26996,11 +28659,11 @@ dB
 aS
 ig
 aS
-aS
+FS
 dT
 ab
-aK
-aK
+eB
+ab
 ab
 cC
 ab
@@ -27237,7 +28900,7 @@ aK
 aK
 aK
 aK
-aK
+wP
 aK
 aK
 ab
@@ -27245,25 +28908,25 @@ gI
 gI
 an
 gL
-VW
+Ao
 bM
 cA
 cA
 gv
 wF
-dS
+df
 aS
-aS
+FS
 dT
 ab
-aK
-ii
+AB
+LD
 ab
 gS
 gX
 gX
 gX
-gX
+qk
 hG
 ab
 cp
@@ -27502,15 +29165,15 @@ gJ
 gK
 ab
 an
-hn
+UR
 an
 an
-ta
+Af
 an
-ZM
+Gh
 an
 an
-bl
+NQ
 an
 ab
 ab
@@ -27749,7 +29412,7 @@ aJ
 ab
 aK
 bF
-gT
+RN
 gU
 gX
 gX
@@ -27757,19 +29420,19 @@ gY
 gX
 gb
 gD
-gT
+RN
 hk
-iE
+Yd
 an
 cB
-dj
+TP
 GW
 vJ
-dZ
+Eg
 an
-aY
+jz
 gf
-bZ
+ru
 el
 aK
 gz
@@ -27777,7 +29440,7 @@ aK
 aK
 aK
 aK
-bZ
+ru
 hH
 ab
 cp
@@ -28015,8 +29678,8 @@ ab
 ab
 ab
 ab
-aX
-iF
+ir
+jk
 an
 an
 an
@@ -28024,7 +29687,7 @@ an
 an
 an
 an
-aY
+jz
 aX
 ab
 ab
@@ -28265,7 +29928,7 @@ cO
 cC
 ab
 gV
-cI
+ro
 cM
 ga
 cR
@@ -28273,7 +29936,7 @@ cZ
 fW
 aq
 ns
-iG
+pH
 bN
 cG
 dk
@@ -28281,15 +29944,15 @@ gs
 dk
 cG
 an
-aY
+zH
 aX
 an
 bD
 hQ
-fs
+Rm
 gi
 hQ
-fs
+Rm
 aS
 ab
 cC
@@ -28520,7 +30183,7 @@ aJ
 ab
 bt
 hb
-gT
+OK
 gW
 cJ
 cJ
@@ -28529,25 +30192,25 @@ cS
 cW
 fX
 aR
+Oi
+pg
+Jw
+be
+be
+be
+be
+be
+Jw
+jz
 aX
-iF
-bO
-be
-be
-be
-be
-be
-bO
-aY
-aX
-fs
-aX
+Rm
+Bm
 Rq
-hT
-aX
+RT
+Bm
 Rq
-hT
-aS
+RT
+pI
 ab
 cC
 ab
@@ -28769,7 +30432,7 @@ cp
 cp
 cp
 az
-aJ
+lS
 aJ
 aJ
 aJ
@@ -28781,31 +30444,31 @@ ab
 cD
 cK
 cK
-Cu
+cK
 cW
 sR
-LF
-fZ
-Pi
-iH
-zI
+vU
+PA
+Sn
+Qj
+qO
 EF
 rr
-tJ
 be
-be
+pW
+HM
+CM
+jT
 aX
-aY
-aX
-hP
-hR
+iY
+wY
 kL
-CT
-hV
+lr
+uX
 sb
-hU
+IK
 dM
-gT
+OK
 hW
 ab
 cp
@@ -29037,14 +30700,14 @@ aK
 ab
 fV
 cJ
+gN
 cJ
 cJ
 cJ
-cJ
-fX
+Gy
 aR
 aX
-iF
+jk
 an
 cG
 dl
@@ -29052,14 +30715,14 @@ dl
 dl
 cG
 an
-aY
-td
-hO
-Qv
-Pe
-Qv
-Qv
-Pe
+UE
+Pi
+yb
+lq
+rD
+DH
+lq
+Qf
 YL
 aS
 ab
@@ -29297,11 +30960,11 @@ cL
 cN
 cQ
 cY
-eI
+XF
 cY
 aq
 RI
-iF
+jk
 an
 an
 an
@@ -29309,15 +30972,15 @@ an
 an
 an
 an
-ue
-Pk
+mT
+qF
 an
 gR
-hS
+Vr
 hS
 hN
-hS
-hS
+QO
+Sa
 aS
 ab
 gS
@@ -29538,7 +31201,7 @@ cp
 cp
 cp
 si
-oK
+Tv
 PZ
 aJ
 bh
@@ -29546,7 +31209,7 @@ bn
 bs
 aJ
 ab
-fS
+uu
 ab
 ab
 ab
@@ -29558,16 +31221,16 @@ ab
 ab
 ab
 aX
-iI
-iK
-iM
-iP
-nX
-Fx
-zI
-bR
-Ts
-tb
+QM
+GV
+yX
+Py
+Wr
+nE
+xU
+xk
+VN
+Fp
 an
 an
 an
@@ -29811,8 +31474,8 @@ gX
 gX
 hg
 aK
-aK
-aK
+sp
+EW
 ab
 ab
 ab
@@ -29820,7 +31483,7 @@ ab
 aY
 iQ
 aY
-Pk
+Zl
 aY
 an
 an
@@ -29828,9 +31491,9 @@ an
 an
 eX
 eX
-fc
+UP
 gr
-fx
+GQ
 eX
 eX
 ab
@@ -30062,22 +31725,22 @@ aJ
 ab
 ab
 ab
-bZ
+PX
 ab
 ab
 ab
-fS
+uu
 ab
 ab
 ab
 ab
-ac
-ac
-ab
+Ny
+Nv
+kA
 aX
 iR
 aY
-NS
+jz
 aX
 an
 ey
@@ -30328,27 +31991,27 @@ bg
 bm
 br
 ab
-aK
-aK
-bZ
+tw
+Nv
+kA
 aX
 iR
 aY
-NS
-aX
+jz
+Dv
 an
 ez
-bT
-eS
+ht
+yH
+zn
 eZ
-eZ
 bT
 bT
 bT
 eZ
-eZ
-fD
-bT
+mr
+QZ
+vS
 fJ
 ab
 aK
@@ -30585,25 +32248,25 @@ bh
 fL
 bs
 ab
-aK
-aK
-ab
-gc
+db
+Nv
+Yy
+aX
 iR
 Qo
-IT
+gC
 gd
 an
 gP
 bT
 eT
-gq
+zD
 bT
 fl
 hL
 fl
 bT
-gQ
+Em
 an
 gq
 fK
@@ -30842,27 +32505,27 @@ bh
 bn
 bs
 ab
-eq
-eq
+XU
+XU
 ab
-bD
+gc
 iR
-aY
-NS
-aX
+kG
+jT
+Gd
 an
 eA
 bT
 eT
+sZ
 bT
-bT
-Nj
+DQ
 hL
-fl
+mB
 bT
-bT
+sZ
 an
-bT
+xv
 fK
 ab
 aK
@@ -31102,23 +32765,23 @@ ab
 ab
 ab
 ab
-aX
+zj
 iR
 aY
-NS
+jz
 aX
 an
 ez
 Jr
-BM
-fa
-fa
-Ki
-wT
-wT
-fa
-fa
-Bt
+lI
+mC
+wC
+wL
+tZ
+JN
+wC
+IO
+Dr
 Tz
 fK
 ab
@@ -31344,7 +33007,7 @@ au
 au
 au
 au
-aJ
+lS
 ct
 aJ
 aJ
@@ -31356,13 +33019,13 @@ aJ
 ct
 aJ
 ab
-aK
-aK
+iW
+Sh
 ab
-aX
+bD
 iR
 aY
-NS
+jz
 aX
 an
 ey
@@ -31370,7 +33033,7 @@ ey
 an
 eX
 eX
-jk
+Aj
 bT
 fx
 aY
@@ -31604,7 +33267,7 @@ by
 bB
 bB
 bB
-bB
+zM
 bB
 bB
 bB
@@ -31619,7 +33282,7 @@ ab
 aY
 iQ
 aY
-Pk
+Zl
 aY
 an
 an
@@ -31627,7 +33290,7 @@ an
 an
 eX
 eX
-jk
+Aj
 bT
 fx
 aY
@@ -31636,8 +33299,8 @@ an
 aY
 fK
 ab
-aK
-cC
+yF
+Fr
 ab
 cp
 cp
@@ -31861,22 +33524,22 @@ by
 bB
 bB
 Pp
-Xs
-Xs
-iW
-Xs
-Hb
-Xs
-zu
-bB
+eu
+tD
+Fu
+tD
+xb
+tD
+Jp
+ES
 az
 aa
 aa
 an
 an
-iS
+Rb
 an
-jM
+Vv
 an
 an
 aa
@@ -31884,10 +33547,10 @@ aa
 an
 an
 an
-Bp
+qI
 cn
 cn
-fm
+Yq
 an
 an
 an
@@ -32124,31 +33787,31 @@ bB
 bB
 hi
 bB
-ss
-aJ
+Fq
+RB
 az
 aa
-ap
-ap
+pJ
+pJ
 bT
 iQ
 gt
-Pk
+Zl
 bT
-ap
-ap
+pJ
+pJ
 aa
 an
 fb
-aX
-Pk
+OP
+Zl
 aX
 gi
 aX
 aX
 aX
 aX
-aX
+wG
 ab
 aK
 cC
@@ -32367,9 +34030,9 @@ cp
 cp
 au
 au
-aI
-aI
-aI
+uQ
+uQ
+uQ
 au
 au
 aO
@@ -32381,31 +34044,31 @@ aJ
 aJ
 aZ
 ha
-bE
+MY
 aJ
 az
 aa
-ap
+pJ
 bT
 bT
 iQ
 aY
-Pk
+Zl
 bT
 bT
-ap
+pJ
 aa
 an
 fb
 bT
-Sf
+yx
 bT
 bT
 bT
 bT
 bT
 bT
-aX
+Xw
 ab
 ii
 cC
@@ -32623,11 +34286,11 @@ cp
 cp
 cp
 dw
-aI
+uQ
 aM
 bj
 bq
-bw
+As
 au
 aP
 ha
@@ -32638,7 +34301,7 @@ gO
 hf
 hj
 aJ
-fT
+Zb
 aJ
 az
 an
@@ -32647,7 +34310,7 @@ bT
 bT
 iQ
 aY
-Pk
+Zl
 bT
 bT
 an
@@ -32655,14 +34318,14 @@ an
 an
 aX
 bT
-Sf
+UN
+Tz
 bT
 bT
 bT
 bT
 bT
-bT
-aX
+wG
 ab
 aK
 cC
@@ -32883,19 +34546,19 @@ iA
 au
 aN
 bk
-bk
-kP
-bz
-cb
-Cd
-Uf
+DN
+Hs
+Du
+Xa
+El
+oW
 fO
 az
 UD
 az
 fO
-aJ
-fT
+Oq
+Ij
 aJ
 aJ
 an
@@ -32904,7 +34567,7 @@ Rq
 aX
 iQ
 aY
-Pk
+Zl
 aX
 Rq
 aX
@@ -32912,11 +34575,11 @@ an
 iw
 bT
 bT
-Sf
+yx
 ft
 fv
 fv
-fB
+oV
 bT
 bT
 aX
@@ -33137,7 +34800,7 @@ cp
 cp
 cp
 dw
-aI
+uQ
 bf
 bj
 bq
@@ -33145,31 +34808,31 @@ bx
 au
 ik
 aJ
-zq
+wr
 fO
 fQ
 ib
 fR
-fN
+Ec
 EK
-fU
-ho
-iC
-iD
-iJ
-iL
-iN
-iT
-YD
-Sx
-TS
-pK
-eB
-eP
-eU
-jh
-Pc
-AJ
+Ur
+jK
+Pd
+CG
+yg
+DW
+Vq
+uk
+Qm
+GP
+Qm
+QD
+wI
+kU
+Vx
+Mx
+BY
+jm
 fu
 fy
 fv
@@ -33177,7 +34840,7 @@ fv
 bT
 bT
 eO
-ij
+ED
 el
 hK
 ab
@@ -33395,42 +35058,42 @@ cp
 cp
 au
 au
-aI
-aI
-aI
+uQ
+uQ
+uQ
 au
 au
 Xr
 aJ
-NZ
-Cd
-Cd
-Cd
-Cd
-Cd
-Cd
+FC
+El
+El
+El
+El
+El
+El
 jq
 aJ
 aJ
 an
 sM
+er
 aX
-aX
-aX
+iQ
 aY
-Pk
+Zl
 aX
-aX
+er
 gd
 an
 aX
 bT
-bT
-Ct
+fZ
+yx
 fv
 fv
-fv
-fC
+NC
+Qv
 bT
 bT
 gd
@@ -33673,9 +35336,9 @@ an
 an
 bT
 bT
-aX
+iQ
 aY
-Pk
+Zl
 bT
 bT
 an
@@ -33683,7 +35346,7 @@ an
 an
 fd
 bT
-bT
+yx
 bT
 bT
 bT
@@ -33924,30 +35587,30 @@ bB
 bB
 bB
 bB
-bB
+pC
 az
 aa
-ap
+pJ
 bT
 bT
-aX
+iQ
 aY
-Pk
+Zl
 bT
 bT
-hM
+KP
 aa
 an
 fb
 bT
-bT
+yx
 ih
 ih
 ih
 bT
 bT
 bT
-aX
+Dv
 ab
 ii
 cC
@@ -34183,24 +35846,24 @@ bB
 cy
 bB
 az
-ap
-ap
-ap
+pJ
+pJ
+pJ
 bT
-aX
+iQ
 gj
-Pk
-bT
-ap
-hM
+Zl
+Ep
+pJ
+KP
 aa
 an
 fe
 fi
+Zl
 aX
-aX
-fi
 hx
+fi
 aX
 aX
 hx
@@ -34444,9 +36107,9 @@ bY
 ck
 an
 an
-dm
+Rb
 an
-jM
+Vv
 an
 an
 aa
@@ -34454,10 +36117,10 @@ aa
 an
 ff
 aY
-aV
+Ri
 eO
+dU
 aY
-wa
 aV
 eO
 dU
@@ -34699,11 +36362,11 @@ bs
 an
 ch
 bT
-cl
+uh
 bT
-bT
+GN
 gr
-Sf
+yx
 bT
 ca
 bP
@@ -34711,7 +36374,7 @@ bP
 bP
 aY
 aY
-aV
+Ri
 eO
 aY
 aY
@@ -34956,19 +36619,19 @@ bs
 ad
 bT
 bT
-an
+xP
 bT
+li
 if
-if
-pL
+tx
 bT
 ca
-ge
+pO
 eC
 bP
 aY
 aY
-aV
+Ri
 eO
 aY
 aY
@@ -35211,21 +36874,21 @@ bi
 bo
 bu
 an
-ci
-ci
+xM
+Bh
 an
 co
+li
 if
-if
-pL
+tx
 bT
 ca
-Wq
-eD
+Hl
+BW
 bP
 aY
 aY
-aV
+Ri
 eO
 gj
 aY
@@ -35456,37 +37119,37 @@ cp
 cp
 cp
 az
-cs
-cs
-cs
+Ms
+Ms
+Ms
 aJ
 aJ
 ic
 aJ
 aJ
-cs
-cs
-cs
+Ms
+Ms
+Ms
 an
 gp
 cj
 an
 OX
+li
 if
-if
-pL
+tx
 bT
 ca
-eE
+Bs
 bP
 bP
 bP
 bP
-fn
+CP
 hM
 hM
 hM
-fn
+Rr
 an
 an
 an
@@ -35715,38 +37378,38 @@ cp
 cp
 cp
 cp
-cs
-cs
-cs
-cs
-cs
-cs
-cs
+Ms
+Ms
+Ms
+Ms
+Ms
+Ms
+Ms
 ec
 ec
-aW
-be
-be
-cm
+wM
+pW
+wz
+jQ
 bT
-if
+li
 iU
-pL
+tx
 bT
-bS
-Mt
-eQ
-eV
+Pc
+pX
+AT
+QF
 eH
 bP
-aX
-aX
-aX
-aX
-aX
-fE
-aX
-aX
+Rt
+Fi
+xU
+sx
+xU
+OS
+XT
+Fp
 fG
 ab
 cC
@@ -35981,28 +37644,28 @@ ec
 ec
 ec
 ec
-aW
+wM
 yr
-EF
-bC
-wT
-EF
-oX
-YA
+yv
+hA
+tZ
+xf
+Lt
+KT
 bT
 cn
-Mt
+pX
 np
 eV
 eH
 bP
 fz
-bT
+Ct
 hy
-bT
+fZ
 hz
 hM
-aX
+er
 aX
 ie
 ab
@@ -36238,19 +37901,19 @@ ec
 ec
 ec
 ec
-aW
+wM
 be
 be
-cm
+jQ
 bT
-be
-aL
-vE
-wT
-Ln
-nF
-pQ
-Br
+wQ
+em
+WY
+QJ
+Db
+PN
+xY
+RZ
 fg
 bP
 fo
@@ -36496,18 +38159,18 @@ ec
 ec
 ec
 an
-cj
+Jy
 cj
 an
-bT
-bT
+zV
+GN
 cv
-Sf
+yx
 bT
 ca
 fH
-gC
-rV
+uZ
+wN
 eH
 bP
 aY
@@ -36752,19 +38415,19 @@ ec
 af
 ag
 ag
-bQ
+ag
 an
 an
 an
 an
-cu
+jo
 an
-FX
+BP
 an
 ca
 eH
 gF
-rV
+wN
 gg
 bP
 aY
@@ -37008,20 +38671,20 @@ ec
 ec
 af
 ah
-ak
-ar
+Ef
+Am
 af
-gE
+mu
 af
 cH
-do
-lw
-zV
-dV
+SD
+in
+ye
+Os
 ae
 eJ
 gF
-rV
+wN
 fg
 bP
 ca
@@ -37265,27 +38928,27 @@ ec
 ec
 af
 ai
-al
-as
-ba
-bG
-bW
-vy
-mh
-mh
-yD
-dV
+rj
+wR
+di
+Ih
+ex
+jB
+XI
+Cx
+Mw
+HB
 ae
 eK
 gF
-lI
-Oh
-fj
-rc
-rc
-rc
-gk
-HU
+DR
+zf
+lo
+bl
+bl
+kz
+KM
+BN
 eD
 bP
 bP
@@ -37522,27 +39185,27 @@ ec
 ec
 af
 ai
-am
-at
+CI
+OU
+cw
+SA
 af
-bH
-af
-Sm
-do
+cH
+SD
 dG
-zV
-dV
+WU
+Zc
 ae
 eK
 gG
 hp
 hp
-hr
+od
 hp
 hr
 hr
 ud
-yl
+YV
 hs
 bP
 bU
@@ -37779,15 +39442,15 @@ ec
 ec
 af
 aj
-et
-et
-ab
-aK
-ab
+aj
+aj
 bX
-dn
+Fb
 bX
-me
+bX
+YQ
+bX
+nU
 bX
 ae
 bP
@@ -37798,16 +39461,16 @@ bP
 fp
 eQ
 eD
-eD
-lI
-ht
-hu
-bV
+mo
+BE
+sO
+QN
+ub
 ce
 gl
 bP
-aK
-cC
+ll
+YR
 ab
 cp
 cp
@@ -38036,16 +39699,16 @@ dY
 ec
 ec
 ec
-aG
-ii
-aK
-aK
-ab
-cP
-cT
-gn
-Ny
-cT
+ae
+Fn
+SC
+in
+bX
+lG
+OD
+FM
+uK
+Xb
 aG
 aG
 aG
@@ -38058,9 +39721,9 @@ eD
 eD
 eD
 eD
-eD
-eD
-cf
+sc
+nc
+Ob
 gm
 bP
 aK
@@ -38293,20 +39956,20 @@ dY
 aG
 aG
 aG
-aG
-aC
-gX
-gD
-it
-aF
-eR
+ae
+pT
+iL
+Cx
+GX
+LN
+Nd
 eW
 iO
 eR
-iu
+HR
 gU
 gX
-gX
+MS
 hq
 bP
 fq
@@ -38316,13 +39979,13 @@ eD
 eD
 eD
 bP
-eD
+Ys
 cf
 gl
 bP
 aK
 cC
-aK
+pA
 ab
 cp
 cp
@@ -38550,31 +40213,31 @@ dY
 aG
 cO
 ii
-aG
-cO
-aK
-aK
-ab
+sk
+jI
+VD
+in
+bX
 dD
 dp
-dE
-dp
-cU
+Rv
+xi
+yo
 ab
-aK
-aK
-aK
+Vt
+NI
+pj
 cC
 bP
-fr
-fr
-fA
-fA
-fr
-fr
+nw
+nw
+LF
+LF
+nw
+nw
 bP
-eD
-cf
+mv
+xC
 gl
 bP
 bP
@@ -38807,16 +40470,16 @@ dY
 aG
 iv
 ii
-aG
-aK
-aK
-aK
-id
-cV
+ae
+Av
+it
+uw
+XB
+Lr
 dq
 dF
 dN
-cV
+Lr
 ab
 ab
 ab
@@ -38831,12 +40494,12 @@ av
 eD
 fw
 cc
-cg
+PT
 eG
 fq
 bP
 cC
-gy
+DV
 ab
 cp
 cp
@@ -39064,17 +40727,17 @@ dY
 aG
 aG
 aG
-aG
-ii
-aK
-ii
-id
+ae
+yN
+in
+oq
+XB
 cH
 cH
-jE
+Ym
 cH
 cH
-db
+nv
 ec
 ec
 ab
@@ -39088,12 +40751,12 @@ eG
 eQ
 is
 fq
-cE
-eG
+ui
+PD
 fq
 bP
 cC
-aK
+Js
 ab
 cp
 cp
@@ -39321,17 +40984,17 @@ dY
 ec
 ec
 ec
-aG
-aG
-aK
-aK
-id
+ae
+mn
+zK
+qR
+XB
 cT
 cT
 cT
 cT
 cT
-db
+nv
 ec
 ec
 ab
@@ -39345,12 +41008,12 @@ ay
 eQ
 bP
 bP
-eu
+IL
 bP
 bP
 bP
 cC
-aK
+uN
 ab
 cp
 cp
@@ -39579,16 +41242,16 @@ cp
 cp
 dY
 ec
-aG
-aG
-aG
-ab
-cX
-ds
-cT
-ds
-dW
-db
+mn
+mn
+mn
+bX
+sl
+Bq
+Lh
+Bq
+ps
+nv
 ec
 ec
 ab
@@ -39601,13 +41264,13 @@ eG
 eG
 eQ
 bP
-aK
-hI
+eq
+of
 gX
 gX
 gX
 hB
-aK
+ho
 ab
 cp
 cp
@@ -39840,12 +41503,12 @@ ec
 ec
 ec
 bX
-da
-dt
+YU
+wj
 go
-dO
-da
-db
+xH
+YU
+nv
 ec
 ec
 ab
@@ -39859,7 +41522,7 @@ eG
 eQ
 bP
 aK
-cC
+Qq
 aK
 aK
 aK
@@ -40097,12 +41760,12 @@ ec
 ec
 ec
 bX
-db
-db
-db
-db
-db
-db
+nv
+nv
+nv
+nv
+nv
+nv
 ec
 ec
 ab
@@ -40114,9 +41777,9 @@ eG
 eG
 eG
 eQ
-cw
+qj
 aK
-cC
+Qq
 ab
 ab
 ab
@@ -40372,10 +42035,10 @@ aA
 eG
 eQ
 bP
-aK
-cC
+yu
+Qq
 NK
-aK
+Ou
 ab
 ec
 ec
@@ -40630,10 +42293,10 @@ fh
 eD
 bP
 aK
-hA
-eN
-aK
-fk
+AR
+zL
+AX
+Ek
 ec
 ec
 ec
@@ -40887,7 +42550,7 @@ bP
 bP
 bP
 aK
-cC
+YA
 ab
 ab
 ab
@@ -41137,14 +42800,14 @@ ab
 gS
 gX
 gX
+Kl
 gX
 gX
 gX
 gX
 gX
 gX
-gX
-hB
+NS
 ab
 ec
 ec

--- a/_maps/map_files/PVP/Hammurabi.dmm
+++ b/_maps/map_files/PVP/Hammurabi.dmm
@@ -679,13 +679,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/hammurabi)
-"dn" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
 "dp" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/mineral/plastitanium/red,
@@ -1248,6 +1241,18 @@
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
+"fC" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
 "fF" = (
 /obj/item/ship_weapon/ammunition/torpedo/nuke,
 /obj/effect/turf_decal/delivery,
@@ -1323,10 +1328,6 @@
 /obj/structure/reagent_dispensers/fueltank/aviation_fuel,
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/hangar)
-"fU" = (
-/obj/machinery/autolathe,
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/maintenance)
 "fV" = (
 /obj/machinery/computer/ship/viewscreen,
 /obj/machinery/light{
@@ -2139,7 +2140,17 @@
 /obj/machinery/porta_turret/syndicate/pod,
 /turf/open/floor/plating/airless,
 /area/hammurabi/maintenance/exterior)
-"iL" = (
+"iO" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8;
+	icon_state = "vent_map_on-2"
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi/bridge)
+"iP" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -2150,17 +2161,8 @@
 /obj/item/folder/syndicate/red{
 	pixel_x = 12
 	},
+/obj/item/toy/figure/syndie,
 /turf/open/floor/carpet/red,
-/area/hammurabi/bridge)
-"iO" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8;
-	icon_state = "vent_map_on-2"
-	},
-/turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/bridge)
 "iQ" = (
 /obj/structure/cable{
@@ -2252,11 +2254,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/hangar)
-"jv" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi)
 "jz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -2340,20 +2337,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi)
-"kj" = (
-/obj/machinery/door/airlock/ship{
-	name = "Missile tubes"
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
 "kG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/mineral/plastitanium/red,
@@ -2431,13 +2414,6 @@
 /obj/machinery/door/firedoor/window,
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
-"lx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet/west,
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/armoury)
 "lI" = (
 /obj/machinery/door/airlock/ship{
 	name = "Torpedo rack"
@@ -2447,10 +2423,36 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
+"lR" = (
+/obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/turf/open/floor/wood{
+	broken = 1
+	},
+/area/hammurabi/maintenance)
 "lS" = (
 /obj/structure/extinguisher_cabinet/north,
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/hangar)
+"lT" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/turf/open/floor/wood,
+/area/hammurabi/maintenance)
+"mb" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/binary/valve/on,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
 "mn" = (
 /obj/machinery/door/firedoor/window,
 /obj/effect/spawner/structure/window/reinforced/ship,
@@ -2547,6 +2549,19 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/armoury)
+"nq" = (
+/obj/machinery/suit_storage_unit/syndicate,
+/obj/effect/turf_decal/box,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4;
+	icon_state = "vent_map_on-2"
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi/armoury)
 "ns" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/tech/grid,
@@ -2572,6 +2587,15 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/armoury)
+"nz" = (
+/obj/structure/extinguisher_cabinet/south,
+/obj/item/ship_weapon/ammunition/torpedo/torpedo_casing,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"nB" = (
+/obj/machinery/computer/atmos_alert,
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
 "nC" = (
 /obj/machinery/door/airlock/ship/engineering{
 	name = "Reactor monitoring"
@@ -2604,14 +2628,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/bridge)
-"nZ" = (
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/airlock/ship{
-	name = "Central frame"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi/maintenance)
 "od" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2635,12 +2651,26 @@
 	},
 /turf/open/floor/plating,
 /area/hammurabi/maintenance)
-"oq" = (
-/mob/living/simple_animal/pet/cat/space{
-	name = "Syndicat"
+"or" = (
+/obj/machinery/door/airlock/ship{
+	name = "Aft frame"
 	},
-/turf/open/floor/carpet/red,
-/area/hammurabi/bridge)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"ot" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/east{
+	req_access = null;
+	req_one_access_txt = "150"
+	},
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
 "oO" = (
 /obj/machinery/door/airlock/ship/maintenance,
 /obj/structure/cable/yellow{
@@ -2662,16 +2692,6 @@
 	},
 /turf/open/floor/plating,
 /area/hammurabi)
-"oT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/armoury)
 "oW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -2681,6 +2701,11 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/hangar)
+"pf" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
 "pg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -2709,6 +2734,11 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/hangar)
+"pp" = (
+/obj/structure/closet/radiation,
+/obj/item/shovel,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/maintenance)
 "ps" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -2720,6 +2750,12 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/bridge)
+"px" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi/medbay)
 "pA" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -2766,6 +2802,10 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/armoury)
+"qe" = (
+/obj/effect/landmark/nuclear_waste_spawner,
+/turf/open/floor/monotile/dark,
+/area/hammurabi/medbay)
 "qj" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	name = "Armoury";
@@ -2782,10 +2822,6 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plating,
 /area/hammurabi/maintenance)
-"qv" = (
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi/armoury)
 "qF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
@@ -2806,13 +2842,21 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
-"qR" = (
-/obj/structure/bed,
-/obj/item/bedsheet/syndie,
-/obj/item/toy/plush/nukeplushie,
-/obj/item/toy/figure/syndie,
-/turf/open/floor/carpet/red,
-/area/hammurabi/bridge)
+"qL" = (
+/obj/item/storage/toolbox/electrical{
+	icon_state = "syndicate"
+	},
+/obj/structure/table/reinforced,
+/obj/item/pipe_dispenser,
+/turf/open/floor/plating,
+/area/hammurabi)
+"qY" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
 "rj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -2823,6 +2867,12 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hammurabi/tcomms)
+"rk" = (
+/obj/machinery/computer/ship/viewscreen,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi/bridge)
 "ro" = (
 /obj/structure/table/optable,
 /obj/machinery/firealarm/directional/west,
@@ -2834,6 +2884,14 @@
 	icon_state = "vent_map_on-2"
 	},
 /turf/open/floor/carpet/red,
+/area/hammurabi)
+"rs" = (
+/obj/machinery/airalarm/directional/north{
+	req_access = null;
+	req_one_access_txt = "150"
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/monotile/dark,
 /area/hammurabi)
 "ru" = (
 /obj/machinery/door/airlock/ship/maintenance,
@@ -2856,24 +2914,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/carpet/red,
 /area/hammurabi)
-"rH" = (
-/obj/structure/chair/stool/bar,
-/turf/open/floor/wood,
-/area/hammurabi/maintenance)
-"rI" = (
-/obj/structure/table/wood/poker,
-/obj/item/dice/d6{
-	pixel_x = 7;
-	pixel_y = 5
-	},
-/obj/item/dice/d6{
-	pixel_x = -4;
-	pixel_y = -2
-	},
-/turf/open/floor/wood{
-	broken = 1
-	},
-/area/hammurabi/maintenance)
 "rK" = (
 /obj/structure/window/reinforced/fulltile/ship/interior,
 /obj/structure/grille,
@@ -2929,39 +2969,6 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/hammurabi/maintenance)
-"st" = (
-/obj/machinery/atmospherics/pipe/manifold4w/orange/visible,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/meter,
-/turf/open/floor/plating,
-/area/hammurabi)
-"sz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/wood{
-	broken = 1
-	},
-/area/hammurabi/maintenance)
-"sC" = (
-/obj/machinery/light/small,
-/obj/structure/table/wood/poker,
-/obj/item/stack/spacecash/c200{
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = 7
-	},
-/turf/open/floor/wood,
-/area/hammurabi/maintenance)
 "sD" = (
 /obj/item/storage/toolbox/syndicate,
 /obj/structure/table/reinforced,
@@ -2971,6 +2978,20 @@
 	},
 /turf/open/floor/plating,
 /area/hammurabi)
+"sG" = (
+/obj/machinery/shower{
+	dir = 8;
+	name = "emergency shower"
+	},
+/turf/open/floor/plasteel/grid/techfloor/grid,
+/area/hammurabi)
+"sI" = (
+/obj/machinery/airalarm/directional/south{
+	req_access = null;
+	req_one_access_txt = "150"
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi/bridge)
 "sM" = (
 /obj/machinery/light{
 	dir = 1
@@ -3007,13 +3028,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/dark,
 /area/hammurabi)
-"tj" = (
-/obj/machinery/airalarm/directional/south{
-	req_access = null;
-	req_one_access_txt = "150"
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi/bridge)
 "tm" = (
 /obj/machinery/light{
 	dir = 4
@@ -3026,6 +3040,21 @@
 	},
 /turf/open/floor/carpet/red,
 /area/hammurabi)
+"to" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4;
+	icon_state = "vent_map_on-2"
+	},
+/turf/open/floor/monotile/dark,
+/area/hammurabi/tcomms)
+"tv" = (
+/obj/structure/chair/stool/bar,
+/turf/open/floor/wood,
+/area/hammurabi/maintenance)
 "tx" = (
 /obj/structure/chair{
 	dir = 4
@@ -3044,11 +3073,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/hangar)
-"tH" = (
-/obj/item/ship_weapon/parts/torpedo/warhead/bunker_buster,
-/obj/structure/table/reinforced,
-/turf/open/floor/plating,
-/area/hammurabi/maintenance)
 "tU" = (
 /obj/machinery/door/airlock/ship/maintenance,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -3158,6 +3182,16 @@
 /obj/machinery/door/firedoor/window,
 /turf/open/floor/plasteel/dark,
 /area/hammurabi/hangar)
+"uR" = (
+/obj/machinery/door/airlock/ship{
+	name = "Ammo rack"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
 "uX" = (
 /obj/machinery/door/poddoor/ship{
 	dir = 4;
@@ -3169,12 +3203,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
-"uY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
 "uZ" = (
@@ -3192,14 +3220,15 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/armoury)
-"vc" = (
-/obj/item/storage/toolbox/electrical{
-	icon_state = "syndicate"
-	},
-/obj/structure/table/reinforced,
-/obj/item/pipe_dispenser,
-/turf/open/floor/plating,
-/area/hammurabi)
+"vj" = (
+/obj/machinery/autolathe,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/maintenance)
+"vp" = (
+/obj/effect/landmark/nuclear_waste_spawner,
+/obj/machinery/holopad,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/bridge)
 "vq" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
 /obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
@@ -3238,6 +3267,17 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/dark,
 /area/hammurabi)
+"vZ" = (
+/obj/machinery/light/small,
+/obj/structure/table/wood/poker,
+/obj/item/stack/spacecash/c200{
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 7
+	},
+/turf/open/floor/wood,
+/area/hammurabi/maintenance)
 "wb" = (
 /obj/structure/window/reinforced/fulltile/ship/interior,
 /obj/structure/grille,
@@ -3255,11 +3295,14 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/bridge)
-"wm" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/ship/interior,
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi/maintenance)
+"wn" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4;
+	icon_state = "vent_map_on-2"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
 "wr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -3270,16 +3313,10 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/hangar)
 "ws" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4;
-	icon_state = "vent_map_on-2"
-	},
-/turf/open/floor/monotile/dark,
-/area/hammurabi/tcomms)
+/obj/structure/girder/reinforced,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
 "wz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
@@ -3381,16 +3418,13 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/bridge)
-"xu" = (
-/obj/machinery/door/airlock/ship{
-	name = "Ammo rack"
+"xl" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
+/obj/structure/extinguisher_cabinet/west,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/armoury)
 "xv" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/mineral/plastitanium,
@@ -3478,6 +3512,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi)
+"yi" = (
+/obj/structure/bed,
+/obj/item/bedsheet/syndie,
+/turf/open/floor/carpet/red,
+/area/hammurabi/bridge)
 "yo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -3489,11 +3528,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/carpet/red,
 /area/hammurabi)
-"ys" = (
-/turf/open/floor/wood{
-	broken = 1
-	},
-/area/hammurabi/maintenance)
 "yu" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -3516,16 +3550,20 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
-"yz" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/wood,
-/area/hammurabi/maintenance)
 "yF" = (
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/plating,
 /area/hammurabi/maintenance)
+"yG" = (
+/obj/structure/extinguisher_cabinet/north,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
 "yH" = (
 /obj/machinery/door/airlock/ship{
 	name = "Torpedo rack"
@@ -3535,11 +3573,6 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
-"yI" = (
-/obj/structure/girder/reinforced,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/hammurabi/maintenance)
 "yN" = (
 /obj/structure/displaycase{
 	req_access = list(151);
@@ -3554,6 +3587,17 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"zd" = (
+/obj/machinery/atmospherics/pipe/manifold4w/orange/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/meter,
+/turf/open/floor/plating,
 /area/hammurabi)
 "zf" = (
 /obj/effect/turf_decal/stripes/line{
@@ -3576,17 +3620,15 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
-"zt" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 8
+"zo" = (
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/monotile/dark,
-/area/hammurabi)
-"zz" = (
-/obj/structure/extinguisher_cabinet/south,
-/obj/item/ship_weapon/ammunition/torpedo/torpedo_casing,
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
+/obj/structure/table/reinforced,
+/obj/item/storage/belt/utility/full,
+/obj/item/storage/belt/utility/full,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/maintenance)
 "zD" = (
 /obj/machinery/light{
 	dir = 1
@@ -3643,12 +3685,19 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/hangar)
-"zO" = (
-/obj/item/chair/stool/bar,
-/turf/open/floor/wood{
-	broken = 1
+"zU" = (
+/obj/machinery/door/airlock/ship{
+	name = "Aft frame"
 	},
-/area/hammurabi/maintenance)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
 "zV" = (
 /obj/structure/extinguisher_cabinet/north,
 /turf/open/floor/mineral/plastitanium,
@@ -3700,16 +3749,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/carpet/red,
 /area/hammurabi/bridge)
-"AC" = (
-/obj/structure/extinguisher_cabinet/north,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
 "AR" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
@@ -3814,41 +3853,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
-"Cn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/airalarm/directional/west{
-	req_access = null;
-	req_one_access_txt = "150"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/armoury)
-"Co" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi)
-"Cp" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/east{
-	req_access = null;
-	req_one_access_txt = "150"
-	},
-/turf/open/floor/monotile/dark,
-/area/hammurabi)
-"Cq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
 "Ct" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8;
@@ -3861,6 +3865,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/carpet/red,
 /area/hammurabi/bridge)
+"CF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/armoury)
 "CG" = (
 /obj/machinery/door/airlock/ship{
 	name = "Hangar bay"
@@ -3882,6 +3896,13 @@
 /obj/item/pen,
 /turf/open/floor/monotile/dark,
 /area/hammurabi/tcomms)
+"CX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
 "Db" = (
 /obj/machinery/door/airlock/ship{
 	name = "Marine suit storage";
@@ -3994,10 +4015,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
-"En" = (
-/obj/item/ship_weapon/ammunition/torpedo/torpedo_casing,
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
 "Ep" = (
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/mineral/plastitanium,
@@ -4053,6 +4070,19 @@
 /obj/structure/extinguisher_cabinet/south,
 /turf/open/floor/plating,
 /area/hammurabi)
+"Fi" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/glass{
+	amount = 15
+	},
+/obj/item/stack/sheet/iron/twenty,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/maintenance)
+"Fl" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/ship/interior,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi/maintenance)
 "Fn" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/carpet/red,
@@ -4080,11 +4110,6 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/plating,
 /area/hammurabi/maintenance)
-"Ft" = (
-/obj/item/organ/wings/moth,
-/obj/effect/decal/remains/human,
-/turf/open/floor/plating,
-/area/hammurabi/maintenance)
 "Fu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/vehicle/sealed/car/realistic/fighter_tug,
@@ -4105,18 +4130,38 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/hangar)
-"FK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+"FH" = (
+/mob/living/simple_animal/pet/cat/space{
+	faction = list("Syndicate");
+	name = "Syndicat"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech/grid,
+/turf/open/floor/carpet/red,
+/area/hammurabi/bridge)
+"FJ" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/cable_coil,
+/obj/item/ship_weapon/parts/torpedo/guidance_system,
+/obj/item/ship_weapon/parts/torpedo/guidance_system,
+/obj/item/ship_weapon/parts/torpedo/guidance_system,
+/obj/item/ship_weapon/parts/torpedo/guidance_system,
+/obj/item/ship_weapon/parts/torpedo/iff_card,
+/obj/item/ship_weapon/parts/torpedo/iff_card,
+/obj/item/ship_weapon/parts/torpedo/iff_card,
+/obj/item/ship_weapon/parts/torpedo/iff_card,
+/obj/item/ship_weapon/parts/torpedo/iff_card,
+/obj/item/ship_weapon/parts/torpedo/iff_card,
+/obj/item/ship_weapon/parts/torpedo/iff_card,
+/obj/item/ship_weapon/parts/torpedo/guidance_system,
+/obj/item/ship_weapon/parts/torpedo/guidance_system,
+/obj/item/ship_weapon/parts/torpedo/guidance_system,
+/turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi)
+"FK" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood,
+/area/hammurabi/maintenance)
 "FM" = (
 /obj/machinery/light{
 	dir = 8
@@ -4125,16 +4170,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/bridge)
-"FR" = (
-/obj/machinery/door/airlock/ship{
-	name = "Aft frame"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
 "FS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -4144,28 +4179,15 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hammurabi)
+"FU" = (
+/obj/structure/grille,
+/obj/structure/table_frame,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
 "Gd" = (
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
-"Gi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/armoury)
-"Gn" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/sheet/glass{
-	amount = 15
-	},
-/obj/item/stack/sheet/iron/twenty,
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/maintenance)
 "GN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4175,24 +4197,6 @@
 "GP" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi)
-"GU" = (
-/obj/structure/table/reinforced,
-/obj/item/ship_weapon/parts/torpedo/propulsion_system,
-/obj/item/ship_weapon/parts/torpedo/propulsion_system,
-/obj/item/ship_weapon/parts/torpedo/propulsion_system,
-/obj/item/ship_weapon/parts/torpedo/propulsion_system,
-/obj/item/ship_weapon/parts/torpedo/warhead,
-/obj/item/ship_weapon/parts/torpedo/warhead,
-/obj/item/ship_weapon/parts/torpedo/warhead/decoy,
-/obj/item/ship_weapon/parts/torpedo/warhead/decoy,
-/obj/item/ship_weapon/parts/torpedo/warhead/decoy,
-/obj/item/ship_weapon/parts/torpedo/warhead,
-/obj/item/ship_weapon/parts/torpedo/warhead,
-/obj/item/ship_weapon/parts/torpedo/propulsion_system,
-/obj/item/ship_weapon/parts/torpedo/propulsion_system,
-/obj/item/ship_weapon/parts/torpedo/propulsion_system,
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi)
 "GW" = (
@@ -4216,6 +4220,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/ship,
 /area/hammurabi/hangar)
+"Hu" = (
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/airlock/ship{
+	name = "Central frame"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi/maintenance)
 "HB" = (
 /obj/structure/closet/radiation,
 /obj/item/clothing/mask/gas,
@@ -4224,6 +4236,10 @@
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/bridge)
+"HG" = (
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi/armoury)
 "HM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/carpet/red,
@@ -4244,13 +4260,20 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/plating,
 /area/hammurabi/maintenance)
-"HY" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4;
-	icon_state = "vent_map_on-2"
+"HV" = (
+/obj/machinery/door/airlock/ship{
+	name = "Plasma Storage"
 	},
-/turf/open/floor/mineral/plastitanium,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
+"Ia" = (
+/obj/item/ship_weapon/ammunition/torpedo/torpedo_casing,
+/turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
 "Id" = (
 /obj/effect/turf_decal/stripes/line,
@@ -4262,6 +4285,15 @@
 	},
 /turf/open/floor/plating,
 /area/hammurabi/maintenance)
+"If" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
 "Ih" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -4286,6 +4318,18 @@
 /obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/hammurabi)
+"IG" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/monotile,
+/area/hammurabi/tcomms)
 "IK" = (
 /obj/structure/window/reinforced/fulltile/ship/interior,
 /obj/structure/grille,
@@ -4336,16 +4380,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/hangar)
-"Jq" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
-	},
-/obj/machinery/atmospherics/components/binary/valve/on,
-/turf/open/floor/plating,
-/area/hammurabi/maintenance)
 "Jr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/mineral/plastitanium,
@@ -4358,6 +4392,20 @@
 /obj/machinery/vending/cola/sodie,
 /turf/open/floor/carpet/red,
 /area/hammurabi)
+"JB" = (
+/obj/structure/table/wood/poker,
+/obj/item/dice/d6{
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/obj/item/dice/d6{
+	pixel_x = -4;
+	pixel_y = -2
+	},
+/turf/open/floor/wood{
+	broken = 1
+	},
+/area/hammurabi/maintenance)
 "JG" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4370,15 +4418,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hammurabi)
-"JI" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/table/reinforced,
-/obj/item/storage/belt/utility/full,
-/obj/item/storage/belt/utility/full,
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/maintenance)
 "JN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
@@ -4386,19 +4425,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
-"Kb" = (
-/obj/machinery/suit_storage_unit/syndicate,
-/obj/effect/turf_decal/box,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4;
-	icon_state = "vent_map_on-2"
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi/armoury)
 "Kl" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4413,20 +4439,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/hangar)
-"KC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/closet/syndicate{
-	name = "equipment closet"
-	},
-/obj/item/clothing/mask/chameleon,
-/obj/machinery/airalarm/directional/south{
-	req_access = null;
-	req_one_access_txt = "150"
-	},
-/turf/open/floor/monotile,
-/area/hammurabi/tcomms)
 "KG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
@@ -4441,22 +4453,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/armoury)
-"KN" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/turf/open/floor/wood,
-/area/hammurabi/maintenance)
-"KO" = (
-/obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
-	dir = 4
-	},
-/obj/structure/table/wood,
-/turf/open/floor/wood{
-	broken = 1
-	},
-/area/hammurabi/maintenance)
 "KP" = (
 /obj/structure/window/reinforced/fulltile/ship/interior,
 /obj/structure/grille,
@@ -4483,6 +4479,18 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hammurabi)
+"KV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"La" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
 "Lh" = (
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/mineral/plastitanium/red,
@@ -4503,25 +4511,12 @@
 	},
 /turf/open/floor/carpet/red,
 /area/hammurabi)
-"Lz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
 "LF" = (
 /obj/item/gun/ballistic/automatic/c20r/toy/unrestricted/riot,
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/armoury)
-"LM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
 "LN" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -4530,14 +4525,21 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/bridge)
-"Md" = (
-/obj/machinery/door/airlock/ship{
-	name = "Plasma Storage"
+"Mo" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/monotile/dark,
-/area/hammurabi)
+/obj/structure/closet/syndicate{
+	name = "equipment closet"
+	},
+/obj/item/clothing/mask/chameleon,
+/obj/machinery/airalarm/directional/south{
+	req_access = null;
+	req_one_access_txt = "150"
+	},
+/obj/item/toy/plush/nukeplushie,
+/turf/open/floor/monotile,
+/area/hammurabi/tcomms)
 "Ms" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
 /obj/machinery/door/firedoor/window,
@@ -4558,10 +4560,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
-"ME" = (
-/obj/effect/landmark/nuclear_waste_spawner,
-/turf/open/floor/monotile/dark,
-/area/hammurabi/medbay)
 "MS" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4570,17 +4568,6 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
-/area/hammurabi/maintenance)
-"MU" = (
-/obj/machinery/airalarm/directional/north{
-	req_access = null;
-	req_one_access_txt = "150"
-	},
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/monotile/dark,
-/area/hammurabi)
-"MW" = (
-/turf/open/floor/plasteel/tech/grid,
 /area/hammurabi/maintenance)
 "MY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -4609,11 +4596,12 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/bridge)
-"Nk" = (
-/obj/effect/landmark/nuclear_waste_spawner,
-/obj/machinery/holopad,
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/bridge)
+"Nz" = (
+/obj/item/chair/stool/bar,
+/turf/open/floor/wood{
+	broken = 1
+	},
+/area/hammurabi/maintenance)
 "NC" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/iron/fifty,
@@ -4663,14 +4651,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/armoury)
-"Oe" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/wood{
-	broken = 1
-	},
-/area/hammurabi/maintenance)
 "Og" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4685,6 +4665,28 @@
 /area/hammurabi)
 "Oi" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"Oj" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood{
+	broken = 1
+	},
+/area/hammurabi/maintenance)
+"Ol" = (
+/obj/machinery/door/airlock/ship{
+	name = "Missile tubes"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
 "Om" = (
@@ -4788,16 +4790,6 @@
 	icon_state = "stairs-m"
 	},
 /area/hammurabi/hangar)
-"Pe" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/open/floor/plating,
-/area/hammurabi)
 "Pi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/mineral/plastitanium/red,
@@ -4829,6 +4821,24 @@
 /obj/machinery/atmospherics/components/binary/stormdrive_reactor/syndicate,
 /turf/open/floor/engine,
 /area/hammurabi)
+"PE" = (
+/obj/structure/table/reinforced,
+/obj/item/ship_weapon/parts/torpedo/propulsion_system,
+/obj/item/ship_weapon/parts/torpedo/propulsion_system,
+/obj/item/ship_weapon/parts/torpedo/propulsion_system,
+/obj/item/ship_weapon/parts/torpedo/propulsion_system,
+/obj/item/ship_weapon/parts/torpedo/warhead,
+/obj/item/ship_weapon/parts/torpedo/warhead,
+/obj/item/ship_weapon/parts/torpedo/warhead/decoy,
+/obj/item/ship_weapon/parts/torpedo/warhead/decoy,
+/obj/item/ship_weapon/parts/torpedo/warhead/decoy,
+/obj/item/ship_weapon/parts/torpedo/warhead,
+/obj/item/ship_weapon/parts/torpedo/warhead,
+/obj/item/ship_weapon/parts/torpedo/propulsion_system,
+/obj/item/ship_weapon/parts/torpedo/propulsion_system,
+/obj/item/ship_weapon/parts/torpedo/propulsion_system,
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi)
 "PN" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -4841,11 +4851,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/armoury)
-"PP" = (
-/obj/structure/closet/radiation,
-/obj/item/shovel,
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/maintenance)
 "PT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -4883,6 +4888,19 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hammurabi)
+"Qg" = (
+/obj/item/ship_weapon/parts/torpedo/warhead/bunker_buster,
+/obj/structure/table/reinforced,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
+"Qi" = (
+/obj/structure/rack,
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/sheet/iron/fifty,
+/obj/machinery/computer/ship/viewscreen,
+/obj/item/clothing/head/welding,
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
 "Qj" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/cable{
@@ -4915,6 +4933,11 @@
 	},
 /turf/open/floor/plating,
 /area/hammurabi/maintenance)
+"Qs" = (
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
 "Qw" = (
 /obj/structure/closet/radiation,
 /obj/item/shovel,
@@ -4936,6 +4959,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
+"QK" = (
+/obj/machinery/door/airlock/glass_large/ship{
+	name = "cryostasis"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
 "QM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -4972,6 +5003,11 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/monotile/dark,
 /area/hammurabi)
+"QP" = (
+/obj/item/organ/wings/moth,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
 "QZ" = (
 /obj/machinery/door/airlock/ship{
 	name = "Small ammunition"
@@ -5016,18 +5052,6 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
-"Rt" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/open/floor/monotile,
-/area/hammurabi/tcomms)
 "Rv" = (
 /obj/machinery/computer/communications{
 	dir = 8;
@@ -5095,12 +5119,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi)
-"Sq" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi/medbay)
 "Sv" = (
 /obj/structure/sign/warning/vacuum/external,
 /turf/closed/wall/ship,
@@ -5138,10 +5156,9 @@
 	},
 /turf/open/floor/plating,
 /area/hammurabi/maintenance)
-"Td" = (
-/obj/machinery/atmospherics/components/binary/valve,
-/turf/open/floor/plating,
-/area/hammurabi)
+"Tl" = (
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi/maintenance)
 "Tu" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -5162,10 +5179,6 @@
 	},
 /turf/open/floor/plating,
 /area/hammurabi/hangar)
-"Tw" = (
-/obj/machinery/computer/atmos_alert,
-/turf/open/floor/monotile/dark,
-/area/hammurabi)
 "Tz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1;
@@ -5173,25 +5186,15 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
-"TQ" = (
-/obj/machinery/door/airlock/ship{
-	name = "Plasma Storage"
+"Uo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/airalarm/directional/west{
+	req_access = null;
+	req_one_access_txt = "150"
 	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/monotile/dark,
-/area/hammurabi)
-"Uj" = (
-/obj/structure/rack,
-/obj/item/stack/cable_coil/random,
-/obj/item/stack/sheet/iron/fifty,
-/obj/machinery/computer/ship/viewscreen,
-/obj/item/clothing/head/welding,
-/turf/open/floor/monotile/dark,
-/area/hammurabi)
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/armoury)
 "Ur" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/cable{
@@ -5243,20 +5246,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/hammurabi/maintenance)
-"Ve" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/airalarm/directional/west{
-	req_access = null;
-	req_one_access_txt = "150"
+"Vm" = (
+/obj/machinery/door/airlock/ship{
+	name = "Plasma Storage"
 	},
-/turf/open/floor/mineral/plastitanium,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/monotile/dark,
 /area/hammurabi)
-"Vi" = (
-/obj/machinery/computer/ship/viewscreen,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi/bridge)
 "Vq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 1
@@ -5319,14 +5316,14 @@
 /obj/item/pen/fountain/captain,
 /turf/open/floor/carpet/red,
 /area/hammurabi/bridge)
-"VE" = (
-/obj/machinery/door/airlock/glass_large/ship{
-	name = "cryostasis"
+"VJ" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/airalarm/directional/west{
+	req_access = null;
+	req_one_access_txt = "150"
 	},
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/armoury)
 "VN" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -5336,36 +5333,23 @@
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
-"Wd" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/cable_coil,
-/obj/item/ship_weapon/parts/torpedo/guidance_system,
-/obj/item/ship_weapon/parts/torpedo/guidance_system,
-/obj/item/ship_weapon/parts/torpedo/guidance_system,
-/obj/item/ship_weapon/parts/torpedo/guidance_system,
-/obj/item/ship_weapon/parts/torpedo/iff_card,
-/obj/item/ship_weapon/parts/torpedo/iff_card,
-/obj/item/ship_weapon/parts/torpedo/iff_card,
-/obj/item/ship_weapon/parts/torpedo/iff_card,
-/obj/item/ship_weapon/parts/torpedo/iff_card,
-/obj/item/ship_weapon/parts/torpedo/iff_card,
-/obj/item/ship_weapon/parts/torpedo/iff_card,
-/obj/item/ship_weapon/parts/torpedo/guidance_system,
-/obj/item/ship_weapon/parts/torpedo/guidance_system,
-/obj/item/ship_weapon/parts/torpedo/guidance_system,
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi)
-"Wj" = (
-/obj/machinery/door/airlock/ship/engineering{
-	dir = 2;
-	icon_state = "closed";
-	name = "Reactor core";
-	req_one_access_txt = null
+"Wa" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
 	},
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
+"Wl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/armoury)
 "Wn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
@@ -5401,11 +5385,23 @@
 /obj/machinery/door/firedoor/window,
 /turf/open/floor/engine,
 /area/hammurabi)
-"WR" = (
+"WN" = (
+/obj/machinery/door/airlock/ship/engineering{
+	dir = 2;
+	icon_state = "closed";
+	name = "Reactor core";
+	req_one_access_txt = null
+	},
 /obj/machinery/door/firedoor/border_only/directional/north,
-/obj/structure/barricade/wooden/crude,
+/obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plating,
-/area/hammurabi/maintenance)
+/area/hammurabi)
+"WR" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
 "WU" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -5435,6 +5431,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/hangar)
+"Xj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/wood{
+	broken = 1
+	},
+/area/hammurabi/maintenance)
 "Xr" = (
 /obj/machinery/light{
 	dir = 1
@@ -5445,14 +5452,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/hangar)
-"Xw" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/airalarm/directional/west{
-	req_access = null;
-	req_one_access_txt = "150"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/armoury)
 "Xy" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	name = "Gravity generator"
@@ -5481,11 +5480,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/carpet/red,
 /area/hammurabi/bridge)
-"XL" = (
-/obj/structure/grille,
-/obj/structure/table_frame,
+"XS" = (
+/obj/machinery/atmospherics/components/binary/valve,
 /turf/open/floor/plating,
-/area/hammurabi/maintenance)
+/area/hammurabi)
 "Yd" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -5500,19 +5498,6 @@
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi)
-"Yi" = (
-/obj/machinery/door/airlock/ship{
-	name = "Aft frame"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
 "Yq" = (
 /obj/machinery/door/airlock/ship{
@@ -5557,6 +5542,16 @@
 	icon_state = "vent_map_on-2"
 	},
 /turf/open/floor/monotile/dark,
+/area/hammurabi)
+"YM" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/open/floor/plating,
 /area/hammurabi)
 "YQ" = (
 /obj/machinery/door/airlock/ship{
@@ -5615,6 +5610,11 @@
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/bridge)
+"Zd" = (
+/turf/open/floor/wood{
+	broken = 1
+	},
+/area/hammurabi/maintenance)
 "Zi" = (
 /obj/machinery/door/airlock/ship/maintenance,
 /obj/structure/cable/yellow{
@@ -5636,12 +5636,13 @@
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
-"Zv" = (
-/obj/machinery/shower{
-	dir = 8;
-	name = "emergency shower"
+"ZV" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/airalarm/directional/west{
+	req_access = null;
+	req_one_access_txt = "150"
 	},
-/turf/open/floor/plasteel/grid/techfloor/grid,
+/turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
 
 (1,1,1) = {"
@@ -26601,7 +26602,7 @@ mJ
 dd
 PC
 dI
-Wj
+WN
 dZ
 dZ
 jA
@@ -27120,8 +27121,8 @@ ca
 nt
 ca
 ab
-yz
-KO
+FK
+lR
 ab
 cC
 ab
@@ -27370,16 +27371,16 @@ KU
 bK
 cz
 dg
-st
+zd
 dL
-Pe
+YM
 ca
 Om
-Zv
+sG
 ab
-KN
-ys
-WR
+lT
+Zd
+Qs
 cC
 ab
 cp
@@ -27622,20 +27623,20 @@ ab
 aK
 SY
 an
-Tw
+nB
 Og
 bL
 aS
 aS
-zt
+WR
 aS
 Fd
 ca
 jJ
 ca
 ab
-Oe
-rH
+Oj
+tv
 ab
 cC
 ab
@@ -27879,7 +27880,7 @@ ab
 cO
 SY
 an
-MU
+rs
 Yz
 oQ
 aS
@@ -27891,8 +27892,8 @@ aS
 jP
 jD
 ab
-yz
-rI
+FK
+JB
 ab
 cC
 ab
@@ -28134,7 +28135,7 @@ an
 aK
 ab
 Wu
-Jq
+mb
 tU
 tf
 vV
@@ -28148,8 +28149,8 @@ dM
 JG
 hD
 OK
-sz
-sC
+Xj
+vZ
 ab
 hF
 ab
@@ -28405,8 +28406,8 @@ aS
 FS
 aS
 ab
-zO
-ys
+Nz
+Zd
 ab
 cC
 ab
@@ -28650,7 +28651,7 @@ ab
 dh
 dh
 an
-Uj
+Qi
 Ao
 bL
 cq
@@ -28662,7 +28663,7 @@ aS
 FS
 dT
 ab
-yI
+ws
 ab
 ab
 cC
@@ -28919,8 +28920,8 @@ aS
 FS
 dT
 ab
-tH
-XL
+Qg
+FU
 ab
 gS
 gX
@@ -29168,9 +29169,9 @@ an
 UR
 an
 an
-Md
+Vm
 an
-TQ
+HV
 an
 an
 NQ
@@ -29425,10 +29426,10 @@ hk
 Yd
 an
 cB
-Td
+XS
 GW
 vJ
-vc
+qL
 an
 jz
 gf
@@ -30194,13 +30195,13 @@ fX
 aR
 Oi
 pg
-VE
+QK
 be
 be
 be
 be
 be
-VE
+QK
 jz
 aX
 Rm
@@ -30451,13 +30452,13 @@ vU
 PA
 Sn
 Qj
-Lz
+KV
 EF
 rr
 be
 pW
 HM
-uY
+La
 jT
 aX
 iY
@@ -30700,11 +30701,11 @@ aK
 ab
 fV
 cJ
-ME
+qe
 cJ
 cJ
 cJ
-Sq
+px
 aR
 aX
 jk
@@ -30976,7 +30977,7 @@ mT
 qF
 an
 gR
-Cp
+ot
 hS
 hN
 QO
@@ -31222,13 +31223,13 @@ ab
 ab
 aX
 QM
-Yi
+zU
 yX
 Py
 Wr
 nE
 xU
-FR
+or
 VN
 Fp
 an
@@ -31493,7 +31494,7 @@ eX
 eX
 UP
 gr
-Ve
+ZV
 eX
 eX
 ab
@@ -31734,9 +31735,9 @@ ab
 ab
 ab
 ab
-fU
-MW
-wm
+vj
+Tl
+Fl
 aX
 iR
 aY
@@ -31991,9 +31992,9 @@ bg
 bm
 br
 ab
-Gn
-MW
-wm
+Fi
+Tl
+Fl
 aX
 iR
 aY
@@ -32248,9 +32249,9 @@ bh
 fL
 bs
 ab
-JI
-MW
-nZ
+zo
+Tl
+Hu
 aX
 iR
 Qo
@@ -32505,8 +32506,8 @@ bh
 bn
 bs
 ab
-PP
-PP
+pp
+pp
 ab
 gc
 iR
@@ -32519,7 +32520,7 @@ bT
 eT
 sZ
 bT
-HY
+wn
 hL
 mB
 bT
@@ -33020,7 +33021,7 @@ ct
 aJ
 ab
 iW
-Ft
+QP
 ab
 bD
 iR
@@ -33811,7 +33812,7 @@ aX
 aX
 aX
 aX
-En
+Ia
 ab
 aK
 cC
@@ -34068,7 +34069,7 @@ bT
 bT
 bT
 bT
-zz
+nz
 ab
 ii
 cC
@@ -34318,14 +34319,14 @@ an
 an
 aX
 bT
-Co
+If
 Tz
 bT
 bT
 bT
 bT
 bT
-En
+Ia
 ab
 aK
 cC
@@ -34579,7 +34580,7 @@ yx
 ft
 fv
 fv
-GU
+PE
 bT
 bT
 aX
@@ -34832,7 +34833,7 @@ kU
 Vx
 Mx
 BY
-jv
+pf
 fu
 fy
 fv
@@ -35093,7 +35094,7 @@ yx
 fv
 fv
 NC
-Wd
+FJ
 bT
 bT
 gd
@@ -36117,7 +36118,7 @@ aa
 an
 ff
 aY
-FK
+fC
 eO
 dU
 aY
@@ -36374,7 +36375,7 @@ bP
 bP
 aY
 aY
-FK
+fC
 eO
 aY
 aY
@@ -36626,12 +36627,12 @@ if
 tx
 bT
 ca
-Kb
+nq
 eC
 bP
 aY
 aY
-FK
+fC
 eO
 aY
 aY
@@ -36883,12 +36884,12 @@ if
 tx
 bT
 ca
-oT
+Wl
 BW
 bP
 aY
 aY
-FK
+fC
 eO
 gj
 aY
@@ -37145,7 +37146,7 @@ bP
 bP
 bP
 bP
-kj
+Ol
 hM
 hM
 hM
@@ -37398,17 +37399,17 @@ tx
 bT
 Pc
 pX
-lx
-Xw
+xl
+VJ
 eH
 bP
-AC
-dn
+yG
+qY
 xU
-Cq
+CX
 xU
-xu
-LM
+uR
+Wa
 Fp
 fG
 ab
@@ -38672,7 +38673,7 @@ ec
 af
 ah
 Ef
-ws
+to
 af
 mu
 af
@@ -38929,7 +38930,7 @@ ec
 af
 ai
 rj
-Rt
+IG
 di
 Ih
 ex
@@ -38946,9 +38947,9 @@ zf
 lo
 bl
 bl
-Cn
+Uo
 KM
-Gi
+CF
 eD
 bP
 bP
@@ -39188,7 +39189,7 @@ ai
 CI
 OU
 cw
-KC
+Mo
 af
 cH
 SD
@@ -39704,11 +39705,11 @@ Fn
 SC
 in
 bX
-Vi
+rk
 OD
 FM
 uK
-tj
+sI
 aG
 aG
 aG
@@ -39958,7 +39959,7 @@ aG
 aG
 ae
 pT
-iL
+iP
 Cx
 GX
 LN
@@ -40730,11 +40731,11 @@ aG
 ae
 yN
 in
-oq
+FH
 XB
 cH
 cH
-Nk
+vp
 cH
 cH
 nv
@@ -40752,7 +40753,7 @@ eQ
 is
 fq
 ui
-qv
+HG
 fq
 bP
 cC
@@ -40987,7 +40988,7 @@ ec
 ae
 mn
 zK
-qR
+yi
 XB
 cT
 cT

--- a/_maps/map_files/PVP/Hammurabi.dmm
+++ b/_maps/map_files/PVP/Hammurabi.dmm
@@ -151,20 +151,9 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/hangar)
-"aR" = (
-/obj/structure/window/reinforced/fulltile/ship/interior,
-/obj/structure/grille,
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi/medbay)
 "aS" = (
 /turf/open/floor/monotile/dark,
 /area/hammurabi)
-"aU" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/hammurabi/maintenance)
 "aV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -439,11 +428,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
-"cn" = (
-/obj/structure/window/reinforced/fulltile/ship/interior,
-/obj/structure/grille,
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi)
 "co" = (
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/mineral/plastitanium,
@@ -514,6 +498,10 @@
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi/medbay)
+"cE" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
 "cF" = (
 /obj/machinery/shower{
 	dir = 8
@@ -568,6 +556,12 @@
 	},
 /turf/open/floor/plating,
 /area/hammurabi/maintenance)
+"cP" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/hangar)
 "cQ" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/dna_scannernew,
@@ -647,15 +641,6 @@
 	},
 /turf/open/floor/plating,
 /area/hammurabi)
-"dh" = (
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/hammurabi/maintenance)
 "di" = (
 /obj/machinery/door/airlock/ship{
 	name = "TE/LE/COM core"
@@ -683,22 +668,27 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/bridge)
-"dq" = (
-/obj/structure/railing{
-	dir = 8;
-	icon_state = "railing0"
-	},
-/obj/structure/railing{
-	dir = 1;
-	icon_state = "railing0"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/bridge)
 "dr" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 1
 	},
 /turf/open/floor/monotile/dark,
+/area/hammurabi)
+"dt" = (
+/obj/machinery/power/port_gen/pacman,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 10
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 10
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating,
 /area/hammurabi)
 "du" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
@@ -772,12 +762,19 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/bridge)
 "dF" = (
-/obj/structure/railing{
-	dir = 8;
-	icon_state = "railing0"
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
 	},
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/bridge)
+/obj/machinery/advanced_airlock_controller/directional/east{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/hammurabi/hangar)
 "dG" = (
 /obj/machinery/light{
 	dir = 4
@@ -800,6 +797,12 @@
 	},
 /turf/open/floor/engine,
 /area/hammurabi)
+"dK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/turf/closed/wall/r_wall/ship,
+/area/hammurabi)
 "dL" = (
 /obj/machinery/atmospherics/components/binary/magnetic_constrictor{
 	dir = 1
@@ -815,14 +818,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hammurabi)
-"dN" = (
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 8;
-	icon_state = "railing0"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/bridge)
 "dR" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -1048,6 +1043,16 @@
 "eO" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"eP" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/turf/open/floor/plating,
 /area/hammurabi)
 "eQ" = (
 /obj/effect/turf_decal/stripes/line{
@@ -1536,32 +1541,14 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/armoury)
-"gI" = (
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/hammurabi/maintenance)
-"gJ" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/closed/wall/ship,
-/area/hammurabi/maintenance)
-"gK" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/closed/wall/ship,
-/area/hammurabi/maintenance)
 "gL" = (
 /obj/item/storage/belt/utility/full,
 /obj/structure/table/reinforced,
 /turf/open/floor/monotile/dark,
+/area/hammurabi)
+"gN" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
 "gO" = (
 /obj/effect/turf_decal/box,
@@ -1863,13 +1850,6 @@
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
-"hA" = (
-/obj/structure/window/reinforced/fulltile/ship/interior,
-/obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/carpet/red,
-/area/hammurabi)
 "hB" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -1942,11 +1922,6 @@
 /obj/structure/reagent_dispensers/fueltank/aviation_fuel,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
-"hM" = (
-/obj/structure/window/reinforced/fulltile/ship/interior,
-/obj/structure/grille,
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
 "hN" = (
 /obj/machinery/light{
 	dir = 4
@@ -1955,6 +1930,10 @@
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
+/area/hammurabi)
+"hO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plating,
 /area/hammurabi)
 "hQ" = (
 /obj/structure/chair{
@@ -2050,15 +2029,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/hangar)
-"im" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/hammurabi/maintenance)
 "in" = (
 /turf/open/floor/carpet/red,
 /area/hammurabi/bridge)
@@ -2071,19 +2041,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/hammurabi)
-"iq" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 10
-	},
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 10
-	},
-/obj/machinery/power/port_gen/pacman,
-/turf/open/floor/plating,
-/area/hammurabi/maintenance)
 "ir" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/plasteel/tech/grid,
@@ -2140,6 +2097,19 @@
 /obj/machinery/porta_turret/syndicate/pod,
 /turf/open/floor/plating/airless,
 /area/hammurabi/maintenance/exterior)
+"iD" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/hammurabi)
 "iO" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2176,6 +2146,20 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi)
+"iT" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/landmark/nuclear_waste_spawner,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
 "iU" = (
 /obj/structure/chair{
 	dir = 4
@@ -2200,18 +2184,6 @@
 /obj/vehicle/sealed/car/realistic/fighter_tug,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/hangar)
-"iY" = (
-/obj/structure/window/reinforced/fulltile/ship/interior,
-/obj/structure/grille,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
 "jf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -2330,6 +2302,12 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/carpet/red,
 /area/hammurabi)
+"jS" = (
+/obj/structure/shuttle/engine/heater{
+	dir = 8
+	},
+/turf/closed/wall/r_wall/ship,
+/area/hammurabi)
 "jT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -2337,6 +2315,26 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi)
+"ka" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	name = "Gravity generator"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plating,
+/area/hammurabi)
+"kh" = (
+/obj/structure/railing{
+	dir = 8;
+	icon_state = "railing0"
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/bridge)
 "kG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/mineral/plastitanium/red,
@@ -2354,6 +2352,19 @@
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
+"kO" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/floor/plating,
+/area/hammurabi)
+"kQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/hangar)
 "kU" = (
 /obj/machinery/door/airlock/ship{
 	name = "Munitions";
@@ -2366,6 +2377,26 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/stairs/medium,
+/area/hammurabi)
+"la" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/overmap/fighter/light/prebuilt/syndicate,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/hangar)
+"ld" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/o2{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/hammurabi)
 "li" = (
 /obj/structure/chair{
@@ -2398,22 +2429,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hammurabi)
-"lr" = (
-/obj/structure/window/reinforced/fulltile/ship/interior,
-/obj/structure/grille,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/landmark/nuclear_waste_spawner,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
 "lI" = (
 /obj/machinery/door/airlock/ship{
 	name = "Torpedo rack"
@@ -2422,6 +2437,13 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
+"lM" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/computer/atmos_control/tank/oxygen_tank,
+/turf/open/floor/monotile/dark,
 /area/hammurabi)
 "lR" = (
 /obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
@@ -2443,21 +2465,6 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass,
 /turf/open/floor/wood,
 /area/hammurabi/maintenance)
-"mb" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
-	},
-/obj/machinery/atmospherics/components/binary/valve/on,
-/turf/open/floor/plating,
-/area/hammurabi/maintenance)
-"mn" = (
-/obj/machinery/door/firedoor/window,
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/bridge)
 "mo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/mineral/plastitanium,
@@ -2513,14 +2520,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
-"mJ" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/engine,
-/area/hammurabi)
 "mT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -2539,6 +2538,10 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/armoury)
+"nk" = (
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
 "np" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -2566,21 +2569,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
-"nt" = (
-/obj/machinery/door/airlock/ship/external/glass,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/hammurabi)
-"nv" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/bridge)
 "nw" = (
 /obj/structure/table/reinforced,
 /obj/item/gun/ballistic/automatic/c20r/toy/unrestricted/riot,
@@ -2765,6 +2753,12 @@
 /obj/structure/extinguisher_cabinet/south,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/hangar)
+"pF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/carpet/red,
+/area/hammurabi)
 "pH" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable{
@@ -2779,12 +2773,24 @@
 /obj/structure/extinguisher_cabinet/south,
 /turf/open/floor/monotile/dark,
 /area/hammurabi)
-"pJ" = (
-/obj/structure/window/reinforced/fulltile/ship/interior,
-/obj/structure/grille,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/monotile/dark,
+"pL" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/oxygen_output{
+	dir = 4
+	},
+/turf/open/floor/engine/o2,
 /area/hammurabi)
+"pN" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/hangar)
 "pT" = (
 /obj/structure/chair/office,
 /turf/open/floor/carpet/red,
@@ -2802,6 +2808,13 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/armoury)
+"pZ" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
 "qe" = (
 /obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/monotile/dark,
@@ -2850,6 +2863,32 @@
 /obj/item/pipe_dispenser,
 /turf/open/floor/plating,
 /area/hammurabi)
+"qM" = (
+/obj/machinery/door/airlock/ship/external/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hammurabi)
+"qR" = (
+/obj/machinery/door/airlock/ship/external/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/plating,
+/area/hammurabi/hangar)
+"qT" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
 "qY" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -2873,6 +2912,10 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/bridge)
+"rm" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plasteel/dark,
+/area/hammurabi/hangar)
 "ro" = (
 /obj/structure/table/optable,
 /obj/machinery/firealarm/directional/west,
@@ -2914,15 +2957,22 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/carpet/red,
 /area/hammurabi)
-"rK" = (
-/obj/structure/window/reinforced/fulltile/ship/interior,
-/obj/structure/grille,
-/obj/machinery/door/firedoor/window,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+"rF" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
+"rR" = (
+/obj/machinery/power/terminal{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
 /turf/open/floor/plating,
 /area/hammurabi)
@@ -2944,11 +2994,6 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/armoury)
-"si" = (
-/obj/machinery/door/airlock/ship/external/glass,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
-/area/hammurabi/hangar)
 "sk" = (
 /obj/machinery/vending/boozeomat/syndicate_access,
 /turf/closed/wall/r_wall/ship,
@@ -2969,6 +3014,15 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/hammurabi/maintenance)
+"sy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
 "sD" = (
 /obj/item/storage/toolbox/syndicate,
 /obj/structure/table/reinforced,
@@ -3020,14 +3074,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
-"tf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/monotile/dark,
-/area/hammurabi)
 "tm" = (
 /obj/machinery/light{
 	dir = 4
@@ -3073,14 +3119,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/hangar)
-"tU" = (
-/obj/machinery/door/airlock/ship/maintenance,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plating,
-/area/hammurabi)
 "tZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -3101,6 +3139,15 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/armoury)
+"uc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
 "ud" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3165,6 +3212,14 @@
 /obj/item/shovel,
 /turf/open/floor/plating,
 /area/hammurabi)
+"uH" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hammurabi)
 "uK" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -3177,11 +3232,6 @@
 /obj/item/poster/random_contraband,
 /turf/open/floor/plating,
 /area/hammurabi/maintenance)
-"uQ" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plasteel/dark,
-/area/hammurabi/hangar)
 "uR" = (
 /obj/machinery/door/airlock/ship{
 	name = "Ammo rack"
@@ -3224,19 +3274,18 @@
 /obj/machinery/autolathe,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/maintenance)
+"vm" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine,
+/area/hammurabi)
 "vp" = (
 /obj/effect/landmark/nuclear_waste_spawner,
 /obj/machinery/holopad,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/bridge)
-"vq" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/hammurabi)
 "vJ" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 9
@@ -3278,12 +3327,6 @@
 	},
 /turf/open/floor/wood,
 /area/hammurabi/maintenance)
-"wb" = (
-/obj/structure/window/reinforced/fulltile/ship/interior,
-/obj/structure/grille,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/hammurabi)
 "wj" = (
 /obj/machinery/computer/ship/tactical{
 	dir = 8;
@@ -3352,11 +3395,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
-"wM" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi)
 "wN" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -3367,10 +3405,10 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/armoury)
-"wP" = (
-/obj/machinery/door/firedoor/border_only/directional/south,
+"wO" = (
+/obj/structure/grille,
 /turf/open/floor/plating,
-/area/hammurabi/maintenance)
+/area/hammurabi)
 "wQ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3580,6 +3618,16 @@
 	},
 /turf/open/floor/carpet/red,
 /area/hammurabi/bridge)
+"yO" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
 "yX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -3607,6 +3655,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/armoury)
+"zi" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
 "zj" = (
 /obj/structure/extinguisher_cabinet/north,
 /turf/open/floor/plasteel/tech/grid,
@@ -3685,6 +3739,18 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/hangar)
+"zS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/hangar)
 "zU" = (
 /obj/machinery/door/airlock/ship{
 	name = "Aft frame"
@@ -3749,6 +3815,19 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/carpet/red,
 /area/hammurabi/bridge)
+"AC" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/engine,
+/area/hammurabi)
+"AJ" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi/hangar)
 "AR" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
@@ -3896,6 +3975,13 @@
 /obj/item/pen,
 /turf/open/floor/monotile/dark,
 /area/hammurabi/tcomms)
+"CU" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/oxygen_input{
+	icon_state = "inje_map-3";
+	piping_layer = 3
+	},
+/turf/open/floor/engine/o2,
+/area/hammurabi)
 "CX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
@@ -4019,6 +4105,16 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
+"Ey" = (
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/hammurabi)
 "EC" = (
 /obj/machinery/computer/ship/viewscreen,
 /obj/structure/cable/yellow{
@@ -4041,10 +4137,32 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/carpet/red,
 /area/hammurabi)
+"EG" = (
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/hammurabi)
 "EK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/hangar)
+"EL" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/hammurabi)
+"EP" = (
+/obj/machinery/door/airlock/ship/maintenance,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/hammurabi)
 "ES" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
@@ -4070,6 +4188,10 @@
 /obj/structure/extinguisher_cabinet/south,
 /turf/open/floor/plating,
 /area/hammurabi)
+"Fe" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/hammurabi/medbay)
 "Fi" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/glass{
@@ -4078,15 +4200,16 @@
 /obj/item/stack/sheet/iron/twenty,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/maintenance)
-"Fl" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/ship/interior,
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi/maintenance)
 "Fn" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/carpet/red,
 /area/hammurabi/bridge)
+"Fo" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/closed/wall/ship,
+/area/hammurabi)
 "Fp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1;
@@ -4130,6 +4253,23 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/hangar)
+"FF" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4;
+	icon_state = "vent_map_on-2"
+	},
+/obj/machinery/airalarm/directional/north{
+	req_access = null;
+	req_one_access_txt = "150"
+	},
+/turf/open/floor/plating,
+/area/hammurabi)
 "FH" = (
 /mob/living/simple_animal/pet/cat/space{
 	faction = list("Syndicate");
@@ -4184,9 +4324,23 @@
 /obj/structure/table_frame,
 /turf/open/floor/plating,
 /area/hammurabi/maintenance)
+"FV" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "Oxygen to Distro"
+	},
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
 "Gd" = (
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"GI" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/hammurabi)
 "GN" = (
 /obj/structure/cable{
@@ -4198,6 +4352,10 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi)
+"GS" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/hammurabi)
 "GW" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
@@ -4228,6 +4386,10 @@
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi/maintenance)
+"Hx" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
 "HB" = (
 /obj/structure/closet/radiation,
 /obj/item/clothing/mask/gas,
@@ -4240,10 +4402,29 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/armoury)
+"HH" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
 "HM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/carpet/red,
 /area/hammurabi)
+"HP" = (
+/obj/structure/railing{
+	dir = 9
+	},
+/obj/structure/railing{
+	dir = 9;
+	icon_state = "railing0"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/bridge)
 "HQ" = (
 /obj/structure/extinguisher_cabinet/east,
 /turf/open/floor/plasteel/tech/grid,
@@ -4275,16 +4456,6 @@
 /obj/item/ship_weapon/ammunition/torpedo/torpedo_casing,
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
-"Id" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/hammurabi/maintenance)
 "If" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -4312,12 +4483,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/hangar)
-"Io" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/hammurabi)
 "IG" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -4330,21 +4495,6 @@
 	},
 /turf/open/floor/monotile,
 /area/hammurabi/tcomms)
-"IK" = (
-/obj/structure/window/reinforced/fulltile/ship/interior,
-/obj/structure/grille,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
 "IL" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	name = "Armoury";
@@ -4418,12 +4568,40 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hammurabi)
+"JJ" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
 "JN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
+"Kb" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hammurabi)
+"Kd" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
 /area/hammurabi)
 "Kl" = (
 /obj/structure/cable{
@@ -4439,12 +4617,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/hangar)
-"KG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
-/turf/closed/wall/ship,
-/area/hammurabi/maintenance)
 "KM" = (
 /obj/machinery/light{
 	dir = 8
@@ -4453,11 +4625,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/armoury)
-"KP" = (
-/obj/structure/window/reinforced/fulltile/ship/interior,
-/obj/structure/grille,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plasteel/tech/grid,
+"KQ" = (
+/obj/machinery/airalarm/directional/west{
+	req_access = null;
+	req_one_access_txt = "150"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/monotile/dark,
 /area/hammurabi)
 "KT" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -4540,11 +4714,6 @@
 /obj/item/toy/plush/nukeplushie,
 /turf/open/floor/monotile,
 /area/hammurabi/tcomms)
-"Ms" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/monotile/dark,
-/area/hammurabi/hangar)
 "Mw" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
@@ -4596,6 +4765,12 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/bridge)
+"Ng" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/turf/closed/wall/r_wall/ship,
+/area/hammurabi)
 "Nz" = (
 /obj/item/chair/stool/bar,
 /turf/open/floor/wood{
@@ -4689,22 +4864,15 @@
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
-"Om" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/hammurabi)
 "Oq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/hangar)
+"Or" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/hammurabi)
 "Os" = (
 /obj/structure/closet/radiation,
 /obj/item/clothing/mask/gas,
@@ -4768,6 +4936,18 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
+"Pb" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/hangar)
 "Pc" = (
 /obj/machinery/door/airlock/ship{
 	name = "Marine suit storage";
@@ -4798,6 +4978,16 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/hangar)
+"Ps" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/hammurabi)
 "Py" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -4821,6 +5011,22 @@
 /obj/machinery/atmospherics/components/binary/stormdrive_reactor/syndicate,
 /turf/open/floor/engine,
 /area/hammurabi)
+"PD" = (
+/obj/machinery/power/port_gen/pacman,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 10
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 10
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/hammurabi)
 "PE" = (
 /obj/structure/table/reinforced,
 /obj/item/ship_weapon/parts/torpedo/propulsion_system,
@@ -4838,6 +5044,13 @@
 /obj/item/ship_weapon/parts/torpedo/propulsion_system,
 /obj/item/ship_weapon/parts/torpedo/propulsion_system,
 /turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi)
+"PJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible/layer3,
+/turf/open/floor/engine/o2,
 /area/hammurabi)
 "PN" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -4872,13 +5085,6 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plating,
 /area/hammurabi/maintenance)
-"PZ" = (
-/obj/machinery/door/airlock/ship/external/glass,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/hammurabi/hangar)
 "Qf" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -5008,6 +5214,15 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/plating,
 /area/hammurabi/maintenance)
+"QR" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/closed/wall/ship,
+/area/hammurabi)
 "QZ" = (
 /obj/machinery/door/airlock/ship{
 	name = "Small ammunition"
@@ -5028,15 +5243,18 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
-"Rm" = (
-/obj/structure/window/reinforced/fulltile/ship/interior,
-/obj/structure/grille,
-/obj/structure/cable{
-	icon_state = "0-4"
+"Rg" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/hangar)
 "Rq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4;
@@ -5067,6 +5285,16 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/hangar)
+"RD" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
+"RG" = (
+/obj/machinery/atmospherics/miner/oxygen,
+/turf/open/floor/engine/o2,
+/area/hammurabi)
 "RI" = (
 /obj/machinery/airalarm/directional/north{
 	req_access = null;
@@ -5083,18 +5311,6 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/plating,
 /area/hammurabi/maintenance)
-"RT" = (
-/obj/structure/window/reinforced/fulltile/ship/interior,
-/obj/structure/grille,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
 "RZ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -5114,11 +5330,25 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hammurabi)
+"Si" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
 "Sn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi)
+"Sq" = (
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/structure/railing{
+	dir = 10;
+	icon_state = "railing0"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/bridge)
 "Sv" = (
 /obj/structure/sign/warning/vacuum/external,
 /turf/closed/wall/ship,
@@ -5142,20 +5372,26 @@
 	},
 /turf/open/floor/carpet/red,
 /area/hammurabi/bridge)
-"SV" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/firedoor/window,
+"SF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/airlock/ship{
+	name = "Engineering"
+	},
 /turf/open/floor/plating,
 /area/hammurabi)
-"SY" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+"SK" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/hammurabi/maintenance)
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/hangar)
 "Tl" = (
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi/maintenance)
@@ -5172,13 +5408,6 @@
 	},
 /turf/open/floor/plating,
 /area/hammurabi)
-"Tv" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/hammurabi/hangar)
 "Tz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1;
@@ -5186,6 +5415,25 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
+"Ua" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/overmap/fighter/light/prebuilt/syndicate,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/hangar)
+"Uc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/hangar)
 "Uo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -5205,6 +5453,12 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/hangar)
+"UB" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/simple/green/visible/layer3,
+/turf/open/floor/plating,
+/area/hammurabi)
 "UD" = (
 /obj/effect/landmark/nuclear_waste_spawner,
 /turf/closed/wall/ship,
@@ -5217,6 +5471,10 @@
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi)
+"UM" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
 /area/hammurabi)
 "UP" = (
 /obj/effect/turf_decal/stripes/line{
@@ -5242,10 +5500,10 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi)
-"UY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plating,
-/area/hammurabi/maintenance)
+"Ve" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/bridge)
 "Vm" = (
 /obj/machinery/door/airlock/ship{
 	name = "Plasma Storage"
@@ -5254,6 +5512,10 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/monotile/dark,
 /area/hammurabi)
+"Vp" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/monotile/dark,
+/area/hammurabi/hangar)
 "Vq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 1
@@ -5340,6 +5602,27 @@
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
+"Wb" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
+"Wh" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi/hangar)
 "Wl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
@@ -5350,12 +5633,6 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/armoury)
-"Wn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
-	},
-/turf/closed/wall/ship,
-/area/hammurabi/maintenance)
 "Wr" = (
 /obj/machinery/light{
 	dir = 8
@@ -5364,26 +5641,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
-"Wu" = (
-/obj/machinery/atmospherics/components/unary/tank/oxygen,
-/turf/open/floor/plating,
-/area/hammurabi/maintenance)
-"Wx" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+"WC" = (
+/obj/machinery/power/terminal{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/light,
 /turf/open/floor/plating,
-/area/hammurabi/maintenance)
-"WH" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/engine,
 /area/hammurabi)
 "WN" = (
 /obj/machinery/door/airlock/ship/engineering{
@@ -5395,6 +5664,13 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plating,
+/area/hammurabi)
+"WP" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4;
+	icon_state = "vent_map_on-2"
+	},
+/turf/open/floor/monotile/dark,
 /area/hammurabi)
 "WR" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
@@ -5442,6 +5718,15 @@
 	broken = 1
 	},
 /area/hammurabi/maintenance)
+"Xk" = (
+/obj/machinery/door/airlock/ship/external/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plating,
+/area/hammurabi/hangar)
 "Xr" = (
 /obj/machinery/light{
 	dir = 1
@@ -5452,14 +5737,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/hangar)
-"Xy" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	name = "Gravity generator"
-	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/plating,
-/area/hammurabi)
 "XB" = (
 /obj/structure/fluff/bleepypanel,
 /turf/closed/wall/ship,
@@ -5536,6 +5813,26 @@
 /obj/item/extinguisher/advanced/hull_repair_juice,
 /turf/open/floor/plating,
 /area/hammurabi/maintenance)
+"YE" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"YI" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
 "YL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1;
@@ -5615,18 +5912,6 @@
 	broken = 1
 	},
 /area/hammurabi/maintenance)
-"Zi" = (
-/obj/machinery/door/airlock/ship/maintenance,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/hammurabi/maintenance)
 "Zl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -5636,6 +5921,18 @@
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
+"Zx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/hangar)
 "ZV" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/airalarm/directional/west{
@@ -25820,13 +26117,13 @@ cp
 cp
 cp
 cp
-ab
-ab
-es
-an
-an
-bb
-an
+ca
+ca
+jS
+ca
+ca
+jS
+ca
 ca
 ec
 ep
@@ -26075,11 +26372,11 @@ cp
 cp
 cp
 Fy
-KG
-es
-ab
-aK
-aK
+Ng
+jS
+ca
+EL
+wO
 an
 be
 fM
@@ -26332,16 +26629,16 @@ cp
 cp
 cp
 ef
-Wn
-UY
-UY
-UY
-Id
+dK
+hO
+hO
+hO
+eP
 oO
 ip
 hY
 be
-WH
+AC
 dc
 dC
 dH
@@ -26589,16 +26886,16 @@ cp
 cp
 cp
 cp
-ab
-aK
-ab
-ab
-Zi
+ca
+ca
+ca
+ca
+Kb
 an
 EC
 hn
 bI
-mJ
+vm
 dd
 PC
 dI
@@ -26846,16 +27143,16 @@ cp
 cp
 cp
 cp
-ab
-aK
-ab
-ii
-SY
+ca
+RG
+pL
+Or
+Kb
 an
 rE
 tm
 be
-WH
+AC
 de
 dx
 dJ
@@ -27103,22 +27400,22 @@ an
 an
 bb
 an
+ca
+CU
+PJ
+UB
+ld
 an
-aK
-ab
-iq
-Wx
-an
-wb
-rK
+GS
+Ps
 nC
 cx
-Io
-vq
-SV
+kO
+GI
+UM
 ca
 ca
-nt
+qM
 ca
 ab
 FK
@@ -27361,10 +27658,10 @@ aX
 aX
 aX
 an
-aK
-ab
-iq
-Wx
+Or
+uH
+ca
+iD
 an
 BI
 KU
@@ -27375,7 +27672,7 @@ zd
 dL
 YM
 ca
-Om
+FF
 sG
 ab
 lT
@@ -27616,12 +27913,12 @@ aX
 dr
 aS
 ei
-aX
+Rq
 an
-aK
-ab
-aK
-SY
+lM
+FV
+KQ
+rF
 an
 nB
 Og
@@ -27873,12 +28170,12 @@ gc
 aS
 eh
 ej
-aX
-Xy
-gy
-ab
-cO
-SY
+sy
+ka
+DH
+pZ
+WP
+Kd
 an
 rs
 Yz
@@ -28130,14 +28427,14 @@ aX
 ee
 aS
 ek
-aX
+er
 an
-aK
-ab
-Wu
-mb
-tU
-tf
+nk
+uc
+rD
+JJ
+SF
+DH
 vV
 dz
 dM
@@ -28389,10 +28686,10 @@ aX
 aX
 HQ
 an
-aK
-ab
-aU
-im
+dt
+Wb
+Wb
+HH
 an
 gZ
 Vz
@@ -28645,11 +28942,11 @@ ab
 ab
 ab
 ab
-ab
-aK
-ab
-dh
-dh
+an
+PD
+RD
+rR
+WC
 an
 Qi
 Ao
@@ -28901,12 +29198,12 @@ aK
 aK
 aK
 aK
-wP
 aK
-aK
-ab
-gI
-gI
+EP
+zi
+aS
+Ey
+EG
 an
 gL
 Ao
@@ -29159,12 +29456,12 @@ aK
 ab
 ab
 ab
-ab
-ab
-ab
-gJ
-gK
-ab
+an
+an
+an
+QR
+Fo
+an
 an
 UR
 an
@@ -29950,10 +30247,10 @@ aX
 an
 bD
 hQ
-Rm
+YE
 gi
 hQ
-Rm
+YE
 aS
 ab
 cC
@@ -30192,7 +30489,7 @@ cJ
 cS
 cW
 fX
-aR
+Fe
 Oi
 pg
 QK
@@ -30204,13 +30501,13 @@ be
 QK
 jz
 aX
-Rm
+YE
 Bm
 Rq
-RT
+yO
 Bm
 Rq
-RT
+yO
 pI
 ab
 cC
@@ -30461,13 +30758,13 @@ HM
 La
 jT
 aX
-iY
+qT
 wY
 kL
-lr
+iT
 uX
 sb
-IK
+YI
 dM
 OK
 hW
@@ -30706,7 +31003,7 @@ cJ
 cJ
 cJ
 px
-aR
+Fe
 aX
 jk
 an
@@ -31201,11 +31498,11 @@ aa
 cp
 cp
 cp
-si
-Tv
-PZ
-aJ
-bh
+qR
+dF
+Xk
+El
+Rg
 bn
 bs
 aJ
@@ -31462,7 +31759,7 @@ az
 az
 az
 aJ
-bi
+pN
 bo
 bu
 aJ
@@ -31719,7 +32016,7 @@ cp
 cp
 az
 pl
-aJ
+wr
 aJ
 aJ
 aJ
@@ -31737,7 +32034,7 @@ ab
 ab
 vj
 Tl
-Fl
+cE
 aX
 iR
 aY
@@ -31976,7 +32273,7 @@ cp
 cp
 az
 aJ
-bg
+Uc
 bm
 br
 aJ
@@ -31994,7 +32291,7 @@ br
 ab
 Fi
 Tl
-Fl
+cE
 aX
 iR
 aY
@@ -32233,12 +32530,12 @@ cp
 cp
 az
 aJ
-bh
-fL
-bs
-aJ
-bh
-fL
+zS
+Ua
+cP
+El
+kQ
+la
 bs
 aJ
 bh
@@ -32495,7 +32792,7 @@ bn
 bs
 aJ
 bh
-bn
+SK
 bs
 aJ
 bh
@@ -32752,7 +33049,7 @@ bo
 bu
 aJ
 bi
-bo
+Zx
 bu
 aJ
 bi
@@ -33009,7 +33306,7 @@ au
 au
 au
 lS
-ct
+Pb
 aJ
 aJ
 aJ
@@ -33266,7 +33563,7 @@ bp
 aB
 by
 bB
-bB
+Fq
 bB
 zM
 bB
@@ -33523,7 +33820,7 @@ aE
 bv
 by
 bB
-bB
+Fq
 Pp
 eu
 tD
@@ -33549,8 +33846,8 @@ an
 an
 an
 qI
-cn
-cn
+Hx
+Hx
 Yq
 an
 an
@@ -33780,7 +34077,7 @@ aH
 aH
 by
 aJ
-bB
+Fq
 bB
 bB
 bB
@@ -33792,15 +34089,15 @@ Fq
 RB
 az
 aa
-pJ
-pJ
+GS
+GS
 bT
 iQ
 gt
 Zl
 bT
-pJ
-pJ
+GS
+GS
 aa
 an
 fb
@@ -34031,13 +34328,13 @@ cp
 cp
 au
 au
-uQ
-uQ
-uQ
+rm
+rm
+rm
 au
 au
 aO
-aJ
+wr
 aJ
 aJ
 aJ
@@ -34049,7 +34346,7 @@ MY
 aJ
 az
 aa
-pJ
+GS
 bT
 bT
 iQ
@@ -34057,7 +34354,7 @@ aY
 Zl
 bT
 bT
-pJ
+GS
 aa
 an
 fb
@@ -34287,14 +34584,14 @@ cp
 cp
 cp
 dw
-uQ
+rm
 aM
 bj
 bq
 As
 au
 aP
-ha
+Wh
 ha
 hd
 he
@@ -34551,7 +34848,7 @@ DN
 Hs
 Du
 Xa
-El
+AJ
 oW
 fO
 az
@@ -34801,7 +35098,7 @@ cp
 cp
 cp
 dw
-uQ
+rm
 bf
 bj
 bq
@@ -35059,9 +35356,9 @@ cp
 cp
 au
 au
-uQ
-uQ
-uQ
+rm
+rm
+rm
 au
 au
 Xr
@@ -35591,7 +35888,7 @@ bB
 pC
 az
 aa
-pJ
+GS
 bT
 bT
 iQ
@@ -35599,7 +35896,7 @@ aY
 Zl
 bT
 bT
-KP
+GS
 aa
 an
 fb
@@ -35847,16 +36144,16 @@ bB
 cy
 bB
 az
-pJ
-pJ
-pJ
+GS
+GS
+GS
 bT
 iQ
 gj
 Zl
 Ep
-pJ
-KP
+GS
+GS
 aa
 an
 fe
@@ -37120,17 +37417,17 @@ cp
 cp
 cp
 az
-Ms
-Ms
-Ms
+Vp
+Vp
+Vp
 aJ
 aJ
 ic
 aJ
 aJ
-Ms
-Ms
-Ms
+Vp
+Vp
+Vp
 an
 gp
 cj
@@ -37147,9 +37444,9 @@ bP
 bP
 bP
 Ol
-hM
-hM
-hM
+Si
+Si
+Si
 Rr
 an
 an
@@ -37379,16 +37676,16 @@ cp
 cp
 cp
 cp
-Ms
-Ms
-Ms
-Ms
-Ms
-Ms
-Ms
+Vp
+Vp
+Vp
+Vp
+Vp
+Vp
+Vp
 ec
 ec
-wM
+gN
 pW
 wz
 jQ
@@ -37645,16 +37942,16 @@ ec
 ec
 ec
 ec
-wM
+gN
 yr
 yv
-hA
+pF
 tZ
 xf
 Lt
 KT
 bT
-cn
+Hx
 pX
 np
 eV
@@ -37665,7 +37962,7 @@ Ct
 hy
 fZ
 hz
-hM
+Si
 er
 aX
 ie
@@ -37902,7 +38199,7 @@ ec
 ec
 ec
 ec
-wM
+gN
 be
 be
 jQ
@@ -37922,7 +38219,7 @@ fi
 fo
 fi
 fo
-hM
+Si
 aX
 aX
 fG
@@ -40477,9 +40774,9 @@ it
 uw
 XB
 Lr
-dq
-dF
-dN
+HP
+kh
+Sq
 Lr
 ab
 ab
@@ -40738,7 +41035,7 @@ cH
 vp
 cH
 cH
-nv
+Ve
 ec
 ec
 ab
@@ -40986,7 +41283,7 @@ ec
 ec
 ec
 ae
-mn
+Ve
 zK
 yi
 XB
@@ -40995,7 +41292,7 @@ cT
 cT
 cT
 cT
-nv
+Ve
 ec
 ec
 ab
@@ -41243,16 +41540,16 @@ cp
 cp
 dY
 ec
-mn
-mn
-mn
+Ve
+Ve
+Ve
 bX
 sl
 Bq
 Lh
 Bq
 ps
-nv
+Ve
 ec
 ec
 ab
@@ -41509,7 +41806,7 @@ wj
 go
 xH
 YU
-nv
+Ve
 ec
 ec
 ab
@@ -41761,12 +42058,12 @@ ec
 ec
 ec
 bX
-nv
-nv
-nv
-nv
-nv
-nv
+Ve
+Ve
+Ve
+Ve
+Ve
+Ve
 ec
 ec
 ab

--- a/_maps/map_files/PVP/Hammurabi.dmm
+++ b/_maps/map_files/PVP/Hammurabi.dmm
@@ -404,13 +404,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/armoury)
-"cd" = (
-/obj/machinery/shower{
-	dir = 8;
-	name = "emergency shower"
-	},
-/turf/open/floor/plasteel/grid/techfloor/grid,
-/area/hammurabi)
 "ce" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -618,15 +611,6 @@
 /obj/item/wrench,
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi/medbay)
-"db" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/table/reinforced,
-/obj/item/storage/belt/utility/full,
-/obj/item/storage/belt/utility/full,
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/maintenance)
 "dc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -694,6 +678,13 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/red,
+/area/hammurabi)
+"dn" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
 "dp" = (
 /obj/structure/table/reinforced,
@@ -1016,11 +1007,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi)
-"eB" = (
-/obj/structure/girder/reinforced,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/hammurabi/maintenance)
 "eC" = (
 /obj/machinery/suit_storage_unit/syndicate,
 /obj/effect/turf_decal/box,
@@ -1042,10 +1028,6 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/armoury)
-"eI" = (
-/obj/machinery/computer/atmos_alert,
-/turf/open/floor/monotile/dark,
-/area/hammurabi)
 "eJ" = (
 /obj/machinery/suit_storage_unit/syndicate/odst,
 /obj/effect/turf_decal/box,
@@ -1342,11 +1324,8 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/hangar)
 "fU" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/turf/open/floor/wood,
+/obj/machinery/autolathe,
+/turf/open/floor/mineral/plastitanium,
 /area/hammurabi/maintenance)
 "fV" = (
 /obj/machinery/computer/ship/viewscreen,
@@ -1583,10 +1562,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/monotile/dark,
 /area/hammurabi)
-"gN" = (
-/obj/effect/landmark/nuclear_waste_spawner,
-/turf/open/floor/monotile/dark,
-/area/hammurabi/medbay)
 "gO" = (
 /obj/effect/turf_decal/box,
 /obj/structure/closet/firecloset,
@@ -2256,11 +2231,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi)
-"jm" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi)
 "jo" = (
 /obj/machinery/door/airlock/ship{
 	name = "Bridge frame";
@@ -2282,6 +2252,11 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/hangar)
+"jv" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
 "jz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -2365,20 +2340,20 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi)
-"kz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/airalarm/directional/west{
-	req_access = null;
-	req_one_access_txt = "150"
+"kj" = (
+/obj/machinery/door/airlock/ship{
+	name = "Missile tubes"
 	},
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/armoury)
-"kA" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/ship/interior,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/tech/grid,
-/area/hammurabi/maintenance)
+/area/hammurabi)
 "kG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/mineral/plastitanium/red,
@@ -2456,12 +2431,13 @@
 /obj/machinery/door/firedoor/window,
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
-"lG" = (
-/obj/machinery/computer/ship/viewscreen,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi/bridge)
+"lx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet/west,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/armoury)
 "lI" = (
 /obj/machinery/door/airlock/ship{
 	name = "Torpedo rack"
@@ -2471,15 +2447,6 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
-"lJ" = (
-/obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
-	dir = 4
-	},
-/obj/structure/table/wood,
-/turf/open/floor/wood{
-	broken = 1
-	},
-/area/hammurabi/maintenance)
 "lS" = (
 /obj/structure/extinguisher_cabinet/north,
 /turf/open/floor/mineral/plastitanium/red,
@@ -2544,16 +2511,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
-"mG" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
-	},
-/obj/machinery/atmospherics/components/binary/valve/on,
-/turf/open/floor/plating,
-/area/hammurabi/maintenance)
 "mJ" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
 /obj/structure/cable/yellow{
@@ -2647,6 +2604,14 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/bridge)
+"nZ" = (
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/airlock/ship{
+	name = "Central frame"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi/maintenance)
 "od" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2697,24 +2662,16 @@
 	},
 /turf/open/floor/plating,
 /area/hammurabi)
-"oV" = (
-/obj/structure/table/reinforced,
-/obj/item/ship_weapon/parts/torpedo/propulsion_system,
-/obj/item/ship_weapon/parts/torpedo/propulsion_system,
-/obj/item/ship_weapon/parts/torpedo/propulsion_system,
-/obj/item/ship_weapon/parts/torpedo/propulsion_system,
-/obj/item/ship_weapon/parts/torpedo/warhead,
-/obj/item/ship_weapon/parts/torpedo/warhead,
-/obj/item/ship_weapon/parts/torpedo/warhead/decoy,
-/obj/item/ship_weapon/parts/torpedo/warhead/decoy,
-/obj/item/ship_weapon/parts/torpedo/warhead/decoy,
-/obj/item/ship_weapon/parts/torpedo/warhead,
-/obj/item/ship_weapon/parts/torpedo/warhead,
-/obj/item/ship_weapon/parts/torpedo/propulsion_system,
-/obj/item/ship_weapon/parts/torpedo/propulsion_system,
-/obj/item/ship_weapon/parts/torpedo/propulsion_system,
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi)
+"oT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/armoury)
 "oW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -2792,19 +2749,6 @@
 /obj/machinery/door/firedoor/window,
 /turf/open/floor/monotile/dark,
 /area/hammurabi)
-"pO" = (
-/obj/machinery/suit_storage_unit/syndicate,
-/obj/effect/turf_decal/box,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4;
-	icon_state = "vent_map_on-2"
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi/armoury)
 "pT" = (
 /obj/structure/chair/office,
 /turf/open/floor/carpet/red,
@@ -2838,6 +2782,10 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plating,
 /area/hammurabi/maintenance)
+"qv" = (
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi/armoury)
 "qF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
@@ -2858,12 +2806,6 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
-"qO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
 "qR" = (
 /obj/structure/bed,
 /obj/item/bedsheet/syndie,
@@ -2871,12 +2813,6 @@
 /obj/item/toy/figure/syndie,
 /turf/open/floor/carpet/red,
 /area/hammurabi/bridge)
-"rh" = (
-/obj/item/chair/stool/bar,
-/turf/open/floor/wood{
-	broken = 1
-	},
-/area/hammurabi/maintenance)
 "rj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -2920,6 +2856,24 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/carpet/red,
 /area/hammurabi)
+"rH" = (
+/obj/structure/chair/stool/bar,
+/turf/open/floor/wood,
+/area/hammurabi/maintenance)
+"rI" = (
+/obj/structure/table/wood/poker,
+/obj/item/dice/d6{
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/obj/item/dice/d6{
+	pixel_x = -4;
+	pixel_y = -2
+	},
+/turf/open/floor/wood{
+	broken = 1
+	},
+/area/hammurabi/maintenance)
 "rK" = (
 /obj/structure/window/reinforced/fulltile/ship/interior,
 /obj/structure/grille,
@@ -2975,13 +2929,39 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/hammurabi/maintenance)
-"sx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+"st" = (
+/obj/machinery/atmospherics/pipe/manifold4w/orange/visible,
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel/tech/grid,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/meter,
+/turf/open/floor/plating,
 /area/hammurabi)
+"sz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/wood{
+	broken = 1
+	},
+/area/hammurabi/maintenance)
+"sC" = (
+/obj/machinery/light/small,
+/obj/structure/table/wood/poker,
+/obj/item/stack/spacecash/c200{
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 7
+	},
+/turf/open/floor/wood,
+/area/hammurabi/maintenance)
 "sD" = (
 /obj/item/storage/toolbox/syndicate,
 /obj/structure/table/reinforced,
@@ -3027,6 +3007,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/dark,
 /area/hammurabi)
+"tj" = (
+/obj/machinery/airalarm/directional/south{
+	req_access = null;
+	req_one_access_txt = "150"
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi/bridge)
 "tm" = (
 /obj/machinery/light{
 	dir = 4
@@ -3039,14 +3026,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/hammurabi)
-"tw" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/sheet/glass{
-	amount = 15
-	},
-/obj/item/stack/sheet/iron/twenty,
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/maintenance)
 "tx" = (
 /obj/structure/chair{
 	dir = 4
@@ -3065,6 +3044,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/hangar)
+"tH" = (
+/obj/item/ship_weapon/parts/torpedo/warhead/bunker_buster,
+/obj/structure/table/reinforced,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
 "tU" = (
 /obj/machinery/door/airlock/ship/maintenance,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -3187,6 +3171,12 @@
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
+"uY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
 "uZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -3202,6 +3192,14 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/armoury)
+"vc" = (
+/obj/item/storage/toolbox/electrical{
+	icon_state = "syndicate"
+	},
+/obj/structure/table/reinforced,
+/obj/item/pipe_dispenser,
+/turf/open/floor/plating,
+/area/hammurabi)
 "vq" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
 /obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
@@ -3216,11 +3214,6 @@
 	},
 /turf/open/floor/plating,
 /area/hammurabi)
-"vL" = (
-/turf/open/floor/wood{
-	broken = 1
-	},
-/area/hammurabi/maintenance)
 "vS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
@@ -3245,17 +3238,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/dark,
 /area/hammurabi)
-"vX" = (
-/obj/machinery/door/airlock/ship/engineering{
-	dir = 2;
-	icon_state = "closed";
-	name = "Reactor core";
-	req_one_access_txt = null
-	},
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plating,
-/area/hammurabi)
 "wb" = (
 /obj/structure/window/reinforced/fulltile/ship/interior,
 /obj/structure/grille,
@@ -3273,6 +3255,11 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/bridge)
+"wm" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/ship/interior,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi/maintenance)
 "wr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -3282,6 +3269,17 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/hangar)
+"ws" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4;
+	icon_state = "vent_map_on-2"
+	},
+/turf/open/floor/monotile/dark,
+/area/hammurabi/tcomms)
 "wz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
@@ -3301,10 +3299,6 @@
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
-/area/hammurabi)
-"wG" = (
-/obj/item/ship_weapon/ammunition/torpedo/torpedo_casing,
-/turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
 "wI" = (
 /obj/effect/turf_decal/stripes/line,
@@ -3349,18 +3343,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/hammurabi)
-"wR" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/open/floor/monotile,
-/area/hammurabi/tcomms)
 "wY" = (
 /obj/machinery/door/poddoor/ship{
 	dir = 4;
@@ -3399,14 +3381,14 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/bridge)
-"xk" = (
+"xu" = (
 /obj/machinery/door/airlock/ship{
-	name = "Aft frame"
+	name = "Ammo rack"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
 "xv" = (
@@ -3507,6 +3489,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/carpet/red,
 /area/hammurabi)
+"ys" = (
+/turf/open/floor/wood{
+	broken = 1
+	},
+/area/hammurabi/maintenance)
 "yu" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -3529,6 +3516,12 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
+"yz" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood,
+/area/hammurabi/maintenance)
 "yF" = (
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/plating,
@@ -3542,6 +3535,11 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
+"yI" = (
+/obj/structure/girder/reinforced,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
 "yN" = (
 /obj/structure/displaycase{
 	req_access = list(151);
@@ -3549,22 +3547,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/hammurabi/bridge)
-"yQ" = (
-/obj/machinery/atmospherics/pipe/manifold4w/orange/visible,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/meter,
-/turf/open/floor/plating,
-/area/hammurabi)
-"yW" = (
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/structure/barricade/wooden/crude,
-/turf/open/floor/plating,
-/area/hammurabi/maintenance)
 "yX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -3593,6 +3575,17 @@
 	dir = 5
 	},
 /turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
+"zt" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
+"zz" = (
+/obj/structure/extinguisher_cabinet/south,
+/obj/item/ship_weapon/ammunition/torpedo/torpedo_casing,
+/turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
 "zD" = (
 /obj/machinery/light{
@@ -3650,17 +3643,15 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/hangar)
+"zO" = (
+/obj/item/chair/stool/bar,
+/turf/open/floor/wood{
+	broken = 1
+	},
+/area/hammurabi/maintenance)
 "zV" = (
 /obj/structure/extinguisher_cabinet/north,
 /turf/open/floor/mineral/plastitanium,
-/area/hammurabi)
-"Af" = (
-/obj/machinery/door/airlock/ship{
-	name = "Plasma Storage"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/monotile/dark,
 /area/hammurabi)
 "Aj" = (
 /obj/effect/turf_decal/stripes/line{
@@ -3674,17 +3665,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
-"Am" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4;
-	icon_state = "vent_map_on-2"
-	},
-/turf/open/floor/monotile/dark,
-/area/hammurabi/tcomms)
 "Ao" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3720,11 +3700,16 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/carpet/red,
 /area/hammurabi/bridge)
-"AB" = (
-/obj/item/ship_weapon/parts/torpedo/warhead/bunker_buster,
-/obj/structure/table/reinforced,
-/turf/open/floor/plating,
-/area/hammurabi/maintenance)
+"AC" = (
+/obj/structure/extinguisher_cabinet/north,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
 "AR" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
@@ -3738,13 +3723,6 @@
 	},
 /turf/open/floor/plating,
 /area/hammurabi/maintenance)
-"AT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet/west,
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/armoury)
 "AX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/components/binary/dp_vent_pump,
@@ -3806,24 +3784,6 @@
 /obj/machinery/computer/monitor,
 /turf/open/floor/monotile/dark,
 /area/hammurabi)
-"BJ" = (
-/obj/machinery/airalarm/directional/north{
-	req_access = null;
-	req_one_access_txt = "150"
-	},
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/monotile/dark,
-/area/hammurabi)
-"BN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/armoury)
 "BP" = (
 /obj/machinery/door/airlock/ship{
 	name = "Bridge frame";
@@ -3853,6 +3813,41 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
+"Cn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/airalarm/directional/west{
+	req_access = null;
+	req_one_access_txt = "150"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/armoury)
+"Co" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
+"Cp" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/east{
+	req_access = null;
+	req_one_access_txt = "150"
+	},
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
+"Cq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
 "Ct" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -3887,26 +3882,6 @@
 /obj/item/pen,
 /turf/open/floor/monotile/dark,
 /area/hammurabi/tcomms)
-"CM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
-"CP" = (
-/obj/machinery/door/airlock/ship{
-	name = "Missile tubes"
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
 "Db" = (
 /obj/machinery/door/airlock/ship{
 	name = "Marine suit storage";
@@ -3957,14 +3932,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/dark,
 /area/hammurabi/hangar)
-"DQ" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4;
-	icon_state = "vent_map_on-2"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi)
 "DR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -4007,14 +3974,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hammurabi/tcomms)
-"Eg" = (
-/obj/item/storage/toolbox/electrical{
-	icon_state = "syndicate"
-	},
-/obj/structure/table/reinforced,
-/obj/item/pipe_dispenser,
-/turf/open/floor/plating,
-/area/hammurabi)
 "Ek" = (
 /obj/machinery/door/airlock/ship/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -4034,6 +3993,10 @@
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
+"En" = (
+/obj/item/ship_weapon/ammunition/torpedo/torpedo_casing,
+/turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
 "Ep" = (
 /obj/machinery/firealarm/directional/east,
@@ -4090,13 +4053,6 @@
 /obj/structure/extinguisher_cabinet/south,
 /turf/open/floor/plating,
 /area/hammurabi)
-"Fi" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
 "Fn" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/carpet/red,
@@ -4124,6 +4080,11 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/plating,
 /area/hammurabi/maintenance)
+"Ft" = (
+/obj/item/organ/wings/moth,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
 "Fu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/vehicle/sealed/car/realistic/fighter_tug,
@@ -4144,6 +4105,18 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/hangar)
+"FK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
 "FM" = (
 /obj/machinery/light{
 	dir = 8
@@ -4152,6 +4125,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/bridge)
+"FR" = (
+/obj/machinery/door/airlock/ship{
+	name = "Aft frame"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
 "FS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -4161,37 +4144,28 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hammurabi)
-"FX" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/open/floor/plating,
-/area/hammurabi)
 "Gd" = (
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
-"Gh" = (
-/obj/machinery/door/airlock/ship{
-	name = "Plasma Storage"
+"Gi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
 	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/monotile/dark,
-/area/hammurabi)
-"Gy" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/armoury)
+"Gn" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/glass{
+	amount = 15
 	},
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi/medbay)
+/obj/item/stack/sheet/iron/twenty,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/maintenance)
 "GN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4203,26 +4177,23 @@
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi)
-"GQ" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/airalarm/directional/west{
-	req_access = null;
-	req_one_access_txt = "150"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi)
-"GV" = (
-/obj/machinery/door/airlock/ship{
-	name = "Aft frame"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/plasteel/tech/grid,
+"GU" = (
+/obj/structure/table/reinforced,
+/obj/item/ship_weapon/parts/torpedo/propulsion_system,
+/obj/item/ship_weapon/parts/torpedo/propulsion_system,
+/obj/item/ship_weapon/parts/torpedo/propulsion_system,
+/obj/item/ship_weapon/parts/torpedo/propulsion_system,
+/obj/item/ship_weapon/parts/torpedo/warhead,
+/obj/item/ship_weapon/parts/torpedo/warhead,
+/obj/item/ship_weapon/parts/torpedo/warhead/decoy,
+/obj/item/ship_weapon/parts/torpedo/warhead/decoy,
+/obj/item/ship_weapon/parts/torpedo/warhead/decoy,
+/obj/item/ship_weapon/parts/torpedo/warhead,
+/obj/item/ship_weapon/parts/torpedo/warhead,
+/obj/item/ship_weapon/parts/torpedo/propulsion_system,
+/obj/item/ship_weapon/parts/torpedo/propulsion_system,
+/obj/item/ship_weapon/parts/torpedo/propulsion_system,
+/turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi)
 "GW" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
@@ -4240,24 +4211,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/bridge)
-"Hc" = (
-/obj/structure/rack,
-/obj/item/stack/cable_coil/random,
-/obj/item/stack/sheet/iron/fifty,
-/obj/machinery/computer/ship/viewscreen,
-/obj/item/clothing/head/welding,
-/turf/open/floor/monotile/dark,
-/area/hammurabi)
-"Hl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/armoury)
 "Hs" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -4291,6 +4244,14 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/plating,
 /area/hammurabi/maintenance)
+"HY" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4;
+	icon_state = "vent_map_on-2"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
 "Id" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable/yellow{
@@ -4319,10 +4280,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/hangar)
-"In" = (
-/obj/structure/chair/stool/bar,
-/turf/open/floor/wood,
-/area/hammurabi/maintenance)
 "Io" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
@@ -4372,17 +4329,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
-"IY" = (
-/obj/machinery/light/small,
-/obj/structure/table/wood/poker,
-/obj/item/stack/spacecash/c200{
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = 7
-	},
-/turf/open/floor/wood,
-/area/hammurabi/maintenance)
 "Jp" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
@@ -4390,6 +4336,16 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/hangar)
+"Jq" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/binary/valve/on,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
 "Jr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/mineral/plastitanium,
@@ -4398,14 +4354,6 @@
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/hammurabi/maintenance)
-"Jw" = (
-/obj/machinery/door/airlock/glass_large/ship{
-	name = "cryostasis"
-	},
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
 "Jy" = (
 /obj/machinery/vending/cola/sodie,
 /turf/open/floor/carpet/red,
@@ -4422,6 +4370,15 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hammurabi)
+"JI" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/belt/utility/full,
+/obj/item/storage/belt/utility/full,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/maintenance)
 "JN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
@@ -4429,6 +4386,19 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
+"Kb" = (
+/obj/machinery/suit_storage_unit/syndicate,
+/obj/effect/turf_decal/box,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4;
+	icon_state = "vent_map_on-2"
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi/armoury)
 "Kl" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4443,18 +4413,26 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/hangar)
+"KC" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/closet/syndicate{
+	name = "equipment closet"
+	},
+/obj/item/clothing/mask/chameleon,
+/obj/machinery/airalarm/directional/south{
+	req_access = null;
+	req_one_access_txt = "150"
+	},
+/turf/open/floor/monotile,
+/area/hammurabi/tcomms)
 "KG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
 /turf/closed/wall/ship,
 /area/hammurabi/maintenance)
-"KL" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 8
-	},
-/turf/open/floor/monotile/dark,
-/area/hammurabi)
 "KM" = (
 /obj/machinery/light{
 	dir = 8
@@ -4463,6 +4441,22 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/armoury)
+"KN" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/turf/open/floor/wood,
+/area/hammurabi/maintenance)
+"KO" = (
+/obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/turf/open/floor/wood{
+	broken = 1
+	},
+/area/hammurabi/maintenance)
 "KP" = (
 /obj/structure/window/reinforced/fulltile/ship/interior,
 /obj/structure/grille,
@@ -4509,17 +4503,25 @@
 	},
 /turf/open/floor/carpet/red,
 /area/hammurabi)
-"LD" = (
-/obj/structure/grille,
-/obj/structure/table_frame,
-/turf/open/floor/plating,
-/area/hammurabi/maintenance)
+"Lz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
 "LF" = (
 /obj/item/gun/ballistic/automatic/c20r/toy/unrestricted/riot,
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/armoury)
+"LM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
 "LN" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -4528,6 +4530,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/bridge)
+"Md" = (
+/obj/machinery/door/airlock/ship{
+	name = "Plasma Storage"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
 "Ms" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
 /obj/machinery/door/firedoor/window,
@@ -4548,6 +4558,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
+"ME" = (
+/obj/effect/landmark/nuclear_waste_spawner,
+/turf/open/floor/monotile/dark,
+/area/hammurabi/medbay)
 "MS" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4556,6 +4570,17 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
+/area/hammurabi/maintenance)
+"MU" = (
+/obj/machinery/airalarm/directional/north{
+	req_access = null;
+	req_one_access_txt = "150"
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
+"MW" = (
+/turf/open/floor/plasteel/tech/grid,
 /area/hammurabi/maintenance)
 "MY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -4584,13 +4609,11 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/bridge)
-"Nv" = (
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi/maintenance)
-"Ny" = (
-/obj/machinery/autolathe,
+"Nk" = (
+/obj/effect/landmark/nuclear_waste_spawner,
+/obj/machinery/holopad,
 /turf/open/floor/mineral/plastitanium,
-/area/hammurabi/maintenance)
+/area/hammurabi/bridge)
 "NC" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/iron/fifty,
@@ -4640,6 +4663,14 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/armoury)
+"Oe" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood{
+	broken = 1
+	},
+/area/hammurabi/maintenance)
 "Og" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4716,16 +4747,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
-"OS" = (
-/obj/machinery/door/airlock/ship{
-	name = "Ammo rack"
-	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
 "OU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -4767,6 +4788,16 @@
 	icon_state = "stairs-m"
 	},
 /area/hammurabi/hangar)
+"Pe" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/open/floor/plating,
+/area/hammurabi)
 "Pi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/mineral/plastitanium/red,
@@ -4798,10 +4829,6 @@
 /obj/machinery/atmospherics/components/binary/stormdrive_reactor/syndicate,
 /turf/open/floor/engine,
 /area/hammurabi)
-"PD" = (
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi/armoury)
 "PN" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -4814,6 +4841,11 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/armoury)
+"PP" = (
+/obj/structure/closet/radiation,
+/obj/item/shovel,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/maintenance)
 "PT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -4883,25 +4915,6 @@
 	},
 /turf/open/floor/plating,
 /area/hammurabi/maintenance)
-"Qv" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/cable_coil,
-/obj/item/ship_weapon/parts/torpedo/guidance_system,
-/obj/item/ship_weapon/parts/torpedo/guidance_system,
-/obj/item/ship_weapon/parts/torpedo/guidance_system,
-/obj/item/ship_weapon/parts/torpedo/guidance_system,
-/obj/item/ship_weapon/parts/torpedo/iff_card,
-/obj/item/ship_weapon/parts/torpedo/iff_card,
-/obj/item/ship_weapon/parts/torpedo/iff_card,
-/obj/item/ship_weapon/parts/torpedo/iff_card,
-/obj/item/ship_weapon/parts/torpedo/iff_card,
-/obj/item/ship_weapon/parts/torpedo/iff_card,
-/obj/item/ship_weapon/parts/torpedo/iff_card,
-/obj/item/ship_weapon/parts/torpedo/guidance_system,
-/obj/item/ship_weapon/parts/torpedo/guidance_system,
-/obj/item/ship_weapon/parts/torpedo/guidance_system,
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi)
 "Qw" = (
 /obj/structure/closet/radiation,
 /obj/item/shovel,
@@ -4916,14 +4929,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi)
-"QF" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/airalarm/directional/west{
-	req_access = null;
-	req_one_access_txt = "150"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/armoury)
 "QJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -4987,18 +4992,6 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
-"Ri" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
 "Rm" = (
 /obj/structure/window/reinforced/fulltile/ship/interior,
 /obj/structure/grille,
@@ -5024,15 +5017,17 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
 "Rt" = (
-/obj/structure/extinguisher_cabinet/north,
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
+/turf/open/floor/monotile,
+/area/hammurabi/tcomms)
 "Rv" = (
 /obj/machinery/computer/communications{
 	dir = 8;
@@ -5095,45 +5090,21 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hammurabi)
-"Sh" = (
-/obj/item/organ/wings/moth,
-/obj/effect/decal/remains/human,
-/turf/open/floor/plating,
-/area/hammurabi/maintenance)
 "Sn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi)
+"Sq" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi/medbay)
 "Sv" = (
 /obj/structure/sign/warning/vacuum/external,
 /turf/closed/wall/ship,
 /area/hammurabi/hangar)
-"Sx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/wood{
-	broken = 1
-	},
-/area/hammurabi/maintenance)
-"SA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/closet/syndicate{
-	name = "equipment closet"
-	},
-/obj/item/clothing/mask/chameleon,
-/obj/machinery/airalarm/directional/south{
-	req_access = null;
-	req_one_access_txt = "150"
-	},
-/turf/open/floor/monotile,
-/area/hammurabi/tcomms)
 "SC" = (
 /obj/structure/table/wood,
 /obj/item/phone{
@@ -5167,6 +5138,10 @@
 	},
 /turf/open/floor/plating,
 /area/hammurabi/maintenance)
+"Td" = (
+/obj/machinery/atmospherics/components/binary/valve,
+/turf/open/floor/plating,
+/area/hammurabi)
 "Tu" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -5187,6 +5162,10 @@
 	},
 /turf/open/floor/plating,
 /area/hammurabi/hangar)
+"Tw" = (
+/obj/machinery/computer/atmos_alert,
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
 "Tz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1;
@@ -5194,17 +5173,24 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
-"TH" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+"TQ" = (
+/obj/machinery/door/airlock/ship{
+	name = "Plasma Storage"
 	},
-/turf/open/floor/wood{
-	broken = 1
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
 	},
-/area/hammurabi/maintenance)
-"TP" = (
-/obj/machinery/atmospherics/components/binary/valve,
-/turf/open/floor/plating,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/monotile/dark,
+/area/hammurabi)
+"Uj" = (
+/obj/structure/rack,
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/sheet/iron/fifty,
+/obj/machinery/computer/ship/viewscreen,
+/obj/item/clothing/head/welding,
+/turf/open/floor/monotile/dark,
 /area/hammurabi)
 "Ur" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -5228,15 +5214,6 @@
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi)
-"UN" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
 "UP" = (
 /obj/effect/turf_decal/stripes/line{
@@ -5266,6 +5243,20 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/hammurabi/maintenance)
+"Ve" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/airalarm/directional/west{
+	req_access = null;
+	req_one_access_txt = "150"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi)
+"Vi" = (
+/obj/machinery/computer/ship/viewscreen,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi/bridge)
 "Vq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 1
@@ -5275,16 +5266,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi)
-"Vr" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/east{
-	req_access = null;
-	req_one_access_txt = "150"
-	},
-/turf/open/floor/monotile/dark,
 /area/hammurabi)
 "Vt" = (
 /obj/machinery/space_heater,
@@ -5339,19 +5320,13 @@
 /turf/open/floor/carpet/red,
 /area/hammurabi/bridge)
 "VE" = (
-/obj/structure/table/wood/poker,
-/obj/item/dice/d6{
-	pixel_x = 7;
-	pixel_y = 5
+/obj/machinery/door/airlock/glass_large/ship{
+	name = "cryostasis"
 	},
-/obj/item/dice/d6{
-	pixel_x = -4;
-	pixel_y = -2
-	},
-/turf/open/floor/wood{
-	broken = 1
-	},
-/area/hammurabi/maintenance)
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
 "VN" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -5360,6 +5335,36 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"Wd" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/cable_coil,
+/obj/item/ship_weapon/parts/torpedo/guidance_system,
+/obj/item/ship_weapon/parts/torpedo/guidance_system,
+/obj/item/ship_weapon/parts/torpedo/guidance_system,
+/obj/item/ship_weapon/parts/torpedo/guidance_system,
+/obj/item/ship_weapon/parts/torpedo/iff_card,
+/obj/item/ship_weapon/parts/torpedo/iff_card,
+/obj/item/ship_weapon/parts/torpedo/iff_card,
+/obj/item/ship_weapon/parts/torpedo/iff_card,
+/obj/item/ship_weapon/parts/torpedo/iff_card,
+/obj/item/ship_weapon/parts/torpedo/iff_card,
+/obj/item/ship_weapon/parts/torpedo/iff_card,
+/obj/item/ship_weapon/parts/torpedo/guidance_system,
+/obj/item/ship_weapon/parts/torpedo/guidance_system,
+/obj/item/ship_weapon/parts/torpedo/guidance_system,
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi)
+"Wj" = (
+/obj/machinery/door/airlock/ship/engineering{
+	dir = 2;
+	icon_state = "closed";
+	name = "Reactor core";
+	req_one_access_txt = null
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
 /area/hammurabi)
 "Wn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -5396,6 +5401,11 @@
 /obj/machinery/door/firedoor/window,
 /turf/open/floor/engine,
 /area/hammurabi)
+"WR" = (
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/plating,
+/area/hammurabi/maintenance)
 "WU" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -5425,13 +5435,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/hangar)
-"Xb" = (
-/obj/machinery/airalarm/directional/south{
-	req_access = null;
-	req_one_access_txt = "150"
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi/bridge)
 "Xr" = (
 /obj/machinery/light{
 	dir = 1
@@ -5443,10 +5446,13 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi/hangar)
 "Xw" = (
-/obj/structure/extinguisher_cabinet/south,
-/obj/item/ship_weapon/ammunition/torpedo/torpedo_casing,
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/airalarm/directional/west{
+	req_access = null;
+	req_one_access_txt = "150"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/armoury)
 "Xy" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	name = "Gravity generator"
@@ -5475,17 +5481,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/carpet/red,
 /area/hammurabi/bridge)
-"XT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi)
-"XU" = (
-/obj/structure/closet/radiation,
-/obj/item/shovel,
-/turf/open/floor/mineral/plastitanium,
+"XL" = (
+/obj/structure/grille,
+/obj/structure/table_frame,
+/turf/open/floor/plating,
 /area/hammurabi/maintenance)
 "Yd" = (
 /obj/structure/cable{
@@ -5503,16 +5502,18 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi)
 "Yi" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/door/airlock/ship{
+	name = "Aft frame"
 	},
-/turf/open/floor/wood,
-/area/hammurabi/maintenance)
-"Ym" = (
-/obj/effect/landmark/nuclear_waste_spawner,
-/obj/machinery/holopad,
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/bridge)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
 "Yq" = (
 /obj/machinery/door/airlock/ship{
 	name = "Storage junction"
@@ -5530,14 +5531,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/armoury)
-"Yy" = (
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/airlock/ship{
-	name = "Central frame"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi/maintenance)
 "Yz" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5642,6 +5635,13 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech/grid,
+/area/hammurabi)
+"Zv" = (
+/obj/machinery/shower{
+	dir = 8;
+	name = "emergency shower"
+	},
+/turf/open/floor/plasteel/grid/techfloor/grid,
 /area/hammurabi)
 
 (1,1,1) = {"
@@ -26601,7 +26601,7 @@ mJ
 dd
 PC
 dI
-vX
+Wj
 dZ
 dZ
 jA
@@ -27120,8 +27120,8 @@ ca
 nt
 ca
 ab
-Yi
-lJ
+yz
+KO
 ab
 cC
 ab
@@ -27370,16 +27370,16 @@ KU
 bK
 cz
 dg
-yQ
+st
 dL
-FX
+Pe
 ca
 Om
-cd
+Zv
 ab
-fU
-vL
-yW
+KN
+ys
+WR
 cC
 ab
 cp
@@ -27622,20 +27622,20 @@ ab
 aK
 SY
 an
-eI
+Tw
 Og
 bL
 aS
 aS
-KL
+zt
 aS
 Fd
 ca
 jJ
 ca
 ab
-TH
-In
+Oe
+rH
 ab
 cC
 ab
@@ -27879,7 +27879,7 @@ ab
 cO
 SY
 an
-BJ
+MU
 Yz
 oQ
 aS
@@ -27891,8 +27891,8 @@ aS
 jP
 jD
 ab
-Yi
-VE
+yz
+rI
 ab
 cC
 ab
@@ -28134,7 +28134,7 @@ an
 aK
 ab
 Wu
-mG
+Jq
 tU
 tf
 vV
@@ -28148,8 +28148,8 @@ dM
 JG
 hD
 OK
-Sx
-IY
+sz
+sC
 ab
 hF
 ab
@@ -28405,8 +28405,8 @@ aS
 FS
 aS
 ab
-rh
-vL
+zO
+ys
 ab
 cC
 ab
@@ -28650,7 +28650,7 @@ ab
 dh
 dh
 an
-Hc
+Uj
 Ao
 bL
 cq
@@ -28662,7 +28662,7 @@ aS
 FS
 dT
 ab
-eB
+yI
 ab
 ab
 cC
@@ -28919,8 +28919,8 @@ aS
 FS
 dT
 ab
-AB
-LD
+tH
+XL
 ab
 gS
 gX
@@ -29168,9 +29168,9 @@ an
 UR
 an
 an
-Af
+Md
 an
-Gh
+TQ
 an
 an
 NQ
@@ -29425,10 +29425,10 @@ hk
 Yd
 an
 cB
-TP
+Td
 GW
 vJ
-Eg
+vc
 an
 jz
 gf
@@ -30194,13 +30194,13 @@ fX
 aR
 Oi
 pg
-Jw
+VE
 be
 be
 be
 be
 be
-Jw
+VE
 jz
 aX
 Rm
@@ -30451,13 +30451,13 @@ vU
 PA
 Sn
 Qj
-qO
+Lz
 EF
 rr
 be
 pW
 HM
-CM
+uY
 jT
 aX
 iY
@@ -30700,11 +30700,11 @@ aK
 ab
 fV
 cJ
-gN
+ME
 cJ
 cJ
 cJ
-Gy
+Sq
 aR
 aX
 jk
@@ -30976,7 +30976,7 @@ mT
 qF
 an
 gR
-Vr
+Cp
 hS
 hN
 QO
@@ -31222,13 +31222,13 @@ ab
 ab
 aX
 QM
-GV
+Yi
 yX
 Py
 Wr
 nE
 xU
-xk
+FR
 VN
 Fp
 an
@@ -31493,7 +31493,7 @@ eX
 eX
 UP
 gr
-GQ
+Ve
 eX
 eX
 ab
@@ -31734,9 +31734,9 @@ ab
 ab
 ab
 ab
-Ny
-Nv
-kA
+fU
+MW
+wm
 aX
 iR
 aY
@@ -31991,9 +31991,9 @@ bg
 bm
 br
 ab
-tw
-Nv
-kA
+Gn
+MW
+wm
 aX
 iR
 aY
@@ -32248,9 +32248,9 @@ bh
 fL
 bs
 ab
-db
-Nv
-Yy
+JI
+MW
+nZ
 aX
 iR
 Qo
@@ -32505,8 +32505,8 @@ bh
 bn
 bs
 ab
-XU
-XU
+PP
+PP
 ab
 gc
 iR
@@ -32519,7 +32519,7 @@ bT
 eT
 sZ
 bT
-DQ
+HY
 hL
 mB
 bT
@@ -33020,7 +33020,7 @@ ct
 aJ
 ab
 iW
-Sh
+Ft
 ab
 bD
 iR
@@ -33811,7 +33811,7 @@ aX
 aX
 aX
 aX
-wG
+En
 ab
 aK
 cC
@@ -34068,7 +34068,7 @@ bT
 bT
 bT
 bT
-Xw
+zz
 ab
 ii
 cC
@@ -34318,14 +34318,14 @@ an
 an
 aX
 bT
-UN
+Co
 Tz
 bT
 bT
 bT
 bT
 bT
-wG
+En
 ab
 aK
 cC
@@ -34579,7 +34579,7 @@ yx
 ft
 fv
 fv
-oV
+GU
 bT
 bT
 aX
@@ -34832,7 +34832,7 @@ kU
 Vx
 Mx
 BY
-jm
+jv
 fu
 fy
 fv
@@ -35093,7 +35093,7 @@ yx
 fv
 fv
 NC
-Qv
+Wd
 bT
 bT
 gd
@@ -36117,7 +36117,7 @@ aa
 an
 ff
 aY
-Ri
+FK
 eO
 dU
 aY
@@ -36374,7 +36374,7 @@ bP
 bP
 aY
 aY
-Ri
+FK
 eO
 aY
 aY
@@ -36626,12 +36626,12 @@ if
 tx
 bT
 ca
-pO
+Kb
 eC
 bP
 aY
 aY
-Ri
+FK
 eO
 aY
 aY
@@ -36883,12 +36883,12 @@ if
 tx
 bT
 ca
-Hl
+oT
 BW
 bP
 aY
 aY
-Ri
+FK
 eO
 gj
 aY
@@ -37145,7 +37145,7 @@ bP
 bP
 bP
 bP
-CP
+kj
 hM
 hM
 hM
@@ -37398,17 +37398,17 @@ tx
 bT
 Pc
 pX
-AT
-QF
+lx
+Xw
 eH
 bP
-Rt
-Fi
+AC
+dn
 xU
-sx
+Cq
 xU
-OS
-XT
+xu
+LM
 Fp
 fG
 ab
@@ -38672,7 +38672,7 @@ ec
 af
 ah
 Ef
-Am
+ws
 af
 mu
 af
@@ -38929,7 +38929,7 @@ ec
 af
 ai
 rj
-wR
+Rt
 di
 Ih
 ex
@@ -38946,9 +38946,9 @@ zf
 lo
 bl
 bl
-kz
+Cn
 KM
-BN
+Gi
 eD
 bP
 bP
@@ -39188,7 +39188,7 @@ ai
 CI
 OU
 cw
-SA
+KC
 af
 cH
 SD
@@ -39704,11 +39704,11 @@ Fn
 SC
 in
 bX
-lG
+Vi
 OD
 FM
 uK
-Xb
+tj
 aG
 aG
 aG
@@ -40734,7 +40734,7 @@ oq
 XB
 cH
 cH
-Ym
+Nk
 cH
 cH
 nv
@@ -40752,7 +40752,7 @@ eQ
 is
 fq
 ui
-PD
+qv
 fq
 bP
 cC

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -275,7 +275,7 @@
 	if(!is_centcom_level(T.z))//if not, don't bother
 		return FALSE
 
-	if(istype(T.loc, /area/shuttle/syndicate) || istype(T.loc, /area/syndicate_mothership) || istype(T.loc, /area/shuttle/assault_pod))
+	if(istype(T.loc, /area/shuttle/syndicate) || istype(T.loc, /area/syndicate_mothership) || istype(T.loc, /area/shuttle/assault_pod || istype(T.loc, /area/hammurabi))
 		return TRUE
 
 	return FALSE

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -275,7 +275,7 @@
 	if(!is_centcom_level(T.z))//if not, don't bother
 		return FALSE
 
-	if(istype(T.loc, /area/shuttle/syndicate) || istype(T.loc, /area/syndicate_mothership) || istype(T.loc, /area/shuttle/assault_pod) || istype(T.loc, /area/hammurabi))
+	if(istype(T.loc, /area/shuttle/syndicate) || istype(T.loc, /area/syndicate_mothership) || istype(T.loc, /area/shuttle/assault_pod) || istype(T.loc, /area/hammurabi)) //NSV13 added Hammurabi as a valid syndicate base
 		return TRUE
 
 	return FALSE

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -275,7 +275,7 @@
 	if(!is_centcom_level(T.z))//if not, don't bother
 		return FALSE
 
-	if(istype(T.loc, /area/shuttle/syndicate) || istype(T.loc, /area/syndicate_mothership) || istype(T.loc, /area/shuttle/assault_pod || istype(T.loc, /area/hammurabi))
+	if(istype(T.loc, /area/shuttle/syndicate) || istype(T.loc, /area/syndicate_mothership) || istype(T.loc, /area/shuttle/assault_pod) || istype(T.loc, /area/hammurabi))
 		return TRUE
 
 	return FALSE


### PR DESCRIPTION
## Changes
Improves the SSV Hammurabi map in various ways which make the Hammurabi less of a pain to play on in general.
I also added an autolathe to the map, something which I have heard many people ask for. Please don't make me regret putting it there.
There's also now air scrubbers, fire alarms, fire extinguishers and hull repair juice on the ship.

## Changelog
:cl:
fix: You can now properly declare war as the Syndicates during PVP.
fix: Makes the SSV Hammurabi Monstermos and Nuke Torpedo compliant.
add: Syndicate Telecommunications operators now get a voice changer to confuse the crew!
add: The Syndicate Captain now has a sweet new office!
add: Gives the Syndicate an autolathe on their ship.
/:cl:

I thought people may wanna see the changed things in a nice picture so I'll add some here:
Captain's room:
![image](https://user-images.githubusercontent.com/43698041/91318056-1a0a3a80-e7bb-11ea-847a-a710b9015d81.png)
Tool storage with autolathe
![image](https://user-images.githubusercontent.com/43698041/91318149-360ddc00-e7bb-11ea-8054-3b42707cd534.png)
New and improved telecomms center with paper for writing notes, intercom for actually communicating and a gas mask voice changer to be an actual comms agent.
![image](https://user-images.githubusercontent.com/43698041/91318379-74a39680-e7bb-11ea-8340-eee3a4744e6f.png)
Reworked engineering, now with: welding mask, rpd, electrical toolbox, atmos and power monitors, a valve for plasma to the reactor and emergency Co2!
![image](https://user-images.githubusercontent.com/43698041/91318800-ebd92a80-e7bb-11ea-9d46-3bca95bb4f59.png)
(also some cheecky hull juice and welding tanks, of which there are more at the airlock just in case)