### PR TITLE
Updates Hammerhead to be Monstermos compatible and have armor pumps + other fixes

### DIFF
--- a/_maps/map_files/Hammerhead/Hammerhead.dmm
+++ b/_maps/map_files/Hammerhead/Hammerhead.dmm
@@ -29153,7 +29153,6 @@
 	id = "ad_torp";
 	name = "Arms Dump Torpedo Storage";
 	pixel_x = -24;
-	pixel_y = 0;
 	req_one_access_txt = "70;71"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -44575,7 +44574,6 @@
 	id = "hos_privacy";
 	name = "Privacy Shutters";
 	pixel_x = 24;
-	pixel_y = 0;
 	req_one_access_txt = "58"
 	},
 /turf/open/floor/plasteel/dark,
@@ -47964,7 +47962,6 @@
 /obj/machinery/button/door{
 	id = "ad_gun";
 	name = "Arms Dump Gun Storage";
-	pixel_x = 0;
 	pixel_y = 24;
 	req_one_access_txt = "3;58"
 	},
@@ -54538,7 +54535,6 @@
 	department = "Head of Security's Desk";
 	departmentType = 5;
 	name = "Head of Security RC";
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/structure/disposalpipe/segment{

--- a/_maps/map_files/Hammerhead/Hammerhead.dmm
+++ b/_maps/map_files/Hammerhead/Hammerhead.dmm
@@ -27921,6 +27921,11 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"dqG" = (
+/obj/item/radio/intercom/directional/west,
+/obj/machinery/computer/monitor/console,
+/turf/open/floor/plasteel/dark,
+/area/maintenance/port/central)
 "dqL" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/structure/closet/secure_closet/engineering_personal,
@@ -28423,6 +28428,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"dKc" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "dKj" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder{
@@ -28463,6 +28477,10 @@
 /obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/plasteel,
 /area/science/lab)
+"dMn" = (
+/obj/structure/chair,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "dMT" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -28552,6 +28570,11 @@
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
+"dQU" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/four,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "dRb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -28882,11 +28905,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/exit)
-"egx" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "egP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -28942,6 +28960,19 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/exit)
+"eiX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "ejn" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Hangar Bay"
@@ -29133,17 +29164,6 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/security/prison)
-"erc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "ert" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/cable{
@@ -29514,6 +29534,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"eHH" = (
+/obj/machinery/mecha_part_fabricator/maint{
+	name = "forgotten exosuit fabricator"
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/circuit/green,
+/area/maintenance/fore)
 "eHR" = (
 /obj/item/wrench,
 /obj/item/stack/sheet/glass{
@@ -30588,6 +30615,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"fzX" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 5
+	},
+/turf/template_noop,
+/area/maintenance/starboard/central)
 "fAj" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
@@ -30956,15 +30998,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/security/courtroom)
-"fNf" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/ship,
-/area/hallway/primary/fore)
 "fNx" = (
 /obj/machinery/light{
 	dir = 8
@@ -31239,6 +31272,15 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/ship,
 /area/ai_monitored/turret_protected/aisat/hallway/support_ship)
+"gan" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "gaw" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	dir = 4;
@@ -31286,14 +31328,6 @@
 /obj/machinery/microwave,
 /turf/open/floor/carpet/orange,
 /area/engine/break_room)
-"geR" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "geX" = (
 /obj/machinery/light{
 	dir = 8
@@ -31489,6 +31523,10 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/exit)
+"goT" = (
+/obj/structure/table_frame,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "gpm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31511,6 +31549,17 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
+"gqw" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "gqM" = (
 /obj/machinery/computer/ship/viewscreen,
 /obj/structure/munitions_trolley,
@@ -31617,6 +31666,14 @@
 /obj/item/book/manual/wiki/security_space_law,
 /turf/open/floor/carpet/red,
 /area/security/detectives_office/private_investigators_office)
+"gvE" = (
+/obj/machinery/door/airlock/ship/engineering{
+	name = "Engineering Post";
+	req_one_access_txt = "10"
+	},
+/obj/effect/mapping_helpers/airlock/abandoned,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "gvH" = (
 /obj/structure/table/reinforced,
 /obj/item/airlock_painter,
@@ -31812,6 +31869,11 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
+"gCv" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/four,
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "gCY" = (
 /obj/machinery/light,
 /turf/open/floor/carpet/ship,
@@ -31914,18 +31976,6 @@
 /obj/structure/closet/wardrobe/white,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
-"gKv" = (
-/obj/machinery/door/airlock/ship/engineering{
-	name = "Engineering Cupboard";
-	req_one_access_txt = "10"
-	},
-/obj/effect/mapping_helpers/airlock/abandoned,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
-"gLu" = (
-/obj/effect/landmark/blobstart,
-/turf/template_noop,
-/area/maintenance/port/central)
 "gLy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -33473,10 +33523,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"hJz" = (
-/obj/effect/landmark/blobstart,
-/turf/template_noop,
-/area/maintenance/department/electrical)
 "hJS" = (
 /obj/machinery/light,
 /obj/structure/closet/l3closet/scientist,
@@ -34234,6 +34280,11 @@
 "iqF" = (
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"iqZ" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "irC" = (
 /obj/machinery/light/floor,
 /turf/open/floor/plasteel/ship/techfloor/alt,
@@ -34752,12 +34803,6 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/maintenance/starboard/central)
-"iJU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "iJX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -34858,6 +34903,10 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/toilet/restrooms)
+"iPd" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "iPn" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -35007,6 +35056,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"iTH" = (
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "iUd" = (
 /obj/machinery/door/airlock/ship/station/mining{
 	name = "Cargo Shipping";
@@ -35346,6 +35399,21 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/port)
+"jhI" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
+"jhL" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "jhZ" = (
 /obj/machinery/computer/telecomms/server,
 /turf/open/floor/plasteel/grimy,
@@ -35403,11 +35471,6 @@
 /obj/effect/landmark/start/ai/secondary,
 /turf/open/floor/plasteel/ship,
 /area/ai_monitored/turret_protected/ai)
-"jjT" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "jkb" = (
 /obj/machinery/nuclearbomb/beer,
 /turf/open/floor/plating,
@@ -35550,10 +35613,24 @@
 /obj/vehicle/sealed/car/realistic/medical,
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/central)
-"jpL" = (
-/obj/effect/landmark/blobstart,
-/turf/template_noop,
-/area/maintenance/port/aft)
+"jpB" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/ship,
+/area/hallway/primary/fore)
 "jqp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -36457,12 +36534,6 @@
 	},
 /turf/open/floor/plasteel/ship/riveted,
 /area/maintenance/starboard/central)
-"jVK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 1
-	},
-/turf/template_noop,
-/area/maintenance/port/central)
 "jWq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -36678,6 +36749,23 @@
 /obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/plating,
 /area/nsv/hanger)
+"khC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "khN" = (
 /obj/machinery/turretid{
 	control_area = "/area/ai_monitored/turret_protected/ai_upload";
@@ -37421,6 +37509,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"kHP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/obj/item/robot_suit,
+/turf/open/floor/plasteel,
+/area/maintenance/fore)
 "kIp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38129,11 +38223,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"lou" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/four,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "loH" = (
 /obj/machinery/modular_computer/console/preset/command,
 /turf/open/floor/plasteel/grimy,
@@ -38808,6 +38897,11 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"lMP" = (
+/obj/structure/grille/broken,
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "lMR" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -39123,6 +39217,10 @@
 "lYW" = (
 /turf/open/floor/plating/airless,
 /area/ai_monitored/turret_protected/ai)
+"lZa" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "lZe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39440,6 +39538,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/lockup)
+"miZ" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "mjD" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -39650,6 +39761,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
+"moi" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "mpA" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/holywater{
@@ -40086,6 +40202,26 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
+"mDV" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "mEb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -41740,6 +41876,18 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"nTA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 10
+	},
+/turf/template_noop,
+/area/maintenance/starboard/central)
 "nTI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 4
@@ -41974,13 +42122,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"nZH" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "nZI" = (
 /obj/structure/table/glass,
 /obj/item/storage/firstaid/o2,
@@ -42611,6 +42752,23 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"oxA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "oxE" = (
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -42624,6 +42782,10 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/entry)
+"oyM" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "oyO" = (
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -42737,11 +42899,6 @@
 /obj/structure/lattice,
 /turf/open/space,
 /area/ai_monitored/turret_protected/ai)
-"oBC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/turf/template_noop,
-/area/maintenance/port/central)
 "oBE" = (
 /obj/machinery/computer/ship/viewscreen,
 /obj/machinery/computer/ship/munitions_computer{
@@ -42974,6 +43131,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"oNC" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "oOe" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -43226,6 +43391,12 @@
 /obj/structure/closet/secure_closet/hydroponics,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"oXY" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "oYa" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -43239,13 +43410,6 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload)
-"oYO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/turf/template_noop,
-/area/maintenance/port/central)
 "oZh" = (
 /obj/machinery/computer/operating{
 	dir = 8
@@ -44106,6 +44270,18 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/hanger)
+"pKA" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "pKD" = (
 /obj/machinery/atmospherics/pipe/manifold4w/general/visible,
 /turf/open/floor/plating,
@@ -44777,6 +44953,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/science/research)
+"qjO" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "qki" = (
 /obj/machinery/door/airlock/public/glass/incinerator/atmos_interior,
 /obj/effect/mapping_helpers/airlock/locked,
@@ -44980,12 +45161,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"qsj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/template_noop,
-/area/maintenance/starboard/central)
 "qsl" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -45018,6 +45193,11 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/port)
+"qtd" = (
+/obj/structure/closet/cardboard,
+/obj/effect/spawner/lootdrop/maintenance/seven,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "qtk" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -46406,16 +46586,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"rvK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "rvO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -46628,12 +46798,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"rCy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/turf/template_noop,
-/area/maintenance/port/central)
 "rDm" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
@@ -47612,6 +47776,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
+"stj" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "stM" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -47630,10 +47798,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/central)
-"stV" = (
-/obj/structure/grille/wall,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "suo" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks,
@@ -47711,20 +47875,6 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/port)
-"swS" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "swW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 4
@@ -47882,16 +48032,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/tcommsat/computer)
-"sDO" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/plating,
-/area/maintenance/department/medical/morgue)
 "sDT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -48306,6 +48446,9 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
+"sWN" = (
+/turf/open/floor/plasteel,
+/area/maintenance/fore)
 "sXM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 4
@@ -48933,6 +49076,10 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/ai_monitored/turret_protected/aisat/hallway/support_ship)
+"tuE" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "tuV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -49232,6 +49379,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
+"tHR" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "tIa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -49598,6 +49752,13 @@
 /obj/machinery/computer/atmos_control/tank/nitrous_tank,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"tUR" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "tVy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 4
@@ -49729,6 +49890,15 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/entry)
+"tYY" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "tZd" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -50767,6 +50937,18 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
+"uMT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "uMU" = (
 /obj/machinery/air_sensor/atmos/nitrous_tank,
 /turf/open/floor/engine/n2o,
@@ -51095,11 +51277,6 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
-"vdZ" = (
-/obj/machinery/computer/security/console,
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/plasteel/dark,
-/area/maintenance/port/central)
 "veF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51253,15 +51430,6 @@
 /obj/machinery/computer/secure_data/laptop,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
-"viG" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/template_noop,
-/area/maintenance/starboard/central)
 "viJ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -51496,6 +51664,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"vrs" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/template_noop,
+/area/maintenance/starboard/central)
 "vrL" = (
 /obj/machinery/suit_storage_unit/security,
 /obj/effect/landmark/nuclear_waste_spawner,
@@ -51664,14 +51847,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"vAH" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "vAJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
@@ -51749,6 +51924,21 @@
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/service)
+"vBY" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/ship,
+/area/hallway/primary/fore)
 "vCL" = (
 /obj/machinery/shieldwallgen/xenobiologyaccess,
 /obj/machinery/door/poddoor/preopen{
@@ -51842,12 +52032,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"vHh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "vHu" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -52227,20 +52411,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"vTm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/ship,
-/area/hallway/primary/fore)
 "vTt" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -52742,15 +52912,6 @@
 /area/maintenance/department/crew_quarters/dorms)
 "wnd" = (
 /turf/closed/wall/r_wall/ship,
-/area/maintenance/starboard/central)
-"wnQ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/template_noop,
 /area/maintenance/starboard/central)
 "wot" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
@@ -53287,12 +53448,6 @@
 /obj/structure/table,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"wIy" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 8
-	},
-/turf/template_noop,
-/area/maintenance/port/central)
 "wJb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53527,18 +53682,6 @@
 /obj/item/lipstick/black,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/theatre)
-"wTk" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "wUk" = (
 /obj/structure/sink/kitchen{
 	pixel_y = 24
@@ -74161,7 +74304,7 @@ aar
 aJB
 cCm
 aJB
-stV
+lZa
 aJB
 fkN
 aaO
@@ -74674,7 +74817,7 @@ fkN
 fkN
 acb
 noG
-jpL
+noG
 noG
 aJB
 fkN
@@ -75187,9 +75330,9 @@ aux
 fkN
 aEn
 acb
-stV
-stV
-aUL
+lZa
+lZa
+lMP
 atd
 fkN
 apW
@@ -78076,7 +78219,7 @@ aho
 aho
 aho
 xmP
-hJz
+xmP
 vRU
 mhr
 xmP
@@ -79363,7 +79506,7 @@ fkN
 aho
 urY
 cWT
-ata
+iTH
 wqP
 aho
 bku
@@ -86763,7 +86906,7 @@ aIx
 aXu
 aIx
 aIx
-gKv
+gvE
 aIx
 ayG
 oew
@@ -87019,7 +87162,7 @@ aar
 aIx
 aIx
 aIx
-vdZ
+dqG
 qem
 aIx
 ayG
@@ -87536,11 +87679,11 @@ aIx
 aIx
 aIx
 aIx
-wTk
-rvK
-oBC
-oYO
-jVK
+pKA
+pwe
+wHE
+wHE
+wHE
 jbD
 aIx
 dSy
@@ -87796,7 +87939,7 @@ aIx
 cZS
 aIx
 wHE
-rCy
+wHE
 wHE
 wHE
 aIx
@@ -88053,7 +88196,7 @@ aIx
 cZS
 aIx
 wHE
-rCy
+wHE
 wHE
 wHE
 aIx
@@ -88307,10 +88450,10 @@ fkN
 aIx
 ctK
 aIx
-cZS
+eiX
 aIx
 wHE
-wIy
+wHE
 wHE
 wHE
 aIx
@@ -88566,7 +88709,7 @@ bhK
 aIx
 cZS
 aIx
-gLu
+wHE
 wHE
 wHE
 wHE
@@ -89078,12 +89221,12 @@ aIx
 aIx
 bhD
 aIx
-cZS
+oxA
 aIx
+qtd
 aub
 aub
-aub
-aub
+moi
 aIx
 abP
 auu
@@ -89336,7 +89479,7 @@ bfI
 bhE
 bhH
 aRz
-aub
+aIx
 aub
 aub
 exc
@@ -89595,7 +89738,7 @@ bhI
 aRz
 aub
 aub
-exc
+iPd
 aIx
 aIx
 vJy
@@ -89850,9 +89993,9 @@ sbd
 bhG
 bhJ
 vQU
-aub
-aub
-aXu
+dMn
+goT
+exc
 aIx
 aYF
 doN
@@ -91129,7 +91272,7 @@ aeX
 aeX
 aeX
 aIx
-aub
+iPd
 sbd
 vQU
 axS
@@ -91940,7 +92083,7 @@ ngq
 dLA
 arM
 arM
-arM
+gCv
 dLA
 dLA
 dLA
@@ -93488,9 +93631,9 @@ hTn
 iSh
 aeR
 ioz
-lou
+qjO
 aeR
-geR
+tYY
 aeR
 gwD
 hVb
@@ -94001,15 +94144,15 @@ aVL
 jru
 iSh
 ePC
-nZH
-jjT
-jHx
-jHx
+miZ
+jhL
+jhI
+tHR
 oNB
 fyw
 jHx
 jHx
-sDO
+dKc
 hkl
 vWS
 rMP
@@ -94258,9 +94401,9 @@ aVL
 jdh
 iSh
 ePC
-vHh
+uMT
 iSh
-iSh
+oXY
 fvQ
 rAf
 bHx
@@ -94515,7 +94658,7 @@ xcC
 xcC
 xcC
 xcC
-vHh
+uMT
 aeR
 crk
 aeR
@@ -94772,7 +94915,7 @@ nYE
 kVt
 bzk
 xcC
-erc
+khC
 aeR
 aeR
 aeR
@@ -95029,8 +95172,8 @@ epl
 kbM
 oUk
 xcC
-qsj
-viG
+nTA
+fzX
 itC
 wSF
 uGe
@@ -95287,7 +95430,7 @@ ieh
 gCY
 xcC
 jHX
-wnQ
+vrs
 jHX
 aeR
 aeR
@@ -95544,7 +95687,7 @@ epl
 uIM
 xcC
 jHX
-wnQ
+vrs
 jHX
 aeR
 fkN
@@ -95801,7 +95944,7 @@ itn
 xcC
 xcC
 aeR
-swS
+mDV
 aeR
 aeR
 fkN
@@ -96058,7 +96201,7 @@ arZ
 sSn
 arZ
 arZ
-fNf
+vBY
 dzc
 arC
 aRk
@@ -96315,7 +96458,7 @@ aOC
 aOC
 aOC
 alA
-vTm
+jpB
 fgY
 bjc
 bjd
@@ -106555,7 +106698,7 @@ bhw
 bht
 bht
 bht
-iJU
+bht
 bhz
 aoW
 aoW
@@ -106812,7 +106955,7 @@ aoW
 aoW
 mgX
 aoW
-egx
+mgX
 aoW
 xgQ
 aoW
@@ -107069,7 +107212,7 @@ esh
 dbv
 dJX
 dEK
-vAH
+esh
 esh
 esh
 ghZ
@@ -109931,19 +110074,19 @@ aQg
 aQg
 aQg
 aQg
+tUR
 avU
-avU
-avU
-bQp
-avU
-avU
-avU
-avU
-avU
-avU
+rhf
+gqw
+sWN
+iqZ
+aQg
+dQU
 avU
 bQp
 avU
+avU
+oNC
 avU
 avU
 dLK
@@ -110190,18 +110333,18 @@ qcR
 wyM
 avU
 avU
-avU
+aQg
+eHH
+kHP
+oyM
+gan
 avU
 avU
 hlW
-avU
-avU
-avU
-avU
-avU
-avU
-avU
-avU
+stj
+tuE
+aQg
+tUR
 avU
 avU
 rhf

--- a/_maps/map_files/Hammerhead/Hammerhead.dmm
+++ b/_maps/map_files/Hammerhead/Hammerhead.dmm
@@ -73,20 +73,6 @@
 "aam" = (
 /turf/closed/wall/r_wall/ship,
 /area/engine/storage)
-"aan" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "aao" = (
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
@@ -152,67 +138,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engine_smes)
-"aaw" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "69"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/bar)
-"aax" = (
-/obj/machinery/atmospherics/pipe/manifold/purple/visible{
-	icon_state = "manifold-2";
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"aay" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Fuel Mix In"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"aaz" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	icon_state = "connector_map-2";
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"aaA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"aaB" = (
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/construction)
-"aaC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "aaD" = (
 /obj/effect/landmark/start/janitor,
 /mob/living/simple_animal/hostile/lizard{
@@ -278,7 +203,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/advanced_airlock_controller/directional/west,
+/obj/machinery/advanced_airlock_controller/directional/west{
+	pixel_y = 24
+	},
 /obj/machinery/atmospherics/components/binary/dp_vent_pump,
 /turf/open/floor/plating,
 /area/crew_quarters/bar/atrium)
@@ -300,31 +227,6 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"aaM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/ship/command/glass{
-	name = "Chief Engineer";
-	req_one_access_txt = "56"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
 "aaN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -341,13 +243,6 @@
 "aaO" = (
 /turf/closed/wall/ship,
 /area/science/mixing)
-"aaP" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/bar)
 "aaQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -360,22 +255,6 @@
 /obj/machinery/door/airlock/ship{
 	name = "Lawyer's office";
 	req_one_access_txt = "38"
-	},
-/turf/open/floor/plasteel/ship,
-/area/lawoffice)
-"aaS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/door/airlock/ship{
-	name = "Lawyer's office";
-	req_one_access_txt = "38"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/ship,
 /area/lawoffice)
@@ -395,19 +274,6 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/carpet/ship,
 /area/bridge)
-"aaU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/door/airlock/ship/security/glass{
-	name = "Brig Control";
-	req_one_access_txt = "3"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/ship,
-/area/security/warden)
 "aaV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -567,7 +433,9 @@
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
-/obj/machinery/advanced_airlock_controller/directional/north,
+/obj/machinery/advanced_airlock_controller/directional/north{
+	pixel_y = 24
+	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "abo" = (
@@ -682,7 +550,9 @@
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/aft)
 "abC" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/effect/turf_decal/delivery/white,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -921,7 +791,9 @@
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/quartermaster/storage)
 "acg" = (
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
@@ -1050,10 +922,6 @@
 /area/hallway/secondary/exit)
 "acx" = (
 /turf/open/floor/plasteel/ship,
-/area/hallway/secondary/exit)
-"acy" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
 /area/hallway/secondary/exit)
 "acz" = (
 /obj/machinery/button/door{
@@ -1354,10 +1222,6 @@
 /area/nsv/hanger/deck2/starboard{
 	name = "Launch tubes 1 and 2"
 	})
-"adb" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/hallway/secondary/exit/departure_lounge)
 "adc" = (
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar/atrium)
@@ -1377,14 +1241,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
-"adf" = (
-/obj/machinery/door/poddoor/ship{
-	id = "launchbay_access";
-	name = "Launch tube access"
-	},
-/obj/effect/turf_decal/stripes/full,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/maintenance/starboard/central)
 "adg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 6
@@ -1425,15 +1281,6 @@
 "adk" = (
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"adl" = (
-/obj/machinery/door/poddoor/ship{
-	id = "launchbay_access";
-	name = "Launch tube access"
-	},
-/obj/effect/turf_decal/stripes/full,
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/maintenance/starboard/central)
 "adm" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "12;69"
@@ -1451,16 +1298,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/exit)
-"ado" = (
-/obj/machinery/door/poddoor/ship{
-	id = "launchbay_tube1";
-	name = "Launch tube 1 access"
-	},
-/obj/effect/turf_decal/stripes/full,
-/turf/open/floor/plating,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
 "adp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -1496,15 +1333,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/central)
-"ads" = (
-/obj/machinery/door/poddoor/ship{
-	id = "launchbay_tube3";
-	name = "Launch tube 3 access"
-	},
-/turf/open/floor/plating,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
 "adt" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 4
@@ -1540,35 +1368,12 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/entry)
-"adw" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12;69"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "adx" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 28
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/aft)
-"ady" = (
-/obj/machinery/door/poddoor/ship{
-	id = "launchbay_tube4";
-	name = "Launch tube 4 access"
-	},
-/turf/open/floor/plating,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
 "adz" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 28
@@ -1699,13 +1504,6 @@
 /area/nsv/hanger/deck2/port{
 	name = "Launch tubes 3 and 4"
 	})
-"adM" = (
-/obj/item/ammo_casing/a357{
-	projectile_type = null
-	},
-/obj/effect/turf_decal/bot_white,
-/turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
 "adN" = (
 /turf/open/floor/plasteel/ship,
 /area/nsv/hanger/deck2/port{
@@ -1772,7 +1570,9 @@
 /turf/open/floor/plasteel/ship,
 /area/nsv/weapons/fore)
 "adU" = (
-/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -1786,7 +1586,9 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "adV" = (
-/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -2131,7 +1933,9 @@
 /obj/machinery/atmospherics/components/binary/dp_vent_pump{
 	dir = 1
 	},
-/obj/machinery/advanced_airlock_controller/directional/east,
+/obj/machinery/advanced_airlock_controller/directional/east{
+	pixel_y = 24
+	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/exit/departure_lounge)
 "aeG" = (
@@ -2238,15 +2042,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"aeU" = (
-/obj/machinery/airalarm/directional/east,
-/obj/structure/closet/firecloset,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/computer/lore_terminal,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/nsv/hanger)
 "aeV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -2309,11 +2104,6 @@
 /obj/machinery/power/compressor,
 /turf/open/floor/engine/vacuum,
 /area/engine/atmospherics_engine)
-"aff" = (
-/obj/structure/closet/firecloset,
-/obj/machinery/computer/lore_terminal,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/nsv/hanger)
 "afg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
 /turf/open/floor/plating,
@@ -2582,16 +2372,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"afL" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "afM" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2{
 	dir = 8
@@ -2687,9 +2467,6 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"afX" = (
-/turf/closed/wall/ship,
-/area/maintenance/department/security)
 "afY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
 /obj/effect/landmark/xeno_spawn,
@@ -2849,13 +2626,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/entry)
-"agr" = (
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer1{
-	dir = 8
-	},
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/engine/atmos)
 "ags" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/cable{
@@ -2942,16 +2712,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"agB" = (
-/obj/machinery/door/poddoor/ship{
-	id = "launchbay_tube2";
-	name = "Launch tube 2 access"
-	},
-/obj/effect/turf_decal/stripes/full,
-/turf/open/floor/plating,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
 "agC" = (
 /obj/item/toy/figure/cmo,
 /obj/machinery/keycard_auth{
@@ -3015,21 +2775,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"agG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/security)
 "agH" = (
 /obj/machinery/door/airlock/ship/hatch{
 	name = "Auxilliary Access Port";
@@ -3092,14 +2837,6 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plasteel/white,
 /area/gateway)
-"agN" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Hangar Bay"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plasteel/dark,
-/area/nsv/hanger)
 "agO" = (
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/engine/engineering/hangar)
@@ -3215,7 +2952,9 @@
 /turf/open/floor/plating,
 /area/nsv/hanger)
 "ahd" = (
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -3241,10 +2980,6 @@
 	},
 /turf/open/floor/plating,
 /area/nsv/hanger)
-"ahg" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/security/checkpoint/science/research)
 "ahh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 9
@@ -3309,16 +3044,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"ahl" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "ahm" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 1
@@ -3357,29 +3082,12 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"ahs" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/camera/autoname,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "aht" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
 	},
 /turf/open/floor/carpet,
 /area/security/courtroom)
-"ahu" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security)
 "ahv" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 1
@@ -3465,19 +3173,6 @@
 	},
 /turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
-"ahE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/ship/station/mining{
-	name = "Cargo Storage";
-	req_one_access_txt = "31; 48"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/quartermaster/office)
 "ahF" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 1
@@ -3509,10 +3204,6 @@
 /obj/machinery/atmospherics/components/binary/valve/layer3,
 /turf/open/floor/plating,
 /area/nsv/hanger)
-"ahI" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/nsv/weapons/fore)
 "ahJ" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Chemistry Manufacturing";
@@ -3574,17 +3265,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/port)
-"ahP" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "31;48"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plating,
-/area/maintenance/disposal)
 "ahQ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -3674,28 +3354,6 @@
 /area/nsv/hanger/deck2/starboard{
 	name = "Launch tubes 1 and 2"
 	})
-"ahY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 10
-	},
-/obj/structure/chair/office{
-	dir = 4
-	},
-/turf/open/floor/plasteel/ship,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
-"ahZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 6
-	},
-/obj/structure/chair/office{
-	dir = 8
-	},
-/turf/open/floor/plasteel/ship,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
 "aia" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 10
@@ -3724,17 +3382,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/nsv/hanger)
-"aie" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/security)
 "aif" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -3794,10 +3441,6 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel/ship,
 /area/crew_quarters/theatre)
-"aik" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/hallway/primary/aft)
 "ail" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
 /turf/open/floor/plating,
@@ -3905,7 +3548,9 @@
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/entry)
 "aiw" = (
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
 /obj/machinery/airalarm/directional/north,
 /obj/structure/cable{
@@ -3925,16 +3570,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/security/prison)
-"aiy" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "aiz" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -4044,7 +3679,9 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "aiL" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -4062,13 +3699,6 @@
 "aiM" = (
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
-"aiN" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/engine/atmos)
 "aiO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/disposalpipe/segment{
@@ -4084,7 +3714,9 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "aiQ" = (
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -4146,22 +3778,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/courtroom)
-"aiX" = (
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/plating,
-/area/construction)
-"aiY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8;
-	name = "Nitrogen to Airmix";
-	target_pressure = 4500
-	},
-/obj/machinery/atmospherics/components/binary/pump/layer3{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "aiZ" = (
 /obj/item/assembly/timer{
 	pixel_x = 5;
@@ -4372,17 +3988,6 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai)
-"ajC" = (
-/obj/effect/turf_decal/arrows/red,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "xoline";
-	name = "XO Line Shutters"
-	},
-/turf/open/floor/plasteel/ship,
-/area/hallway/primary/fore)
 "ajD" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 8
@@ -4577,18 +4182,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"aka" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security)
 "akb" = (
 /obj/machinery/atmospherics/pipe/simple/brown/hidden,
 /obj/effect/turf_decal/stripes/white/line{
@@ -4819,14 +4412,6 @@
 "akz" = (
 /turf/closed/wall/ship,
 /area/crew_quarters/heads/hor)
-"akA" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor/northleft{
-	name = "Security Desk";
-	req_access_txt = "1"
-	},
-/turf/open/floor/plating,
-/area/security)
 "akB" = (
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/light{
@@ -4921,18 +4506,6 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos)
-"akN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/security/prison)
 "akO" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Cloning Exit";
@@ -4946,15 +4519,6 @@
 "akP" = (
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
-"akQ" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "akR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 1
@@ -4989,9 +4553,6 @@
 /obj/machinery/smartfridge/extract/preloaded,
 /turf/closed/wall/ship,
 /area/science/xenobiology)
-"akV" = (
-/turf/open/floor/plating,
-/area/security)
 "akW" = (
 /obj/structure/table,
 /obj/machinery/airalarm/directional/east,
@@ -5010,32 +4571,14 @@
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
 "akZ" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /turf/open/floor/carpet/ship,
 /area/bridge/meeting_room)
-"ala" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Stormdrive Plasma Constriction";
-	req_one_access_txt = "11; 24"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engine_room)
 "alb" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -5052,15 +4595,6 @@
 /obj/machinery/monkey_recycler,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"ald" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/engine/o2,
-/area/engine/atmos)
 "ale" = (
 /obj/machinery/computer/rdconsole/robotics{
 	dir = 4
@@ -5115,7 +4649,9 @@
 /obj/machinery/atmospherics/components/binary/dp_vent_pump{
 	dir = 1
 	},
-/obj/machinery/advanced_airlock_controller/directional/west,
+/obj/machinery/advanced_airlock_controller/directional/west{
+	pixel_y = 24
+	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/exit/departure_lounge)
 "aln" = (
@@ -5127,20 +4663,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"alo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8;
-	name = "Oxygen to Airmix";
-	target_pressure = 4500
-	},
-/obj/machinery/atmospherics/components/binary/pump/layer3{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "alp" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/machinery/vending/dinnerware,
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -5178,9 +4704,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/engine/break_room)
-"alt" = (
-/turf/open/floor/plating,
-/area/maintenance/department/security)
 "alu" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -5429,7 +4952,9 @@
 /area/engine/gravity_generator)
 "alZ" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -5604,7 +5129,9 @@
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/exit)
 "amr" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -5625,7 +5152,9 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "amt" = (
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/conveyor/inverted{
 	dir = 10;
@@ -5747,7 +5276,9 @@
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/fore)
 "amI" = (
-/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -5852,7 +5383,9 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
 "amT" = (
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -5919,13 +5452,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/gateway)
-"ana" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 8
-	},
-/obj/item/ship_weapon/ammunition/torpedo,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory/lockup)
 "anb" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -5939,7 +5465,9 @@
 /turf/open/floor/plasteel/ship,
 /area/security/main)
 "and" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -6004,7 +5532,9 @@
 /obj/machinery/atmospherics/components/binary/dp_vent_pump{
 	dir = 1
 	},
-/obj/machinery/advanced_airlock_controller/directional/east,
+/obj/machinery/advanced_airlock_controller/directional/east{
+	pixel_y = 24
+	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/exit/departure_lounge)
 "anm" = (
@@ -6049,7 +5579,9 @@
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/exit/departure_lounge)
 "anr" = (
-/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
 /obj/machinery/photocopier,
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -6074,37 +5606,9 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/quartermaster/storage)
-"anu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security)
 "anv" = (
 /turf/closed/wall/ship,
 /area/engine/engineering)
-"anw" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/obj/machinery/door/airlock/ship/maintenance{
-	name = "Medbay Service";
-	req_one_access_txt = "5;33"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "anx" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6198,28 +5702,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
-"anI" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/engine_room)
-"anJ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security)
 "anK" = (
 /turf/open/floor/carpet/ship,
 /area/bridge/meeting_room)
@@ -6243,7 +5725,9 @@
 /turf/open/floor/wood,
 /area/library)
 "anN" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/machinery/computer/scan_consolenew{
 	dir = 8
 	},
@@ -6348,7 +5832,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/light/small{
 	dir = 4
@@ -6407,14 +5893,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/exit)
-"aoe" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 1
-	},
-/obj/structure/table/reinforced,
-/obj/item/clothing/glasses/blindfold/white,
-/turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
 "aof" = (
 /obj/machinery/atmospherics/pipe/simple/dark/hidden/layer1{
 	dir = 8
@@ -6442,13 +5920,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"aok" = (
-/obj/effect/turf_decal/caution/white,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "aol" = (
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -6491,12 +5962,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/research)
-"aoq" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/construction)
 "aor" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/border_only/directional/north,
@@ -6581,15 +6046,6 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/engine/atmos)
-"aoE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/security)
 "aoF" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -6603,7 +6059,9 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
 "aoG" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/safe,
 /obj/item/bikehorn/golden,
 /obj/item/book/random,
@@ -6635,10 +6093,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/port)
-"aoJ" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/quartermaster/office)
 "aoK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -6854,7 +6308,9 @@
 /turf/open/floor/plasteel/ship,
 /area/engine/gravity_generator)
 "api" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -6870,7 +6326,9 @@
 /turf/open/floor/wood,
 /area/security/detectives_office/private_investigators_office)
 "apk" = (
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
 /obj/machinery/airalarm/directional/north,
 /obj/structure/cable{
@@ -6878,14 +6336,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/patients_rooms/room_a)
-"apl" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/white/line,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "apm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -7202,7 +6652,9 @@
 /turf/open/floor/plating,
 /area/science/mixing)
 "apX" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -7215,9 +6667,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo)
-"apY" = (
-/turf/closed/wall/r_wall/ship,
-/area/security)
 "apZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 8
@@ -7338,7 +6787,9 @@
 /turf/open/floor/wood,
 /area/library/lounge)
 "aqm" = (
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
@@ -7421,16 +6872,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"aqv" = (
-/obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped/inverse{
-	dir = 1
-	},
-/obj/effect/landmark/start/atmospheric_technician,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "aqw" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor/northleft{
@@ -7540,7 +6981,9 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "aqG" = (
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
@@ -7678,19 +7121,6 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/service)
-"aqW" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security)
 "aqX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /obj/structure/table/reinforced,
@@ -7835,16 +7265,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"arl" = (
-/obj/effect/turf_decal/arrows/red{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "xoline";
-	name = "XO Line Shutters"
-	},
-/turf/open/floor/plasteel/ship,
-/area/hallway/primary/fore)
 "arm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /obj/effect/turf_decal/tile/red{
@@ -7909,7 +7329,9 @@
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
 "aru" = (
-/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -8099,27 +7521,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"arS" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/engine/gravity_generator)
 "arT" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"arU" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "hos_privacy";
-	name = "privacy shutter"
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hos)
 "arV" = (
 /obj/machinery/mass_driver{
 	id = "chapelgun"
@@ -8186,24 +7593,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/hanger)
-"ase" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "asf" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -8355,23 +7744,15 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "asw" = (
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar/atrium)
 "asx" = (
 /turf/closed/wall/r_wall/ship,
 /area/security/brig)
-"asy" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security)
 "asz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 5
@@ -8513,12 +7894,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
-"asR" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/engine/plasma,
-/area/engine/atmos)
 "asS" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -8552,16 +7927,6 @@
 	},
 /turf/open/floor/wood,
 /area/library/lounge)
-"asV" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	dir = 4;
-	req_one_access_txt = "2"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
 "asW" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -8680,13 +8045,6 @@
 /obj/structure/window/reinforced/spawner/north,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
-"ath" = (
-/obj/structure/closet/firecloset,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/nsv/hanger)
 "ati" = (
 /turf/closed/wall/r_wall/ship,
 /area/crew_quarters/heads/hop)
@@ -8740,7 +8098,9 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "atp" = (
@@ -8753,7 +8113,9 @@
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/weapons/fore)
 "atq" = (
-/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -8771,10 +8133,6 @@
 "atr" = (
 /turf/closed/wall/ship,
 /area/crew_quarters/heads/captain)
-"ats" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/hallway/primary/port)
 "att" = (
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/service/support_ship)
@@ -9059,13 +8417,6 @@
 "aub" = (
 /turf/open/floor/plating,
 /area/maintenance/port/central)
-"auc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/ship,
-/area/hallway/primary/fore)
 "aud" = (
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/ship/techfloor/alt,
@@ -9111,21 +8462,6 @@
 /obj/machinery/telecomms/hub/preset,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
-"aum" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/construction)
 "aun" = (
 /turf/closed/wall/r_wall/ship,
 /area/construction)
@@ -9139,15 +8475,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/central)
-"aup" = (
-/obj/machinery/door/airlock/ship/station/mining{
-	name = "Cargo Shipping";
-	req_one_access_txt = "31"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plasteel/ship,
-/area/quartermaster/office)
 "auq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -9196,7 +8523,9 @@
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/central)
 "auv" = (
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
 	},
@@ -9269,11 +8598,15 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/central)
 "auB" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -9369,16 +8702,6 @@
 "auM" = (
 /turf/closed/wall/r_wall/ship,
 /area/ai_monitored/turret_protected/ai)
-"auN" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security)
 "auO" = (
 /obj/structure/table/reinforced,
 /obj/item/toner{
@@ -9435,7 +8758,9 @@
 /turf/open/floor/carpet/black,
 /area/crew_quarters/heads/hor)
 "auU" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -9776,7 +9101,9 @@
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/hanger)
 "avL" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -9817,7 +9144,9 @@
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/entry)
 "avO" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -9874,7 +9203,9 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "avV" = (
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
 /obj/machinery/atmospherics/pipe/simple/brown/visible{
 	dir = 4
 	},
@@ -9995,16 +9326,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"awl" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel/ship,
-/area/security/prison)
 "awm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -10032,7 +9353,9 @@
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/ai_monitored/turret_protected/ai_upload)
 "awo" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/machinery/vending/medical,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -10052,19 +9375,6 @@
 "awp" = (
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"awq" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/medical/medbay/central)
 "awr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -10105,22 +9415,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/quartermaster/storage)
-"awx" = (
-/obj/machinery/airalarm/directional/north,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/camera/autoname,
-/turf/open/floor/plasteel,
-/area/security)
 "awy" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -10174,11 +9468,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/fore)
-"awF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory/lockup)
 "awG" = (
 /turf/closed/wall/ship,
 /area/security/courtroom)
@@ -10325,7 +9614,9 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "awX" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
@@ -10337,24 +9628,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
-"awY" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/bridge)
-"awZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/construction)
 "axa" = (
 /obj/machinery/rnd/production/protolathe/department/engineering,
 /obj/machinery/light{
@@ -10409,22 +9682,6 @@
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"axi" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security)
 "axj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -10483,14 +9740,6 @@
 	dir = 1
 	},
 /area/chapel/main)
-"axp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/effect/landmark/event_spawn,
-/obj/machinery/holopad,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory/lockup)
 "axq" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -10537,20 +9786,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/hanger)
-"axv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "axw" = (
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel,
@@ -10590,7 +9825,9 @@
 /area/quartermaster/qm)
 "axB" = (
 /obj/structure/closet/secure_closet/freezer/meat,
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -10840,14 +10077,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
-"ayc" = (
-/obj/machinery/airalarm/directional/south,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/grille_or_trash,
-/turf/open/floor/plating,
-/area/maintenance/department/security)
 "ayd" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 8
@@ -10932,26 +10161,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"ayl" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "xoprivacy";
-	name = "Privacy Shutters"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hop)
 "aym" = (
 /turf/closed/wall/ship,
 /area/crew_quarters/heads/hos)
@@ -11026,10 +10235,6 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
-"ayu" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/captain)
 "ayv" = (
 /obj/structure/table/glass,
 /turf/open/floor/carpet/ship,
@@ -11256,21 +10461,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"ayT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/ship/security/glass{
-	name = "Head of Security";
-	req_one_access_txt = "58"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hos)
 "ayU" = (
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -11338,10 +10532,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"azc" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel,
-/area/security)
 "azd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -11402,7 +10592,9 @@
 /turf/open/floor/plasteel/ship,
 /area/ai_monitored/turret_protected/ai)
 "azj" = (
-/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
 /obj/structure/closet/secure_closet/quartermaster,
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -11438,7 +10630,9 @@
 /obj/item/restraints/handcuffs,
 /obj/item/restraints/handcuffs,
 /obj/item/restraints/handcuffs,
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -11536,16 +10730,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/port)
-"azx" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
 "azy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -11569,18 +10753,6 @@
 /obj/item/assembly/flash,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/security/brig)
-"azB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/construction)
 "azC" = (
 /obj/structure/chair/wood/normal{
 	dir = 4
@@ -11781,16 +10953,6 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"azX" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible/layer3,
-/obj/machinery/atmospherics/pipe/simple/brown/visible{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "azY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -11821,19 +10983,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo)
-"aAb" = (
-/obj/machinery/atmospherics/pipe/simple/brown/visible{
-	dir = 10
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engine_room)
 "aAc" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -11903,14 +11052,6 @@
 /obj/effect/landmark/start/botanist,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"aAj" = (
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/obj/structure/closet/bombcloset/security,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/plasteel/ship,
-/area/nsv/weapons/fore)
 "aAk" = (
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/plating,
@@ -11987,27 +11128,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/toilet/restrooms)
-"aAu" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Stormdrive Plasma Constriction";
-	req_one_access_txt = "11; 24"
-	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Plasma To Stormdrive";
-	target_pressure = 50
-	},
-/turf/open/floor/plasteel,
-/area/engine/engine_room)
 "aAv" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -12049,51 +11169,16 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"aAA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/construction)
 "aAB" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"aAC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security)
-"aAD" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/storage)
 "aAE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/exit)
-"aAF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security)
 "aAG" = (
 /obj/structure/chair/wood/wings,
 /obj/machinery/computer/ship/viewscreen,
@@ -12402,24 +11487,9 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/fore)
-"aBq" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 8
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel/dark,
-/area/security)
 "aBr" = (
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
-"aBs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security)
 "aBt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -12592,7 +11662,9 @@
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/exit)
 "aBP" = (
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
@@ -12601,9 +11673,6 @@
 /obj/effect/landmark/start/librarian,
 /turf/open/floor/plasteel/cult,
 /area/library)
-"aBR" = (
-/turf/closed/wall/ship,
-/area/security)
 "aBS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -12704,7 +11773,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aCd" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 10
 	},
@@ -12885,22 +11956,14 @@
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
-"aCv" = (
-/obj/machinery/power/apc/auto_name/west,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/security)
 "aCw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
 "aCx" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -12963,29 +12026,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
-"aCE" = (
-/obj/machinery/power/apc/auto_name/south,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/item/ship_weapon/ammunition/missile,
-/obj/item/ship_weapon/ammunition/missile{
-	pixel_y = 2
-	},
-/obj/item/ship_weapon/ammunition/missile{
-	pixel_y = 4
-	},
-/obj/item/ship_weapon/ammunition/missile{
-	pixel_y = 6
-	},
-/obj/item/ship_weapon/ammunition/missile{
-	pixel_y = 8
-	},
-/obj/item/ship_weapon/ammunition/missile{
-	pixel_y = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory/lockup)
 "aCF" = (
 /obj/structure/closet/crate/engineering{
 	name = "pdc ammo crate"
@@ -12993,7 +12033,9 @@
 /obj/item/ammo_box/magazine/pdc,
 /obj/item/ammo_box/magazine/pdc,
 /obj/item/ammo_box/magazine/pdc,
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -13039,18 +12081,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
 /turf/open/floor/plasteel/ship/padded,
 /area/ai_monitored/turret_protected/ai_upload)
-"aCN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/door/airlock/ship/security/glass{
-	name = "Medical Security Post";
-	req_one_access_txt = "63"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/medical)
 "aCO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -13106,16 +12136,6 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"aCU" = (
-/obj/machinery/door/airlock/ship/security/glass{
-	name = "Customs Observation Desk";
-	req_one_access_txt = "1"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/customs/auxiliary)
 "aCV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/effect/turf_decal/tile/purple{
@@ -13150,17 +12170,6 @@
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"aCY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"aCZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/pump/layer3,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "aDa" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/turf_decal/stripes/white/box,
@@ -13195,7 +12204,9 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "aDe" = (
-/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -13265,16 +12276,6 @@
 /obj/machinery/telecomms/processor/preset_two,
 /turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
-"aDo" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible/layer3,
-/obj/machinery/atmospherics/pipe/simple/brown/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "aDp" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 1
@@ -13331,7 +12332,9 @@
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/security/brig)
 "aDt" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -13345,7 +12348,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -13371,7 +12376,9 @@
 /turf/open/floor/plasteel/ship,
 /area/crew_quarters/bar)
 "aDw" = (
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -13444,15 +12451,6 @@
 /obj/structure/bookcase/manuals/research_and_development,
 /turf/open/floor/wood,
 /area/library)
-"aDG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security)
 "aDH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 8
@@ -13479,20 +12477,6 @@
 /obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/exit/departure_lounge)
-"aDL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
 "aDM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -13506,7 +12490,9 @@
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
 "aDN" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -13531,12 +12517,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"aDQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory/lockup)
 "aDR" = (
 /obj/effect/turf_decal/stripes/red/full,
 /turf/open/floor/plating,
@@ -13686,7 +12666,9 @@
 /turf/closed/wall/ship,
 /area/medical/chemistry)
 "aEk" = (
-/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 5
 	},
@@ -13704,19 +12686,6 @@
 /obj/structure/closet/secure_closet/warden,
 /turf/open/floor/plasteel/ship,
 /area/security/warden)
-"aEm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/ship/command{
-	name = "Captain's Quarters";
-	req_one_access_txt = "20"
-	},
-/turf/open/floor/carpet/ship,
-/area/crew_quarters/heads/captain/private)
 "aEn" = (
 /obj/structure/shuttle/engine/large{
 	dir = 1;
@@ -13736,10 +12705,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"aEq" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security)
 "aEr" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible/layer1{
 	dir = 4
@@ -13796,17 +12761,6 @@
 	},
 /turf/open/floor/plasteel/freezer/airless,
 /area/science/xenobiology)
-"aEx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/table/wood,
-/obj/item/pen/fountain,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "aEy" = (
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/ai_monitored/turret_protected/aisat/hallway/support_ship/aft)
@@ -13819,15 +12773,6 @@
 "aEA" = (
 /turf/open/floor/plasteel,
 /area/storage/eva)
-"aEB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security)
 "aEC" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -14075,10 +13020,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
-"aFd" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/security)
 "aFe" = (
 /turf/closed/wall/r_wall/ship,
 /area/bridge)
@@ -14114,24 +13055,6 @@
 	},
 /turf/open/floor/engine/air,
 /area/engine/atmos)
-"aFi" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/door/airlock/ship/security/glass{
-	name = "Long-Term Confinement";
-	req_one_access_txt = "2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/security/prison)
 "aFj" = (
 /obj/machinery/computer/ship/viewscreen,
 /obj/machinery/light{
@@ -14173,24 +13096,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"aFn" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/door/airlock/ship/security/glass{
-	name = "Long-Term Confinement";
-	req_one_access_txt = "2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/security/prison)
 "aFo" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -14201,35 +13106,14 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "aFp" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"aFq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/door/airlock/ship/security/glass{
-	name = "Long-Term Confinement";
-	req_one_access_txt = "2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/security/prison)
 "aFr" = (
 /obj/effect/turf_decal/arrows/red{
 	dir = 1
@@ -14273,7 +13157,9 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "aFx" = (
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -14525,10 +13411,6 @@
 /obj/structure/extinguisher_cabinet/west,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"aGd" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/crew_quarters/bar/atrium)
 "aGe" = (
 /obj/effect/turf_decal/stripes/red/line,
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible/layer3{
@@ -14631,17 +13513,16 @@
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/port)
 "aGp" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security)
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plasteel/ship,
+/area/nsv/hanger/deck2/port{
+	name = "Launch tubes 3 and 4"
+	})
 "aGq" = (
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/security/prison)
@@ -14659,16 +13540,6 @@
 "aGt" = (
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
-"aGu" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/suit_storage_unit/pilot,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/nsv/hanger)
 "aGv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
@@ -14778,7 +13649,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -14850,7 +13723,9 @@
 /turf/open/floor/wood,
 /area/security/courtroom)
 "aGP" = (
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
@@ -15046,18 +13921,6 @@
 /obj/machinery/atmospherics/pipe/simple/dark/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"aHn" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/brown/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "aHo" = (
 /obj/machinery/light{
 	dir = 8
@@ -15129,19 +13992,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"aHy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/door/airlock/ship/security/glass{
-	name = "Arms Depot Desk";
-	req_one_access_txt = "63;69"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security)
 "aHz" = (
 /obj/machinery/atmospherics/components/unary/tank/air,
 /turf/open/floor/plating,
@@ -15213,15 +14063,13 @@
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/security/prison)
-"aHH" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/lobby)
 "aHI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -15268,7 +14116,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/advanced_airlock_controller/directional/east,
+/obj/machinery/advanced_airlock_controller/directional/east{
+	pixel_y = 24
+	},
 /obj/machinery/atmospherics/components/binary/dp_vent_pump{
 	dir = 1
 	},
@@ -15390,7 +14240,9 @@
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "aIc" = (
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 10
 	},
@@ -15442,7 +14294,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aIi" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin,
 /obj/structure/cable{
@@ -15522,26 +14376,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/nsv/weapons/fore)
-"aIq" = (
-/obj/machinery/power/apc/auto_name/north,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot_red/left,
-/obj/item/ammo_casing/a357{
-	projectile_type = null
-	},
-/obj/item/ammo_casing/a357{
-	projectile_type = null
-	},
-/obj/item/ammo_casing/a357{
-	projectile_type = null
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
 "aIr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
 /turf/open/floor/wood,
@@ -15666,34 +14500,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/entry)
-"aIE" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 1
-	},
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 4;
-	sortType = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/security)
 "aIF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/table/wood,
@@ -15751,22 +14557,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
-"aIM" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/westright{
-	name = "Executive Officer's Desk"
-	},
-/obj/machinery/door/window/brigdoor/eastleft{
-	name = "Executive Officer's Desk";
-	req_one_access_txt = "57"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "xoprivacy";
-	name = "Privacy Shutters"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hop)
 "aIN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 1
@@ -15799,15 +14589,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"aIQ" = (
-/obj/machinery/door/airlock/glass_large/ship{
-	name = "Pilot Ready Room";
-	req_access_txt = "69"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/turf/open/floor/plasteel/dark,
-/area/nsv/hanger)
 "aIR" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /obj/machinery/camera/autoname,
@@ -15824,13 +14605,6 @@
 /obj/effect/turf_decal/stripes/red/box,
 /turf/open/floor/engine/plasma,
 /area/engine/atmos)
-"aIU" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "aIV" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -15845,15 +14619,6 @@
 /obj/structure/window/plasma/reinforced/spawner/west,
 /turf/open/floor/plasteel,
 /area/gateway)
-"aIW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security)
 "aIX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -15925,7 +14690,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -15968,10 +14735,6 @@
 "aJh" = (
 /turf/closed/wall/ship,
 /area/bridge/meeting_room)
-"aJi" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/atmospherics_engine)
 "aJj" = (
 /obj/machinery/computer/communications{
 	dir = 8
@@ -16072,7 +14835,9 @@
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/ai_monitored/turret_protected/aisat/hallway/support_ship/aft)
 "aJu" = (
-/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
@@ -16223,9 +14988,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"aJN" = (
-/turf/open/floor/plasteel,
-/area/security)
 "aJO" = (
 /obj/machinery/telecomms/receiver/preset_left,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -16369,24 +15131,6 @@
 "aKg" = (
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"aKh" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "aKi" = (
 /obj/machinery/atmospherics/components/unary/portables_connector,
 /obj/machinery/light/small{
@@ -16404,7 +15148,9 @@
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/central)
 "aKk" = (
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -16514,9 +15260,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/engine/engineering/hangar)
-"aKu" = (
-/turf/closed/wall/r_wall/ship,
-/area/maintenance/department/security)
 "aKv" = (
 /obj/item/ship_weapon/ammunition/missile,
 /obj/item/ship_weapon/ammunition/missile{
@@ -16608,7 +15351,9 @@
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/heads/captain)
 "aKF" = (
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -16653,7 +15398,9 @@
 /turf/open/floor/carpet/black,
 /area/security/courtroom)
 "aKK" = (
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -16728,7 +15475,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "aKW" = (
-/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
@@ -16807,10 +15556,6 @@
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/security/prison)
-"aLe" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/security/main)
 "aLf" = (
 /obj/machinery/door/airlock/ship/public{
 	name = "Theatre Backroom";
@@ -16862,41 +15607,16 @@
 /obj/machinery/camera/preset/toxins,
 /turf/open/floor/plating/airless,
 /area/science/test_area)
-"aLk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/ship/command{
-	dir = 4;
-	name = "Captain's Office";
-	req_one_access_txt = "20"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/captain)
 "aLl" = (
 /obj/structure/closet/secure_closet/lethalshots,
 /obj/machinery/airalarm/directional/north,
 /obj/effect/spawner/lootdrop/armory_contraband/donutstation,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/security)
-"aLm" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "26"
-	},
-/turf/open/floor/plating,
-/area/janitor)
 "aLn" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -17005,7 +15725,9 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "aLy" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -17133,17 +15855,11 @@
 "aLK" = (
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
-"aLL" = (
-/obj/machinery/airalarm/directional/west,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
 "aLM" = (
 /obj/machinery/telecomms/broadcaster/preset_left,
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/structure/cable,
 /turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
@@ -17202,7 +15918,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -17221,18 +15939,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
-"aLX" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/ship,
-/area/security/prison)
 "aLY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -17307,10 +16013,6 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/hanger)
-"aMe" = (
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory/lockup)
 "aMf" = (
 /obj/effect/turf_decal/bot_red,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
@@ -17325,7 +16027,9 @@
 /obj/effect/turf_decal/box/red/corners{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -17336,7 +16040,7 @@
 	areastring = "/area/engine/atmos";
 	dir = 1;
 	name = "Atmospherics APC";
-	pixel_y = 23
+	pixel_y = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -17526,20 +16230,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"aMH" = (
-/obj/machinery/holopad,
-/turf/open/floor/plasteel,
-/area/security)
-"aMI" = (
-/obj/machinery/door/airlock/glass_large/ship{
-	bound_height = 64;
-	bound_width = 32;
-	dir = 4;
-	name = "CIC";
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "aMJ" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 10
@@ -17575,10 +16265,6 @@
 	},
 /turf/closed/wall/ship,
 /area/maintenance/port/central)
-"aMN" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering/hangar)
 "aMO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
 /turf/open/floor/plasteel/ship,
@@ -17596,7 +16282,9 @@
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/central)
 "aMQ" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -17663,27 +16351,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/entry)
-"aMZ" = (
-/obj/machinery/button/door{
-	dir = 8;
-	id = "firingsquad";
-	name = "Firing Squad Shutters";
-	pixel_x = 22;
-	pixel_y = -8;
-	req_one_access_txt = "3"
-	},
-/obj/machinery/button/door{
-	dir = 8;
-	id = "hos_privacy";
-	name = "Privacy Shutters";
-	pixel_x = 22;
-	req_one_access_txt = "58"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "aNa" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 1
@@ -17701,19 +16368,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/central)
-"aNc" = (
-/obj/machinery/door/airlock/vault/ship{
-	req_access_txt = "53"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/ship,
-/area/ai_monitored/nuke_storage)
 "aNd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -17726,7 +16380,9 @@
 /turf/open/floor/plasteel/ship,
 /area/security/prison)
 "aNe" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/keycard_auth{
 	pixel_y = 35
@@ -17825,7 +16481,9 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "aNl" = (
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -17869,11 +16527,15 @@
 /obj/machinery/atmospherics/components/binary/dp_vent_pump{
 	dir = 1
 	},
-/obj/machinery/advanced_airlock_controller/directional/west,
+/obj/machinery/advanced_airlock_controller/directional/west{
+	pixel_y = 24
+	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/exit/departure_lounge)
 "aNq" = (
-/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/disposalpipe/segment,
@@ -17916,21 +16578,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"aNu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
 "aNv" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/dark/hidden/layer1{
 	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"aNw" = (
-/obj/effect/turf_decal/stripes/red/corner{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -17979,7 +16631,9 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "aNE" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
 	},
@@ -18042,7 +16696,9 @@
 /turf/open/floor/carpet,
 /area/security/courtroom)
 "aNM" = (
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -18062,7 +16718,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port/central)
 "aNO" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/machinery/chem_master,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -18214,21 +16872,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"aOg" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1,
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"aOh" = (
-/obj/structure/window/reinforced/fulltile/ship,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/chapel/office)
 "aOi" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/disposalpipe/segment{
@@ -18422,7 +17065,9 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "aOE" = (
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
@@ -18435,7 +17080,9 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "aOG" = (
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -18664,18 +17311,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"aPf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "32"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
 "aPg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 5
@@ -18769,15 +17404,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
-"aPq" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer1{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "aPr" = (
 /obj/effect/turf_decal/stripes/box,
 /obj/machinery/atmospherics/components/binary/pump/layer1{
@@ -19027,7 +17653,9 @@
 /turf/open/floor/plasteel/ship,
 /area/security/prison)
 "aPX" = (
-/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
 /obj/machinery/light/small,
 /obj/structure/table/glass,
 /obj/item/book/manual/wiki/surgery,
@@ -19079,7 +17707,9 @@
 /turf/open/floor/plasteel/ship,
 /area/security/prison)
 "aQc" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -19182,14 +17812,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/warden)
-"aQp" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/medical/virology)
-"aQq" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/nsv/weapons/fore)
 "aQr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
 /turf/open/floor/plasteel/dark,
@@ -19314,26 +17936,10 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/security/prison)
-"aQG" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/security)
 "aQH" = (
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -19372,17 +17978,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"aQO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "45"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/security)
 "aQP" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2{
 	dir = 1
@@ -19475,23 +18070,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/nsv/hanger)
-"aRa" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"aRb" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/atmos)
 "aRc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 6
@@ -19615,17 +18193,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/central)
-"aRq" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "ce_window";
-	name = "privacy shutter"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/chief)
 "aRr" = (
 /obj/effect/turf_decal/stripes/white/line,
 /obj/structure/chair{
@@ -19709,22 +18276,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/central)
-"aRA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 6
-	},
-/obj/machinery/airalarm/directional/west,
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security)
-"aRB" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/construction)
 "aRC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /obj/structure/table/optable,
@@ -19745,40 +18296,14 @@
 /turf/open/floor/plasteel/ship,
 /area/security/prison)
 "aRE" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
-"aRF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/security)
-"aRG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/computer/ship/viewscreen,
-/turf/open/floor/plasteel,
-/area/security)
 "aRH" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 8
@@ -19898,12 +18423,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"aRS" = (
-/obj/machinery/atmospherics/pipe/simple/brown/visible{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/engine_room)
 "aRT" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 8
@@ -19983,16 +18502,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/aft)
-"aSa" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/atmos)
 "aSb" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/chair/comfy/brown,
@@ -20066,7 +18575,9 @@
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
 "aSm" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
 /obj/effect/landmark/xeno_spawn,
 /obj/structure/cable{
@@ -20102,7 +18613,9 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "aSq" = (
-/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -20188,34 +18701,6 @@
 /obj/machinery/microwave,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"aSA" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/table/wood,
-/obj/item/folder/red,
-/obj/item/folder/blue,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
-"aSB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/door/airlock/ship/security/glass{
-	name = "Riot Armory";
-	req_one_access_txt = "3"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/ship,
-/area/ai_monitored/security/armory/security)
 "aSC" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
@@ -20232,7 +18717,9 @@
 /area/science/robotics/mechbay)
 "aSE" = (
 /obj/effect/landmark/start/captain,
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 8
 	},
@@ -20242,15 +18729,6 @@
 /obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/heads/captain/private)
-"aSF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
 "aSG" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -20263,11 +18741,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
-"aSH" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3,
-/turf/open/floor/plating,
-/area/engine/atmos)
 "aSI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 4
@@ -20283,20 +18756,6 @@
 	},
 /turf/closed/wall/r_wall/ship,
 /area/tcommsat/server)
-"aSK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel/ship,
-/area/security/prison)
 "aSL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -20328,7 +18787,9 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "aSP" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/machinery/vending/cola/random,
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -20421,23 +18882,6 @@
 /obj/item/circuitboard/machine/stasis,
 /turf/open/floor/plating,
 /area/storage/tech)
-"aSZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Hangar Bay"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plasteel/dark,
-/area/nsv/hanger)
 "aTa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -20656,13 +19100,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"aTu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory/lockup)
 "aTv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 8
@@ -20730,10 +19167,6 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"aTC" = (
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/plasteel,
-/area/security)
 "aTD" = (
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
@@ -20750,10 +19183,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"aTF" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/storage/tech)
 "aTG" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
@@ -20779,14 +19208,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"aTI" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "aTJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/disposalpipe/segment,
@@ -20820,11 +19241,6 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/plasteel/ship,
 /area/nsv/weapons/fore)
-"aTO" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison)
 "aTP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/disposalpipe/segment,
@@ -20942,30 +19358,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"aUa" = (
-/obj/machinery/power/apc/auto_name/west,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel,
-/area/security)
 "aUb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/plasteel,
 /area/maintenance/department/science/central)
 "aUc" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/obj/machinery/computer/crew,
+/obj/structure/window/reinforced/spawner/north,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/lobby)
 "aUd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -21009,18 +19412,6 @@
 /obj/structure/bed,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/security/prison)
-"aUj" = (
-/obj/machinery/atmospherics/components/binary/pump/on/layer3{
-	dir = 8;
-	name = "Tanks to Mix"
-	},
-/obj/effect/turf_decal/stripes/red/box,
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer1,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "aUk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 6
@@ -21067,18 +19458,6 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos)
-"aUr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/door/airlock/ship/hatch{
-	name = "Secure Storage";
-	req_one_access_txt = "3"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/execution/transfer)
 "aUs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 6
@@ -21097,21 +19476,6 @@
 	},
 /turf/open/floor/engine/air,
 /area/engine/atmos)
-"aUu" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security)
 "aUv" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -21127,7 +19491,9 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aUx" = (
-/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/disposalpipe/segment,
@@ -21153,7 +19519,9 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "aUA" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -21199,7 +19567,9 @@
 /turf/open/floor/plasteel/ship,
 /area/nsv/weapons/fore)
 "aUF" = (
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -21238,10 +19608,6 @@
 /obj/structure/extinguisher_cabinet/west,
 /turf/open/floor/plasteel/ship,
 /area/engine/gravity_generator)
-"aUJ" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/security/checkpoint/customs/auxiliary)
 "aUK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/disposalpipe/segment,
@@ -21554,7 +19920,9 @@
 /turf/open/floor/plasteel/ship/padded,
 /area/ai_monitored/turret_protected/ai_upload)
 "aVC" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -21673,10 +20041,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/security/prison)
-"aVO" = (
-/obj/machinery/atmospherics/pipe/simple/brown/visible,
-/turf/open/floor/plasteel,
-/area/engine/engine_room)
 "aVP" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 8
@@ -21690,11 +20054,6 @@
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/plasteel/dark,
 /area/gateway)
-"aVR" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "aVS" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer1,
@@ -22216,10 +20575,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"aXd" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/engine/atmos)
 "aXe" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/northleft{
@@ -22236,17 +20591,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/lawoffice)
-"aXg" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/ship/command{
-	name = "Executive Officer's Office";
-	req_one_access_txt = "57"
-	},
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hop)
 "aXh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -22338,12 +20682,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/engine/break_room)
-"aXs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory/lockup)
 "aXt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrous_output,
 /turf/open/floor/engine/n2o,
@@ -22396,13 +20734,6 @@
 /obj/machinery/flasher{
 	id = "pw_7";
 	pixel_x = -24
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/security/prison)
-"aXA" = (
-/obj/machinery/door/window/brigdoor/security/cell/southright{
-	id = "pw_1";
-	name = "Cell 1"
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/security/prison)
@@ -22605,15 +20936,10 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos)
-"aYa" = (
-/obj/machinery/door/window/brigdoor/security/cell/southright{
-	id = "pw_2";
-	name = "Cell 2"
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/security/prison)
 "aYb" = (
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/structure/cable,
 /turf/open/floor/plasteel/ship,
@@ -22622,7 +20948,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "aYd" = (
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -22649,13 +20977,6 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plating,
 /area/security/checkpoint/customs)
-"aYf" = (
-/obj/machinery/door/window/brigdoor/security/cell/southright{
-	id = "pw_3";
-	name = "Cell 3"
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/security/prison)
 "aYg" = (
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
@@ -22754,13 +21075,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"aYt" = (
-/obj/machinery/door/window/brigdoor/security/cell/southright{
-	id = "pw_4";
-	name = "Cell 4"
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/security/prison)
 "aYu" = (
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/dark,
@@ -22779,20 +21093,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/eva)
-"aYx" = (
-/obj/machinery/door/window/brigdoor/security/cell/southright{
-	id = "pw_5";
-	name = "Cell 5"
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/security/prison)
-"aYy" = (
-/obj/machinery/door/window/brigdoor/security/cell/southright{
-	id = "pw_6";
-	name = "Cell 6"
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/security/prison)
 "aYz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -22936,16 +21236,6 @@
 /mob/living/simple_animal/pet/cat/Runtime,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo)
-"aYR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/pump/layer3,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Plasma To Stormdrive"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "aYS" = (
 /obj/machinery/ship_weapon/torpedo_launcher,
 /obj/effect/turf_decal/delivery/red,
@@ -23057,13 +21347,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/aft)
-"aZe" = (
-/obj/machinery/door/window/brigdoor/security/cell/southright{
-	id = "pw_7";
-	name = "Cell 7"
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/security/prison)
 "aZf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer1{
 	dir = 6
@@ -23078,7 +21361,9 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /turf/open/floor/plasteel/ship,
 /area/security/prison)
 "aZh" = (
@@ -23130,16 +21415,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"aZm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "31;48"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "aZn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/carbon_output,
 /turf/open/floor/engine/co2,
@@ -23157,33 +21432,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"aZp" = (
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer1{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"aZq" = (
-/obj/machinery/atmospherics/pipe/simple/brown/visible,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Engineering EVA";
-	req_one_access_txt = "32"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engine_room)
 "aZr" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
@@ -23219,10 +21467,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"aZv" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/captain/private)
 "aZw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -23327,13 +21571,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/crew_quarters/heads/hor)
-"aZF" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/atmos)
 "aZG" = (
 /obj/structure/sign/departments/medbay/alt{
 	pixel_y = -32
@@ -23469,19 +21706,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"aZV" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "xoprivacy";
-	name = "Privacy Shutters"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hop)
 "aZW" = (
-/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -23560,19 +21788,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"bae" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
 	},
@@ -23879,10 +22094,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo)
-"baL" = (
-/obj/machinery/computer/ship/viewscreen,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "baM" = (
 /obj/machinery/light,
 /obj/structure/table/wood,
@@ -23912,20 +22123,6 @@
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"baP" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/computer/ship/viewscreen,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security)
 "baQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -23951,104 +22148,6 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plasteel/ship,
 /area/security/main)
-"baR" = (
-/obj/machinery/firealarm{
-	pixel_y = 30
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security)
-"baS" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security)
-"baT" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/fore)
-"baU" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security)
-"baV" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security)
-"baW" = (
-/turf/open/floor/plasteel/dark,
-/area/security)
-"baX" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel/dark,
-/area/security)
-"baY" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/fore)
-"baZ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security)
-"bba" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security)
 "bbb" = (
 /obj/machinery/door/airlock/ship{
 	name = "Server Access";
@@ -24069,20 +22168,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/hydroponics)
-"bbd" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
-"bbe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/door/airlock/ship/public/glass,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/ship,
-/area/hallway/primary/fore)
 "bbf" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plasteel,
@@ -24352,19 +22437,6 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/bridge)
-"bbP" = (
-/obj/machinery/door/airlock/glass_large/ship{
-	bound_height = 64;
-	bound_width = 32;
-	dir = 4;
-	name = "CIC";
-	pixel_x = -32
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "bbQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/camera/autoname{
@@ -24383,12 +22455,6 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/ship,
-/area/bridge)
-"bbT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "bbU" = (
 /obj/structure/disposalpipe/trunk{
@@ -24667,7 +22733,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
 	},
-/obj/machinery/advanced_airlock_controller/directional/north,
+/obj/machinery/advanced_airlock_controller/directional/north{
+	pixel_y = 24
+	},
 /turf/open/floor/plating,
 /area/engine/atmos)
 "bcz" = (
@@ -24757,10 +22825,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
-"bcI" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/bridge)
 "bcJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -24792,10 +22856,6 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
-"bcL" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "bcM" = (
 /obj/machinery/door/airlock/ship/external{
 	req_one_access_txt = "24"
@@ -24996,12 +23056,6 @@
 	},
 /turf/closed/wall/ship,
 /area/security/checkpoint/customs)
-"bdj" = (
-/obj/structure/sign/directions/security{
-	dir = 1
-	},
-/turf/closed/wall/r_wall/ship,
-/area/nsv/crew_quarters/heads/maa)
 "bdk" = (
 /obj/structure/sign/directions/security{
 	dir = 4
@@ -25060,7 +23114,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
 	},
-/obj/machinery/advanced_airlock_controller/directional/north,
+/obj/machinery/advanced_airlock_controller/directional/north{
+	pixel_y = 24
+	},
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
 "bds" = (
@@ -25270,16 +23326,6 @@
 	},
 /turf/open/floor/wood,
 /area/library/lounge)
-"bdU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/morgue{
-	name = "Private Study";
-	req_access_txt = "37"
-	},
-/turf/open/floor/wood,
-/area/library)
 "bdV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -25396,7 +23442,9 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "bei" = (
-/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
@@ -25506,18 +23554,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/locker)
-"bex" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "5"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "bey" = (
 /obj/machinery/button/door{
 	id = "hang_storage";
@@ -25684,7 +23720,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/advanced_airlock_controller/directional/east,
+/obj/machinery/advanced_airlock_controller/directional/east{
+	pixel_y = 24
+	},
 /obj/machinery/atmospherics/components/binary/dp_vent_pump,
 /turf/open/floor/plating,
 /area/crew_quarters/bar/atrium)
@@ -25847,21 +23885,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"beZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
-/turf/open/floor/plasteel,
-/area/security)
 "bfa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -26007,7 +24030,9 @@
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/ai_monitored/turret_protected/aisat/service/support_ship)
 "bfp" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
 	},
@@ -26161,7 +24186,9 @@
 /area/medical/genetics/cloning)
 "bfA" = (
 /obj/effect/turf_decal/stripes/white/line,
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/machinery/meter,
 /obj/structure/cable{
@@ -26317,13 +24344,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"bfX" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
 "bfY" = (
 /obj/machinery/door/airlock/ship/external{
 	req_one_access_txt = "13"
@@ -26368,7 +24388,9 @@
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
-/obj/machinery/advanced_airlock_controller/directional/north,
+/obj/machinery/advanced_airlock_controller/directional/north{
+	pixel_y = 24
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "bge" = (
@@ -26405,90 +24427,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"bgj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/security)
-"bgk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/security)
-"bgl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/security)
-"bgm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/turf/open/floor/plating,
-/area/maintenance/department/security)
-"bgn" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/security)
-"bgo" = (
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/security)
-"bgp" = (
-/obj/machinery/door/airlock/ship/external{
-	req_one_access_txt = "13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/turf/open/floor/plating,
-/area/maintenance/department/security)
-"bgq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/components/binary/dp_vent_pump,
-/turf/open/floor/plating,
-/area/maintenance/department/security)
-"bgr" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/machinery/advanced_airlock_controller/directional/west,
-/turf/open/floor/plating,
-/area/maintenance/department/security)
 "bgs" = (
 /obj/effect/turf_decal/delivery/white,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -26507,13 +24445,6 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/hanger)
-"bgu" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "69"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "bgv" = (
 /obj/machinery/light{
 	dir = 1
@@ -26599,18 +24530,6 @@
 	},
 /turf/open/floor/plasteel/ship/riveted,
 /area/maintenance/starboard/central)
-"bgB" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12;69"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "bgC" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -26622,7 +24541,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "bgD" = (
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -26649,7 +24570,9 @@
 /area/maintenance/starboard/central)
 "bgH" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/machinery/advanced_airlock_controller/directional/west,
+/obj/machinery/advanced_airlock_controller/directional/west{
+	pixel_y = 24
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "bgI" = (
@@ -26670,7 +24593,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "bgL" = (
-/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -26827,7 +24752,9 @@
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
-/obj/machinery/advanced_airlock_controller/directional/north,
+/obj/machinery/advanced_airlock_controller/directional/north{
+	pixel_y = 24
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "bhb" = (
@@ -26889,7 +24816,9 @@
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
 "bhh" = (
-/obj/machinery/advanced_airlock_controller/directional/north,
+/obj/machinery/advanced_airlock_controller/directional/north{
+	pixel_y = 24
+	},
 /obj/machinery/atmospherics/components/binary/dp_vent_pump{
 	dir = 4
 	},
@@ -26946,7 +24875,9 @@
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
-/obj/machinery/advanced_airlock_controller/directional/north,
+/obj/machinery/advanced_airlock_controller/directional/north{
+	pixel_y = 24
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "bhp" = (
@@ -27148,7 +25079,9 @@
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
-/obj/machinery/advanced_airlock_controller/directional/north,
+/obj/machinery/advanced_airlock_controller/directional/north{
+	pixel_y = 24
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/central)
 "bhL" = (
@@ -27295,15 +25228,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"bib" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "bic" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -27340,7 +25264,9 @@
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
-/obj/machinery/advanced_airlock_controller/directional/north,
+/obj/machinery/advanced_airlock_controller/directional/north{
+	pixel_y = 24
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bih" = (
@@ -27358,11 +25284,6 @@
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"bij" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
 /area/science/xenobiology)
 "bik" = (
 /obj/machinery/light{
@@ -27465,12 +25386,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"biv" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/central)
 "biw" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -27563,7 +25478,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/advanced_airlock_controller/directional/east,
+/obj/machinery/advanced_airlock_controller/directional/east{
+	pixel_y = 24
+	},
 /obj/machinery/atmospherics/components/binary/dp_vent_pump{
 	dir = 1
 	},
@@ -27587,18 +25504,21 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar/atrium)
 "biH" = (
-/obj/machinery/door/airlock/ship/security/glass{
-	name = "Security Arms Depot";
-	req_one_access_txt = "63;69"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	name = "Nitrogen to Airmix";
+	target_pressure = 4500
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump/layer3{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump/layer1{
+	dir = 8;
+	name = "N2 to Stormdrive"
 	},
 /turf/open/floor/plasteel,
-/area/security)
+/area/engine/atmos)
 "biI" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/ship/external/glass{
@@ -27613,7 +25533,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/advanced_airlock_controller/directional/west,
+/obj/machinery/advanced_airlock_controller/directional/west{
+	pixel_y = 24
+	},
 /obj/machinery/atmospherics/components/binary/dp_vent_pump{
 	dir = 1
 	},
@@ -27736,57 +25658,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/entry)
-"biY" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 10
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
-"biZ" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
-"bja" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/plasteel/ship,
-/area/hallway/primary/fore)
-"bjb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
 "bjc" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	name = "Auxiliary Shuttle Dock"
@@ -27803,7 +25674,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/components/binary/dp_vent_pump,
-/obj/machinery/advanced_airlock_controller/directional/east,
+/obj/machinery/advanced_airlock_controller/directional/east{
+	pixel_y = 24
+	},
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
 "bje" = (
@@ -27823,122 +25696,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/eva)
-"bjg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security)
-"bjh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security)
-"bji" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/security)
-"bjj" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/plasteel,
-/area/security)
-"bjk" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/security)
-"bjl" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/security)
-"bjm" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security)
-"bjn" = (
-/obj/machinery/door/airlock/ship/external/glass{
-	name = "Auxiliary Shuttle Dock";
-	req_one_access_txt = "63;69"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/security)
-"bjo" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/advanced_airlock_controller/directional/north,
-/turf/open/floor/plating,
-/area/security)
 "bjp" = (
-/obj/machinery/door/airlock/ship/external/glass{
-	name = "Auxiliary Shuttle Dock";
-	req_one_access_txt = "63;69"
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
+/obj/structure/chair{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/security)
+/turf/open/floor/plasteel/ship/riveted,
+/area/maintenance/department/medical/morgue)
 "bjq" = (
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "bjr" = (
-/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -28027,7 +25801,9 @@
 /obj/machinery/atmospherics/components/binary/dp_vent_pump{
 	dir = 1
 	},
-/obj/machinery/advanced_airlock_controller/directional/west,
+/obj/machinery/advanced_airlock_controller/directional/west{
+	pixel_y = 24
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bjA" = (
@@ -28392,8 +26168,8 @@
 /area/crew_quarters/heads/hop)
 "bkr" = (
 /obj/machinery/computer/squad_manager{
-	icon_state = "computer";
-	dir = 4
+	dir = 4;
+	icon_state = "computer"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
@@ -28448,34 +26224,6 @@
 /obj/structure/disposaloutlet,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"bkz" = (
-/obj/structure/hull_plate,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
-"bkA" = (
-/obj/structure/hull_plate,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
-"bkB" = (
-/obj/structure/hull_plate,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
-"bkC" = (
-/obj/structure/hull_plate,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "bkD" = (
 /obj/structure/lattice,
 /obj/structure/girder,
@@ -28492,10 +26240,6 @@
 /obj/effect/decal/cleanable/molten_object/large{
 	layer = 2.201
 	},
-/turf/open/space,
-/area/space/nearstation)
-"bkG" = (
-/obj/structure/hull_plate,
 /turf/open/space,
 /area/space/nearstation)
 "bkH" = (
@@ -28538,10 +26282,6 @@
 /area/space/nearstation)
 "bkO" = (
 /obj/structure/grille,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
-"bkP" = (
-/obj/structure/grille/broken,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "bkQ" = (
@@ -28744,6 +26484,14 @@
 /obj/effect/turf_decal/delivery/white,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"blW" = (
+/obj/machinery/door/poddoor{
+	id = "chapelgun";
+	name = "Chapel Launcher Door"
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/security/execution/transfer)
 "bmf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -28773,6 +26521,16 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/central)
+"bmO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump/layer3,
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "N2O to Stormdrive"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "bnb" = (
 /obj/machinery/newscaster{
 	pixel_y = -30
@@ -28801,13 +26559,26 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/central)
-"bpD" = (
-/obj/machinery/door/airlock/ship/station/mining{
-	name = "Cargo Storage";
-	req_one_access_txt = "31; 48"
+"boF" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "69"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/bar)
+"boH" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plating,
-/area/quartermaster/office)
+/area/maintenance/department/medical/morgue)
 "bqb" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/heavy,
@@ -28826,6 +26597,15 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/ai_monitored/turret_protected/aisat/service/support_ship)
+"bqs" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "bqI" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -28837,9 +26617,25 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"bqJ" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "brd" = (
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/hanger)
+"brq" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "bry" = (
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel/ship,
@@ -28850,6 +26646,31 @@
 	},
 /turf/open/floor/plating,
 /area/construction)
+"bsg" = (
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
+"bsr" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "xoprivacy";
+	name = "Privacy Shutters"
+	},
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hop)
 "bsP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -28887,6 +26708,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"buH" = (
+/obj/machinery/computer/med_data,
+/obj/structure/window/reinforced/spawner/north,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/lobby)
 "bva" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel/ship,
@@ -28927,6 +26754,33 @@
 /obj/machinery/light/broken,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"bxo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/command/glass{
+	name = "Chief Engineer";
+	req_one_access_txt = "56"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "byc" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -28938,10 +26792,19 @@
 /obj/machinery/vending/cart,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
-"byo" = (
-/obj/machinery/light/small,
-/turf/open/floor/plating,
-/area/maintenance/department/security)
+"bzd" = (
+/obj/machinery/light{
+	brightness = 5;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/construction)
+"bzk" = (
+/obj/machinery/computer/ship/fighter_controller{
+	dir = 1
+	},
+/turf/open/floor/carpet/ship,
+/area/nsv/crew_quarters/heads/maa)
 "bzl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -28958,11 +26821,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/gateway)
-"bzx" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plating,
-/area/science/mixing)
 "bAv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/effect/turf_decal/tile/brown{
@@ -28985,6 +26843,41 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/ship,
 /area/ai_monitored/turret_protected/ai)
+"bAU" = (
+/obj/machinery/atmospherics/pipe/simple/brown/visible,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Engineering EVA";
+	req_one_access_txt = "32"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
+"bBg" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/brown/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "bCt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -28993,6 +26886,17 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/exit)
+"bCx" = (
+/obj/machinery/door/window/eastright{
+	name = "Launch Chamber";
+	req_one_access_txt = "8"
+	},
+/obj/effect/turf_decal/loading_area/red{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "bCy" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -29032,6 +26936,13 @@
 /obj/effect/landmark/start/roboticist,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"bGc" = (
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/effect/landmark/start/head_of_security,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "bGf" = (
 /obj/machinery/sleeper{
 	dir = 1
@@ -29042,6 +26953,13 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"bGg" = (
+/obj/item/ship_weapon/ammunition/torpedo,
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory/lockup)
 "bGF" = (
 /obj/effect/landmark/secequipment,
 /obj/effect/turf_decal/tile/red,
@@ -29070,6 +26988,11 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
+"bHx" = (
+/obj/structure/table/wood/poker,
+/obj/item/stack/spacecash/c100,
+/turf/open/floor/wood,
+/area/maintenance/starboard/central)
 "bHG" = (
 /obj/structure/chair/stool,
 /turf/open/floor/wood,
@@ -29084,12 +27007,6 @@
 /obj/structure/closet/secure_closet/brig_phys,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"bJo" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
 "bLb" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plasteel/dark,
@@ -29122,6 +27039,23 @@
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
+"bMh" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory/lockup)
+"bMm" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/ship/riveted,
+/area/maintenance/department/medical/morgue)
 "bMn" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -29219,12 +27153,6 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
-"bRB" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/bar)
 "bRE" = (
 /obj/machinery/light{
 	dir = 8
@@ -29278,6 +27206,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/patients_rooms/room_a)
+"bSP" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "ce_window";
+	name = "privacy shutter"
+	},
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/crew_quarters/heads/chief)
 "bSV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29290,19 +27228,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"bSZ" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/security)
 "bTe" = (
 /obj/machinery/light{
 	dir = 4
@@ -29393,21 +27318,6 @@
 /obj/effect/landmark/start/botanist,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"bWq" = (
-/obj/machinery/door/airlock/ship/security/glass{
-	name = "Security Arms Depot";
-	req_one_access_txt = "63;69"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plasteel,
-/area/security)
 "bWs" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -29437,16 +27347,16 @@
 /obj/machinery/vending/wardrobe/cargo_wardrobe,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"bXP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "bYk" = (
 /obj/structure/extinguisher_cabinet/west,
 /turf/open/floor/plating,
 /area/storage/tech)
-"bYJ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security)
 "bYK" = (
 /obj/item/storage/box/donkpockets,
 /obj/structure/table/wood,
@@ -29609,12 +27519,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/central)
-"cgZ" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/security)
 "chM" = (
 /obj/effect/landmark/start/assistant,
 /obj/structure/chair/comfy/brown{
@@ -29661,6 +27565,43 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
+"ckc" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/brown/visible/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"ckt" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12;69"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
+"ckw" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 1;
+	icon_state = "connector_map-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "ckE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -29673,16 +27614,6 @@
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar/atrium)
-"cla" = (
-/obj/machinery/door/poddoor/ship{
-	id = "launchbay_tube3";
-	name = "Launch tube 3 access"
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/turf/open/floor/plating,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
 "clF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/cable{
@@ -29760,6 +27691,13 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/library)
+"cqz" = (
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Prison Sleepers"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plasteel/ship,
+/area/security/prison)
 "cqZ" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
@@ -29769,6 +27707,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"crk" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "crT" = (
 /obj/structure/disposaloutlet{
 	dir = 8
@@ -29778,21 +27721,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"crU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/extinguisher_cabinet/west,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "csp" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -29827,6 +27755,30 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/central)
+"ctL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel/ship,
+/area/hallway/primary/fore)
+"ctY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/door/airlock/ship/hatch{
+	name = "Chaplain's Office";
+	req_one_access_txt = "22"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plasteel/dark,
+/area/chapel/main)
 "cut" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -29907,6 +27859,31 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"cye" = (
+/obj/machinery/button/door{
+	dir = 8;
+	id = "firingsquad";
+	name = "Firing Squad Shutters";
+	pixel_x = 22;
+	pixel_y = -8;
+	req_one_access_txt = "3"
+	},
+/obj/machinery/button/door{
+	dir = 8;
+	id = "hos_privacy";
+	name = "Privacy Shutters";
+	pixel_x = 22;
+	req_one_access_txt = "58"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/airalarm/directional/south,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "cyj" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/detective,
@@ -30079,6 +28056,15 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"cED" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "rd_window";
+	name = "privacy shutter"
+	},
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/science/lab)
 "cEN" = (
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
@@ -30105,6 +28091,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"cHg" = (
+/obj/machinery/door/poddoor/shutters/ship{
+	dir = 1;
+	id = "ad_gun";
+	name = "Arms Dump Shutters"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory/lockup)
 "cHo" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
@@ -30136,6 +28130,12 @@
 	},
 /turf/open/floor/plasteel/ship/riveted,
 /area/maintenance/starboard/central)
+"cIN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "cJj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -30198,29 +28198,11 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/entry)
-"cMn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/central)
-"cNg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
+"cNp" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/engine/gravity_generator)
 "cNO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -30294,6 +28276,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
+"cQp" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/security/execution/transfer)
 "cQr" = (
 /obj/structure/table/reinforced,
 /obj/item/pen/fourcolor,
@@ -30320,6 +28307,13 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/ai_monitored/turret_protected/aisat/service/support_ship)
+"cSH" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/brown/visible{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "cSN" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -30331,6 +28325,13 @@
 /obj/structure/filingcabinet,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
+"cSY" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/secure_data/laptop{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "cTr" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -30348,17 +28349,12 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/port/central)
-"cTV" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "30"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
+"cTY" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/window,
+/obj/machinery/atmospherics/pipe/simple/brown/hidden,
 /turf/open/floor/plating,
-/area/maintenance/port/central)
+/area/engine/engine_room)
 "cUn" = (
 /obj/machinery/requests_console{
 	department = "Atmospherics";
@@ -30392,15 +28388,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"cXH" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/central)
 "cXR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -30430,30 +28417,6 @@
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plasteel,
 /area/engine/storage)
-"cYl" = (
-/obj/machinery/door/window/eastright{
-	name = "Launch Chamber";
-	req_one_access_txt = "8"
-	},
-/obj/effect/turf_decal/loading_area/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
-"cYE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cYR" = (
 /obj/machinery/door/airlock/virology/glass{
 	name = "Test Subject Supply";
@@ -30479,6 +28442,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"cZb" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/bar)
 "cZm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -30545,6 +28516,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"dbC" = (
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "dbR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -30608,6 +28584,14 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/exit)
+"den" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/north,
+/obj/structure/closet/secure_closet/munitions_technician,
+/turf/open/floor/plasteel/ship,
+/area/nsv/weapons/fore)
 "deC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -30625,6 +28609,18 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/central)
+"dft" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/maintenance{
+	name = "Medbay Service";
+	req_one_access_txt = "5;33"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "dfy" = (
 /obj/machinery/teleport/station,
 /turf/open/floor/plasteel/ship,
@@ -30637,6 +28633,16 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"dgc" = (
+/obj/machinery/button/door{
+	id = "ad_gun";
+	name = "Arms Dump Gun Storage";
+	pixel_x = 0;
+	pixel_y = 24;
+	req_one_access_txt = "3;58"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory/lockup)
 "dgl" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -30710,17 +28716,6 @@
 /obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/wood,
 /area/library)
-"djp" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/ship/station/mining{
-	name = "Quartermaster's Office";
-	req_one_access_txt = "41"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "djr" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -30737,13 +28732,12 @@
 /obj/item/clothing/head/helmet/riot,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/security)
-"djK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
+"djT" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/item/ship_weapon/ammunition/torpedo,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory/lockup)
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/construction)
 "dkf" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
@@ -30777,14 +28771,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plasteel/ship,
 /area/ai_monitored/turret_protected/aisat/service/support_ship)
-"dlW" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/landmark/start/brig_phys,
-/turf/open/floor/plasteel/ship,
-/area/security/prison)
 "dmg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -30846,6 +28832,21 @@
 /obj/effect/landmark/nuclear_waste_spawner/strong,
 /turf/open/floor/engine,
 /area/engine/engine_room)
+"dnO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/security/glass{
+	name = "Brig Control";
+	req_one_access_txt = "3"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/ship,
+/area/security/warden)
 "dog" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/brown{
@@ -30874,6 +28875,12 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"dor" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "doN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -30885,6 +28892,9 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/central)
+"dpq" = (
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/fore)
 "dpx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30897,17 +28907,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
-"dpL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security)
 "dql" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30924,6 +28923,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
+"dqr" = (
+/obj/effect/spawner/room/threexfive,
+/turf/template_noop,
+/area/maintenance/department/medical/morgue)
 "dqt" = (
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
@@ -31050,6 +29053,20 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"dvl" = (
+/obj/machinery/atmospherics/pipe/manifold/purple/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "dvm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31099,6 +29116,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"dvz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "dvN" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -31109,6 +29134,12 @@
 /obj/machinery/nanite_programmer,
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"dvV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/fore)
 "dvZ" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -31153,6 +29184,21 @@
 /obj/effect/turf_decal/delivery/white,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/security)
+"dxy" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/ship,
+/area/hallway/primary/central)
 "dxL" = (
 /obj/machinery/button/door{
 	dir = 1;
@@ -31190,12 +29236,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
-"dyL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "dyT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -31224,6 +29264,27 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"dzM" = (
+/obj/machinery/light,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Head of Security's Desk";
+	departmentType = 5;
+	name = "Head of Security RC";
+	pixel_x = 0;
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
+"dAf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory/lockup)
 "dAN" = (
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/showroomfloor,
@@ -31285,11 +29346,15 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
-"dGC" = (
-/obj/machinery/airalarm/directional/west,
-/obj/structure/closet/firecloset,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/nsv/hanger)
+"dHt" = (
+/obj/machinery/camera/autoname,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/structure/closet/secure_closet/munitions_technician,
+/turf/open/floor/plasteel/ship,
+/area/nsv/weapons/fore)
 "dHw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -31301,6 +29366,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/eva)
+"dHJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/ai_monitored/security/armory/lockup)
 "dHQ" = (
 /obj/machinery/door/airlock/ship/hatch{
 	name = "Air Control Right";
@@ -31314,6 +29394,18 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
+"dIH" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "xoprivacy";
+	name = "Privacy Shutters"
+	},
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hop)
 "dIV" = (
 /obj/machinery/modular_computer/console/preset/research{
 	dir = 4
@@ -31323,21 +29415,15 @@
 	},
 /turf/open/floor/carpet/black,
 /area/crew_quarters/heads/hor)
-"dJf" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+"dJa" = (
+/obj/machinery/door/airlock/ship/station/mining{
+	name = "Cargo Storage";
+	req_one_access_txt = "31; 48"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/fore)
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/quartermaster/office)
 "dJj" = (
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/ship,
@@ -31557,20 +29643,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/central)
-"dSS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security)
 "dSX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/effect/turf_decal/tile/blue{
@@ -31589,13 +29661,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/ai_monitored/nuke_storage)
-"dTm" = (
-/obj/machinery/door/airlock/ship/hatch{
-	name = "Secure Storage";
-	req_access_txt = "3;58"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "dTs" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/ship/techfloor/alt,
@@ -31641,11 +29706,35 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"dVu" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/security/prison)
 "dVB" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/port/central)
+"dVO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/brown/visible,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "dWy" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -31690,6 +29779,29 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"dZS" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Stormdrive Plasma Constriction";
+	req_one_access_txt = "11; 24"
+	},
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Plasma To Stormdrive";
+	target_pressure = 50
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "eaw" = (
 /obj/machinery/computer/telecomms/monitor,
 /turf/open/floor/plasteel/grimy,
@@ -31729,6 +29841,12 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/fore)
+"ecJ" = (
+/obj/machinery/computer/card/minor/hos{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "ecL" = (
 /mob/living/simple_animal/slime,
 /turf/open/floor/engine,
@@ -31736,40 +29854,47 @@
 "ecZ" = (
 /turf/open/floor/plasteel/ship,
 /area/ai_monitored/turret_protected/aisat/service/support_ship)
-"efI" = (
-/obj/structure/closet/firecloset,
+"edN" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Dorms-0.5";
+	location = "Dorms-0"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/ship,
+/area/hallway/primary/central)
+"efz" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	name = "Kitchen maintenance";
+	req_access_txt = "35;28"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plating,
-/area/maintenance/department/security)
+/area/crew_quarters/kitchen)
 "efL" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel,
 /area/science/research)
-"egm" = (
+"ego" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "12"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
-"egu" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/obj/effect/landmark/start/brig_phys,
-/turf/open/floor/plasteel/ship,
-/area/security/prison)
+/area/maintenance/central)
 "egw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -31809,7 +29934,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "eiu" = (
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -31829,6 +29956,14 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/exit)
+"ejn" = (
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Hangar Bay"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/fore)
 "ejN" = (
 /obj/item/storage/toolbox/mechanical,
 /obj/structure/rack,
@@ -31844,22 +29979,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"ekb" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/ship/riveted,
+/area/maintenance/department/medical/morgue)
 "eki" = (
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
-"ekn" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "ce_window";
-	name = "privacy shutter"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/chief)
 "elf" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -31921,6 +30051,17 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"epl" = (
+/turf/open/floor/carpet/ship,
+/area/nsv/crew_quarters/heads/maa)
+"epm" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "26"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/janitor)
 "epq" = (
 /obj/effect/turf_decal/box/red/corners,
 /turf/open/floor/plating,
@@ -31942,11 +30083,6 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/security/armory/security)
-"eqo" = (
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
-/turf/open/floor/plasteel,
-/area/security)
 "eqq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -31985,6 +30121,22 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/wood,
 /area/science/research)
+"ert" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/button/door{
+	id = "ad_torp";
+	name = "Arms Dump Torpedo Storage";
+	pixel_x = -24;
+	pixel_y = 0;
+	req_one_access_txt = "70;71"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory/lockup)
 "erO" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/red,
@@ -32071,31 +30223,11 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
-"euT" = (
-/obj/machinery/computer/prisoner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "euY" = (
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_exterior,
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
-"evo" = (
-/obj/machinery/door/airlock/ship/security/glass{
-	id_tag = "pw_fd_outer";
-	name = "Brig";
-	req_one_access_txt = "63"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/security/prison)
-"ewo" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced/spawner/north,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/lobby)
 "ewW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -32120,15 +30252,17 @@
 	},
 /turf/open/floor/plating,
 /area/nsv/weapons/fore)
-"eze" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/ship/security/glass{
-	id_tag = "pw_fd_outer";
-	name = "Brig";
-	req_one_access_txt = "63"
+"eza" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
 	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/security/prison)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "ezn" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/ship/techfloor/alt,
@@ -32150,30 +30284,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/quartermaster/storage)
-"eAP" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security)
-"eAS" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "eAZ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -32194,6 +30304,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs/auxiliary)
+"eBF" = (
+/obj/machinery/door/window/brigdoor/security/cell/southright{
+	id = "pw_7";
+	name = "Cell 7"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/security/prison)
 "eBJ" = (
 /obj/machinery/light{
 	dir = 8
@@ -32210,6 +30328,10 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"eCU" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "eDd" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -32296,6 +30418,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
+"eGt" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/nsv/hanger/deck2/port{
+	name = "Launch tubes 3 and 4"
+	})
 "eGO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -32380,6 +30509,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"eKC" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "eKK" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
@@ -32393,16 +30528,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"eLN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/door/airlock/ship/security/glass{
-	name = "Brig Control";
-	req_one_access_txt = "3"
-	},
-/turf/open/floor/plasteel/ship,
-/area/security/warden)
 "eLW" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/recharge_station,
@@ -32453,22 +30578,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"eNu" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/newscaster/security_unit{
-	pixel_y = -30
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security)
 "eNw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -32514,6 +30623,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"ePt" = (
+/obj/effect/turf_decal/arrows/red,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "xoline";
+	name = "XO Line Shutters"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plasteel/ship,
+/area/hallway/primary/fore)
 "ePu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -32687,6 +30808,23 @@
 	},
 /turf/open/floor/carpet/black,
 /area/crew_quarters/heads/hor)
+"eWc" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/landmark/start/brig_phys,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/ship,
+/area/security/prison)
 "eWo" = (
 /obj/item/bedsheet/random,
 /obj/structure/bed,
@@ -32712,6 +30850,34 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/storage)
+"eYk" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "10"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
+"eYz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "eYE" = (
 /obj/machinery/newscaster{
 	dir = 4;
@@ -32776,6 +30942,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"fbm" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/crew_quarters/bar/atrium)
 "fcs" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -32839,6 +31010,12 @@
 /obj/effect/spawner/lootdrop/maintenance/five,
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
+"ffM" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/science/mixing)
 "ffW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -32870,6 +31047,24 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/fore)
+"fgY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/ship,
+/area/hallway/primary/fore)
 "fgZ" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -32890,6 +31085,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
+"fiq" = (
+/obj/machinery/door/window/brigdoor/security/cell/southright{
+	id = "pw_6";
+	name = "Cell 6"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/security/prison)
 "fjv" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -32902,11 +31105,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
-"fjA" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/engine/atmos)
 "fkM" = (
 /obj/structure/bed/dogbed/runtime,
 /obj/structure/cable{
@@ -32920,13 +31118,11 @@
 "fkN" = (
 /turf/open/space/basic,
 /area/space/nearstation)
-"flf" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
+"flG" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
-/area/maintenance/department/medical/morgue)
+/area/engine/engine_room)
 "fmb" = (
 /obj/effect/landmark/start/atmospheric_technician,
 /obj/machinery/camera/autoname{
@@ -32964,6 +31160,13 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plasteel/ship/riveted,
 /area/maintenance/starboard/central)
+"fpD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "fpL" = (
 /turf/open/floor/wood,
 /area/science/research)
@@ -32991,6 +31194,18 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/security/main)
+"fqG" = (
+/obj/machinery/door/poddoor/ship{
+	id = "launchbay_tube2";
+	name = "Launch tube 2 access"
+	},
+/obj/effect/turf_decal/stripes/full,
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/nsv/hanger/deck2/starboard{
+	name = "Launch tubes 1 and 2"
+	})
 "fqL" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -33036,6 +31251,11 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/ai_monitored/turret_protected/aisat/hallway/support_ship)
+"fsn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/fore)
 "fst" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
@@ -33107,6 +31327,18 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/central)
+"fvF" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "69"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/department/chapel)
+"fvQ" = (
+/obj/item/chair/stool/bar,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "fwe" = (
 /turf/open/floor/plating/airless,
 /area/science/xenobiology)
@@ -33114,6 +31346,14 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"fwl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "fwB" = (
 /obj/item/radio/intercom{
 	pixel_y = -32
@@ -33161,6 +31401,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"fyw" = (
+/obj/structure/table_frame/wood,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "fzR" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -33177,6 +31422,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"fAg" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "fAj" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
@@ -33197,6 +31447,11 @@
 	},
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
+"fBK" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "fBU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -33246,6 +31501,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"fCU" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "fDf" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -33317,6 +31579,17 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
+"fEY" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "fFH" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -33329,11 +31602,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"fGM" = (
-/obj/machinery/suit_storage_unit/pilot,
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/nsv/hanger)
+"fHD" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
+"fIp" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "fIM" = (
 /obj/structure/chair/pew/right,
 /obj/effect/landmark/start/assistant,
@@ -33374,12 +31658,36 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/toilet/restrooms)
-"fJU" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
+"fJM" = (
+/obj/machinery/door/poddoor/ship{
+	id = "launchbay_tube4";
+	name = "Launch tube 4 access"
 	},
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
-/area/maintenance/port/central)
+/area/nsv/hanger/deck2/port{
+	name = "Launch tubes 3 and 4"
+	})
+"fKx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "6;12"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "fKy" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -33431,23 +31739,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
-"fKV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/newscaster/security_unit{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel,
-/area/security)
 "fLr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -33478,6 +31769,17 @@
 /obj/effect/mob_spawn/human/clown/corpse,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"fMH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters/ship{
+	dir = 1;
+	id = "ad_gun";
+	name = "Arms Dump Shutters"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory/lockup)
 "fMX" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -33487,6 +31789,15 @@
 	},
 /turf/open/floor/carpet/black,
 /area/security/courtroom)
+"fNf" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/ship,
+/area/hallway/primary/fore)
 "fNx" = (
 /obj/machinery/light{
 	dir = 8
@@ -33559,10 +31870,6 @@
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"fQZ" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/maintenance/department/security)
 "fRb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33602,15 +31909,12 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/entry)
-"fSt" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "32"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
+"fSp" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/electrical)
+/area/maintenance/department/medical)
 "fSI" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -33621,6 +31925,10 @@
 "fTe" = (
 /turf/closed/wall/r_wall/ship,
 /area/ai_monitored/turret_protected/aisat/service/support_ship)
+"fTu" = (
+/obj/machinery/armour_plating_nanorepair_pump/aft_port,
+/turf/open/floor/plasteel/ship,
+/area/construction)
 "fTE" = (
 /obj/machinery/door/airlock/ship{
 	name = "RD Bulk Storage";
@@ -33630,12 +31938,6 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/plasteel,
 /area/science/research)
-"fTU" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "5"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "fUf" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/visible,
 /obj/machinery/airalarm/directional/west,
@@ -33651,11 +31953,33 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison)
+"fUX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/ship,
+/area/security/prison)
 "fVK" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/engine/atmos)
+"fVU" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory/lockup)
 "fWk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33674,14 +31998,6 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"fWO" = (
-/obj/machinery/requests_console{
-	department = "Engineering";
-	departmentType = 3;
-	name = "Engineering RC"
-	},
-/turf/closed/wall/ship,
-/area/engine/engine_room)
 "fXB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -33714,12 +32030,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"fYr" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical/morgue)
 "fYU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -33789,6 +32099,13 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"gba" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/brown/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "gbc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -33798,6 +32115,25 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/central)
+"gbq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/ship/security/glass{
+	dir = 8;
+	name = "Head of Security";
+	req_one_access_txt = "58"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/ship,
+/area/security/prison)
 "gbL" = (
 /obj/structure/grille,
 /obj/structure/cable{
@@ -33826,6 +32162,13 @@
 /obj/machinery/microwave,
 /turf/open/floor/carpet/orange,
 /area/engine/break_room)
+"geQ" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "geX" = (
 /obj/machinery/light{
 	dir = 8
@@ -33836,15 +32179,11 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/hanger)
-"gfC" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
+"gft" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
-/area/maintenance/department/electrical)
+/area/hallway/secondary/exit)
 "gfK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 5
@@ -33861,12 +32200,6 @@
 /obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/plasteel/ship,
 /area/security/main)
-"ggZ" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/construction)
 "ghn" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/machinery/requests_console{
@@ -33910,17 +32243,6 @@
 /obj/machinery/vending/tool,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"giB" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "giC" = (
 /obj/machinery/button/door{
 	id = "riot_storage";
@@ -33937,19 +32259,6 @@
 	},
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/plasteel/white,
-/area/maintenance/department/medical)
-"gka" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plating,
 /area/maintenance/department/medical)
 "gkO" = (
 /obj/effect/turf_decal/tile/red{
@@ -33994,6 +32303,13 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/nsv/hanger/storage)
+"gmu" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 10
+	},
+/turf/open/floor/plasteel/ship,
+/area/hallway/primary/fore)
 "gmw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -34003,6 +32319,11 @@
 	},
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
+"gmI" = (
+/obj/structure/closet/crate,
+/obj/item/stack/spacecash/c1,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "gnT" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -34022,12 +32343,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/port)
-"goa" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/security)
 "gon" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -34065,6 +32380,17 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
+"gpm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "31;48"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "gpr" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/machinery/button/door{
@@ -34090,6 +32416,11 @@
 /obj/effect/decal/cleanable/oil/streak,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"grF" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/engine/atmospherics_engine)
 "grQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
@@ -34133,6 +32464,17 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/aft)
+"gtQ" = (
+/turf/template_noop,
+/area/maintenance/department/medical/morgue)
+"gum" = (
+/obj/effect/turf_decal/caution/white,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/brown/visible,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "guL" = (
 /obj/machinery/light{
 	dir = 4
@@ -34203,6 +32545,11 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/ship,
 /area/ai_monitored/turret_protected/aisat/service/support_ship)
+"gwD" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/glowstick,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "gwJ" = (
 /obj/machinery/holopad,
 /turf/open/floor/carpet/ship,
@@ -34232,6 +32579,22 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"gxS" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/crew_quarters/fitness)
+"gyg" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/security/checkpoint/customs/auxiliary)
 "gyv" = (
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/plasteel/white,
@@ -34263,6 +32626,10 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/ship,
 /area/security/prison)
+"gzQ" = (
+/obj/structure/railing,
+/turf/open/floor/plating,
+/area/construction)
 "gzR" = (
 /obj/effect/landmark/start/flight_leader,
 /turf/open/floor/plasteel/ship,
@@ -34313,16 +32680,6 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel,
 /area/storage/eva)
-"gAQ" = (
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 1;
-	sortType = 7
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security)
 "gCk" = (
 /obj/effect/landmark/start/atmospheric_technician,
 /obj/structure/sign/plaques/atmos{
@@ -34334,6 +32691,10 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
+"gCY" = (
+/obj/machinery/light,
+/turf/open/floor/carpet/ship,
+/area/nsv/crew_quarters/heads/maa)
 "gDS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 5
@@ -34350,24 +32711,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/incinerator_output,
 /turf/open/floor/engine/vacuum,
 /area/engine/atmospherics_engine)
-"gEB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/security)
 "gEJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 8
@@ -34380,6 +32723,11 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/tcommsat/computer)
+"gES" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/bridge/meeting_room)
 "gEV" = (
 /obj/structure/tank_dispenser,
 /turf/open/floor/plasteel,
@@ -34406,12 +32754,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/gateway)
-"gHK" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
+"gIK" = (
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 9
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical/morgue)
 "gIS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -34432,6 +32781,24 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
+"gJq" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
+"gJJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/armour_plating_nanorepair_pump/forward_starboard,
+/turf/open/floor/plasteel/ship,
+/area/construction)
 "gJQ" = (
 /obj/structure/closet/wardrobe/white,
 /turf/open/floor/plasteel/white,
@@ -34475,6 +32842,22 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"gMi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "45"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
+"gMn" = (
+/turf/open/floor/wood,
+/area/maintenance/starboard/central)
 "gMA" = (
 /obj/machinery/light/broken{
 	dir = 4
@@ -34506,6 +32889,18 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
+"gOU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/security/glass{
+	name = "Brig Control";
+	req_one_access_txt = "3"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/ship,
+/area/security/warden)
 "gRn" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -34631,6 +33026,10 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"gWh" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "gWx" = (
 /turf/open/floor/carpet/orange,
 /area/engine/break_room)
@@ -34710,22 +33109,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"hax" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 4;
-	sortType = "7;8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/security)
 "haO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/door/airlock/ship{
@@ -34777,15 +33160,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"hbp" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "55"
+"hbc" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/door/airlock/ship/security/glass{
+	id_tag = "pw_fd_inner";
+	name = "Brig";
+	req_one_access_txt = "63"
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/security/prison)
 "hbs" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -34888,6 +33276,26 @@
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/storage)
+"het" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/ship/security/glass{
+	dir = 8;
+	name = "Head of Security";
+	req_one_access_txt = "58"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hos)
 "hew" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -34922,6 +33330,15 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
+"hfd" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/construction)
 "hfq" = (
 /obj/effect/turf_decal/delivery/white,
 /obj/structure/disposalpipe/segment{
@@ -34975,6 +33392,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/central)
+"hfN" = (
+/obj/structure/hull_plate/end,
+/obj/structure/hull_plate/end,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "hfV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -35019,6 +33441,14 @@
 /obj/machinery/computer/secure_data/laptop,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/heads/hop)
+"hgn" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "hgo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -35051,15 +33481,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
-"hiR" = (
-/obj/structure/closet/bombcloset/security,
-/obj/machinery/camera/autoname,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/ship,
-/area/nsv/weapons/fore)
 "hiT" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 8
@@ -35071,15 +33492,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/office)
-"hjq" = (
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/security)
 "hjw" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -35106,9 +33518,6 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"hjM" = (
-/turf/open/floor/plasteel/dark,
-/area/nsv/hanger)
 "hjQ" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -35126,6 +33535,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"hkl" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "hkw" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -35157,14 +33575,6 @@
 /obj/item/gun/ballistic/shotgun/riot,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/security)
-"hlm" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet/ship,
-/area/nsv/crew_quarters/heads/maa)
 "hlo" = (
 /obj/structure/chair/stool/bar,
 /turf/open/floor/carpet/orange,
@@ -35243,6 +33653,23 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
+"hpc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/sign/plaques/golden{
+	desc = "Make. Torp.";
+	name = "The 40mm torp award for torpedo production";
+	pixel_y = 26
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/ship,
+/area/nsv/crew_quarters/heads/maa)
 "hph" = (
 /obj/machinery/stasis,
 /obj/machinery/light,
@@ -35264,6 +33691,14 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"hpB" = (
+/obj/machinery/computer/ship/viewscreen,
+/obj/effect/landmark/start/assistant,
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "hpG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -35275,34 +33710,44 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/central)
-"hqj" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+"hqD" = (
+/obj/machinery/keycard_auth{
+	pixel_y = 35
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"hqs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "6"
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_y = 24
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
+	},
+/obj/machinery/button/door{
+	id = "hos_window";
+	name = "Privacy Shutters";
+	pixel_x = 24;
+	pixel_y = 0;
+	req_one_access_txt = "58"
 	},
 /turf/open/floor/plasteel/dark,
-/area/maintenance/department/medical/morgue)
+/area/crew_quarters/heads/hos)
 "hqT" = (
 /obj/structure/table/wood,
 /obj/item/toy/cards/deck/cas,
 /turf/open/floor/wood,
 /area/library/lounge)
+"hro" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "30"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "hrR" = (
 /obj/machinery/light{
 	dir = 8
@@ -35340,13 +33785,20 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"hsX" = (
-/obj/machinery/door/poddoor/shutters/ship{
-	id = "ad_storage";
-	name = "Arms Dump Shutters"
+"hsL" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "6"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory/lockup)
+/area/maintenance/department/medical/morgue)
 "htL" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Engineering Hangar Bay";
@@ -35359,6 +33811,27 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"hui" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/brown/visible{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "huo" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -35368,6 +33841,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"huV" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/medical/virology)
 "hvo" = (
 /obj/machinery/vending/games,
 /obj/structure/extinguisher_cabinet/north,
@@ -35383,36 +33861,10 @@
 /obj/machinery/vending/wardrobe/medi_wardrobe,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"hvW" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/security)
-"hwH" = (
-/obj/machinery/door_timer{
-	id = "pw_1";
-	name = "Cell 1";
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel/ship,
-/area/security/prison)
+"hwP" = (
+/obj/structure/chair/stool/bar,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "hwZ" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -35456,6 +33908,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"hyi" = (
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory/lockup)
 "hyt" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -35493,6 +33951,16 @@
 /obj/structure/chair/office,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"hAU" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/ship/riveted,
+/area/maintenance/department/medical/morgue)
 "hBa" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -35536,13 +34004,16 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/aft)
-"hCZ" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+"hCU" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/security)
+/turf/closed/wall/ship,
+/area/engine/engineering)
 "hDy" = (
 /obj/machinery/processor,
 /turf/open/floor/plasteel/cafeteria,
@@ -35570,6 +34041,15 @@
 /obj/structure/extinguisher_cabinet/south,
 /turf/open/floor/plasteel/ship,
 /area/security/warden)
+"hEF" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "hEG" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/snacks/mint,
@@ -35608,6 +34088,10 @@
 	},
 /turf/open/floor/plating,
 /area/nsv/hanger/storage)
+"hFE" = (
+/obj/effect/spawner/room/threexthree,
+/turf/template_noop,
+/area/maintenance/port/aft)
 "hFG" = (
 /obj/effect/landmark/blobstart,
 /obj/structure/cable{
@@ -35630,17 +34114,17 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
+"hGy" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/engine/engine_room)
 "hGA" = (
 /obj/machinery/computer/security/mining{
 	dir = 4
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
-"hGC" = (
-/obj/machinery/computer/med_data,
-/obj/structure/window/reinforced/spawner/north,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/lobby)
 "hGK" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -35703,6 +34187,14 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
+"hIL" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "hIQ" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/machinery/camera/autoname{
@@ -35754,10 +34246,6 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/weapons/fore)
-"hMw" = (
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/plating,
-/area/maintenance/department/medical/morgue)
 "hNa" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -35771,18 +34259,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
-"hNs" = (
-/obj/machinery/keycard_auth{
-	pixel_y = 35
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
+"hNV" = (
+/obj/effect/turf_decal/bot_red/right,
+/obj/item/ammo_casing/a357{
+	dir = 8;
+	projectile_type = null
 	},
 /turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
+/area/security/execution/transfer)
 "hOw" = (
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/computer/operating{
@@ -35790,13 +34274,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
-"hPa" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/item/ship_weapon/ammunition/torpedo,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory/lockup)
+"hOL" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/hallway/primary/fore)
 "hPq" = (
 /obj/machinery/light{
 	dir = 4
@@ -35842,15 +34324,6 @@
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"hQO" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "29"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "hRc" = (
 /obj/machinery/status_display/evac{
 	pixel_y = 32
@@ -35900,23 +34373,30 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/eva)
+"hTn" = (
+/obj/structure/rack,
+/obj/item/weldingtool,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "hTE" = (
 /turf/open/floor/plasteel/ship,
 /area/ai_monitored/turret_protected/aisat/hallway/support_ship)
+"hTL" = (
+/obj/effect/turf_decal/arrows/red{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "xoline";
+	name = "XO Line Shutters"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/ship,
+/area/hallway/primary/fore)
 "hTW" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/britcup,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar/atrium)
-"hUh" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/item/folder/blue,
-/turf/open/floor/carpet/ship,
-/area/nsv/crew_quarters/heads/maa)
 "hUl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -35940,12 +34420,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
-"hUB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/effect/landmark/nuclear_waste_spawner/strong,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
+"hVb" = (
+/obj/structure/rack,
+/obj/item/chair/stool/bar,
+/turf/open/floor/wood,
+/area/maintenance/starboard/central)
 "hVn" = (
 /obj/effect/landmark/start/atmospheric_technician,
 /obj/structure/extinguisher_cabinet/south,
@@ -35966,43 +34445,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"hWh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/virology{
-	autoclose = 0;
-	frequency = 1449;
-	id_tag = "virology_airlock_exterior";
-	name = "Virology Exterior Airlock";
-	req_access_txt = "39"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/doorButtons/access_button{
-	idDoor = "virology_airlock_exterior";
-	idSelf = "virology_airlock_control";
-	name = "Virology Access Button";
-	pixel_x = -24;
-	req_access_txt = "39"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
-"hWj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
+"hWA" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
-/area/maintenance/department/medical)
+/area/nsv/weapons/fore)
 "hXb" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/candle_box,
@@ -36039,6 +34486,15 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /turf/open/floor/plasteel,
 /area/maintenance/department/science/central)
+"hYe" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/firedoor/window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "hos_privacy";
+	name = "privacy shutter"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hos)
 "hYg" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -36121,6 +34577,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"ibq" = (
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel/ship,
+/area/hallway/primary/fore)
 "ibL" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -36146,6 +34609,25 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/exit)
+"idQ" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/item/gun/ballistic/automatic/pistol/m1911/no_mag,
+/obj/item/gun/ballistic/automatic/pistol/m1911/no_mag,
+/obj/item/gun/ballistic/automatic/pistol/m1911/no_mag,
+/obj/item/gun/ballistic/automatic/pistol/m1911/no_mag,
+/obj/item/gun/ballistic/automatic/pistol/m1911/no_mag,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory/lockup)
+"ieh" = (
+/obj/effect/landmark/start/master_at_arms,
+/obj/structure/chair/office{
+	dir = 8
+	},
+/turf/open/floor/carpet/ship,
+/area/nsv/crew_quarters/heads/maa)
 "iet" = (
 /obj/machinery/camera/motion{
 	dir = 1
@@ -36158,6 +34640,12 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/ai_monitored/turret_protected/aisat/hallway/support_ship/aft)
+"ifm" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/construction)
 "ifs" = (
 /obj/effect/landmark/blobstart,
 /obj/structure/cable{
@@ -36171,6 +34659,29 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/hanger/storage)
+"ifP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 10
+	},
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plasteel/ship,
+/area/nsv/hanger/deck2/starboard{
+	name = "Launch tubes 1 and 2"
+	})
+"ifS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/door/airlock/ship{
+	name = "Courtroom"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plasteel/ship,
+/area/hallway/secondary/exit)
 "igt" = (
 /obj/machinery/atmospherics/pipe/simple/brown/hidden,
 /obj/machinery/camera/autoname{
@@ -36202,6 +34713,22 @@
 /obj/machinery/smartfridge/chemistry/preloaded,
 /turf/open/floor/plating,
 /area/medical/medbay/lobby)
+"igH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/extinguisher_cabinet/west,
+/obj/machinery/atmospherics/pipe/simple/brown/visible,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "igP" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -36237,10 +34764,6 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/engine/plasma,
 /area/engine/atmos)
-"ikd" = (
-/obj/machinery/camera/autoname,
-/turf/open/floor/plasteel/dark,
-/area/nsv/hanger)
 "ikl" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/turf_decal/tile/blue{
@@ -36340,6 +34863,25 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/quartermaster/storage)
+"imr" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/door/airlock/ship/security/glass{
+	name = "Long-Term Confinement";
+	req_one_access_txt = "2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/security/prison)
 "imt" = (
 /obj/machinery/status_display/ai/west,
 /turf/open/floor/plasteel/ship/techfloor/alt,
@@ -36383,6 +34925,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"ini" = (
+/obj/structure/rack,
+/obj/item/clothing/head/hardhat/orange,
+/obj/item/clothing/head/hardhat/orange,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "inv" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
@@ -36432,6 +34980,11 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/central)
+"ioz" = (
+/obj/structure/rack,
+/obj/item/stack/spacecash/c10,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "ioC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -36489,13 +35042,6 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/science/mixing)
-"isu" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/obj/effect/landmark/start/head_of_security,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "isx" = (
 /obj/effect/turf_decal/bot_white,
 /obj/structure/closet/crate/internals,
@@ -36522,6 +35068,25 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"itC" = (
+/obj/effect/spawner/room/threexthree,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/template_noop,
+/area/maintenance/starboard/central)
+"iua" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Fuel Mix In"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "iuh" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -36557,6 +35122,15 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"ive" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "38"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/bar)
 "ivs" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/landmark/nuclear_waste_spawner,
@@ -36570,11 +35144,15 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"iwE" = (
-/obj/structure/table/reinforced,
-/obj/item/gun/energy/laser/practice,
-/turf/open/floor/plasteel,
-/area/security)
+"iwP" = (
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/ship/padded,
+/area/construction)
 "iwV" = (
 /obj/structure/table/wood,
 /obj/structure/disposalpipe/segment,
@@ -36605,17 +35183,17 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"ixK" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory/lockup)
 "ixV" = (
 /obj/machinery/vending/robotics,
 /obj/effect/turf_decal/delivery/white,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"iyn" = (
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory/lockup)
 "iyP" = (
 /obj/machinery/suit_storage_unit/hos,
 /turf/open/floor/plasteel/dark,
@@ -36631,6 +35209,26 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/ai_monitored/turret_protected/aisat/service/support_ship)
+"izl" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "29"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
+"izt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/effect/landmark/nuclear_waste_spawner/strong,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "izF" = (
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/plating,
@@ -36674,6 +35272,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/storage)
+"iAk" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "iAL" = (
 /obj/machinery/light/small,
 /obj/structure/reagent_dispensers/fueltank,
@@ -36705,18 +35311,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/lockup)
-"iCf" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security)
 "iDr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -36791,6 +35385,23 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plating,
 /area/hydroponics)
+"iFt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 8;
+	name = "medsec trunk";
+	sortType = "7;8;9;10;11;23;27"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "iGa" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Escape-3";
@@ -36830,6 +35441,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/service)
+"iGM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "iHg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -36851,29 +35477,6 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"iHn" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
-"iHp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security)
 "iHT" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -36902,6 +35505,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/central)
+"iIr" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "hos_privacy";
+	name = "privacy shutter"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hos)
 "iIR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -36919,6 +35534,16 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"iJz" = (
+/obj/machinery/door/poddoor/ship{
+	id = "launchbay_access";
+	name = "Launch tube access"
+	},
+/obj/effect/turf_decal/stripes/full,
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/maintenance/starboard/central)
 "iJX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -36957,6 +35582,17 @@
 /obj/machinery/suit_storage_unit/pilot,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/hanger)
+"iMC" = (
+/obj/machinery/door/poddoor/ship{
+	id = "launchbay_tube1";
+	name = "Launch tube 1 access"
+	},
+/obj/effect/turf_decal/stripes/full,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/nsv/hanger/deck2/starboard{
+	name = "Launch tubes 1 and 2"
+	})
 "iMZ" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -36972,6 +35608,13 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/port)
+"iNr" = (
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/advanced_airlock_controller/directional/west{
+	pixel_y = 24
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "iNu" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/structure/cable{
@@ -37026,6 +35669,16 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/ai_monitored/turret_protected/aisat/service/support_ship)
+"iRq" = (
+/obj/machinery/computer/monitor{
+	dir = 2
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/structure/table,
+/turf/open/floor/plasteel/ship,
+/area/construction)
 "iRX" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -37039,6 +35692,11 @@
 "iSh" = (
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"iSl" = (
+/obj/structure/grille,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "iSw" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -37066,16 +35724,50 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"iSz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/virology{
+	autoclose = 0;
+	frequency = 1449;
+	id_tag = "virology_airlock_exterior";
+	name = "Virology Exterior Airlock";
+	req_access_txt = "39"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/doorButtons/access_button{
+	idDoor = "virology_airlock_exterior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Button";
+	pixel_x = -24;
+	req_access_txt = "39"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "iTC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"iTS" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/plating,
-/area/maintenance/department/security)
+"iUd" = (
+/obj/machinery/door/airlock/ship/station/mining{
+	name = "Cargo Shipping";
+	req_one_access_txt = "31"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/ship,
+/area/quartermaster/office)
 "iUn" = (
 /obj/machinery/light{
 	dir = 4
@@ -37100,18 +35792,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"iVs" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security)
 "iWi" = (
 /obj/machinery/light,
 /obj/structure/cable{
@@ -37133,21 +35813,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"iXv" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory/lockup)
-"iXK" = (
-/obj/structure/table/reinforced,
-/obj/item/key/fighter_tug,
-/obj/item/key/fighter_tug{
-	pixel_x = 3;
-	pixel_y = 3
-	},
+"iWT" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
-/area/nsv/hanger)
+/area/hallway/primary/port)
 "iYh" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/ship/techfloor/alt,
@@ -37167,21 +35837,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/crew_quarters/dorms)
-"iZo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "iZG" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/machinery/camera/autoname{
@@ -37257,21 +35912,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"jcc" = (
-/obj/machinery/door/poddoor/ship{
-	id = "launchbay_tube1";
-	name = "Launch tube 1 access"
-	},
-/obj/effect/turf_decal/stripes/full,
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/turf/open/floor/plating,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
-"jco" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/department/security)
 "jdg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -37320,12 +35960,37 @@
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/plasteel/ship,
 /area/quartermaster/storage)
-"jeH" = (
+"jeJ" = (
+/obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "10"
+	req_one_access_txt = "5"
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
+"jfv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/security/glass{
+	name = "Riot Armory";
+	req_one_access_txt = "3"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/ship,
+/area/ai_monitored/security/armory/security)
 "jfD" = (
 /obj/machinery/cryopod,
 /obj/machinery/light{
@@ -37355,6 +36020,21 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/patients_rooms/room_c)
+"jgt" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/brown/visible,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "jgF" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -37366,6 +36046,12 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"jgG" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/ship,
+/area/construction)
 "jgN" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -37443,6 +36129,11 @@
 /obj/effect/landmark/start/ai/secondary,
 /turf/open/floor/plasteel/ship,
 /area/ai_monitored/turret_protected/ai)
+"jjT" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "jkb" = (
 /obj/machinery/nuclearbomb/beer,
 /turf/open/floor/plating,
@@ -37453,6 +36144,16 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/exit)
+"jkN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/engine/break_room)
 "jkW" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -37472,11 +36173,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/crew_quarters/heads/hor)
-"jmj" = (
-/obj/effect/landmark/nuclear_waste_spawner,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
 "jms" = (
 /obj/machinery/light{
 	dir = 4
@@ -37564,6 +36260,10 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"jpL" = (
+/obj/effect/landmark/blobstart,
+/turf/template_noop,
+/area/maintenance/port/aft)
 "jqp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -37584,11 +36284,10 @@
 	},
 /turf/open/floor/carpet/black,
 /area/crew_quarters/heads/hor)
-"jrs" = (
-/obj/machinery/magnetic_module,
-/obj/structure/target_stake,
+"jru" = (
+/obj/structure/closet/toolcloset,
 /turf/open/floor/plating,
-/area/security)
+/area/maintenance/starboard/central)
 "jrJ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -37609,6 +36308,27 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
+"jsr" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/brown/visible/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"jsv" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12;69"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "jsQ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -37618,6 +36338,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"jtv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/security/prison)
 "jtI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -37654,18 +36389,32 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
-"juZ" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "jvq" = (
 /obj/machinery/vending/wardrobe/law_wardrobe,
 /turf/open/floor/wood,
 /area/lawoffice)
+"jvX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/ship/command{
+	dir = 4;
+	name = "Captain's Office";
+	req_one_access_txt = "20"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/captain)
 "jwf" = (
 /obj/structure/table/glass,
 /obj/item/storage/firstaid/toxin,
@@ -37673,6 +36422,18 @@
 /obj/item/storage/firstaid/toxin,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"jwM" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/ship/command{
+	name = "Executive Officer's Office";
+	req_one_access_txt = "57"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hop)
 "jxb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37769,6 +36530,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"jzK" = (
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced/spawner/north,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/lobby)
 "jAx" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -37795,10 +36563,20 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/central)
+"jBT" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/engine/storage)
 "jCp" = (
 /obj/effect/turf_decal/caution,
 /turf/open/floor/plasteel/ship,
 /area/nsv/hanger)
+"jCA" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/lobby)
 "jDE" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -37845,17 +36623,6 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/fore)
-"jDV" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	name = "intra ship intercom";
-	pixel_x = 26
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet/ship,
-/area/nsv/crew_quarters/heads/maa)
 "jEW" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -37982,6 +36749,10 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/engine/engineering/hangar)
+"jHx" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "jHE" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -38003,6 +36774,9 @@
 /obj/item/multitool,
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"jHX" = (
+/turf/template_noop,
+/area/maintenance/starboard/central)
 "jIa" = (
 /obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/plasteel,
@@ -38067,6 +36841,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
+"jKL" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "jKZ" = (
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/machinery/camera/autoname{
@@ -38136,6 +36917,18 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"jMI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/trinary/mixer,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "jNg" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -38147,6 +36940,14 @@
 /obj/machinery/portable_atmospherics/scrubber/huge,
 /turf/open/floor/plasteel/dark,
 /area/science/storage)
+"jNK" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "jNO" = (
 /obj/machinery/newscaster{
 	pixel_x = 32
@@ -38315,6 +37116,19 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel,
 /area/storage/eva)
+"jVm" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/brown/visible/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "jVG" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
@@ -38358,15 +37172,32 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/security)
-"jXC" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "69"
+"jXM" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/engine/atmos)
+"kac" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/bar)
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/fore)
 "kah" = (
 /turf/closed/wall/ship,
 /area/nsv/hanger)
@@ -38382,6 +37213,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"kas" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/bar)
+"kbM" = (
+/obj/structure/table/reinforced,
+/obj/item/folder/blue,
+/turf/open/floor/carpet/ship,
+/area/nsv/crew_quarters/heads/maa)
 "kbN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -38413,6 +37257,12 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"kcU" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/closed/wall/ship,
+/area/engine/engineering)
 "kdm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38444,6 +37294,10 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/nsv/hanger)
+"kfw" = (
+/obj/structure/table,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "kfy" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/beer,
@@ -38501,16 +37355,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
-"kio" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "kit" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/computer/atmos_control/tank/air_tank{
@@ -38569,18 +37413,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"kkc" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security)
-"kkk" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/carpet/ship,
-/area/nsv/crew_quarters/heads/maa)
 "kkt" = (
 /obj/item/radio/intercom{
 	pixel_y = -32
@@ -38589,6 +37421,13 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/ship/riveted,
+/area/maintenance/starboard/central)
+"kkv" = (
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "kkw" = (
 /obj/effect/turf_decal/tile/purple{
@@ -38649,17 +37488,23 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"kns" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/morgue{
+	name = "Private Study";
+	req_access_txt = "37"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/wood,
+/area/library)
 "kpj" = (
 /obj/machinery/computer/warrant{
 	dir = 8
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
-"kpu" = (
-/obj/machinery/computer/crew,
-/obj/structure/window/reinforced/spawner/north,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/lobby)
 "kpI" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/wood,
@@ -38693,6 +37538,18 @@
 "kqJ" = (
 /turf/closed/wall/r_wall/ship,
 /area/engine/atmospherics_engine)
+"kqS" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "kqX" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 1
@@ -38741,10 +37598,22 @@
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"ksw" = (
+/obj/machinery/atmospherics/pipe/simple/brown/visible{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "ksA" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/closed/wall/r_wall/ship,
 /area/engine/atmospherics_engine)
+"ksI" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/carpet/ship,
+/area/nsv/crew_quarters/heads/maa)
 "ksP" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -38808,6 +37677,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"kwG" = (
+/obj/structure/window/reinforced/fulltile/ship,
+/obj/structure/grille,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/chapel/office)
 "kwH" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/AI,
@@ -38857,6 +37732,13 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/nsv/weapons/fore)
+"kxd" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/brown/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "kxn" = (
 /obj/effect/landmark/start/botanist,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -38919,12 +37801,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/port)
-"kyr" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
 "kyI" = (
 /obj/machinery/ship_weapon/mac{
 	dir = 4;
@@ -38981,20 +37857,19 @@
 /obj/machinery/autolathe,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/quartermaster/storage)
-"kAq" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security)
 "kAA" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"kBf" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/brown/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "kBx" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
@@ -39003,43 +37878,17 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
-"kBD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Dorms-0.5";
-	location = "Dorms-0"
-	},
-/turf/open/floor/plasteel/ship,
-/area/hallway/primary/central)
 "kBF" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
-"kBR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+"kBJ" = (
+/obj/item/radio/intercom{
+	pixel_y = 26
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
+/obj/structure/closet/secure_closet/deck_technician,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/nsv/hanger)
 "kCD" = (
 /obj/machinery/mineral/stacking_machine{
 	input_dir = 1
@@ -39058,13 +37907,18 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
-"kDc" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
+"kDH" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/security)
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/brown/visible/layer1{
+	dir = 4
+	},
+/turf/open/floor/engine/o2,
+/area/engine/atmos)
 "kDM" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -39119,6 +37973,16 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/port/central)
+"kFl" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/brown/visible/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "kFm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -39166,6 +38030,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"kIp" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "kIq" = (
 /obj/structure/rack,
 /obj/effect/landmark/event_spawn,
@@ -39188,6 +38066,19 @@
 	},
 /turf/open/floor/plating,
 /area/tcommsat/server)
+"kIG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/virology{
+	name = "Virology";
+	req_one_access_txt = "5;39"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "kJP" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -39375,6 +38266,21 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
+"kUv" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/nsv/hanger/deck2/starboard{
+	name = "Launch tubes 1 and 2"
+	})
+"kUJ" = (
+/obj/machinery/door/poddoor{
+	id = "chapelgun";
+	name = "Chapel Launcher Door"
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/crew_quarters/heads/hos)
 "kUO" = (
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/plasteel/dark,
@@ -39383,6 +38289,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"kVt" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/obj/machinery/computer/ship/viewscreen{
+	pixel_x = -32;
+	pixel_y = -6
+	},
+/turf/open/floor/carpet/ship,
+/area/nsv/crew_quarters/heads/maa)
 "kVK" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -39416,12 +38332,6 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"kWo" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "69"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/chapel)
 "kWS" = (
 /obj/machinery/smartfridge/drinks,
 /obj/machinery/door/firedoor/border_only/directional/west,
@@ -39441,6 +38351,18 @@
 /obj/item/reagent_containers/dropper,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"kXG" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	name = "Medbay Service";
+	req_one_access_txt = "40"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "kXQ" = (
 /obj/machinery/light,
 /obj/structure/disposalpipe/segment{
@@ -39519,6 +38441,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"lbN" = (
+/obj/machinery/atmospherics/pipe/simple/brown/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
+"lcj" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/nsv/weapons/fore)
 "lcD" = (
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/plasteel/white,
@@ -39556,6 +38489,14 @@
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
+"ldW" = (
+/turf/open/floor/plasteel/ship,
+/area/construction)
+"ldX" = (
+/obj/machinery/computer/lore_terminal,
+/obj/structure/closet/secure_closet/fighter_pilot,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/nsv/hanger)
 "leF" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -39569,6 +38510,15 @@
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"lfk" = (
+/obj/effect/landmark/event_spawn,
+/obj/machinery/holopad,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory/lockup)
 "lhf" = (
 /obj/effect/turf_decal/caution/white,
 /obj/effect/turf_decal/stripes/red/line{
@@ -39618,6 +38568,27 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/entry)
+"lio" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/virology{
+	autoclose = 0;
+	frequency = 1449;
+	id_tag = "virology_airlock_interior";
+	name = "Virology Interior Airlock";
+	req_access_txt = "39"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "ljc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39627,6 +38598,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"ljw" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/structure/disposalpipe/segment,
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "ljz" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -39652,6 +38632,10 @@
 	},
 /turf/open/floor/carpet/red,
 /area/security/detectives_office/private_investigators_office)
+"llp" = (
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "llA" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/purple{
@@ -39660,6 +38644,13 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"lmv" = (
+/obj/item/chair/stool,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "lmJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/effect/turf_decal/tile/yellow{
@@ -39711,24 +38702,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"loh" = (
-/obj/item/ship_weapon/ammunition/torpedo,
-/obj/machinery/camera/autoname,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory/lockup)
-"loG" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
+"lou" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance/four,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/starboard/central)
 "loH" = (
 /obj/machinery/modular_computer/console/preset/command,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
+"lpG" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "lqb" = (
 /obj/effect/landmark/start/munitions_tech,
 /turf/open/floor/plasteel/ship,
@@ -39737,6 +38729,23 @@
 /obj/machinery/atmospherics/pipe/manifold4w/general/visible,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"lro" = (
+/obj/machinery/requests_console{
+	department = "Engineering";
+	departmentType = 3;
+	name = "Engineering RC"
+	},
+/obj/machinery/atmospherics/pipe/simple/brown/hidden{
+	dir = 8
+	},
+/turf/closed/wall/ship,
+/area/engine/engine_room)
+"lrz" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory/lockup)
 "lsd" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -39747,6 +38756,11 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
+"lsu" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/science/mixing)
 "lsX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -39758,15 +38772,6 @@
 /obj/effect/landmark/start/librarian,
 /turf/open/floor/wood,
 /area/library)
-"ltw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/engine/break_room)
 "ltV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -39813,6 +38818,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"lvz" = (
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 4;
+	sortType = "7;8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "lvB" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -39865,7 +38880,9 @@
 /area/engine/engine_room)
 "lwo" = (
 /obj/machinery/hydroponics/constructable,
-/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
@@ -39904,6 +38921,19 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"lxT" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/ship/station/mining{
+	name = "Quartermaster's Office";
+	req_one_access_txt = "41"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "lyj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -39947,6 +38977,31 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/engine/break_room)
+"lzs" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/transfer)
+"lzu" = (
+/obj/machinery/door/airlock/glass_large/ship{
+	bound_height = 64;
+	bound_width = 32;
+	dir = 4;
+	name = "CIC";
+	pixel_x = -32
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "lzv" = (
 /obj/structure/table/wood,
 /obj/item/clothing/under/misc/burial,
@@ -39956,18 +39011,10 @@
 /obj/item/clothing/under/misc/burial,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"lzx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/bar)
+"lzy" = (
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/ai_monitored/security/armory/lockup)
 "lzC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -40064,6 +39111,14 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/nsv/hanger/storage)
+"lDW" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "5"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "lEb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -40116,18 +39171,42 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/ai_monitored/turret_protected/aisat/service/support_ship)
+"lFV" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	dir = 4;
+	req_one_access_txt = "2"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plating,
+/area/maintenance/department/security/brig)
+"lGq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/structure/table/wood,
+/obj/item/folder/red,
+/obj/item/folder/blue,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "lGt" = (
 /obj/item/bikehorn/rubberducky,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/toilet/restrooms)
-"lGS" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+"lGT" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "fab_window";
+	name = "privacy shutter"
 	},
-/turf/open/floor/plasteel,
-/area/security)
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/science/robotics/lab)
 "lHF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank{
@@ -40135,6 +39214,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"lID" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "lIL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -40174,14 +39265,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/exit)
-"lLx" = (
-/obj/effect/turf_decal/delivery/red,
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/blood/gibs/old,
-/turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
 "lLE" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/purple{
@@ -40408,6 +39491,11 @@
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
+"lWu" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/engine/break_room)
 "lWA" = (
 /obj/machinery/light/small,
 /obj/structure/disposalpipe/segment{
@@ -40432,34 +39520,6 @@
 /obj/item/storage/firstaid/ancient,
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"lWX" = (
-/obj/machinery/door/airlock/vault/ship{
-	req_access_txt = "53"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/ship,
-/area/ai_monitored/nuke_storage)
-"lYp" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/requests_console{
-	department = "Engineering";
-	departmentType = 3;
-	name = "Engineering RC";
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "lYN" = (
 /obj/machinery/light{
 	dir = 4
@@ -40467,6 +39527,20 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/aft)
+"lYQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/bar)
 "lYW" = (
 /turf/open/floor/plating/airless,
 /area/ai_monitored/turret_protected/ai)
@@ -40520,6 +39594,18 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"mcm" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/transfer)
 "mcs" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -40579,6 +39665,12 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"mel" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel/ship,
+/area/construction)
 "men" = (
 /obj/machinery/light/small,
 /obj/machinery/door/firedoor/border_only/directional/west,
@@ -40669,6 +39761,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"mfO" = (
+/obj/machinery/door/airlock/ship/hatch{
+	dir = 8;
+	name = "Secure Storage";
+	req_one_access_txt = "3"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/ship,
+/area/security/brig)
 "mgG" = (
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/dark,
@@ -40728,6 +39830,21 @@
 "mhv" = (
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"mia" = (
+/obj/machinery/door_timer{
+	id = "pw_1";
+	name = "Cell 1";
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
+/turf/open/floor/plasteel/ship,
+/area/security/prison)
 "mie" = (
 /obj/structure/table/optable,
 /obj/machinery/camera/autoname{
@@ -40735,17 +39852,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"miA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/door/airlock/ship{
-	name = "Courtroom"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/ship,
-/area/hallway/secondary/exit)
 "miI" = (
 /obj/vehicle/sealed/car/realistic/fighter_tug{
 	dir = 1;
@@ -40776,12 +39882,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"mjH" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/library)
 "mjR" = (
 /obj/machinery/computer/message_monitor,
 /turf/open/floor/plasteel/grimy,
@@ -40862,21 +39962,6 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/plating,
 /area/quartermaster/office)
-"mmo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "mms" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -40948,18 +40033,25 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
-"mnh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
+"mnR" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
+"moh" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
+/obj/structure/table/wood,
+/obj/item/pen/fountain,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
+	dir = 6
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/nsv/hanger)
+/area/crew_quarters/heads/hos)
 "mpA" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/holywater{
@@ -40968,12 +40060,29 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
+"mql" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/central)
 "mqN" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/aft)
+"mqS" = (
+/obj/structure/grille/broken,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "mqX" = (
 /obj/machinery/computer/teleporter,
 /turf/open/floor/plasteel,
@@ -40997,6 +40106,33 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/lockup)
+"msf" = (
+/obj/machinery/door/poddoor/ship{
+	id = "launchbay_tube1";
+	name = "Launch tube 1 access"
+	},
+/obj/effect/turf_decal/stripes/full,
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/nsv/hanger/deck2/starboard{
+	name = "Launch tubes 1 and 2"
+	})
+"msj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/ship/station/mining{
+	name = "Cargo Storage";
+	req_one_access_txt = "31; 48"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/quartermaster/office)
 "mte" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -41032,6 +40168,14 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/entry)
+"mtI" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/brown/visible/layer1,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "mtO" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -41069,16 +40213,31 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"mvQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "mws" = (
 /obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/weapons/fore)
-"mwO" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+"mwT" = (
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/construction)
+/obj/machinery/atmospherics/pipe/simple/brown/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "mxc" = (
 /obj/machinery/light/floor,
 /turf/open/floor/plasteel/ship,
@@ -41127,16 +40286,32 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
-"mzq" = (
-/obj/machinery/computer/card/minor/hos{
-	dir = 1
+"mzs" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/simple/brown/visible/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "mzw" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet/orange,
 /area/engine/break_room)
+"mzJ" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "31"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "mAo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -41172,10 +40347,11 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/entry)
-"mBy" = (
-/obj/effect/spawner/structure/window/reinforced,
+"mBg" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
-/area/engine/break_room)
+/area/maintenance/department/crew_quarters/bar)
 "mBN" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -41337,36 +40513,36 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"mHZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+"mIp" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "12"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+/obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plating,
-/area/maintenance/department/medical)
-"mIx" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	name = "Kitchen maintenance";
-	req_access_txt = "35;28"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/kitchen)
+/area/maintenance/department/medical/morgue)
 "mIE" = (
 /obj/machinery/vending/boozeomat/pubby_captain,
 /turf/closed/wall/r_wall/ship,
 /area/crew_quarters/heads/captain/private)
-"mIK" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
+"mIH" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
 	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plating,
-/area/maintenance/department/security)
+/area/maintenance/starboard/central)
+"mJP" = (
+/obj/machinery/door/airlock/ship/hatch{
+	dir = 8;
+	name = "Secure Storage";
+	req_one_access_txt = "3"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/ship,
+/area/security/execution/transfer)
 "mKS" = (
 /obj/structure/chair/stool,
 /obj/effect/turf_decal/stripes/red/line{
@@ -41416,6 +40592,18 @@
 /mob/living/carbon/monkey,
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
+"mMR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/ship,
+/area/construction)
 "mNw" = (
 /obj/machinery/firealarm{
 	pixel_y = -24
@@ -41472,6 +40660,11 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"mPu" = (
+/obj/machinery/airalarm/directional/west,
+/obj/structure/closet/secure_closet/fighter_pilot,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/nsv/hanger)
 "mQs" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -41510,20 +40703,14 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/ai_monitored/turret_protected/aisat/hallway/support_ship)
-"mSp" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+"mSt" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/requests_console{
-	department = "Security";
-	departmentType = 7;
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel,
-/area/security)
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/library)
 "mTA" = (
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -41576,6 +40763,19 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/engine/break_room)
+"mVC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "32"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "mVE" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -41635,6 +40835,17 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/exit)
+"mZN" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/rack,
+/obj/item/stack/sheet/mineral/titanium/fifty{
+	amount = 35
+	},
+/obj/item/stack/sheet/iron/fifty,
+/turf/open/floor/plasteel/ship,
+/area/construction)
 "mZS" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -41658,6 +40869,11 @@
 "mZW" = (
 /turf/open/floor/plating,
 /area/nsv/hanger)
+"naO" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/crew_quarters/heads/captain)
 "naW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -41676,6 +40892,17 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"nbz" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "27"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plating,
+/area/maintenance/department/chapel)
 "nbE" = (
 /obj/machinery/status_display/evac{
 	pixel_y = 32
@@ -41709,6 +40936,30 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/port)
+"ndB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/door/airlock/ship/security/glass{
+	name = "Long-Term Confinement";
+	req_one_access_txt = "2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/security/prison)
 "ndC" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -41722,16 +40973,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"neN" = (
-/obj/machinery/door/poddoor/ship{
-	id = "launchbay_tube4";
-	name = "Launch tube 4 access"
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible,
+"ndM" = (
+/obj/structure/closet/emcloset,
 /turf/open/floor/plating,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
+/area/maintenance/starboard/central)
 "neU" = (
 /obj/structure/sign/directions/security{
 	pixel_y = 28
@@ -41745,6 +40990,11 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/aft)
+"ngq" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance/six,
+/turf/open/floor/plasteel/ship/riveted,
+/area/maintenance/department/medical/morgue)
 "ngH" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -41774,18 +41024,14 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
-"nhY" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/rack,
-/obj/item/gun/ballistic/automatic/pistol/m1911/no_mag,
-/obj/item/gun/ballistic/automatic/pistol/m1911/no_mag,
-/obj/item/gun/ballistic/automatic/pistol/m1911/no_mag,
-/obj/item/gun/ballistic/automatic/pistol/m1911/no_mag,
-/obj/item/gun/ballistic/automatic/pistol/m1911/no_mag,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory/lockup)
+"nhh" = (
+/obj/machinery/atmospherics/pipe/simple/brown/hidden,
+/turf/closed/wall/r_wall/ship,
+/area/engine/engine_room)
+"nhn" = (
+/obj/structure/closet/radiation,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "nif" = (
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/hanger/storage)
@@ -41834,24 +41080,31 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/central)
+"njf" = (
+/obj/effect/turf_decal/bot_red/left,
+/obj/item/ammo_casing/a357{
+	dir = 8;
+	projectile_type = null
+	},
+/obj/item/ammo_casing/a357{
+	dir = 8;
+	projectile_type = null
+	},
+/obj/item/ammo_casing/a357{
+	dir = 8;
+	projectile_type = null
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/transfer)
 "njp" = (
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/aft)
-"njt" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 8
-	},
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/carpet/ship,
-/area/nsv/crew_quarters/heads/maa)
 "njF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/keycard_auth,
@@ -41860,6 +41113,20 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/tcommsat/computer)
+"njH" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "njY" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -41873,6 +41140,14 @@
 /obj/machinery/smartfridge/organ,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"nkd" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "4"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "nkn" = (
 /obj/machinery/chem_master,
 /turf/open/floor/plasteel/white,
@@ -41902,6 +41177,22 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/miningoffice)
+"nlF" = (
+/obj/effect/turf_decal/stripes/white/line,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/atc,
+/turf/open/floor/plasteel/ship,
+/area/nsv/hanger)
+"nlN" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "46"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "nmN" = (
 /obj/effect/landmark/start/cook,
 /turf/open/floor/plasteel/cafeteria,
@@ -41910,6 +41201,10 @@
 /obj/effect/turf_decal/delivery/red,
 /turf/open/floor/plasteel/ship,
 /area/nsv/weapons/fore)
+"nok" = (
+/obj/structure/closet/wardrobe/grey,
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "nol" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -41922,6 +41217,9 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"noG" = (
+/turf/template_noop,
+/area/maintenance/port/aft)
 "noN" = (
 /obj/machinery/computer/lore_terminal,
 /turf/open/floor/plasteel/dark,
@@ -41947,19 +41245,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
-"npD" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plasteel,
-/area/security)
 "npS" = (
 /obj/structure/table/optable,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"npU" = (
+/obj/effect/landmark/start/assistant,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/fore)
 "nqC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -41982,6 +41277,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"nrM" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/bridge)
 "nrV" = (
 /obj/machinery/light{
 	dir = 8
@@ -42006,12 +41306,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"num" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12;69"
+"ntz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 10
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/construction)
+"nub" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating/airless,
+/area/maintenance/department/medical/morgue)
 "nuA" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -42026,15 +41333,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"nvK" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "10"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "nxc" = (
 /obj/effect/turf_decal/stripes/red/full,
 /obj/machinery/light/small{
@@ -42093,50 +41391,26 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
-"nzg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/virology{
-	name = "Virology";
-	req_one_access_txt = "5;39"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "nzn" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet/black,
 /area/science/research)
-"nzS" = (
+"nAm" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/brown/visible{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
+"nBl" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	target_pressure = 4500
 	},
 /turf/open/floor/plasteel,
-/area/security)
-"nAz" = (
-/obj/machinery/door/airlock/ship{
-	name = "Toxins Research";
-	req_one_access_txt = "8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/port/aft)
-"nAC" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "27"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plating,
-/area/maintenance/department/chapel)
+/area/engine/engine_room)
 "nBs" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -42201,6 +41475,13 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"nCR" = (
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced/spawner/north,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/lobby)
 "nDl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -42243,6 +41524,29 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/ai_monitored/turret_protected/aisat/hallway/support_ship)
+"nDV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "55"
+	},
+/turf/open/floor/plating,
+/area/science/xenobiology)
+"nDX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/brown/visible,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "nEF" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -42275,6 +41579,21 @@
 /obj/machinery/light/floor,
 /turf/open/floor/engine,
 /area/engine/engine_room)
+"nFo" = (
+/obj/machinery/door/airlock/glass_large/ship{
+	bound_height = 64;
+	bound_width = 32;
+	dir = 4;
+	name = "CIC";
+	pixel_x = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "nFL" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8;
@@ -42286,6 +41605,21 @@
 /obj/structure/grille,
 /turf/closed/wall/r_wall/ship,
 /area/ai_monitored/turret_protected/ai)
+"nGg" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"nGo" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/fighter_pilot,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/nsv/hanger)
 "nGH" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -42360,19 +41694,14 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
-"nKo" = (
-/obj/machinery/door/poddoor/shutters/ship{
-	id = "ad_storage";
-	name = "Arms Dump Shutters"
+"nKX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/machinery/button/door{
-	id = "ad_storage";
-	name = "Arms Dump Access Control";
-	pixel_x = 24;
-	req_one_access_txt = "3;58;70"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory/lockup)
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "nLs" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/machinery/requests_console{
@@ -42383,29 +41712,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
-"nMk" = (
-/obj/machinery/computer/ship/viewscreen,
-/turf/open/floor/carpet/ship,
-/area/nsv/crew_quarters/heads/maa)
-"nMK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/virology{
-	autoclose = 0;
-	frequency = 1449;
-	id_tag = "virology_airlock_interior";
-	name = "Virology Interior Airlock";
-	req_access_txt = "39"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "nNA" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/green{
@@ -42446,7 +41752,9 @@
 /obj/item/tank/internals/oxygen/empty,
 /obj/item/tank/internals/emergency_oxygen/double/empty,
 /obj/item/tank/internals/emergency_oxygen/double/empty,
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -42470,6 +41778,27 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/ai_monitored/turret_protected/aisat/hallway/support_ship)
+"nPO" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
+	},
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
+"nQJ" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/dorms)
 "nRg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -42517,14 +41846,6 @@
 /obj/machinery/igniter/incinerator_toxmix,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
-"nSm" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/closet/bombcloset/security,
-/obj/structure/extinguisher_cabinet/north,
-/turf/open/floor/plasteel/ship,
-/area/nsv/weapons/fore)
 "nSL" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -42535,16 +41856,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"nSR" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/plating,
-/area/maintenance/department/security)
 "nTd" = (
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
+"nTi" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump/layer3,
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Plasma to Stormdrive"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "nTy" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/yellow{
@@ -42568,12 +41892,6 @@
 /obj/item/storage/firstaid/brute,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"nTV" = (
-/obj/effect/landmark/start/assistant,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/turf/open/floor/plasteel/dark,
-/area/nsv/hanger)
 "nUp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -42606,6 +41924,12 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"nUL" = (
+/obj/machinery/computer/security/hos{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "nVw" = (
 /obj/item/paper_bin,
 /obj/item/stamp/cmo,
@@ -42618,12 +41942,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo)
-"nVL" = (
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/security)
 "nXg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 8
@@ -42655,6 +41973,10 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/fore)
+"nXx" = (
+/obj/machinery/camera/autoname,
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/fore)
 "nXS" = (
 /obj/machinery/conveyor{
 	id = "cmbelt"
@@ -42683,6 +42005,12 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/central)
+"nYE" = (
+/obj/item/radio/intercom{
+	pixel_x = -26
+	},
+/turf/open/floor/carpet/ship,
+/area/nsv/crew_quarters/heads/maa)
 "nYF" = (
 /obj/machinery/newscaster{
 	pixel_x = -30
@@ -42746,6 +42074,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"nZH" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "nZI" = (
 /obj/structure/table/glass,
 /obj/item/storage/firstaid/o2,
@@ -42766,6 +42101,34 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"oaz" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/security/glass{
+	name = "Research Security Post";
+	req_one_access_txt = "63"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/science/research)
 "oaJ" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -42777,6 +42140,15 @@
 /obj/machinery/nanite_program_hub,
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"oaN" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "obE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -42808,14 +42180,6 @@
 /obj/item/stamp/law,
 /turf/open/floor/wood,
 /area/lawoffice)
-"odV" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "odW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -42866,13 +42230,35 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
+"ofi" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory/lockup)
 "ofA" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
 /area/ai_monitored/turret_protected/ai)
+"ogm" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "ogo" = (
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"ogx" = (
+/obj/effect/landmark/nuclear_waste_spawner,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/fore)
 "ogL" = (
 /obj/machinery/light/small,
 /obj/structure/disposalpipe/trunk{
@@ -42907,6 +42293,11 @@
 "ohZ" = (
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
+"oiD" = (
+/obj/structure/table,
+/obj/item/stack/rods/twentyfive,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/construction)
 "oiF" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -42943,6 +42334,13 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/construction)
+"ojG" = (
+/obj/effect/landmark/start/atmospheric_technician,
+/obj/machinery/atmospherics/pipe/simple/brown/visible/layer1{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "ojZ" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/light{
@@ -42982,6 +42380,16 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/ai_monitored/turret_protected/aisat/service/support_ship)
+"okv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump/layer3,
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "CO2 to Stormdrive"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "okZ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -42994,23 +42402,6 @@
 /obj/item/encryptionkey/headset_service,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
-"omf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/ship,
-/area/security/prison)
 "oml" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 8
@@ -43039,6 +42430,10 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/exit)
+"omU" = (
+/obj/structure/closet/crate/trashcart,
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "onx" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel/ship/techfloor/alt,
@@ -43063,6 +42458,29 @@
 	},
 /turf/open/floor/carpet/red,
 /area/security/detectives_office/private_investigators_office)
+"ooU" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/brown/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
+"opj" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/atmospherics/pipe/simple/brown/visible{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "opv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -43171,14 +42589,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"ouG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory/lockup)
 "ouW" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
@@ -43256,6 +42666,24 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"oxo" = (
+/obj/machinery/door/airlock/ship/station/mining{
+	name = "Mining Shuttle Dock";
+	req_one_access_txt = "48"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/quartermaster/warehouse)
 "oxz" = (
 /obj/effect/landmark/start/geneticist,
 /obj/structure/chair/office{
@@ -43291,6 +42719,27 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
+"oyW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/construction)
+"ozc" = (
+/obj/effect/turf_decal/delivery/red,
+/obj/structure/chair,
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/transfer)
 "ozn" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -43313,12 +42762,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
-"oAe" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "oAh" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Cloning Exit";
@@ -43340,18 +42783,6 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"oAo" = (
-/obj/machinery/power/apc/auto_name/west,
-/obj/structure/closet/secure_closet/hos,
-/obj/item/storage/secure/safe/HoS{
-	pixel_x = 8;
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "oAF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43383,6 +42814,18 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/ship,
 /area/nsv/weapons/fore)
+"oBW" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "oDp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -43412,6 +42855,11 @@
 /obj/machinery/light/runway/delay5,
 /turf/open/space/basic,
 /area/engine/engine_room)
+"oEb" = (
+/turf/open/floor/plasteel/stairs/old{
+	dir = 1
+	},
+/area/maintenance/starboard/central)
 "oEf" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -43504,11 +42952,6 @@
 /obj/machinery/cell_charger,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"oHs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/turf/open/floor/plasteel/dark,
-/area/nsv/hanger)
 "oHC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -43522,16 +42965,25 @@
 /obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"oIJ" = (
+/obj/machinery/power/apc/auto_name/north{
+	dir = 2;
+	pixel_y = -24
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory/lockup)
 "oKf" = (
 /obj/machinery/light/small,
 /obj/item/bedsheet/random,
 /obj/structure/bed,
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
-"oKF" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/security)
 "oLM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43569,24 +43021,16 @@
 /obj/item/bedsheet/medical,
 /turf/open/floor/plasteel/white,
 /area/medical/patients_rooms/room_a)
-"oNy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "6;12"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+"oNs" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"oNB" = (
+/obj/structure/table/wood/poker,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "oOb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -43691,13 +43135,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"oRO" = (
-/obj/machinery/door/poddoor/ship{
-	id = "launchbay_access";
-	name = "Launch tube access"
+"oRi" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/maintenance/starboard/central)
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/atmospherics/pipe/simple/brown/visible{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "oRR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -43752,6 +43201,29 @@
 /obj/item/storage/photo_album,
 /turf/open/floor/plasteel/cult,
 /area/library)
+"oUk" = (
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "maashutter"
+	},
+/turf/open/floor/carpet/ship,
+/area/nsv/crew_quarters/heads/maa)
+"oUs" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
+"oUA" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/hallway/primary/aft)
 "oUZ" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -43843,6 +43315,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"oZx" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/ship/riveted,
+/area/maintenance/department/medical/morgue)
 "oZG" = (
 /turf/closed/wall/r_wall/ship,
 /area/crew_quarters/heads/hos)
@@ -43862,6 +43344,18 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"pav" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "31;48"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "pax" = (
 /obj/machinery/status_display/evac{
 	pixel_x = -32
@@ -43909,7 +43403,9 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "pcq" = (
-/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
 /obj/structure/table,
 /obj/item/aiModule/reset,
 /obj/item/aicard,
@@ -43932,6 +43428,10 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/plasteel/dark,
 /area/science/server)
+"pfn" = (
+/obj/structure/closet/secure_closet/munitions_technician,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory/lockup)
 "pfr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43945,12 +43445,6 @@
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"pfO" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
 "pgK" = (
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
@@ -43976,15 +43470,12 @@
 	},
 /turf/open/floor/plating,
 /area/nsv/hanger)
-"pig" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "8"
-	},
-/obj/structure/cable{
+"phS" = (
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/turf/open/floor/plasteel/ship/padded,
+/area/construction)
 "pij" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -44010,6 +43501,17 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"piQ" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/structure/reagent_dispensers/watertank,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "pjs" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil{
@@ -44040,6 +43542,11 @@
 	dir = 1
 	},
 /area/engine/storage)
+"pjY" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/electrical,
+/turf/open/floor/plasteel/ship/padded,
+/area/construction)
 "pkS" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
@@ -44084,24 +43591,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/fore)
-"pmv" = (
-/obj/machinery/door/airlock/ship/security/glass{
-	name = "Security Arms Depot";
-	req_one_access_txt = "63;69"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plasteel,
-/area/security)
 "pmx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -44149,6 +43638,16 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
+"pnI" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = -24
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/central)
 "pnQ" = (
 /obj/machinery/status_display/ai{
 	pixel_x = 32
@@ -44191,6 +43690,17 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/security/prison)
+"pph" = (
+/obj/machinery/door/poddoor/ship{
+	id = "launchbay_tube4";
+	name = "Launch tube 4 access"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/nsv/hanger/deck2/port{
+	name = "Launch tubes 3 and 4"
+	})
 "ppq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -44206,6 +43716,20 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/ai_monitored/turret_protected/aisat/service/support_ship)
+"pqx" = (
+/obj/machinery/door/window/brigdoor/security/cell/southright{
+	id = "pw_1";
+	name = "Cell 1"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/security/prison)
+"pqQ" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/structure/cable,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/security/prison)
 "prh" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -44294,6 +43818,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/patients_rooms/room_b)
+"pwe" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "pwk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -44316,21 +43848,29 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"pwp" = (
+/obj/machinery/door/airlock/ship/command{
+	name = "Master At Arms";
+	req_one_access_txt = "70"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/ship,
+/area/nsv/crew_quarters/heads/maa)
 "pwz" = (
 /obj/machinery/vending/boozeomat,
 /turf/closed/wall/ship,
 /area/crew_quarters/bar)
-"pwD" = (
-/obj/machinery/door/airlock/ship/security/glass{
-	id_tag = "pw_fd_inner";
-	name = "Brig";
-	req_one_access_txt = "63"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/security/prison)
 "pwI" = (
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/ship,
@@ -44380,6 +43920,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"pzX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/armour_plating_nanorepair_pump/aft_starboard,
+/turf/open/floor/plasteel/ship,
+/area/construction)
 "pAj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /turf/open/floor/plating,
@@ -44467,6 +44020,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/storage)
+"pCl" = (
+/obj/machinery/door/poddoor/ship{
+	id = "launchbay_access";
+	name = "Launch tube access"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/maintenance/starboard/central)
 "pDr" = (
 /obj/machinery/light,
 /obj/machinery/vending/security,
@@ -44545,6 +44107,16 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/aft)
+"pGC" = (
+/obj/machinery/door/airlock/ship/hatch{
+	dir = 1;
+	name = "Secure Storage";
+	req_access_txt = "3;58"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "pHG" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/structure/chair,
@@ -44592,6 +44164,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"pJE" = (
+/obj/structure/table/reinforced,
+/obj/item/key/fighter_tug,
+/turf/open/floor/plating,
+/area/nsv/hanger)
 "pKs" = (
 /obj/machinery/light{
 	dir = 8
@@ -44615,15 +44192,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/eva)
-"pKR" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
-/turf/open/floor/carpet/ship,
-/area/nsv/crew_quarters/heads/maa)
-"pLe" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/secure_data/laptop,
+"pLc" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/manifold/brown/visible,
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer1{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
+/area/engine/atmos)
 "pLq" = (
 /obj/structure/grille,
 /obj/structure/cable/yellow{
@@ -44770,12 +44348,6 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"pSB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory/lockup)
 "pSE" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/spawner/structure/window/reinforced,
@@ -44791,6 +44363,18 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
+"pTK" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "ce_window";
+	name = "privacy shutter"
+	},
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/crew_quarters/heads/chief)
 "pTM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -44821,6 +44405,10 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/security/main)
+"pUG" = (
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/transfer)
 "pUR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -44855,8 +44443,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"pVU" = (
+/obj/machinery/door/poddoor/ship{
+	id = "launchbay_tube2";
+	name = "Launch tube 2 access"
+	},
+/obj/effect/turf_decal/stripes/full,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/nsv/hanger/deck2/starboard{
+	name = "Launch tubes 1 and 2"
+	})
 "pWg" = (
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -44921,6 +44522,26 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
+"pYy" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/central)
+"pYC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel/ship,
+/area/construction)
 "pYL" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -44960,15 +44581,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"qbx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory/lockup)
 "qbE" = (
 /obj/effect/landmark/nuclear_waste_spawner/strong,
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
-"qck" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/heavy,
+"qbH" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/maintenance/four,
 /turf/open/floor/plating,
-/area/engine/engine_room)
+/area/maintenance/starboard/central)
 "qcm" = (
 /obj/machinery/suit_storage_unit/atmos,
 /turf/open/floor/plasteel,
@@ -45012,12 +44639,34 @@
 	},
 /turf/closed/wall/r_wall/ship,
 /area/ai_monitored/turret_protected/aisat/hallway/support_ship)
+"qdB" = (
+/obj/machinery/door/poddoor/ship{
+	id = "launchbay_tube3";
+	name = "Launch tube 3 access"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/nsv/hanger/deck2/port{
+	name = "Launch tubes 3 and 4"
+	})
 "qdD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
+"qdG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "qdJ" = (
 /obj/structure/table/wood,
 /obj/item/storage/crayons,
@@ -45075,6 +44724,10 @@
 	},
 /turf/open/floor/carpet/red,
 /area/security/detectives_office/private_investigators_office)
+"qgm" = (
+/obj/structure/table_frame,
+/turf/open/floor/plasteel,
+/area/construction)
 "qgo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -45090,12 +44743,38 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"qgX" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory/lockup)
 "qhv" = (
 /obj/structure/chair/office/light{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"qhE" = (
+/obj/machinery/door/airlock/ship{
+	dir = 4;
+	name = "Arrivals Emergency Storage"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
+"qhS" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "qhU" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
@@ -45114,13 +44793,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/science/research)
-"qjO" = (
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
 "qki" = (
 /obj/machinery/door/airlock/public/glass/incinerator/atmos_interior,
 /obj/effect/mapping_helpers/airlock/locked,
@@ -45155,6 +44827,20 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plating,
 /area/nsv/hanger/storage)
+"qlf" = (
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
+"qlg" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/quartermaster/office)
 "qlj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 5
@@ -45167,6 +44853,21 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/ai_monitored/turret_protected/aisat/service/support_ship)
+"qlq" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/ship,
+/area/security/prison)
 "qls" = (
 /obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/plating,
@@ -45183,25 +44884,10 @@
 	},
 /turf/open/floor/carpet/black,
 /area/crew_quarters/heads/chief)
-"qlS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 8;
-	name = "medsec trunk";
-	sortType = "7;8;9;10;11;23;27"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
+"qmE" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/vending/tool,
+/turf/open/floor/plasteel/ship/riveted,
 /area/maintenance/department/medical/morgue)
 "qoL" = (
 /obj/machinery/status_display/ai{
@@ -45262,12 +44948,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"qql" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/security)
 "qqK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -45293,6 +44973,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"qsj" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/template_noop,
+/area/maintenance/starboard/central)
 "qsl" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -45349,6 +45035,15 @@
 /obj/machinery/status_display/ai/west,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/ai_monitored/turret_protected/aisat/service/support_ship)
+"quQ" = (
+/obj/machinery/door/airlock/ship/station/mining{
+	name = "Cargo Shipping";
+	req_one_access_txt = "31"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/ship,
+/area/quartermaster/office)
 "quW" = (
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
@@ -45390,17 +45085,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"qwI" = (
-/obj/machinery/door/poddoor/ship{
-	id = "launchbay_tube2";
-	name = "Launch tube 2 access"
-	},
-/obj/effect/turf_decal/stripes/full,
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/turf/open/floor/plating,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
 "qxv" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 1
@@ -45423,22 +45107,20 @@
 /obj/item/clothing/glasses/sunglasses/advanced,
 /turf/open/floor/wood,
 /area/lawoffice)
-"qyN" = (
-/obj/machinery/door/airlock/ship/security/glass{
-	name = "Security Arms Depot";
-	req_one_access_txt = "63;69"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+"qzh" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security)
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "qzO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45476,6 +45158,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"qCz" = (
+/turf/open/floor/plasteel/ship/padded,
+/area/construction)
 "qCI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/chair/pew/left,
@@ -45618,12 +45303,6 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/entry)
-"qIk" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "qIs" = (
 /obj/structure/cable{
 	icon_state = "6-8"
@@ -45643,6 +45322,14 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
 /turf/open/floor/plasteel/ship,
 /area/ai_monitored/turret_protected/aisat/service/support_ship)
+"qJF" = (
+/obj/effect/turf_decal/stripes/white/line,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/atc,
+/turf/open/floor/plasteel/ship,
+/area/nsv/hanger)
 "qKb" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -45679,6 +45366,16 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/toilet/restrooms)
+"qMQ" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer1{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/brown/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "qNb" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Engineering Break Room";
@@ -45707,6 +45404,13 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/nsv/hanger)
+"qNR" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/construction)
 "qNU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45767,33 +45471,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
-"qQH" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/item/target/alien,
-/obj/item/target/alien,
-/obj/item/target/clown,
-/obj/item/target/clown,
-/obj/item/target/syndicate,
-/obj/item/target/syndicate,
-/obj/item/target,
-/obj/item/target,
-/obj/structure/closet/crate,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel,
-/area/security)
 "qRf" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/landmark/start/chemist,
@@ -45819,11 +45496,10 @@
 /obj/item/clothing/glasses/meson/engine,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"qSW" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/lobby)
+"qRU" = (
+/obj/effect/spawner/room/threexthree,
+/turf/template_noop,
+/area/maintenance/department/medical/morgue)
 "qTb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -45909,15 +45585,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"qUP" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/fitness)
 "qUR" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -46008,22 +45675,28 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"qXn" = (
+"qYe" = (
 /obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "46"
+	req_one_access_txt = "12;69"
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/plating,
-/area/maintenance/port/central)
-"qXQ" = (
-/obj/machinery/light/small{
+/area/maintenance/starboard/central)
+"qYP" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
-/area/maintenance/department/security)
+/area/engine/storage)
 "qYV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -46054,6 +45727,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"qZL" = (
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory/lockup)
 "qZQ" = (
 /obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/plasteel/dark,
@@ -46080,13 +45757,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"rag" = (
-/obj/machinery/door/airlock/ship{
-	dir = 4;
-	name = "Arrivals Emergency Storage"
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "raj" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -46123,6 +45793,26 @@
 /obj/machinery/light/small,
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
+"rbx" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "rbS" = (
 /obj/structure/table/reinforced,
 /obj/item/phone,
@@ -46192,26 +45882,17 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/aft)
-"rdP" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel,
-/area/security)
-"reh" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "rel" = (
 /obj/item/disk/nuclear/fake,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"reo" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "reO" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -46244,6 +45925,33 @@
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
+"rfS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
+"rfX" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "rgi" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -46291,6 +45999,14 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"rhf" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "rhk" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -46326,18 +46042,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"riK" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/security)
 "riS" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -46371,6 +46075,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"rjQ" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "rkj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -46408,18 +46116,6 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/entry)
-"rky" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
-"rkE" = (
-/obj/machinery/computer/ship/fighter_controller{
-	dir = 4
-	},
-/turf/open/floor/carpet/ship,
-/area/nsv/crew_quarters/heads/maa)
 "rlF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor/eastleft{
@@ -46458,6 +46154,20 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"rmy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/ship/command{
+	name = "Captain's Quarters";
+	req_one_access_txt = "20"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/heads/captain/private)
 "rmD" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/ship/techfloor/alt,
@@ -46468,6 +46178,9 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/security/prison)
+"rnJ" = (
+/turf/open/floor/engine/plasma,
+/area/engine/atmos)
 "rnS" = (
 /obj/structure/table/glass,
 /obj/item/storage/firstaid/fire,
@@ -46478,6 +46191,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"rnW" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/dorms)
 "roi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -46522,18 +46243,10 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/ai_monitored/turret_protected/aisat/hallway/support_ship)
-"rri" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/nsv/hanger)
+"rrk" = (
+/obj/effect/spawner/room/threexthree,
+/turf/template_noop,
+/area/maintenance/starboard/central)
 "rrv" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
@@ -46553,15 +46266,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
-"rrZ" = (
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer1,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "rsz" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -46706,6 +46410,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/entry)
+"rwD" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/ship,
+/area/construction)
 "rwT" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -46735,6 +46445,10 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/entry)
+"rxz" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/construction)
 "ryf" = (
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/plasteel/ship/techfloor/alt,
@@ -46781,14 +46495,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/central)
-"rzB" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	name = "Disposals Access";
-	req_one_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plating,
-/area/maintenance/disposal)
 "rzF" = (
 /obj/machinery/light,
 /obj/machinery/firealarm{
@@ -46797,18 +46503,11 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/quartermaster/storage)
-"rAp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor/shutters/ship{
-	id = "ad_storage";
-	name = "Arms Dump Shutters"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory/lockup)
+"rAf" = (
+/obj/structure/table/wood/poker,
+/obj/item/taperecorder/empty,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "rAr" = (
 /obj/structure/grille,
 /obj/structure/cable{
@@ -46827,6 +46526,10 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/ai_monitored/turret_protected/aisat/service/support_ship)
+"rAY" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/construction)
 "rBw" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 1
@@ -46884,6 +46587,15 @@
 /obj/effect/landmark/start/roboticist,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"rEw" = (
+/obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/computer/lore_terminal,
+/obj/structure/closet/secure_closet/fighter_pilot,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/nsv/hanger)
 "rFi" = (
 /obj/machinery/door/airlock/ship/hatch{
 	name = "Support Vessel Aft";
@@ -46907,6 +46619,22 @@
 	},
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
+"rHE" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "22"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/department/chapel)
+"rHU" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/window,
+/obj/machinery/atmospherics/pipe/simple/brown/hidden{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/engine/engine_room)
 "rIu" = (
 /obj/effect/turf_decal/delivery/white,
 /obj/structure/reagent_dispensers/fueltank,
@@ -46935,20 +46663,27 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload)
-"rJk" = (
-/obj/machinery/light{
+"rJF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/ship,
+/area/security/prison)
+"rJN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Head of Security's Desk";
-	departmentType = 5;
-	name = "Head of Security RC";
-	pixel_x = 30
-	},
 /turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
+/area/ai_monitored/security/armory/lockup)
 "rKc" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /obj/machinery/firealarm{
@@ -46956,6 +46691,11 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"rKs" = (
+/obj/structure/hull_plate,
+/obj/structure/hull_plate,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "rKF" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -46986,6 +46726,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"rLM" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/item/stack/spacecash/c200,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "rMz" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/ship/techfloor/alt,
@@ -46995,6 +46740,9 @@
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"rMP" = (
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/department/medical/morgue)
 "rNj" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -47013,6 +46761,14 @@
 /obj/machinery/light/small,
 /turf/open/floor/wood,
 /area/science/research)
+"rNz" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance/eight,
+/turf/open/floor/plasteel/ship/riveted,
+/area/maintenance/department/medical/morgue)
 "rNF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -47167,6 +46923,25 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/ai_monitored/turret_protected/aisat/service/support_ship)
+"rXv" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/brown/visible,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "rXA" = (
 /obj/machinery/chem_master/condimaster{
 	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
@@ -47186,10 +46961,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
-"rYG" = (
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plasteel,
-/area/security)
 "rYW" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -47209,22 +46980,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"rZp" = (
-/obj/machinery/door/airlock/ship/command{
-	name = "Master At Arms";
-	req_one_access_txt = "70"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/carpet/ship,
-/area/nsv/crew_quarters/heads/maa)
 "rZw" = (
 /obj/machinery/vending/autodrobe,
 /obj/structure/sign/poster/contraband/clown{
@@ -47335,6 +47090,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"sdD" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/construction)
 "sdZ" = (
 /obj/machinery/camera/autoname,
 /turf/open/floor/plating,
@@ -47391,15 +47155,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"shx" = (
-/obj/machinery/computer/secure_data{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/dark,
-/area/security)
 "sie" = (
 /obj/structure/window,
 /obj/structure/cable{
@@ -47407,20 +47162,36 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"siA" = (
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer1{
-	dir = 5
+"sim" = (
+/obj/machinery/door/airlock/vault/ship{
+	req_access_txt = "53"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/locked,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plasteel/ship,
+/area/ai_monitored/nuke_storage)
 "siM" = (
 /obj/structure/table/wood,
 /obj/machinery/reagentgrinder,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"sjG" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/ship/security/glass{
+	id_tag = "pw_fd_outer";
+	name = "Brig";
+	req_one_access_txt = "63"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/security/prison)
 "sll" = (
 /obj/machinery/porta_turret/ai,
 /obj/effect/turf_decal/stripes/box,
@@ -47448,15 +47219,6 @@
 /obj/item/reagent_containers/food/drinks/flask/gold,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/heads/captain/private)
-"smu" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "smI" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/scientist,
@@ -47476,6 +47238,14 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"sof" = (
+/obj/machinery/door/window/brigdoor/security/cell/southright{
+	id = "pw_3";
+	name = "Cell 3"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/security/prison)
 "sov" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/machinery/status_display/evac{
@@ -47522,34 +47292,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"spa" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/security)
-"spo" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	name = "Medbay Service";
-	req_one_access_txt = "40"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "sps" = (
 /obj/machinery/light{
 	dir = 4
@@ -47568,9 +47310,28 @@
 /obj/machinery/status_display/evac/south,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/aft)
+"spS" = (
+/obj/structure/closet/crate/engineering,
+/obj/item/reagent_containers/food/drinks/bottle/vodka,
+/obj/effect/spawner/lootdrop/gloves,
+/turf/open/floor/plasteel/ship/riveted,
+/area/maintenance/department/medical/morgue)
 "spY" = (
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/department/chapel)
+"sqe" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer1{
+	dir = 8
+	},
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/engine/atmos)
+"sqF" = (
+/obj/machinery/disposal/bin,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/carpet/ship,
+/area/nsv/crew_quarters/heads/maa)
 "sqK" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -47581,14 +47342,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"srM" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plating,
-/area/maintenance/department/security)
 "sse" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -47598,12 +47351,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/security/warden)
-"sso" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Prison Sleepers"
-	},
-/turf/open/floor/plasteel/ship,
-/area/security/prison)
 "sst" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable{
@@ -47611,6 +47358,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"ssu" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_room)
+"stC" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/security/checkpoint/science/research)
 "stM" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -47629,6 +47394,10 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/central)
+"stV" = (
+/obj/structure/grille/wall,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "suo" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks,
@@ -47650,6 +47419,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"svM" = (
+/obj/machinery/armour_plating_nanorepair_pump/forward_port,
+/turf/open/floor/plasteel/ship,
+/area/construction)
 "svT" = (
 /obj/machinery/light{
 	dir = 4
@@ -47678,6 +47451,43 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/port)
+"swS" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
+"swW" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/ship_weapon/ammunition/torpedo/nuke/antonio,
+/obj/structure/bed/dogbed,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
+/turf/open/floor/carpet/ship,
+/area/nsv/crew_quarters/heads/maa)
+"sxk" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "sxJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/brown{
@@ -47708,12 +47518,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/fore)
-"syM" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security)
 "syY" = (
 /obj/structure/table/glass,
 /obj/structure/window/reinforced/spawner/east,
@@ -47722,14 +47526,6 @@
 /obj/item/aiModule/supplied/freeform,
 /turf/open/floor/circuit/red,
 /area/ai_monitored/turret_protected/ai_upload)
-"szi" = (
-/obj/machinery/door/poddoor/ship{
-	id = "launchbay_access";
-	name = "Launch tube access"
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/maintenance/starboard/central)
 "sAd" = (
 /turf/closed/wall/r_wall/ship,
 /area/security/main)
@@ -47764,15 +47560,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
-"sCf" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "ce_window";
-	name = "privacy shutter"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/chief)
+"sBx" = (
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall/ship,
+/area/maintenance/department/medical/morgue)
 "sCS" = (
 /obj/machinery/door/airlock/ship{
 	name = "Research Department";
@@ -47868,6 +47659,9 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
+"sIx" = (
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/construction)
 "sIz" = (
 /obj/machinery/light{
 	dir = 8
@@ -47877,6 +47671,41 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/ai_monitored/turret_protected/ai)
+"sID" = (
+/obj/structure/closet/secure_closet/bridge,
+/turf/open/floor/carpet/ship,
+/area/bridge)
+"sIE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/central)
+"sIW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/door/airlock/ship/security/glass{
+	name = "Medical Security Post";
+	req_one_access_txt = "63"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/medical)
 "sJb" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -47895,6 +47724,10 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/ship,
 /area/crew_quarters/dorms)
+"sKu" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship/riveted,
+/area/maintenance/department/medical/morgue)
 "sLb" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/condiment/peppermill{
@@ -47933,6 +47766,13 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/engine/break_room)
+"sLM" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/ship_weapon/ammunition/torpedo,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory/lockup)
 "sMJ" = (
 /obj/structure/grille,
 /obj/structure/cable{
@@ -47983,6 +47823,15 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/nsv/weapons/fore)
+"sPO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "sQf" = (
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/ship/techfloor/alt,
@@ -47993,6 +47842,10 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/service/support_ship)
+"sQx" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/nsv/hanger)
 "sQz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
@@ -48000,12 +47853,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/port)
-"sQT" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/turf/open/floor/carpet/ship,
-/area/nsv/crew_quarters/heads/maa)
 "sRQ" = (
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /obj/structure/table/glass,
@@ -48035,36 +47882,18 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
-"sTh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red{
+"sSY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/camera/autoname{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
 	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
-/area/security)
-"sTn" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plating,
-/area/engine/atmos)
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/fore)
 "sTv" = (
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/camera/autoname{
@@ -48103,6 +47932,29 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"sUc" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/door/airlock/ship/security/glass{
+	name = "Long-Term Confinement";
+	req_one_access_txt = "2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/security/prison)
+"sUf" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/nsv/hanger)
 "sUw" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -48126,6 +47978,15 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/aft)
+"sWe" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "sWy" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -48164,6 +48025,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"sZu" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"sZR" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/transfer)
 "taf" = (
 /obj/item/ship_weapon/ammunition/torpedo,
 /turf/open/floor/plasteel/dark,
@@ -48202,16 +48074,6 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/construction)
-"taX" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/structure/table/reinforced,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/belt/utility/full,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/nsv/hanger)
 "tbc" = (
 /obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/plasteel,
@@ -48248,6 +48110,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
+"tca" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory/lockup)
 "tce" = (
 /obj/machinery/light{
 	dir = 1
@@ -48278,6 +48146,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"tcI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters/ship{
+	dir = 1;
+	id = "ad_torp";
+	name = "Arms Dump Shutters"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory/lockup)
 "tcP" = (
 /obj/machinery/space_heater,
 /obj/item/storage/box/lights/mixed,
@@ -48327,6 +48206,17 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"tdX" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/ship/riveted,
+/area/maintenance/department/medical/morgue)
 "teh" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -48489,6 +48379,19 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
+"tle" = (
+/obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped/inverse{
+	dir = 1
+	},
+/obj/effect/landmark/start/atmospheric_technician,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/brown/visible/layer1{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "tmM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -48541,12 +48444,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"tpc" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "31"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "tpK" = (
 /obj/structure/rack,
 /obj/item/stack/packageWrap,
@@ -48562,13 +48459,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"tqb" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plasteel,
-/area/construction)
 "tqQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -48596,6 +48486,19 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/central)
+"trS" = (
+/obj/machinery/atmospherics/components/binary/pump/on/layer3{
+	dir = 8;
+	name = "Tanks to Mix"
+	},
+/obj/effect/turf_decal/stripes/red/box,
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/brown/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "trU" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -48603,6 +48506,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/gateway)
+"tsg" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "32"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "tsA" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Escape-2";
@@ -48689,6 +48603,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
+"twK" = (
+/obj/machinery/door/window/brigdoor/security/cell/southright{
+	id = "pw_5";
+	name = "Cell 5"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/security/prison)
 "twS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -48814,6 +48736,18 @@
 /obj/machinery/recharge_station,
 /turf/open/floor/plasteel/ship,
 /area/ai_monitored/turret_protected/aisat/service/support_ship)
+"tDJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "tEq" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/grown/harebell,
@@ -48840,6 +48774,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"tFt" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3,
+/obj/machinery/atmospherics/pipe/simple/brown/visible,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "tFH" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -48851,18 +48791,6 @@
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"tFQ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "rd_window";
-	name = "privacy shutter"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "rd_lockdown";
-	name = "security shutter"
-	},
-/turf/open/floor/plating,
-/area/science/lab)
 "tGs" = (
 /obj/machinery/computer/ship/viewscreen,
 /obj/machinery/navbeacon{
@@ -48871,17 +48799,17 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/fore)
-"tGA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+"tGG" = (
+/obj/machinery/door/airlock/glass_large/ship{
+	name = "Pilot Ready Room";
+	req_access_txt = "69"
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/central)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plasteel/dark,
+/area/nsv/hanger)
 "tGU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -48926,21 +48854,11 @@
 	},
 /turf/open/floor/plating,
 /area/hydroponics)
-"tIB" = (
-/obj/structure/rack,
-/obj/item/ammo_box/magazine/m45,
-/obj/item/ammo_box/magazine/m45,
-/obj/item/ammo_box/magazine/m45,
-/obj/item/ammo_box/magazine/m45,
-/obj/item/ammo_box/magazine/m45,
-/obj/item/ammo_box/magazine/m45,
-/obj/item/ammo_box/magazine/m45,
-/obj/item/ammo_box/magazine/m45,
-/obj/item/ammo_box/magazine/m45,
-/obj/item/ammo_box/magazine/m45,
-/obj/machinery/camera/autoname,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory/lockup)
+"tIL" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "tJN" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -48964,6 +48882,14 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/engine/engineering/hangar)
+"tLc" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "tLg" = (
 /obj/machinery/light{
 	dir = 4
@@ -49012,6 +48938,19 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/aft)
+"tMV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Dorms-0";
+	location = "CentHallCurv-1"
+	},
+/turf/open/floor/plasteel/ship,
+/area/hallway/primary/central)
 "tMZ" = (
 /obj/structure/table/wood,
 /obj/item/camera,
@@ -49120,18 +49059,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/central)
-"tQX" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "fab_window";
-	name = "privacy shutter"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "rd_lockdown";
-	name = "security shutter"
-	},
-/turf/open/floor/plating,
-/area/science/robotics/lab)
 "tRz" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -49139,6 +49066,21 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/hanger)
+"tRX" = (
+/obj/machinery/door/airlock/ship{
+	name = "Toxins Research";
+	req_one_access_txt = "8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel,
+/area/maintenance/port/aft)
 "tRZ" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1
@@ -49209,6 +49151,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"tTk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/door/airlock/vault/ship{
+	name = "Arms Dump";
+	req_one_access_txt = "3;58;70"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory/lockup)
 "tTM" = (
 /obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -49231,6 +49185,14 @@
 /obj/machinery/computer/atmos_control/tank/nitrous_tank,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"tVy" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/item/clothing/glasses/blindfold/white,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/transfer)
 "tVQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/table,
@@ -49240,12 +49202,6 @@
 /obj/effect/turf_decal/delivery/white,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"tWe" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/security)
 "tWm" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Medbay Lobby";
@@ -49276,7 +49232,9 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -49302,6 +49260,18 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"tXI" = (
+/obj/machinery/door/airlock/ship/security/glass{
+	name = "Customs Observation Desk";
+	req_one_access_txt = "1"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/customs/auxiliary)
 "tXO" = (
 /obj/machinery/vending/wardrobe/curator_wardrobe,
 /turf/open/floor/plasteel/cult,
@@ -49318,18 +49288,20 @@
 	},
 /turf/open/floor/plating,
 /area/nsv/weapons/fore)
+"tYx" = (
+/obj/machinery/airalarm/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "tYJ" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/entry)
-"tYU" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "tZd" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -49361,6 +49333,20 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/exit)
+"ubM" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/ship,
+/area/security/prison)
 "ucs" = (
 /turf/open/floor/plasteel,
 /area/maintenance/department/science/central)
@@ -49447,14 +49433,16 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"ufY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+"ufV" = (
+/obj/machinery/door/poddoor/ship{
+	id = "launchbay_tube3";
+	name = "Launch tube 3 access"
 	},
-/obj/structure/bed/dogbed,
-/obj/item/ship_weapon/ammunition/torpedo/nuke/antonio,
-/turf/open/floor/carpet/ship,
-/area/nsv/crew_quarters/heads/maa)
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/nsv/hanger/deck2/port{
+	name = "Launch tubes 3 and 4"
+	})
 "ugw" = (
 /obj/structure/grille,
 /obj/structure/cable{
@@ -49472,6 +49460,13 @@
 /obj/machinery/door/poddoor/incinerator_atmos_aux,
 /turf/open/floor/engine/vacuum,
 /area/engine/atmospherics_engine)
+"uhh" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/closet/firecloset,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/nsv/hanger)
 "uib" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/camera/autoname{
@@ -49498,6 +49493,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"ujP" = (
+/obj/machinery/door/airlock/ship/security/glass{
+	id_tag = "pw_fd_outer";
+	name = "Brig";
+	req_one_access_txt = "63"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/security/prison)
 "ujZ" = (
 /obj/machinery/shower{
 	dir = 8
@@ -49516,6 +49522,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"ulI" = (
+/obj/structure/chair,
+/turf/open/floor/plasteel/ship/riveted,
+/area/maintenance/department/medical/morgue)
 "umK" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -49556,6 +49566,23 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"umU" = (
+/obj/machinery/door/window/brigdoor/security/cell/southright{
+	id = "pw_2";
+	name = "Cell 2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/security/prison)
+"umW" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/grille/broken,
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance/seven,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "unu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -49597,17 +49624,23 @@
 	},
 /turf/open/floor/plasteel/ship/padded,
 /area/ai_monitored/turret_protected/ai_upload)
-"unV" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/power/apc/auto_name/west,
-/obj/structure/cable{
-	icon_state = "0-2"
+"uoc" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/westright{
+	name = "Executive Officer's Desk"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/door/window/brigdoor/eastleft{
+	name = "Executive Officer's Desk";
+	req_one_access_txt = "57"
 	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "xoprivacy";
+	name = "Privacy Shutters"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/plating,
-/area/maintenance/department/medical/morgue)
+/area/crew_quarters/heads/hop)
 "uoB" = (
 /obj/machinery/iv_drip,
 /obj/item/radio/intercom{
@@ -49615,10 +49648,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"uoJ" = (
-/obj/effect/landmark/start/master_at_arms,
-/turf/open/floor/carpet/ship,
-/area/nsv/crew_quarters/heads/maa)
 "uoZ" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8;
@@ -49654,24 +49683,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
-"usP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "63;69"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/security)
 "usR" = (
 /obj/machinery/holopad,
 /obj/effect/landmark/event_spawn,
@@ -49685,6 +49696,23 @@
 /obj/item/ship_weapon/ammunition/torpedo/nuke,
 /turf/open/floor/plasteel/ship,
 /area/nsv/weapons/fore)
+"utd" = (
+/obj/structure/rack,
+/obj/item/ammo_box/magazine/m45,
+/obj/item/ammo_box/magazine/m45,
+/obj/item/ammo_box/magazine/m45,
+/obj/item/ammo_box/magazine/m45,
+/obj/item/ammo_box/magazine/m45,
+/obj/item/ammo_box/magazine/m45,
+/obj/item/ammo_box/magazine/m45,
+/obj/item/ammo_box/magazine/m45,
+/obj/item/ammo_box/magazine/m45,
+/obj/item/ammo_box/magazine/m45,
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory/lockup)
 "utk" = (
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/light{
@@ -49699,21 +49727,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"uuY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/security)
 "uve" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -49860,6 +49873,22 @@
 	},
 /turf/closed/wall/ship,
 /area/engine/engine_smes)
+"uzn" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	department = "Engineering";
+	departmentType = 3;
+	name = "Engineering RC";
+	pixel_y = -30
+	},
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "uzN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 8
@@ -49873,6 +49902,11 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"uAy" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "uAz" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -49886,6 +49920,54 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"uAL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/disposalpipe/junction/flip{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
+"uAY" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/medical/medbay/central)
+"uBv" = (
+/obj/machinery/door/airlock/vault/ship{
+	req_access_txt = "53"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plasteel/ship,
+/area/ai_monitored/nuke_storage)
 "uBM" = (
 /obj/structure/closet/secure_closet/medical2,
 /obj/effect/turf_decal/tile/blue{
@@ -49938,6 +50020,19 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/toilet/restrooms)
+"uDi" = (
+/obj/machinery/door/airlock/ship/security/glass{
+	id_tag = "pw_fd_inner";
+	name = "Brig";
+	req_one_access_txt = "63"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/security/prison)
 "uEh" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -50011,6 +50106,12 @@
 /obj/machinery/stasis,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"uGe" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "uHa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -50103,6 +50204,16 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/ai_monitored/turret_protected/ai)
+"uJA" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/transfer)
 "uJE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -50167,15 +50278,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
-"uMb" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security)
 "uMl" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 4
@@ -50187,6 +50289,34 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/quartermaster/storage)
+"uMt" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	name = "Disposals Access";
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"uMu" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
+"uMB" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/bar)
 "uMU" = (
 /obj/machinery/air_sensor/atmos/nitrous_tank,
 /turf/open/floor/engine/n2o,
@@ -50201,13 +50331,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"uNZ" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "uOc" = (
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/maintenance/department/crew_quarters/dorms)
@@ -50234,12 +50357,6 @@
 /obj/effect/spawner/xmastree,
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/central)
-"uOU" = (
-/obj/machinery/computer/security/hos{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "uOV" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks{
@@ -50247,14 +50364,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"uPz" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor/northright{
-	name = "Security Desk";
-	req_access_txt = "1"
-	},
-/turf/open/floor/plating,
-/area/security)
 "uPO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -50332,21 +50441,26 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
-"uWs" = (
-/obj/machinery/camera/autoname,
-/obj/machinery/requests_console{
-	department = "Hangar Bay";
-	pixel_y = 32
-	},
-/obj/structure/closet/emcloset,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/nsv/hanger)
 "uWV" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/ship,
 /area/engine/engineering/hangar)
+"uXJ" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/department/chapel)
+"uXP" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "uYk" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible/layer3{
 	dir = 8
@@ -50359,6 +50473,14 @@
 "uYX" = (
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
+"uZj" = (
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible/layer3,
+/obj/machinery/atmospherics/pipe/manifold/brown/visible,
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "uZl" = (
 /obj/machinery/button/door{
 	id = "rd_window";
@@ -50387,13 +50509,14 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"vak" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+"uZK" = (
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
-/area/engine/storage)
+/area/maintenance/department/medical/morgue)
+"vab" = (
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory/lockup)
 "vau" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -50464,6 +50587,15 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
+"veg" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/window{
+	req_one_access_txt = "11"
+	},
+/turf/open/floor/plating,
+/area/construction)
 "veF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -50600,6 +50732,15 @@
 /obj/machinery/computer/secure_data/laptop,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
+"viG" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/template_noop,
+/area/maintenance/starboard/central)
 "viJ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -50651,18 +50792,17 @@
 /obj/machinery/computer/bounty,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/quartermaster/storage)
-"vlQ" = (
-/obj/item/radio/intercom{
-	pixel_y = 26
+"vkW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
 	},
-/obj/structure/closet/secure_closet/engineering_welding{
-	anchored = 1;
-	name = "munitions welding supplies locker";
-	req_access = null;
-	req_one_access_txt = "69"
+/obj/machinery/door/poddoor/shutters/ship{
+	dir = 1;
+	id = "ad_gun";
+	name = "Arms Dump Shutters"
 	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/nsv/hanger)
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory/lockup)
 "vlV" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -50729,6 +50869,14 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
+"vpo" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "vpv" = (
 /obj/effect/turf_decal/stripes/red/line,
 /obj/machinery/light,
@@ -50757,6 +50905,11 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"vrk" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/medical/medbay/central)
 "vrr" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -50830,6 +50983,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"vvT" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
 "vwk" = (
 /obj/structure/table/wood,
 /obj/item/paicard,
@@ -50903,6 +51067,16 @@
 "vzz" = (
 /obj/machinery/door/airlock/ship/external{
 	req_one_access_txt = "13"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
+"vzL" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
@@ -50982,6 +51156,14 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/exit)
+"vBs" = (
+/obj/item/ammo_casing/a357{
+	dir = 8;
+	projectile_type = null
+	},
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/transfer)
 "vBI" = (
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/plasteel/dark,
@@ -51014,6 +51196,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
+"vEW" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/construction)
+"vFq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 5
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"vFH" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "vFY" = (
 /obj/effect/turf_decal/stripes/white/line,
 /obj/effect/turf_decal/tile/brown{
@@ -51045,12 +51250,33 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"vHh" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "vHw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"vIY" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "69"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
+"vJk" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "vJy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -51170,31 +51396,24 @@
 	},
 /turf/open/floor/plating,
 /area/storage/primary)
-"vOy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security)
+"vOF" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/security/main)
 "vPg" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/carpet/black,
 /area/science/research)
+"vPp" = (
+/obj/machinery/door/airlock/ship/security/glass{
+	name = "Riot Armory";
+	req_one_access_txt = "3"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/ship,
+/area/ai_monitored/security/armory/security)
 "vPx" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel/white,
@@ -51218,6 +51437,12 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
+"vPY" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "vQn" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -51240,6 +51465,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"vQy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters/ship{
+	dir = 1;
+	id = "ad_torp";
+	name = "Arms Dump Shutters"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory/lockup)
 "vQz" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -51262,22 +51498,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/central)
-"vRb" = (
-/obj/effect/landmark/nuclear_waste_spawner,
-/turf/open/floor/plasteel/ship,
-/area/hallway/primary/central)
+"vRf" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "69"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/bar)
 "vRg" = (
 /obj/machinery/camera/autoname{
 	dir = 8
 	},
 /turf/open/floor/carpet/orange,
 /area/engine/break_room)
-"vRi" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "vRm" = (
 /obj/structure/sign/departments/evac{
 	pixel_x = 32
@@ -51290,7 +51524,9 @@
 "vRw" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/advanced_airlock_controller/directional/east,
+/obj/machinery/advanced_airlock_controller/directional/east{
+	pixel_y = 24
+	},
 /obj/machinery/light/small{
 	brightness = 3;
 	dir = 8
@@ -51309,12 +51545,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/service)
-"vSG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security)
 "vSR" = (
 /obj/machinery/button/massdriver{
 	id = "toxgun";
@@ -51329,6 +51559,33 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"vTi" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "ce_window";
+	name = "privacy shutter"
+	},
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/crew_quarters/heads/chief)
+"vTm" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/ship,
+/area/hallway/primary/fore)
 "vTo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -51357,16 +51614,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science/research)
-"vTO" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/security)
 "vTT" = (
 /obj/effect/turf_decal/stripes/white/line,
 /obj/effect/turf_decal/arrows/white{
@@ -51380,15 +51627,31 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"vUr" = (
-/obj/machinery/door/airlock/ship/security/glass{
-	name = "Firing Range";
-	req_one_access_txt = "63;69"
+"vTU" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
 	},
-/turf/open/floor/plasteel,
-/area/security)
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/bar)
+"vUO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/ship/riveted,
+/area/maintenance/department/medical/morgue)
 "vVh" = (
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -51426,15 +51689,10 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/toilet/restrooms)
-"vXp" = (
-/obj/machinery/light,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
-/turf/open/floor/plasteel/dark,
-/area/nsv/hanger)
+"vWS" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "vYz" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -51450,6 +51708,10 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"vYP" = (
+/obj/structure/railing,
+/turf/open/floor/plasteel,
+/area/construction)
 "vYZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -51520,6 +51782,15 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"wbk" = (
+/obj/machinery/door/poddoor/ship{
+	id = "launchbay_access";
+	name = "Launch tube access"
+	},
+/obj/effect/turf_decal/stripes/full,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/maintenance/starboard/central)
 "wbx" = (
 /obj/effect/landmark/blobstart,
 /obj/effect/decal/cleanable/cobweb,
@@ -51565,6 +51836,20 @@
 	},
 /turf/open/floor/plating,
 /area/nsv/weapons/fore)
+"wdK" = (
+/obj/structure/closet/secure_closet/hos,
+/obj/item/storage/secure/safe/HoS{
+	pixel_x = 8;
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "wdW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -51586,6 +51871,15 @@
 /obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"weO" = (
+/obj/machinery/camera/autoname,
+/obj/machinery/requests_console{
+	department = "Hangar Bay";
+	pixel_y = 32
+	},
+/obj/structure/closet/secure_closet/flight_leader,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/nsv/hanger)
 "wfC" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -51642,6 +51936,10 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/fore)
+"wgo" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/construction)
 "wgI" = (
 /obj/machinery/atmospherics/pipe/manifold/brown/visible{
 	dir = 8
@@ -51669,6 +51967,15 @@
 /obj/item/ship_weapon/ammunition/railgun_ammo,
 /turf/open/floor/plasteel/ship,
 /area/nsv/weapons/fore)
+"wiy" = (
+/obj/machinery/door/firedoor/heavy,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "maashutter"
+	},
+/turf/open/floor/plating,
+/area/nsv/crew_quarters/heads/maa)
 "wiH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51679,21 +51986,6 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/central)
-"wjx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plasteel,
-/area/security)
 "wjB" = (
 /obj/machinery/air_sensor/atmos/incinerator_tank{
 	pixel_y = 32
@@ -51765,6 +52057,15 @@
 "wnd" = (
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/starboard/central)
+"wnQ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/template_noop,
+/area/maintenance/starboard/central)
 "wot" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -51794,10 +52095,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"wqc" = (
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/carpet/ship,
-/area/nsv/crew_quarters/heads/maa)
 "wqk" = (
 /obj/machinery/mineral/stacking_unit_console{
 	machinedir = 4;
@@ -51806,7 +52103,9 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "wqA" = (
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
 /obj/structure/cable,
 /obj/structure/closet/secure_closet/miner,
 /turf/open/floor/plating,
@@ -51837,18 +52136,22 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/ai_monitored/turret_protected/aisat/service/support_ship)
-"wrI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+"wrq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	name = "Oxygen to Airmix";
+	target_pressure = 4500
+	},
+/obj/machinery/atmospherics/components/binary/pump/layer3{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/components/binary/pump/layer1{
+	dir = 8;
+	name = "O2 to Stormdrive"
 	},
 /turf/open/floor/plasteel,
-/area/construction)
+/area/engine/atmos)
 "wrO" = (
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -51894,6 +52197,38 @@
 /obj/structure/closet/crate/silvercrate,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/ai_monitored/nuke_storage)
+"wte" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/ship,
+/area/hallway/primary/fore)
+"wtn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/brown/visible,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "wtN" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -51921,10 +52256,17 @@
 /obj/machinery/rnd/production/protolathe/department/science,
 /turf/open/floor/plasteel,
 /area/science/lab)
-"wuo" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
+"wud" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/plating,
-/area/crew_quarters/heads/hos)
+/area/maintenance/port/aft)
 "wuv" = (
 /obj/effect/turf_decal/delivery/white,
 /obj/effect/landmark/start/flight_leader,
@@ -51937,14 +52279,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
-"wvk" = (
-/obj/structure/sign/plaques/golden{
-	desc = "Make. Torp.";
-	name = "The 40mm torp award for torpedo production";
-	pixel_y = 26
+"wwa" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
-/turf/open/floor/carpet/ship,
-/area/nsv/crew_quarters/heads/maa)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/simple/brown/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "wwk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -51957,6 +52305,12 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
+"wwp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/transfer)
 "wwM" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -52122,6 +52476,26 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
+"wEc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/ship,
+/area/security/prison)
 "wEo" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -52132,20 +52506,10 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/exit)
-"wEp" = (
-/obj/machinery/door/airlock/ship/station/mining{
-	name = "Cargo Shipping";
-	req_one_access_txt = "31"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plasteel/ship,
-/area/quartermaster/office)
 "wET" = (
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
 /obj/structure/table/glass,
 /obj/effect/spawner/lootdrop/aimodule_harmless,
 /obj/structure/cable,
@@ -52175,15 +52539,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/ai_monitored/turret_protected/aisat/service/support_ship)
-"wFW" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security)
 "wGc" = (
 /obj/machinery/cryopod{
 	dir = 4
@@ -52310,38 +52665,32 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"wND" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/door/airlock/ship/security/glass{
-	name = "Research Security Post";
-	req_one_access_txt = "63"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+"wNv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/science/research)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "wOo" = (
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/ai_monitored/turret_protected/ai_upload)
+"wOC" = (
+/obj/machinery/armour_plating_nanorepair_well,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/ship/padded,
+/area/construction)
 "wOQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -52362,6 +52711,14 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/construction)
+"wPD" = (
+/obj/machinery/door/window/brigdoor/security/cell/southright{
+	id = "pw_4";
+	name = "Cell 4"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/security/prison)
 "wPJ" = (
 /obj/structure/urinal{
 	pixel_y = 29
@@ -52419,32 +52776,32 @@
 /obj/item/lipstick/black,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/theatre)
-"wTZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/structure/disposalpipe/junction/flip{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical/morgue)
 "wUk" = (
 /obj/structure/sink/kitchen{
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"wVY" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/ship,
+"wVa" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/fore)
+"wVb" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "10"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plating,
-/area/maintenance/department/chapel)
+/area/maintenance/department/engine)
 "wWE" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -52478,6 +52835,21 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"wYj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/ship,
+/area/construction)
 "wYE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -52490,12 +52862,11 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"wZf" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/chapel)
+"wYX" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/solgovcup,
+/turf/open/floor/plasteel/ship/riveted,
+/area/maintenance/department/medical/morgue)
 "wZh" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -52520,6 +52891,53 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"xaB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
+"xaC" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/construction)
+"xaI" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/brown/visible/layer1,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"xaU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "xbx" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -52619,6 +53037,24 @@
 /obj/effect/decal/cleanable/oil/streak,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"xhe" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 30
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/ship,
+/area/nsv/crew_quarters/heads/maa)
 "xhr" = (
 /obj/effect/turf_decal/stripes/white/line,
 /obj/effect/turf_decal/arrows/white{
@@ -52633,6 +53069,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"xhA" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "xhL" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/structure/cable{
@@ -52655,10 +53099,21 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"xjb" = (
-/obj/machinery/space_heater,
+"xiD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
+"xjD" = (
+/obj/structure/rack,
 /turf/open/floor/plating,
-/area/maintenance/department/security)
+/area/maintenance/department/medical/morgue)
 "xjJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -52668,34 +53123,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/security/detectives_office/private_investigators_office)
+"xks" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/lobby)
 "xkE" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel/ship,
 /area/security/warden)
-"xkL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/door/airlock/ship/hatch{
-	name = "Chaplain's Office";
-	req_one_access_txt = "22"
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/main)
-"xkR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/landmark/nuclear_waste_spawner,
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Dorms-0";
-	location = "CentHallCurv-1"
-	},
-/turf/open/floor/plasteel/ship,
-/area/hallway/primary/central)
 "xll" = (
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -52708,6 +53147,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"xlN" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/suit_storage_unit/pilot,
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/nsv/hanger)
+"xmq" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "xmu" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -52745,6 +53203,20 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/nsv/weapons/fore)
+"xnB" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/dorms)
 "xnH" = (
 /obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/plasteel/dark,
@@ -52761,6 +53233,12 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/security/warden)
+"xoq" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/ship,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/maintenance/department/chapel)
 "xov" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -52772,16 +53250,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/engine/engineering/hangar)
-"xpc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/landmark/nuclear_waste_spawner,
-/turf/open/floor/plasteel/ship,
-/area/hallway/secondary/entry)
 "xpi" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/plasteel/ship,
@@ -52795,6 +53263,19 @@
 /obj/item/clothing/glasses/sunglasses/advanced,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"xpE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "xpM" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/ship,
@@ -52871,7 +53352,7 @@
 	areastring = "/area/bridge";
 	dir = 8;
 	name = "Bridge APC";
-	pixel_x = -25
+	pixel_x = -24
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -52880,6 +53361,14 @@
 /obj/machinery/microwave,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"xsZ" = (
+/obj/machinery/door/poddoor/shutters/ship{
+	dir = 1;
+	id = "ad_torp";
+	name = "Arms Dump Shutters"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory/lockup)
 "xtY" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
@@ -52924,6 +53413,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"xux" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
+"xuE" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/brown/visible/layer1{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "xuG" = (
 /obj/structure/table/wood,
 /obj/item/pinpointer/nuke,
@@ -52945,28 +53452,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"xvI" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "22"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/chapel)
 "xvJ" = (
 /obj/effect/spawner/lootdrop/maintenance/five,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
-"xwv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/carpet/ship,
-/area/nsv/crew_quarters/heads/maa)
 "xww" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -52992,6 +53481,17 @@
 /obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"xxX" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "55"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "xys" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -53052,7 +53552,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "xCp" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -53076,11 +53578,6 @@
 /obj/item/gun/ballistic/automatic/pistol/m1911/no_mag,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/security)
-"xDC" = (
-/obj/structure/table/reinforced,
-/obj/machinery/magnetic_controller,
-/turf/open/floor/plasteel,
-/area/security)
 "xDD" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/armor/bulletproof,
@@ -53116,12 +53613,29 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"xEZ" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "xFg" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"xFh" = (
+/obj/machinery/computer/prisoner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "xFl" = (
 /obj/machinery/door/airlock/ship/public{
 	name = "Service Break Room";
@@ -53148,13 +53662,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"xGo" = (
-/obj/effect/turf_decal/bot_red/right,
-/obj/item/ammo_casing/a357{
-	projectile_type = null
+"xGt" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/brown/visible,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/engine/atmos)
 "xGu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -53174,6 +53688,13 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/quartermaster/storage)
+"xGE" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory/lockup)
 "xHm" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -53186,6 +53707,26 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
+"xHO" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Stormdrive Plasma Constriction";
+	req_one_access_txt = "11; 24"
+	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/plasma/flipped{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "xIc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -53302,16 +53843,6 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/hanger)
-"xNv" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/security)
 "xND" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -53345,6 +53876,24 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/central)
+"xOj" = (
+/obj/machinery/door/airlock/ship/external{
+	req_one_access_txt = "13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
+"xON" = (
+/obj/machinery/light,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/fore)
 "xPt" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light{
@@ -53359,22 +53908,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
-"xQB" = (
-/obj/machinery/door/airlock/ship/station/mining{
-	name = "Mining Shuttle Dock";
-	req_one_access_txt = "48"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/quartermaster/warehouse)
 "xQR" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -53429,19 +53962,17 @@
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel/ship,
 /area/security/main)
-"xSb" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "38"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/bar)
 "xSj" = (
 /obj/structure/chair/stool,
 /obj/effect/turf_decal/stripes/white/line,
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/plasteel,
 /area/science/lab)
+"xSw" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/crew_quarters/heads/captain/private)
 "xSz" = (
 /obj/machinery/light{
 	dir = 8
@@ -53518,6 +54049,23 @@
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
+"xUx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Hangar Bay"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/fore)
 "xUX" = (
 /obj/machinery/computer/crew,
 /obj/machinery/computer/security/telescreen/cmo{
@@ -53543,6 +54091,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"xVu" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/storage/tech)
 "xVF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53557,13 +54110,6 @@
 /obj/structure/table/glass,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"xWu" = (
-/obj/machinery/door/airlock/ship/security/glass{
-	name = "Riot Armory";
-	req_one_access_txt = "3"
-	},
-/turf/open/floor/plasteel/ship,
-/area/ai_monitored/security/armory/security)
 "xWG" = (
 /obj/structure/grille,
 /obj/structure/cable{
@@ -53719,6 +54265,14 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/aft)
+"yac" = (
+/obj/machinery/door/poddoor/ship{
+	id = "launchbay_access";
+	name = "Launch tube access"
+	},
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/maintenance/starboard/central)
 "yau" = (
 /obj/structure/grille,
 /obj/structure/cable{
@@ -53780,6 +54334,17 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"ycn" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/belt/utility/full,
+/obj/item/clothing/head/helmet/decktech,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/nsv/hanger)
 "ycB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53860,6 +54425,11 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/central)
+"yfL" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "ygn" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/maintenance/four,
@@ -53868,6 +54438,14 @@
 "ygr" = (
 /turf/open/space/basic,
 /area/ai_monitored/turret_protected/ai)
+"ygv" = (
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/south,
+/obj/structure/closet/secure_closet/munitions_technician,
+/turf/open/floor/plasteel/ship,
+/area/nsv/weapons/fore)
 "ygR" = (
 /obj/structure/grille,
 /obj/structure/cable{
@@ -53878,15 +54456,26 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload)
-"yht" = (
-/obj/structure/disposalpipe/segment{
+"yhc" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/landmark/start/brig_phys,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/security)
+/turf/open/floor/plasteel/ship,
+/area/security/prison)
 "yhA" = (
 /obj/structure/grille,
 /obj/structure/cable,
@@ -53895,6 +54484,11 @@
 	},
 /turf/open/floor/plating,
 /area/nsv/weapons/fore)
+"yhB" = (
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plasteel/dark,
+/area/nsv/hanger)
 "yhI" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -53911,6 +54505,24 @@
 /obj/structure/dresser,
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
+"yig" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship{
+	name = "Lawyer's office";
+	req_one_access_txt = "38"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/ship,
+/area/lawoffice)
 "yiU" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -53947,17 +54559,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/port)
-"ykX" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/airlock/ship/security/glass{
-	id_tag = "pw_fd_inner";
-	name = "Brig";
-	req_one_access_txt = "63"
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/security/prison)
 "ylf" = (
 /obj/machinery/status_display/ai/west,
 /turf/open/floor/plasteel/ship/techfloor/alt,
@@ -59543,7 +60144,7 @@ bgf
 aDf
 aRH
 aDf
-agr
+sqe
 aDf
 aRH
 aDf
@@ -60550,7 +61151,7 @@ aEX
 asC
 fkN
 fkN
-aTF
+xVu
 kwH
 luQ
 nkV
@@ -60578,9 +61179,9 @@ aDf
 aDf
 aDf
 aDI
-kdS
-aoT
-aoT
+ojG
+aTy
+ksw
 kdS
 apu
 fVK
@@ -60807,7 +61408,7 @@ aEX
 asC
 fkN
 fkN
-aTF
+xVu
 ldu
 aoa
 oms
@@ -60823,7 +61424,7 @@ vrW
 kkP
 kkP
 agJ
-aiP
+vFH
 bdl
 bdm
 bce
@@ -60835,12 +61436,12 @@ ium
 afT
 aYk
 akJ
+ckc
 aYk
-aYk
-aYk
-aZp
-aNw
-aTI
+cSH
+kxd
+mwT
+opj
 aLx
 aIy
 alM
@@ -60854,7 +61455,7 @@ diq
 ako
 aBc
 aKU
-aXd
+fBK
 fkN
 aBl
 fkN
@@ -61073,11 +61674,11 @@ fkN
 fkN
 aPK
 aPK
-aJi
-aJi
+grF
+grF
 aPK
-aJi
-aJi
+grF
+grF
 aPK
 eEb
 aDf
@@ -61090,28 +61691,28 @@ dcR
 aEr
 nZr
 kEk
-afL
-ahl
-aRa
-aRa
-aqv
+xuE
+xaI
+kFl
+mtI
+tle
 avx
 diX
-rrZ
-aUj
-siA
-hWe
-hWe
-hWe
-apl
-aok
-tYU
-tYU
-tYU
-tYU
-tYU
+oRi
+trS
+qMQ
+gba
+gba
+gba
+kBf
+gum
+xGt
+xGt
+xGt
+xGt
+nAm
 ask
-aXd
+fBK
 aar
 aBl
 fkN
@@ -61347,11 +61948,11 @@ aPr
 xXW
 aYG
 aXn
-aiy
+jsr
 all
 all
 all
-aOg
+jVm
 anO
 apN
 yaQ
@@ -61366,9 +61967,9 @@ aTL
 aTL
 aTL
 aTL
-aPq
+ooU
 ymj
-aXd
+fBK
 fkN
 aBl
 fkN
@@ -61604,11 +62205,11 @@ aTf
 azr
 aZl
 aTy
-alo
+wrq
 aQP
 wDA
 uib
-aiY
+biH
 lHF
 aAB
 xzD
@@ -61623,7 +62224,7 @@ arA
 aYj
 arA
 aLb
-akQ
+bBg
 ymj
 aYi
 fkN
@@ -61842,7 +62443,7 @@ qAn
 aWl
 aar
 aux
-aXd
+fBK
 aps
 aoT
 alk
@@ -61861,13 +62462,13 @@ aoT
 aCf
 aYl
 fVK
-sTn
+mzs
 lke
 aYi
 aYi
-aRb
-aUl
-aZF
+mzs
+fVK
+lke
 aYi
 aSp
 fVK
@@ -61880,9 +62481,9 @@ fVK
 lke
 fVK
 aHj
-akQ
+bBg
 ymj
-aXd
+fBK
 fkN
 aBl
 fkN
@@ -62099,7 +62700,7 @@ aSY
 aWl
 fkN
 aar
-aXd
+fBK
 gEV
 aoT
 aoT
@@ -62108,7 +62709,7 @@ akF
 aoT
 aoT
 aoT
-aiP
+vFH
 aoT
 avX
 aGC
@@ -62118,7 +62719,7 @@ aTy
 arT
 aiR
 fVK
-ald
+kDH
 auY
 aoH
 anB
@@ -62136,10 +62737,10 @@ aro
 azE
 aqq
 aqi
-aYR
-azX
+nTi
+uZj
 ymj
-aXd
+fBK
 aar
 aBl
 fkN
@@ -62356,7 +62957,7 @@ ank
 aWl
 fkN
 fkN
-aXd
+fBK
 qcm
 aoT
 aoT
@@ -62365,7 +62966,7 @@ aUz
 aoT
 aoT
 aWp
-aiP
+vFH
 aoT
 aAH
 sbV
@@ -62389,14 +62990,14 @@ aKo
 anB
 aRV
 anB
-asR
+rnJ
 aIT
 aqx
 fVK
 cOm
 amu
 ymj
-aXd
+fBK
 fkN
 aBl
 fkN
@@ -62590,7 +63191,7 @@ aBl
 fkN
 awB
 bif
-bij
+nDV
 bil
 bil
 bim
@@ -62869,7 +63470,7 @@ aEG
 aTz
 aWl
 fkN
-aXd
+fBK
 ahr
 ahr
 ahr
@@ -62879,7 +63480,7 @@ aoT
 aoT
 aoT
 azP
-aiP
+vFH
 aoT
 aAH
 sbV
@@ -63126,7 +63727,7 @@ aEG
 aLs
 aWl
 fkN
-aXd
+fBK
 aoT
 aoT
 aoT
@@ -63136,7 +63737,7 @@ aoT
 eRN
 dkf
 esI
-fjA
+vPY
 dkf
 aiK
 xFt
@@ -63163,11 +63764,11 @@ anB
 akY
 aXt
 aQQ
-aSH
-aCZ
-aDo
+tFt
+bmO
+uZj
 ymj
-aXd
+fBK
 aar
 aBl
 fkN
@@ -63383,7 +63984,7 @@ aEG
 aOo
 aWl
 fkN
-aXd
+fBK
 ahr
 ahr
 ahr
@@ -63424,7 +64025,7 @@ aUl
 tUJ
 amu
 ymj
-aXd
+fBK
 fkN
 aBl
 fkN
@@ -63632,7 +64233,7 @@ rmw
 aEX
 awB
 aWl
-aTF
+xVu
 aWl
 aWl
 aWl
@@ -63641,22 +64242,22 @@ aWl
 aWl
 abA
 aDf
-aiP
-aiP
-aiP
+vFH
+vFH
+vFH
 aDf
 aDf
 awC
-aiP
-aiP
+vFH
+vFH
 ajO
 aDf
 aDf
-aiN
+tLc
 axQ
-aSa
+jXM
 aDf
-aiP
+vFH
 aYi
 aDf
 aYi
@@ -63681,7 +64282,7 @@ apc
 apn
 amu
 ymj
-aXd
+fBK
 fkN
 aBl
 fkN
@@ -63891,7 +64492,7 @@ awB
 fkN
 aar
 fkN
-aik
+oUA
 abB
 aXy
 abB
@@ -64148,7 +64749,7 @@ awB
 aar
 aar
 aar
-aik
+oUA
 abB
 axZ
 aYp
@@ -64173,9 +64774,9 @@ apv
 apv
 apv
 apv
-aNc
+sim
 aAZ
-lWX
+uBv
 iaV
 azQ
 atI
@@ -64191,11 +64792,11 @@ anB
 axb
 aZn
 awJ
-aSH
-aCZ
-aHn
+tFt
+okv
+pLc
 ymj
-aXd
+fBK
 fkN
 aHu
 aGt
@@ -64405,7 +65006,7 @@ awB
 aar
 fkN
 fkN
-aik
+oUA
 jEW
 aRZ
 jEW
@@ -64452,15 +65053,15 @@ aGf
 afM
 aCe
 ymj
-aXd
+fBK
 fkN
-arS
+cNp
 aGt
 aBH
 avM
 aBw
 aGt
-arS
+cNp
 fkN
 fkN
 bkD
@@ -64659,8 +65260,8 @@ aEX
 rmw
 aEX
 awB
-ahg
-ahg
+stC
+stC
 aKN
 aKN
 mYf
@@ -64684,7 +65285,7 @@ hCo
 mAo
 hCo
 aZN
-gHK
+hgn
 aZN
 aZN
 aSr
@@ -64709,15 +65310,15 @@ akk
 aMJ
 aLv
 akf
-aXd
+fBK
 aar
-arS
+cNp
 aGt
 avM
 pcv
 akt
 aGt
-arS
+cNp
 fkN
 fkN
 bkD
@@ -64968,13 +65569,13 @@ aRU
 eNw
 aYi
 bdq
-arS
+cNp
 aGt
 aOL
 avM
 azu
 aGt
-arS
+cNp
 fkN
 fkN
 bkD
@@ -65457,7 +66058,7 @@ abB
 aZN
 vqb
 apR
-gHK
+hgn
 awd
 awd
 awd
@@ -65722,7 +66323,7 @@ aKD
 bco
 xAP
 bcu
-mBy
+lWu
 geE
 rsX
 aEh
@@ -65945,7 +66546,7 @@ awB
 vMM
 awB
 aKN
-wND
+oaz
 aKN
 aKN
 aMS
@@ -65968,7 +66569,7 @@ gAF
 kRY
 bVq
 pFO
-loG
+uMu
 vQz
 apR
 arx
@@ -65979,13 +66580,13 @@ aMj
 aMj
 aMj
 bcv
-mBy
+lWu
 idC
 gWx
 gWx
 hlo
 mzw
-aMN
+tIL
 alH
 aXx
 azR
@@ -66236,13 +66837,13 @@ aMj
 bcp
 aMj
 bcv
-mBy
+lWu
 mzw
 gWx
 nBK
 hlo
 mzw
-aMN
+tIL
 alH
 avA
 aJT
@@ -66493,7 +67094,7 @@ aSu
 bcq
 aSu
 bcw
-ltw
+jkN
 rNF
 aBt
 qTl
@@ -66750,13 +67351,13 @@ bcm
 bcr
 bcs
 bcx
-mBy
+lWu
 ibY
 gWx
 gAB
 hlo
 mzw
-aMN
+tIL
 xZy
 tKN
 aTR
@@ -67007,13 +67608,13 @@ aMj
 aMj
 bcs
 bcz
-mBy
+lWu
 ibY
 gWx
 gWx
 hlo
 mzw
-aMN
+tIL
 alH
 uWV
 aKt
@@ -67512,7 +68113,7 @@ amA
 abB
 aZN
 aJs
-jeH
+wVb
 aIO
 aWV
 aYA
@@ -67767,17 +68368,17 @@ aop
 abB
 amA
 abB
-gHK
+hIL
 aJs
 ajk
 aeJ
 ajk
 ahj
 ajk
-aCY
-aCY
-aCY
-aCY
+sZu
+sZu
+sZu
+sZu
 ajk
 atG
 atG
@@ -68036,7 +68637,7 @@ jsQ
 jsQ
 jsQ
 axa
-anI
+hGy
 lwd
 hHo
 hHo
@@ -68293,7 +68894,7 @@ anC
 anC
 anC
 alQ
-anI
+hGy
 dbm
 aEo
 aEo
@@ -68506,7 +69107,7 @@ awB
 ckE
 ckE
 awB
-hbp
+xxX
 awB
 riS
 lhv
@@ -68550,7 +69151,7 @@ iQe
 iQe
 mms
 aZo
-anI
+hGy
 dbm
 aEo
 aEo
@@ -69064,7 +69665,7 @@ taG
 taG
 sBc
 are
-aZq
+bAU
 xuc
 amQ
 aRO
@@ -69322,18 +69923,18 @@ air
 aCt
 avV
 atG
+flG
 aTe
-aTe
-aTe
-aTe
+flG
+flG
 atG
-aTe
-aTe
-aTe
+flG
+flG
+flG
 atG
-qck
+hGy
 ayo
-qck
+hGy
 atG
 arQ
 arQ
@@ -69578,7 +70179,7 @@ apM
 aCt
 avS
 aJy
-aTe
+flG
 aDB
 aDB
 aDB
@@ -69587,11 +70188,11 @@ aDB
 aDB
 aDB
 aDB
-aTe
+flG
 nFf
 aWt
 nFf
-aTe
+flG
 bjq
 bjq
 aux
@@ -69835,7 +70436,7 @@ ajS
 aGF
 avq
 amS
-aTe
+flG
 aTk
 mCc
 qNr
@@ -69844,11 +70445,11 @@ uxG
 oDR
 mCc
 aTk
-aTe
+flG
 aYU
 bko
 dnE
-aTe
+flG
 bjq
 bjq
 aux
@@ -70082,7 +70683,7 @@ amA
 nUC
 aZN
 eIg
-nvK
+eYk
 xKM
 sZr
 egP
@@ -70092,7 +70693,7 @@ aCt
 tju
 awf
 aoL
-aTe
+flG
 aDB
 aDB
 aDB
@@ -70101,11 +70702,11 @@ aDB
 aDB
 aDB
 aDB
-aTe
+flG
 nFf
 aQC
 nFf
-aTe
+flG
 bjq
 bjq
 aux
@@ -70350,18 +70951,18 @@ aCt
 aCt
 ahb
 atG
+flG
+flG
 aTe
+flG
 aTe
-aTe
-aTe
-aTe
-aTe
-aTe
-aTe
+flG
+flG
+flG
 atG
-qck
+hGy
 aab
-qck
+hGy
 aSW
 ajk
 ajk
@@ -70562,7 +71163,7 @@ aJB
 aUL
 dOP
 aJB
-pig
+rfX
 aaO
 afI
 aaZ
@@ -70605,11 +71206,11 @@ aCt
 aCt
 aCt
 hcQ
-aAb
-aAu
+ssu
+dZS
 aSG
 wgI
-aVO
+wgI
 jjm
 aIj
 aIj
@@ -70815,7 +71416,7 @@ aJB
 aJB
 aJB
 bhY
-vRi
+wud
 aUL
 aaO
 aaO
@@ -70862,11 +71463,11 @@ pnG
 pnG
 pnG
 wHr
-fWO
+lro
 atG
 aIA
-aRS
-aVO
+nBl
+lbN
 jjm
 aIj
 byc
@@ -70883,7 +71484,7 @@ dqL
 anC
 oFx
 anv
-aJR
+vEW
 aJR
 pdq
 aJR
@@ -71119,15 +71720,15 @@ jgN
 jgN
 jgN
 jsQ
-hqj
+wwa
 atG
 jUE
-anI
-anI
-anI
-anI
-atG
-ala
+rHU
+cTY
+cTY
+cTY
+nhh
+xHO
 qUo
 atG
 iZK
@@ -71376,26 +71977,26 @@ tSU
 tSU
 tSU
 tSU
-ase
-crU
-kBR
-cNg
-cNg
-aKh
-cYE
-mmo
-aan
+hui
+igH
+wtn
+jgt
+jgt
+rXv
+nDX
+dVO
+jMI
 aas
 qUR
 wCW
-aax
-aay
-aaz
-hUB
-aaA
-aaA
-aaC
-juZ
+dvl
+iua
+ckw
+izt
+nKX
+nKX
+vFq
+piQ
 anv
 aJR
 aJR
@@ -71652,9 +72253,9 @@ sst
 mZV
 mZV
 jzC
-giB
+njH
 anv
-aJR
+pdq
 aJR
 aJR
 akX
@@ -71882,13 +72483,13 @@ ajW
 aZN
 vqb
 avT
-aRq
-ekn
-aaM
-sCf
+pTK
+vTi
+bxo
+bSP
 axD
-vak
-aAD
+qYP
+jBT
 aRf
 ryv
 qDZ
@@ -71905,11 +72506,11 @@ cDe
 anC
 anC
 anC
-lYp
+uzn
 anv
 anv
 aqz
-anv
+kcU
 anv
 aJR
 aJR
@@ -72162,15 +72763,15 @@ axF
 anC
 vwV
 wpN
-bae
+hCU
 anv
-aaB
-aum
-aJR
-aJR
-aJR
-aJR
-aJR
+iwP
+oyW
+sdD
+hfd
+sIx
+sIx
+qCz
 aAn
 bfO
 bkE
@@ -72420,14 +73021,14 @@ uNy
 vPA
 ayH
 anv
-anv
-aiX
-wrI
-aJR
-aJR
-aJR
-aJR
-aJR
+iRq
+djT
+wYj
+jgG
+rwD
+ldW
+ldW
+sIx
 aAn
 bkE
 aeX
@@ -72613,7 +73214,7 @@ aar
 aJB
 cCm
 aJB
-aUL
+stV
 aJB
 fkN
 aaO
@@ -72657,7 +73258,7 @@ agZ
 uxS
 anE
 acX
-sCf
+bSP
 viJ
 auE
 alO
@@ -72677,14 +73278,14 @@ anv
 anv
 anv
 anv
-brZ
-aJR
-wrI
-aye
-aye
-aye
-aye
-aye
+mZN
+sIx
+pzX
+qCz
+phS
+qCz
+fTu
+sIx
 aAn
 bkE
 aeX
@@ -72868,9 +73469,9 @@ aux
 fkN
 aEn
 acb
-aUL
-aUL
-aUL
+noG
+noG
+hFE
 aJB
 fkN
 aaO
@@ -72891,7 +73492,7 @@ xSj
 aQV
 cnp
 rYW
-tFQ
+cED
 vFY
 awS
 anR
@@ -72914,7 +73515,7 @@ xso
 aGU
 aXD
 qlK
-sCf
+bSP
 bkp
 auE
 hdT
@@ -72929,19 +73530,19 @@ ajw
 ajw
 ajw
 aun
-aye
-aye
+qgm
+qgm
 uyy
-aye
-aye
 aJR
-aJR
-wrI
-aye
-aye
-aJR
-aJR
-pdq
+akX
+akX
+rAY
+mMR
+qCz
+phS
+qCz
+ldW
+sIx
 aAn
 bfO
 aeX
@@ -73125,9 +73726,9 @@ aux
 fkN
 fkN
 acb
-aUL
-reh
-aUL
+noG
+jpL
+noG
 aJB
 fkN
 aaO
@@ -73139,7 +73740,7 @@ abZ
 eKt
 aza
 pWh
-bzx
+ffM
 hew
 kGA
 aMD
@@ -73148,7 +73749,7 @@ dMa
 aOD
 rKF
 oTg
-tFQ
+cED
 xhr
 dRV
 bcA
@@ -73164,14 +73765,14 @@ aMC
 abB
 wot
 pFO
-loG
+uMu
 vQz
 avT
 lAM
 mYm
 orF
 vKa
-sCf
+bSP
 cXW
 pjs
 fxt
@@ -73188,17 +73789,17 @@ ata
 akX
 aye
 aye
-aye
-aye
-aye
-aye
-aye
-wrI
-aye
-aye
 aJR
-ipX
-akX
+aJR
+aJR
+gzQ
+sIx
+mMR
+qCz
+phS
+qCz
+ldW
+sIx
 akX
 aeX
 bkE
@@ -73382,12 +73983,12 @@ aux
 aar
 aar
 aJB
-aUL
-aUL
-aUL
+noG
+noG
+noG
 atd
 fkN
-apW
+lsu
 abl
 aaZ
 aaZ
@@ -73396,7 +73997,7 @@ aaZ
 dgl
 rsR
 mft
-bzx
+ffM
 but
 nDN
 aug
@@ -73434,7 +74035,7 @@ aam
 aam
 aam
 aam
-aPf
+mVC
 aam
 dSe
 bVr
@@ -73442,21 +74043,21 @@ bVr
 bVr
 bVr
 bVr
-fSt
+tsg
 mCn
 mCn
 mCn
 mCn
-tqb
-mwO
-mwO
-azB
-aye
-aJR
-aJR
+qNR
+veg
+ifm
+gJJ
+qCz
+wOC
+qCz
+svM
+sIx
 akX
-akX
-bkG
 aeX
 aeX
 bfT
@@ -73639,12 +74240,12 @@ aux
 fkN
 aEn
 acb
-aUL
-aUL
+stV
+stV
 aUL
 atd
 fkN
-apW
+lsu
 aiT
 aaZ
 aSc
@@ -73692,7 +74293,7 @@ sXM
 bag
 aaf
 uiM
-gfC
+xEZ
 nzc
 aho
 aho
@@ -73705,20 +74306,20 @@ aye
 aye
 aye
 aye
-aJR
-aJR
-awZ
-aoq
-aJR
+gzQ
+sIx
+pYC
+mel
+ldW
+ldW
+ldW
+rxz
 akX
-akX
-bkE
+aeX
 aeX
 bfT
 fkN
 fkN
-fkN
-aaa
 aaa
 aaa
 aaa
@@ -73901,7 +74502,7 @@ aUL
 bia
 atd
 fkN
-apW
+lsu
 nTy
 aaZ
 aaZ
@@ -73947,7 +74548,7 @@ tIa
 apA
 avN
 aqA
-azx
+fIp
 jqp
 aho
 aho
@@ -73958,24 +74559,24 @@ kBF
 tcP
 akX
 wPr
-aye
-aye
-aye
-aye
 aJR
 aJR
-aAA
-aRB
+aye
+aye
+vYP
+sIx
+ntz
+xaC
+sIx
+wgo
+oiD
+pjY
 akX
-akX
-aHd
-aux
-aar
+aeX
+bfT
 fkN
 fkN
 fkN
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -74217,22 +74818,22 @@ akX
 akX
 akX
 tAi
-ggZ
+bzd
 aye
-aye
+vYP
 akX
 akX
 akX
 akX
-aHd
-aHd
-aux
-aar
+akX
+akX
+akX
+akX
+bdx
+bfV
 fkN
 fkN
-aaa
-aaa
-aaa
+fkN
 aaa
 aaa
 aaa
@@ -74412,7 +75013,7 @@ aar
 aJB
 aJB
 aJB
-bib
+qhS
 aJB
 fkN
 aaO
@@ -74442,17 +75043,17 @@ aEZ
 aPo
 aUC
 aCL
-abo
-abo
+gJq
+gJq
 aaf
-abo
-abo
-abo
-abo
-abo
+gJq
+gJq
+gJq
+gJq
+gJq
 aaf
-abo
-abo
+gJq
+gJq
 aKL
 asE
 ays
@@ -74470,7 +75071,7 @@ ata
 ata
 ata
 ata
-bJo
+jNK
 ata
 akX
 akX
@@ -74486,7 +75087,7 @@ aHd
 aux
 aar
 fkN
-aaa
+fkN
 aaa
 aaa
 aaa
@@ -74698,7 +75299,7 @@ aEZ
 aUO
 adc
 asY
-aGd
+fbm
 fkN
 fkN
 fkN
@@ -74710,7 +75311,7 @@ fkN
 fkN
 fkN
 fkN
-aUJ
+gyg
 aEd
 kDM
 auK
@@ -74743,7 +75344,7 @@ aux
 aux
 aar
 fkN
-aaa
+fkN
 aaa
 aaa
 aaa
@@ -74947,7 +75548,7 @@ mhv
 aDq
 mhv
 abX
-tQX
+lGT
 aaj
 aIz
 aaj
@@ -74955,7 +75556,7 @@ aEZ
 ojZ
 adc
 asY
-aGd
+fbm
 fkN
 fkN
 fkN
@@ -74967,7 +75568,7 @@ fkN
 fkN
 fkN
 fkN
-aUJ
+gyg
 aUB
 afZ
 arD
@@ -75204,7 +75805,7 @@ pRD
 aTZ
 hAT
 eUW
-tQX
+lGT
 aaj
 aIz
 aaj
@@ -75212,7 +75813,7 @@ aEZ
 pZy
 adc
 asY
-aGd
+fbm
 fkN
 fkN
 fkN
@@ -75224,7 +75825,7 @@ fkN
 fkN
 fkN
 fkN
-aUJ
+gyg
 aBh
 azp
 bMn
@@ -75438,9 +76039,9 @@ aaO
 aaO
 aaO
 aaO
-nAz
+tRX
 aaO
-vRi
+xhA
 aJB
 fkN
 aaO
@@ -75461,7 +76062,7 @@ bFG
 axG
 mhv
 oHd
-tQX
+lGT
 aaj
 aIz
 aaj
@@ -75469,7 +76070,7 @@ aEZ
 ckT
 adc
 asY
-aGd
+fbm
 fkN
 fkN
 fkN
@@ -75481,7 +76082,7 @@ fkN
 fkN
 fkN
 fkN
-aUJ
+gyg
 gkO
 atD
 eBE
@@ -75997,7 +76598,7 @@ aaf
 abo
 aKL
 aKL
-aCU
+tXI
 aKL
 aKL
 aaj
@@ -76463,7 +77064,7 @@ aaO
 aaO
 aaO
 apm
-cYl
+bCx
 aaO
 aaO
 aaO
@@ -76498,7 +77099,7 @@ adc
 aGS
 biy
 aCL
-aGd
+fbm
 aCL
 fkN
 fkN
@@ -76756,7 +77357,7 @@ aKH
 biA
 suo
 adc
-aGd
+fbm
 fkN
 fkN
 fkN
@@ -77013,7 +77614,7 @@ aZw
 biA
 hTW
 puq
-aGd
+fbm
 fkN
 fkN
 fkN
@@ -77023,7 +77624,7 @@ fkN
 fkN
 fkN
 fkN
-abo
+gJq
 sWG
 uyM
 biN
@@ -77034,7 +77635,7 @@ aHQ
 aaf
 aaf
 vHw
-bJo
+geQ
 ata
 ata
 eki
@@ -77248,7 +77849,7 @@ aIZ
 aIZ
 bPL
 alx
-cTV
+hro
 gDS
 aVe
 eLW
@@ -77270,7 +77871,7 @@ aZw
 biA
 rPQ
 adc
-aGd
+fbm
 fkN
 fkN
 fkN
@@ -77280,7 +77881,7 @@ fkN
 fkN
 fkN
 fkN
-abo
+gJq
 sWG
 uyM
 biV
@@ -77527,7 +78128,7 @@ biw
 biA
 pSh
 adc
-aGd
+fbm
 fkN
 fkN
 fkN
@@ -77783,7 +78384,7 @@ adc
 bix
 biF
 aCL
-aGd
+fbm
 aCL
 fkN
 fkN
@@ -78023,7 +78624,7 @@ dRy
 cTr
 wBI
 aVe
-hQO
+izl
 aVe
 aVe
 aVe
@@ -78288,7 +78889,7 @@ aki
 aki
 sAU
 aki
-tGA
+xpE
 gVz
 agl
 aaj
@@ -78307,10 +78908,10 @@ fkN
 fkN
 fkN
 aaf
-abo
+gJq
 aaf
 aaf
-rag
+qhE
 aaf
 aaf
 gyQ
@@ -78543,7 +79144,7 @@ aIx
 aJp
 aJp
 aJp
-qUP
+gxS
 aJp
 aJp
 gyQ
@@ -79068,20 +79669,20 @@ aEZ
 aoO
 aqt
 avl
-abo
-abo
+gJq
+gJq
 aaf
-abo
-abo
-abo
-abo
-abo
+gJq
+gJq
+gJq
+gJq
+gJq
 aaf
-abo
-abo
+gJq
+gJq
 aaf
 aaf
-rag
+qhE
 aaf
 aaf
 aaj
@@ -79354,7 +79955,7 @@ fkN
 fkN
 aho
 bfe
-bfX
+hEF
 bga
 aho
 aux
@@ -79592,7 +80193,7 @@ aqC
 lhA
 lhA
 lhA
-xpc
+lhA
 lhA
 lhA
 lhA
@@ -80092,7 +80693,7 @@ aBm
 aBm
 aBm
 aBm
-cXH
+pYy
 aBm
 aBm
 acB
@@ -80110,9 +80711,9 @@ aWP
 aWP
 aWP
 aWP
-cze
-awq
-cze
+vrk
+uAY
+vrk
 axM
 axM
 axM
@@ -80893,7 +81494,7 @@ tAh
 apo
 bdW
 beq
-bex
+jeJ
 bfa
 aWJ
 aux
@@ -81115,7 +81716,7 @@ aJp
 bNx
 alW
 bek
-biv
+ogm
 aJL
 aAk
 aBm
@@ -81665,7 +82266,7 @@ axM
 axM
 axM
 axM
-hWj
+qzh
 aWJ
 vLb
 dyX
@@ -82144,12 +82745,12 @@ ahy
 aUd
 ahy
 aJp
-biv
+ego
 aBm
 aBm
 aBm
 aBm
-biv
+ego
 aBm
 acB
 aEt
@@ -82396,7 +82997,7 @@ aub
 aub
 aub
 aub
-fJU
+pwe
 abP
 aTQ
 abO
@@ -82934,8 +83535,8 @@ cam
 app
 app
 oFm
-ewo
-qSW
+jzK
+xks
 atV
 cbx
 eqq
@@ -82945,7 +83546,7 @@ hYv
 fkM
 axR
 axR
-spo
+kXG
 jHE
 qsi
 sie
@@ -83172,7 +83773,7 @@ aoP
 aZK
 abO
 aFX
-kyr
+nQJ
 aVo
 alD
 alD
@@ -83191,7 +83792,7 @@ atV
 bah
 app
 oFm
-kpu
+aUc
 lFF
 tWm
 kXR
@@ -83203,10 +83804,10 @@ aTi
 aTi
 aTi
 aQf
-anw
+dft
 aQf
 aQf
-gka
+kIp
 aWJ
 aWJ
 hNn
@@ -83448,7 +84049,7 @@ atV
 aQi
 app
 oFm
-hGC
+buH
 dvx
 tWm
 kXR
@@ -83705,8 +84306,8 @@ cam
 app
 app
 oFm
-ewo
-aHH
+nCR
+jCA
 atV
 aRN
 aqO
@@ -84991,7 +85592,7 @@ tbI
 aHT
 aKp
 aqT
-aCN
+sIW
 avR
 cVr
 cHo
@@ -85537,7 +86138,7 @@ dKj
 mUQ
 aOP
 oEi
-aQp
+huV
 fkN
 bfF
 fkN
@@ -85736,12 +86337,12 @@ aIx
 iIq
 aub
 afB
-oAe
+nkd
 afB
 afG
 qUZ
 abO
-kyr
+rnW
 aiM
 aiM
 alD
@@ -85794,7 +86395,7 @@ azK
 azK
 axN
 awO
-aQp
+huV
 fkN
 bfF
 fkN
@@ -86051,7 +86652,7 @@ dbp
 qwt
 jSG
 eGg
-aQp
+huV
 fkN
 bfF
 fkN
@@ -86515,7 +87116,7 @@ yeU
 aFX
 aiM
 aiM
-kyr
+rnW
 abO
 abP
 aYF
@@ -86564,7 +87165,7 @@ amF
 due
 aCT
 aTa
-aQp
+huV
 fkN
 fkN
 bfF
@@ -86802,13 +87403,13 @@ ybs
 kgJ
 xTc
 axx
-fTU
+lDW
 aWJ
 aWJ
 aWJ
 aWJ
 aWJ
-mHZ
+mvQ
 aWJ
 amF
 amF
@@ -86821,7 +87422,7 @@ amF
 baO
 asJ
 aTa
-aQp
+huV
 aar
 aar
 bfF
@@ -87041,7 +87642,7 @@ aVx
 bew
 ayy
 dLA
-oNy
+fKx
 aJF
 aJF
 aJF
@@ -87078,7 +87679,7 @@ amF
 bWs
 asJ
 aTa
-aQp
+huV
 fkN
 fkN
 bfF
@@ -87320,14 +87921,14 @@ wlF
 aZI
 atn
 ayh
-nzg
+kIG
 ayh
 azn
 kjX
-hWh
+iSz
 aWT
 soN
-nMK
+lio
 tSc
 aJJ
 ayY
@@ -87335,7 +87936,7 @@ amF
 aUk
 aAP
 aFm
-aQp
+huV
 fkN
 fkN
 bfF
@@ -87578,7 +88179,7 @@ drQ
 azs
 aZI
 aWK
-baL
+hpB
 dJU
 poC
 amF
@@ -87592,7 +88193,7 @@ amF
 asc
 asJ
 asP
-aQp
+huV
 fkN
 fkN
 bfF
@@ -87835,9 +88436,9 @@ ajp
 cze
 cze
 aWK
-afX
-yht
-afX
+aWJ
+qdG
+aWJ
 amF
 amF
 amF
@@ -87849,7 +88450,7 @@ amF
 aNT
 aPn
 aIS
-aQp
+huV
 aar
 aar
 bfF
@@ -88092,9 +88693,9 @@ ajp
 puj
 amw
 aPX
-afX
-tWe
-efI
+aWJ
+fSp
+eCU
 amF
 aqF
 pPn
@@ -88105,8 +88706,8 @@ aqF
 amF
 aSz
 fcQ
-aQp
-aQp
+huV
+huV
 fkN
 fkN
 bfF
@@ -88316,7 +88917,7 @@ aiM
 aLW
 wGc
 abO
-vRb
+abP
 eAd
 ayy
 bai
@@ -88349,9 +88950,9 @@ ajp
 aRC
 ayd
 azv
-aQO
-aRF
-byo
+gMi
+xaU
+eFX
 amF
 aZL
 aqF
@@ -88360,9 +88961,9 @@ xXf
 agw
 uyo
 amF
-aQp
-aQp
-aQp
+huV
+huV
+huV
 fkN
 fkN
 fkN
@@ -88606,9 +89207,9 @@ ajp
 agU
 aJk
 aAS
-afX
-agG
-iTS
+aWJ
+xaB
+gWh
 amF
 aqF
 raj
@@ -88813,7 +89414,7 @@ fkN
 aEn
 aMM
 aRz
-qXn
+nlN
 aMx
 aIn
 wTa
@@ -88863,9 +89464,9 @@ ajp
 aOX
 awj
 aOX
-afX
-spa
-afX
+aWJ
+rbx
+aWJ
 amF
 amF
 amF
@@ -89120,12 +89721,12 @@ cJj
 cJj
 aWF
 aWK
-jco
-bgj
-bgm
-bgp
-bgq
-bgr
+rjQ
+iGM
+fpD
+xOj
+oNs
+iNr
 bfY
 bkx
 aeX
@@ -89377,12 +89978,12 @@ aZI
 aZI
 hmp
 aWK
-fQZ
-bgk
-bgn
-afX
-afX
-afX
+uZK
+lID
+brq
+dLA
+dLA
+dLA
 bfZ
 bky
 aeX
@@ -89593,7 +90194,7 @@ fRr
 axS
 rWs
 dmA
-egm
+xnB
 wmH
 wmH
 ifs
@@ -89617,7 +90218,7 @@ aNV
 aNV
 aNV
 aNV
-hqs
+hsL
 aNV
 inE
 cUB
@@ -89634,10 +90235,10 @@ cUB
 rOt
 vVy
 aWK
-efI
-bgl
-bgo
-afX
+vWS
+tDJ
+gIK
+dLA
 aeX
 aeX
 aeX
@@ -89839,7 +90440,7 @@ act
 act
 aIx
 aIx
-iZo
+eYz
 axS
 axS
 rZw
@@ -89867,14 +90468,14 @@ ayy
 aVx
 aVx
 ayy
-qlS
-qFD
-unV
-qFD
-qFD
-qFD
-qFD
-eVB
+iFt
+gLT
+sBx
+qmE
+oZx
+sKu
+sKu
+vUO
 aWK
 aWK
 aWK
@@ -89891,20 +90492,20 @@ aWK
 aWK
 aWK
 aWK
-xjb
-hax
-goa
-afX
+fHD
+lvz
+bXP
+dLA
 aeX
 aeX
 aeX
 aeX
-aeX
-aeX
-bfT
+bdx
+bdx
+bfV
 fkN
-aaa
-aaa
+fkN
+fkN
 aaa
 aaa
 aaa
@@ -90092,7 +90693,7 @@ fkN
 abx
 aeX
 apQ
-acy
+gft
 acw
 acx
 wBH
@@ -90124,44 +90725,44 @@ abO
 ilH
 dmz
 dLA
-wTZ
-gLT
-gLT
-gLT
-gLT
-gLT
-gLT
-flf
+uAL
+qFD
+oBW
+bMm
+hAU
+bjp
+ekb
+tdX
+oBW
 qFD
 qFD
-xNv
-srM
-mIK
-mIK
-aCv
-qXQ
-mIK
-mIK
-mIK
-mIK
-mIK
-mIK
-hjq
-mIK
-mIK
-gEB
-ayc
-oZG
-oZG
-wuo
-wuo
-bkz
-bkB
+qFD
+xmq
+qFD
+qFD
+lpG
+qFD
+qFD
+qFD
+qFD
+qFD
+qFD
+qlf
+xmq
+qFD
+eVB
+tYx
+rMP
+aeX
+aeX
 aeX
 bfT
 fkN
-aaa
-aaa
+fkN
+fkN
+fkN
+fkN
+fkN
 aaa
 aaa
 aaa
@@ -90349,7 +90950,7 @@ fkN
 abx
 aeX
 apQ
-acy
+gft
 acw
 aaF
 acw
@@ -90381,44 +90982,44 @@ wSt
 mkP
 niw
 dLA
-oNy
+fKx
 dLA
 dLA
-hMw
+spS
+ulI
+wYX
+rNz
+ngq
+dLA
 arM
 arM
-fYr
 arM
+dLA
+dLA
+oUs
+dLA
+dLA
+dLA
+dLA
 arM
+jzg
+dLA
+reo
+dLA
 arM
-aKu
-aKu
-aKu
-aKu
-aKu
-aKu
-aKu
-aKu
-aKu
-aKu
-aKu
-aKu
-nSR
-afX
-alt
-uuY
-qql
-oZG
-oAo
-iyP
-wuo
-wuo
-bkz
-bkB
+sPO
+cIN
+rMP
+aeX
+aeX
+aeX
 bfT
 fkN
-aaa
-aaa
+fkN
+fkN
+fkN
+fkN
+fkN
 aaa
 aaa
 aaa
@@ -90605,7 +91206,7 @@ fkN
 fkN
 abx
 acT
-adb
+xux
 acT
 xxc
 xnI
@@ -90648,34 +91249,34 @@ aVL
 aVL
 aVL
 aVL
-apY
-aFd
-aFd
-aFd
-aFd
-aFd
-aFd
-aFd
-aFd
-aFd
-aFd
-apY
-apY
-aBR
-afX
-usP
-afX
-oZG
-hNs
-aVR
-pLe
-wuo
-wuo
-bfO
+aVL
+aVL
+aVL
+gtQ
+gtQ
+gtQ
+gtQ
+dqr
+dLA
+mIp
+dLA
+dLA
+dLA
+dLA
+dLA
+boH
+xjD
+rMP
+rMP
+aeX
 aeX
 bfT
-aaa
-aaa
+fkN
+fkN
+fkN
+fkN
+fkN
+fkN
 aaa
 aaa
 aaa
@@ -90860,7 +91461,7 @@ fkN
 fkN
 fkN
 acT
-adb
+xux
 acT
 lNC
 aRr
@@ -90892,7 +91493,7 @@ avI
 avI
 tfb
 abO
-xkR
+tMV
 stN
 stN
 oDp
@@ -90904,33 +91505,33 @@ aPH
 aPH
 aPH
 aPH
+lzy
+lzy
+lzy
 aVL
-aFd
-aFd
-apY
-apY
-apY
-apY
-apY
-apY
-apY
-apY
-apY
-apY
-qQH
-mSp
-aUa
-aIE
-sTh
-ayT
-axv
-aEx
-isu
-mzq
-wuo
-bfO
-aeX
+gtQ
+gtQ
+gtQ
+gtQ
+gtQ
+dLA
+iSh
+suQ
+jHX
+jHX
+rrk
+dLA
+boH
+dLA
+rMP
+rMP
+nub
+nub
 bfT
+fkN
+fkN
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -91115,8 +91716,8 @@ fkN
 fkN
 fkN
 acT
-adb
-adb
+xux
+xux
 lNC
 lOK
 adR
@@ -91163,31 +91764,31 @@ aVL
 aVL
 aVL
 aVL
-apY
-apY
-akV
-nVL
-akV
-aTC
-aJN
-kDc
-eqo
-iCf
-iVs
-bYJ
-aJN
-aJN
-aAC
-kkc
-oZG
-ahs
-aSA
-aWk
-uOU
-wuo
-bfO
-aeX
+lzy
+aVL
+gtQ
+gtQ
+gtQ
+gtQ
+gtQ
+dLA
+iSh
+oEb
+jHX
+jHX
+jHX
+dLA
+boH
+dLA
+gtQ
+gtQ
+qRU
+nub
 bfT
+fkN
+fkN
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -91414,37 +92015,37 @@ aIK
 aVL
 aPH
 aVL
-tQC
-iyn
-nhY
+iAT
 aHp
-tQC
+sLM
+qZL
+pfn
 aVL
-aFd
-apY
-akV
-jrs
-akV
-aJN
-aJN
-aJN
-iwE
-uMb
-aJN
-aMH
-aJN
-azc
-aAC
-kkc
-arU
-iHn
-rky
-aWk
-euT
-wuo
-bfO
-aeX
+lzy
+aVL
+dLA
+dLA
+dLA
+vpo
+dLA
+dLA
+iSh
+suQ
+jHX
+jHX
+jHX
+dLA
+boH
+vJk
+gtQ
+gtQ
+gtQ
+nub
 bfT
+fkN
+fkN
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -91671,37 +92272,37 @@ wSj
 aVL
 aPH
 aVL
-tIB
+mrj
 aBk
-xZo
-aHp
-xZo
+taf
+qgX
+bGg
 aVL
-aFd
-apY
-akV
-cgZ
-akV
-aJN
-aJN
-aJN
-xDC
-kAq
-hCZ
-syM
-aJN
-azc
-aAC
-kkc
-arU
-aMZ
-dyL
-rJk
-uNZ
-wuo
-bfO
-aeX
+lzy
+aVL
+ini
+iSh
+bsg
+iSh
+iSh
+iSh
+iSh
+aeR
+aeR
+aeR
+aeR
+dLA
+boH
+dLA
+gtQ
+gtQ
+gtQ
+nub
 bfT
+fkN
+fkN
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -91928,37 +92529,37 @@ ilH
 aVL
 aPH
 aVL
-aHp
-aXs
-aHp
-aHp
-aHp
+mrj
+rJN
+taf
+qbx
+taf
 aVL
+lzy
 aVL
-apY
-vUr
-aBR
-aBR
-aEq
-aEq
-aBR
-aBR
-aBR
-aBR
-rdP
-aJN
-azc
-aAC
-kkc
-oZG
-oZG
-dTm
-aym
-kBx
-oZG
-aeX
-aeX
+hTn
+iSh
+aeR
+ioz
+lou
+aeR
+mIH
+aeR
+gwD
+hVb
+dLA
+jzg
+boH
+dLA
+rMP
+rMP
+nub
+nub
 bfT
+fkN
+fkN
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -92143,7 +92744,7 @@ fkN
 fkN
 fkN
 acT
-adb
+xux
 acT
 aMQ
 hnd
@@ -92181,41 +92782,41 @@ avI
 avI
 abO
 tQs
-cMn
+pnI
 aVL
-aPH
 aVL
-aHp
-aDQ
-aTu
-awF
-ouG
-miQ
-rAp
-anu
-anJ
-eAP
-dSS
-dSS
-dSS
-vOy
-fKV
-wjx
-anJ
-dpL
-aBs
-aGp
-aQG
-aka
-aUr
-aDL
-aNu
-aNu
-aoe
-aVb
-bfO
+aVL
+xsZ
+tcI
+xsZ
+vQy
+xsZ
+aVL
+lzy
+aVL
+mnR
+llp
+aeR
+aeR
+aeR
+aeR
+iSh
+hwP
+iSh
+rLM
+dLA
+dLA
+boH
+nok
+rMP
+rMP
+aeX
 aeX
 bfT
+fkN
+fkN
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -92401,7 +93002,7 @@ fkN
 fkN
 fkN
 fkN
-adb
+xux
 pwI
 adR
 cjT
@@ -92437,42 +93038,42 @@ aHK
 aXj
 tEP
 aRx
-kBD
-ilH
+edN
+sIE
+dHJ
+tTk
+ert
+miQ
+dAf
+lfk
+bMh
+xGE
 aVL
-aPH
+lzy
 aVL
-aMe
-aHp
-axp
-aHp
-iXv
-aHp
-hsX
-asy
-aIW
-aEB
-aJN
-aJN
-aMH
-nzS
-aJN
-rYG
-aDG
-aJN
-aJN
-aEB
-vSG
-kkc
-apq
-aIq
-adM
-xGo
-mna
-aVb
-bfO
+jru
+iSh
+bsg
+nZH
+jjT
+jHx
+jHx
+oNB
+fyw
+jHx
+jHx
+ljw
+hkl
+vWS
+rMP
 aeX
-bfT
+aeX
+aeX
+bfV
+fkN
+fkN
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -92658,7 +93259,7 @@ fkN
 fkN
 fkN
 fkN
-adb
+xux
 pwI
 adR
 adR
@@ -92694,42 +93295,42 @@ tch
 uxO
 avI
 ryX
-tQs
-ilH
+dxy
+mql
 aVL
-aPH
 aVL
-aHp
-aHp
-pSB
-aHp
-iXv
-aHp
-nKo
-kAq
-aqW
-hvW
-riK
-vTO
-hCZ
-bSZ
-aie
-npD
-iHp
-lGS
-gAQ
-bjg
-bji
-bjk
-aTt
-aSF
-pfO
-pfO
-pfO
-aVb
-bfO
+aVL
+dgc
+ofi
+fVU
+lrz
+oIJ
+aVL
+lzy
+aVL
+nhn
+iSh
+bsg
+vHh
+iSh
+iSh
+fvQ
+rAf
+bHx
+hwP
+gMn
+dLA
+eKC
+omU
+rMP
+aeX
 aeX
 bfT
+fkN
+fkN
+fkN
+aaa
+aaa
 aaa
 pFp
 aaa
@@ -92915,7 +93516,7 @@ fkN
 fkN
 fkN
 fkN
-adb
+xux
 pwI
 adR
 adR
@@ -92956,37 +93557,37 @@ iok
 aVL
 aPH
 aVL
-taf
-aHp
-djK
-aHp
-aCE
+cHg
+vkW
+cHg
+fMH
+cHg
 xcC
 xcC
 xcC
 xcC
-rZp
 xcC
-biH
-aEq
-qyN
-aBR
-aBR
-aHy
-aBR
-beZ
-bjh
-bjj
-bjl
-aTt
-aUc
-mEY
-tNS
-avy
-aVb
-bfO
+xcC
+kkv
+aeR
+crk
+aeR
+aeR
+aeR
+aeR
+aeR
+dLA
+fEY
+dLA
+rMP
+aeX
 aeX
 bfT
+fkN
+fkN
+fkN
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -93171,7 +93772,7 @@ fkN
 fkN
 fkN
 acT
-adb
+xux
 acT
 ban
 adR
@@ -93194,7 +93795,7 @@ abP
 abP
 sUz
 aiq
-kyr
+rnW
 aiM
 aiM
 avI
@@ -93213,37 +93814,37 @@ ilH
 aVL
 aPH
 aVL
-loh
-aHp
-ana
-aHp
-mrj
+xZo
+ixK
+xZo
+tca
+utd
 xcC
-uIM
-wqc
-pKR
-xwv
+sqF
+nYE
+kVt
+bzk
 xcC
-aUu
-baU
-baZ
-akA
-aRA
-aoE
-aBR
-aRG
-aAF
-auN
-bjm
-aTt
-avy
-lLx
-avy
-avy
-aVb
-bfO
+bqs
+aeR
+aeR
+aeR
+iSh
+dor
+vzL
+uGe
+lmv
+sxk
+kfw
+wnd
+aeX
 aeX
 bfT
+fkN
+fkN
+fkN
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -93470,37 +94071,37 @@ xOb
 aVL
 aPH
 aVL
-taf
-aHp
-hPa
-aHp
-iAT
+tQC
+vab
+idQ
+hyi
+tQC
 xcC
-wvk
-uoJ
-sQT
-njt
+swW
+epl
+kbM
+oUk
 xcC
-baP
-baV
-bba
-uPz
-ahu
-aBq
-aBR
-awx
-axi
-aBR
-bjn
-apq
-avy
-avy
-avy
-aVb
-aVb
-bfO
-aeX
-bfT
+qsj
+viG
+itC
+sWe
+uGe
+umW
+aeR
+jru
+kfw
+kfw
+qbH
+wnd
+rKs
+rKs
+hfN
+fkN
+fkN
+fkN
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -93733,31 +94334,31 @@ aVL
 aVL
 aVL
 xcC
-nMk
+hpc
 gwJ
-rkE
-hUh
+ieh
+gCY
 xcC
-bWq
-aEq
-pmv
-aBR
-shx
-baW
-aBR
-aBR
-aBR
-aBR
-bjo
-apq
-qjO
-avy
-aVb
-aVb
-bkA
-bkC
+jHX
+wnQ
+jHX
+aeR
+aeR
+aeR
+aeR
+aeR
+suQ
+suQ
+aeR
+wnd
+aeX
+aeX
 bfT
 fkN
+fkN
+fkN
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -93967,7 +94568,7 @@ asu
 jAM
 aFX
 aVo
-kyr
+nQJ
 aVo
 aVo
 aVo
@@ -93990,31 +94591,31 @@ aPH
 aPH
 aPH
 xcC
-kkk
-hlm
-jDV
-ufY
+xhe
+ksI
+epl
+uIM
 xcC
-baR
-baW
-wFW
-aBR
-oKF
-oKF
-aBR
+jHX
+wnQ
+jHX
+aeR
 fkN
 fkN
-oKF
-bjp
-apY
-apq
-aVb
-aVb
-bkA
-bkC
-aeX
-bfT
 fkN
+fkN
+fkN
+fkN
+fkN
+fkN
+fkN
+fkN
+fkN
+fkN
+fkN
+fkN
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -94199,7 +94800,7 @@ fkN
 fkN
 fkN
 acT
-adb
+xux
 acT
 lPa
 lPa
@@ -94247,15 +94848,15 @@ aVL
 aVL
 aVL
 xcC
+pwp
+wiy
+wiy
 xcC
 xcC
-xcC
-xcC
-bdj
-baS
-baX
-eNu
-aBR
+aeR
+swS
+aeR
+aeR
 fkN
 fkN
 fkN
@@ -94270,8 +94871,8 @@ fkN
 fkN
 fkN
 fkN
-fkN
-fkN
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -94458,9 +95059,9 @@ fkN
 fkN
 fkN
 acT
-adb
-adb
-adb
+xux
+xux
+xux
 acT
 acw
 aod
@@ -94504,16 +95105,16 @@ emD
 tKa
 kyP
 emD
-emD
-emD
-oRT
-aLL
-bbd
-baT
-baY
-dJf
+kac
+arZ
+arZ
+sSn
+arZ
+arZ
+fNf
+dzc
 arC
-aRk
+hOL
 arC
 fkN
 fkN
@@ -94527,8 +95128,8 @@ fkN
 fkN
 fkN
 fkN
-fkN
-fkN
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -94718,7 +95319,7 @@ fkN
 abx
 aeX
 apQ
-acy
+gft
 tsA
 acw
 acw
@@ -94761,14 +95362,14 @@ aOC
 aOC
 aOC
 aOC
+wte
 aOC
 aOC
 aOC
 aOC
-bbe
 alA
-azH
-bja
+vTm
+fgY
 bjc
 bjd
 bje
@@ -94784,8 +95385,8 @@ fkN
 fkN
 fkN
 fkN
-fkN
-fkN
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -94975,7 +95576,7 @@ fkN
 abx
 aeX
 apQ
-acy
+gft
 acx
 acx
 acx
@@ -95020,12 +95621,12 @@ qoL
 emD
 emD
 emD
-jmj
+ogx
 emD
-bbd
-biY
-biZ
-bjb
+emD
+gmu
+ibq
+ctL
 arC
 arC
 arC
@@ -95041,8 +95642,8 @@ fkN
 fkN
 fkN
 fkN
-fkN
-fkN
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -95232,7 +95833,7 @@ fkN
 abx
 aeX
 apQ
-acy
+gft
 acx
 acx
 acx
@@ -95246,7 +95847,7 @@ agi
 azC
 aXX
 aaQ
-miA
+ifS
 aRT
 aKs
 pbr
@@ -95280,10 +95881,10 @@ kah
 kah
 kah
 kah
-agN
-agN
-aSZ
-kah
+ejn
+ejn
+xUx
+arC
 fkN
 fkN
 fkN
@@ -95298,8 +95899,8 @@ fkN
 fkN
 fkN
 fkN
-fkN
-fkN
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -95489,7 +96090,7 @@ fkN
 abx
 aeX
 apQ
-acy
+gft
 acx
 acx
 acx
@@ -95509,7 +96110,7 @@ taw
 aYK
 aYK
 aYK
-bRB
+kas
 aYK
 aYK
 aYK
@@ -95519,7 +96120,7 @@ kUc
 aTo
 aTo
 aTo
-bRB
+cZb
 arZ
 ecH
 bdd
@@ -95532,15 +96133,15 @@ aKR
 pht
 aKv
 kah
-aGu
-fGM
+xlN
+kyY
 iMz
 tSD
 kah
-ikd
-hjM
-mnh
-kah
+nXx
+dpq
+sSY
+arC
 fkN
 fkN
 fkN
@@ -95793,11 +96394,11 @@ rwp
 grQ
 vAJ
 jnZ
-aIQ
-oHs
-nTV
-vXp
-kah
+tGG
+fsn
+npU
+xON
+aeR
 aeR
 aeR
 aeR
@@ -96004,7 +96605,7 @@ fkN
 abx
 aeX
 apQ
-acy
+gft
 acx
 acx
 acx
@@ -96031,7 +96632,7 @@ aac
 aac
 aac
 aac
-aaw
+vRf
 aac
 aac
 beA
@@ -96050,11 +96651,11 @@ hmw
 aid
 oDG
 brd
-hjM
-hjM
-hjM
-rri
-odV
+yhB
+dpq
+dpq
+wVa
+bqJ
 bgE
 qpQ
 bgE
@@ -96261,7 +96862,7 @@ fkN
 abx
 aeX
 apQ
-acy
+gft
 acx
 acx
 acx
@@ -96298,23 +96899,23 @@ kah
 qEO
 aLD
 kah
-vlQ
+kBJ
 hVs
 brd
-taX
+ycn
 kah
 aEN
 kyY
 kyY
 dJO
 kah
-hjM
-hjM
-mnh
-kah
+dpq
+dpq
+sSY
+aeR
 jdH
 iSh
-iSh
+ndM
 aeR
 aeR
 aeR
@@ -96518,7 +97119,7 @@ fkN
 abx
 aeX
 apQ
-acy
+gft
 acx
 idJ
 acx
@@ -97034,7 +97635,7 @@ aeX
 aeX
 aeX
 apQ
-acy
+gft
 aED
 aOw
 aOw
@@ -97083,9 +97684,9 @@ afs
 ahc
 ahm
 aky
-adl
+iJz
 agz
-ado
+iMC
 aaX
 abh
 abh
@@ -97291,7 +97892,7 @@ aeX
 aeX
 aeX
 apQ
-acy
+gft
 aAE
 ahq
 ahq
@@ -97340,9 +97941,9 @@ aeO
 afq
 aft
 amC
-adf
+wbk
 agy
-jcc
+msf
 aaY
 abT
 pKD
@@ -97554,7 +98155,7 @@ acx
 acx
 aFA
 aFA
-aaS
+yig
 aFA
 aQJ
 aQJ
@@ -97597,9 +98198,9 @@ afu
 ahf
 ahF
 amP
-adl
+iJz
 agz
-ado
+iMC
 abb
 abj
 abj
@@ -97806,7 +98407,7 @@ aeX
 aeX
 aeX
 apQ
-acy
+gft
 acx
 acx
 aFA
@@ -97858,14 +98459,14 @@ aeR
 cIF
 aaW
 aaW
-ail
-ail
-ail
-ail
+kUv
+kUv
+kUv
+kUv
 aaW
 aaW
-ail
-ail
+kUv
+kUv
 aaW
 bfL
 bfK
@@ -98063,7 +98664,7 @@ aeX
 aeX
 aeX
 apQ
-acy
+gft
 acx
 acx
 aaR
@@ -98123,7 +98724,7 @@ aaW
 adE
 aib
 acF
-ail
+kUv
 aux
 aux
 aux
@@ -98320,7 +98921,7 @@ aeX
 aeX
 aeX
 apQ
-acy
+gft
 acx
 ddL
 aFA
@@ -98380,7 +98981,7 @@ adY
 aej
 ahV
 acI
-ail
+kUv
 aux
 fkN
 fkN
@@ -98578,8 +99179,8 @@ bdx
 bdx
 bdx
 act
-acy
-acy
+gft
+gft
 aFA
 aFA
 hBz
@@ -98630,9 +99231,9 @@ bgw
 aaW
 abg
 abR
-abm
-ahY
-ace
+abR
+ifP
+qJF
 acz
 afo
 aid
@@ -98886,14 +99487,14 @@ aeR
 bgx
 aaW
 aaW
+kUv
+kUv
 ail
-ail
-ail
-ail
+kUv
 aaW
 aaW
-ail
-ail
+kUv
+kUv
 aaW
 bfL
 bfK
@@ -99103,7 +99704,7 @@ aYJ
 aBX
 aFA
 aFA
-lzx
+lYQ
 aYK
 aTo
 aac
@@ -99139,9 +99740,9 @@ aeY
 aeY
 ahm
 ahG
-adl
+iJz
 bgy
-agB
+pVU
 aaX
 tfa
 tfa
@@ -99359,11 +99960,11 @@ aFA
 kpj
 aGE
 sHA
-xSb
+ive
 npk
 vYZ
 vYZ
-jXC
+boF
 pAP
 nol
 nol
@@ -99396,9 +99997,9 @@ afb
 afb
 afr
 afH
-adf
+wbk
 bgz
-qwI
+fqG
 aaY
 awR
 pKD
@@ -99653,9 +100254,9 @@ oHC
 oHC
 euv
 ahH
-adl
+iJz
 bgA
-agB
+pVU
 abb
 xMK
 xMK
@@ -99877,7 +100478,7 @@ aFA
 awX
 wqE
 wqE
-aaP
+vTU
 bOf
 xPt
 fgz
@@ -99899,10 +100500,10 @@ brd
 brd
 brd
 brd
-iXK
+pJE
 kah
-aeU
-ath
+rEw
+nGo
 kah
 auO
 avf
@@ -99911,15 +100512,15 @@ avf
 awb
 avf
 aeR
-bgB
+ckt
 aaW
 aaW
+kUv
 ail
-ail
-ail
-ail
-ail
-ail
+kUv
+kUv
+kUv
+kUv
 aaW
 aaW
 aaW
@@ -100161,13 +100762,13 @@ kah
 kah
 kah
 kah
-uWs
+weO
 wuv
 avB
 rIu
 bgs
 bgt
-bgu
+vIY
 bgC
 bgD
 bgE
@@ -100415,8 +101016,8 @@ brd
 brd
 lnt
 kah
-aff
-dGC
+ldX
+mPu
 kah
 gvH
 brd
@@ -100425,15 +101026,15 @@ brd
 mLP
 rmD
 aeR
-num
+jsv
 adq
 adq
-adI
-adI
-adI
-adI
-adI
-adI
+eGt
+eGt
+eGt
+eGt
+eGt
+eGt
 adq
 adq
 adq
@@ -100646,7 +101247,7 @@ fkN
 abx
 aeX
 apQ
-aIh
+mBg
 aTo
 aHB
 hHj
@@ -100681,9 +101282,9 @@ aeY
 aeY
 ahm
 afv
-szi
+pCl
 qVv
-ads
+ufV
 adA
 adJ
 abp
@@ -100903,7 +101504,7 @@ fkN
 abx
 aeX
 apQ
-aIh
+mBg
 aTo
 aJQ
 aVq
@@ -100938,9 +101539,9 @@ afb
 afb
 afr
 afH
-oRO
+yac
 ebZ
-cla
+qdB
 adC
 awT
 lCT
@@ -101160,7 +101761,7 @@ fkN
 abx
 aeX
 apQ
-aIh
+mBg
 aTo
 aJQ
 aVq
@@ -101195,9 +101796,9 @@ mZW
 mZW
 afz
 ayw
-szi
+pCl
 fpq
-ads
+ufV
 adD
 adL
 adL
@@ -101417,7 +102018,7 @@ fkN
 abx
 aeX
 apQ
-aIh
+mBg
 aTo
 aJQ
 aVq
@@ -101456,14 +102057,14 @@ aeR
 kkt
 adq
 adq
-adI
-adI
-adI
-adI
+eGt
+eGt
+eGt
+eGt
 adq
 adq
-adI
-adI
+eGt
+eGt
 adq
 bfL
 bfK
@@ -101674,7 +102275,7 @@ fkN
 abx
 aeX
 apQ
-aIh
+mBg
 aTo
 aJQ
 uHX
@@ -101714,14 +102315,14 @@ pFN
 adq
 acl
 adX
-adN
-ahZ
-abU
+adX
+aGp
+nlF
 adq
 aei
 aib
 aen
-adI
+eGt
 aux
 aux
 aux
@@ -101931,7 +102532,7 @@ fkN
 abx
 aeX
 apQ
-aIh
+mBg
 aTo
 aJQ
 jiW
@@ -102188,7 +102789,7 @@ fkN
 abx
 aeX
 apQ
-aIh
+mBg
 aTo
 aJQ
 aYL
@@ -102235,7 +102836,7 @@ aii
 aek
 aid
 aer
-adI
+eGt
 aux
 aux
 aux
@@ -102484,14 +103085,14 @@ aeR
 xXH
 adq
 adq
+eGt
 adI
-adI
-adI
-adI
+eGt
+eGt
 adq
 adq
-adI
-adI
+eGt
+eGt
 adq
 bfL
 bfK
@@ -102702,7 +103303,7 @@ fkN
 abx
 aeX
 apQ
-aIh
+mBg
 aTo
 ama
 pAO
@@ -102737,9 +103338,9 @@ afn
 afn
 axV
 ayQ
-szi
+pCl
 jTY
-ady
+fJM
 adA
 adP
 adP
@@ -102959,7 +103560,7 @@ fkN
 abx
 aeX
 apQ
-aIh
+mBg
 aTo
 ama
 oFZ
@@ -102994,9 +103595,9 @@ ivs
 aeO
 afy
 afH
-oRO
+yac
 jVG
-neN
+pph
 adC
 adS
 lCT
@@ -103216,7 +103817,7 @@ fkN
 abx
 aeX
 apQ
-aIh
+mBg
 aTo
 ama
 fwj
@@ -103251,9 +103852,9 @@ afu
 afu
 afa
 afF
-szi
+pCl
 jTY
-ady
+fJM
 adD
 eIP
 eIP
@@ -103496,8 +104097,8 @@ guL
 gfa
 brd
 osO
-brd
-hRC
+sUf
+uhh
 brd
 hRC
 eaZ
@@ -103506,10 +104107,10 @@ uER
 brd
 tRz
 utk
-brd
+sQx
 kah
 aeR
-adw
+qYe
 adq
 adq
 adq
@@ -103755,7 +104356,7 @@ kah
 kah
 kah
 kah
-kWo
+fvF
 kah
 kah
 kah
@@ -103984,9 +104585,9 @@ bhp
 aVi
 fkN
 asn
-ats
-ats
-ats
+iWT
+iWT
+iWT
 aYK
 aTo
 ama
@@ -104004,7 +104605,7 @@ aHB
 voL
 mes
 kjB
-wZf
+uXJ
 aad
 aad
 aad
@@ -104027,7 +104628,7 @@ roi
 dOG
 dQI
 vEf
-wVY
+xoq
 bgi
 aeX
 bfT
@@ -104037,18 +104638,18 @@ fkN
 fkN
 fkN
 fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
+hYe
+hYe
+hYe
+hYe
+hYe
+oZG
+cQp
+cQp
+aVb
+cQp
+cQp
+cQp
 fkN
 fkN
 fkN
@@ -104244,9 +104845,9 @@ aVi
 auh
 afl
 auh
-bRB
+uMB
 aTo
-mIx
+efz
 ava
 uzY
 xsL
@@ -104276,7 +104877,7 @@ qwo
 qwo
 qwo
 qwo
-xvI
+rHE
 qwo
 qwo
 vVh
@@ -104293,20 +104894,20 @@ fkN
 fkN
 fkN
 fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
+hYe
+hYe
+ecJ
+nUL
+xFh
+fCU
+kBx
+tVy
+mna
+sZR
+avy
+avy
+cQp
+cQp
 fkN
 fkN
 fkN
@@ -104537,10 +105138,10 @@ alK
 alK
 aHY
 aHY
-nAC
+nbz
 aHY
-aOh
-aOh
+kwG
+kwG
 aHY
 bgW
 bgW
@@ -104549,22 +105150,22 @@ bgW
 fkN
 fkN
 fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
+hYe
+hYe
+cSY
+bGc
+aWk
+aWk
+dzM
+aym
+wwp
+hNV
+sZR
+tNS
+avy
+avy
+cQp
+cQp
 fkN
 fkN
 fkN
@@ -104798,7 +105399,7 @@ aqH
 lzv
 mpA
 tdr
-aOh
+kwG
 bfO
 aeX
 bfT
@@ -104806,22 +105407,22 @@ bgW
 bgW
 fkN
 fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
+hYe
+iyP
+uXP
+moh
+lGq
+dvz
+xiD
+pGC
+mcm
+vBs
+sZR
+mEY
+ozc
+avy
+avy
+cQp
 fkN
 fkN
 fkN
@@ -105043,7 +105644,7 @@ aFR
 kwU
 aJz
 anh
-xkL
+ctY
 anL
 aIF
 aGQ
@@ -105055,30 +105656,30 @@ aHS
 bHw
 aOT
 alK
-aOh
+kwG
 bfO
 aeX
 bfT
 fkN
 bgW
 bgW
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
+ajz
+oZG
+wdK
+hqD
+rfS
+nPO
+oaN
+cye
+oZG
+lzs
+njf
+uJA
+avy
+avy
+avy
+pUG
+apq
 bkO
 bkO
 bkO
@@ -105317,25 +105918,25 @@ aeX
 aeX
 bfT
 fkN
-fkN
 bgW
 bgW
 fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
+oZG
+oZG
+oZG
+het
+oZG
+iIr
+iIr
+oZG
+aTt
+aTt
+apq
+apq
+mJP
+apq
+apq
+apq
 fkN
 aar
 fkN
@@ -105347,7 +105948,7 @@ aar
 fkN
 fkN
 fkN
-bkO
+iSl
 aaa
 aaa
 aaa
@@ -105577,34 +106178,34 @@ fkN
 fkN
 aar
 aar
-aar
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-fkN
-aar
-fkN
-fkN
-fkN
-fkN
+kUJ
+ajz
+aIJ
+wNv
+aIJ
+ajz
+yfL
+ajz
+ajz
+ajz
+ajz
+aIJ
+aIJ
+aIJ
+ajz
+blW
 fkN
 aar
 fkN
 fkN
 fkN
-bkP
+fkN
+fkN
+aar
+fkN
+fkN
+fkN
+mqS
 aaa
 aaa
 aaa
@@ -105837,31 +106438,31 @@ pPU
 pPU
 pPU
 pPU
-pPU
+gbq
 aVX
-aLe
-aLe
-aLe
-aLe
-aLe
+vOF
+vOF
+vOF
+vOF
+vOF
 sAd
 asx
+mfO
 asx
-asx
 pPU
 pPU
 pPU
 pPU
-aIU
-aIU
+dVu
+dVu
 pPU
 pPU
-aIU
-aIU
+dVu
+dVu
 pPU
 fkN
 fkN
-bkO
+iSl
 aaa
 aaa
 aaa
@@ -106092,9 +106693,9 @@ pmo
 fUs
 axt
 aVN
-aqU
+jKL
 pWP
-egu
+yhc
 aqU
 aKm
 fqA
@@ -106115,7 +106716,7 @@ aNW
 aQx
 aRu
 aSU
-aTO
+pqQ
 fkN
 fkN
 bkO
@@ -106296,7 +106897,7 @@ aVi
 bfU
 mHG
 hye
-kio
+kqS
 vZG
 pRE
 tuV
@@ -106349,9 +106950,9 @@ aUP
 fUs
 aGq
 aVA
-aXA
+pqx
 xqm
-dlW
+eWc
 aqU
 aNU
 ack
@@ -106362,7 +106963,7 @@ aOz
 ayF
 aCj
 aDz
-aFi
+sUc
 aGq
 aGq
 aHG
@@ -106372,7 +106973,7 @@ aOn
 aQF
 aRD
 aTb
-aTO
+pqQ
 fkN
 fkN
 bkO
@@ -106551,7 +107152,7 @@ aoW
 aoW
 aVi
 aVi
-eAS
+nGg
 aVi
 aVi
 auh
@@ -106607,8 +107208,8 @@ aVX
 aVX
 aVX
 aVX
-hwH
-awl
+mia
+ubM
 aqU
 aNU
 ack
@@ -106629,7 +107230,7 @@ aOW
 aGA
 aRI
 aTh
-aTO
+pqQ
 fkN
 fkN
 bkO
@@ -106798,7 +107399,7 @@ aba
 aba
 aba
 aba
-tpc
+mzJ
 aba
 aba
 aba
@@ -106863,9 +107464,9 @@ cXR
 fUs
 aUf
 aWb
-aYa
+umU
 hPH
-aSK
+rJF
 aVX
 bcP
 ack
@@ -107113,7 +107714,7 @@ ajz
 ajz
 aQg
 avU
-dLK
+gmI
 aQg
 fgL
 cXR
@@ -107122,7 +107723,7 @@ aUi
 aWc
 aqU
 xqm
-asp
+fUX
 aqU
 bcR
 ack
@@ -107143,7 +107744,7 @@ aPC
 aGA
 aRI
 aTh
-aTO
+pqQ
 rny
 fIP
 pPU
@@ -107379,7 +107980,7 @@ aVX
 aVX
 aVX
 xLX
-asp
+fUX
 aqU
 bcR
 ack
@@ -107390,7 +107991,7 @@ aOz
 azU
 aCJ
 aDz
-aFn
+imr
 aGq
 aGq
 aIw
@@ -107400,7 +108001,7 @@ aPD
 aMs
 aSd
 gzh
-sso
+cqz
 aGA
 xpM
 pPU
@@ -107613,7 +108214,7 @@ aiB
 caC
 arL
 eDC
-bdU
+kns
 ahA
 aJc
 aOV
@@ -107636,7 +108237,7 @@ aUV
 aWe
 aqU
 xqm
-asp
+fUX
 aqU
 bcR
 ack
@@ -107866,7 +108467,7 @@ aUN
 aUN
 aUN
 aUN
-mjH
+mSt
 aUN
 aUN
 aQg
@@ -107891,9 +108492,9 @@ cXR
 fUs
 aGq
 aGq
-aYf
+sof
 xqm
-asp
+fUX
 aVX
 bcS
 ack
@@ -108120,7 +108721,7 @@ aNA
 gvZ
 lJi
 aLq
-aLm
+epm
 avU
 bQp
 avU
@@ -108171,7 +108772,7 @@ aPD
 aGA
 aRI
 aTh
-aTO
+pqQ
 fkN
 fkN
 bkO
@@ -108407,7 +109008,7 @@ rIP
 aoC
 hrY
 xqm
-asp
+fUX
 aqU
 bcR
 ack
@@ -108418,7 +109019,7 @@ aOz
 aAv
 aCJ
 aDz
-aFn
+imr
 aGq
 aGq
 aIG
@@ -108428,7 +109029,7 @@ aPC
 aGA
 aRI
 aTh
-aTO
+pqQ
 fkN
 fkN
 bkO
@@ -108656,7 +109257,7 @@ avU
 avU
 avU
 avU
-qIk
+rhf
 arc
 aGh
 goM
@@ -108664,7 +109265,7 @@ qhv
 mgG
 aVX
 bat
-asp
+fUX
 aqU
 bcT
 mZS
@@ -108685,7 +109286,7 @@ aPC
 aGA
 aRI
 aTh
-aTO
+pqQ
 fkN
 fkN
 bkO
@@ -108905,7 +109506,7 @@ aQg
 aQg
 aQg
 aQg
-qIk
+iAk
 aQg
 aQg
 aQg
@@ -108921,7 +109522,7 @@ rlF
 gpa
 aVX
 aMb
-omf
+wEc
 aVX
 aOz
 aOz
@@ -109173,12 +109774,12 @@ arZ
 nBU
 arZ
 aHV
-eze
+sjG
 aLU
 aLU
-pwD
+uDi
 kDO
-akN
+jtv
 nBs
 sJb
 nBs
@@ -109199,7 +109800,7 @@ aQa
 aGA
 aRI
 aTh
-aTO
+pqQ
 fkN
 fkN
 bkO
@@ -109420,7 +110021,7 @@ deC
 deC
 azH
 azH
-auc
+alA
 aWa
 jDL
 azH
@@ -109435,7 +110036,7 @@ aCl
 aCl
 odW
 ani
-aLX
+qlq
 aCl
 aCl
 aCl
@@ -109446,7 +110047,7 @@ aoK
 aBA
 aDb
 aEP
-aFq
+ndB
 aGG
 aGG
 aZC
@@ -109456,7 +110057,7 @@ aQb
 aOn
 aSg
 aTh
-aTO
+pqQ
 aar
 aar
 bkO
@@ -109652,13 +110253,13 @@ arv
 arv
 arv
 jPK
-nSm
-aAj
+den
+ygv
 arv
 kjB
 iGo
 iVe
-smu
+eza
 ias
 ias
 kxW
@@ -109677,7 +110278,7 @@ dzc
 dzc
 arc
 sps
-arZ
+dvV
 arB
 pWp
 sps
@@ -109687,10 +110288,10 @@ arZ
 bhM
 pTf
 bgQ
-evo
+ujP
 cFc
 aLU
-ykX
+hbc
 aVz
 sQf
 cFg
@@ -109713,7 +110314,7 @@ aQj
 aRm
 aSo
 aTp
-aTO
+pqQ
 fkN
 fkN
 bkO
@@ -109932,9 +110533,9 @@ apH
 apH
 apH
 bhg
-arl
+hTL
 aZT
-awY
+vvT
 alw
 alw
 alw
@@ -109953,12 +110554,12 @@ stM
 aFQ
 wRw
 aFQ
-eLN
-aaU
+gOU
+dnO
 aFQ
 alR
 alR
-asV
+lFV
 alR
 aVX
 aVX
@@ -110182,7 +110783,7 @@ arZ
 lSQ
 orz
 amH
-ajC
+ePt
 aBC
 ami
 key
@@ -110389,7 +110990,7 @@ aVi
 aoW
 aae
 aae
-aZm
+gpm
 aba
 kqd
 aOq
@@ -110440,12 +111041,12 @@ azH
 asK
 bcb
 ati
-ayl
-aZV
-aZV
-aZV
-aZV
-aIM
+bsr
+dIH
+dIH
+dIH
+dIH
+uoc
 ati
 ati
 aWY
@@ -110461,7 +111062,7 @@ bgS
 pPU
 aGq
 aVA
-aYt
+wPD
 apD
 gzh
 gIS
@@ -110651,10 +111252,10 @@ aae
 afS
 aSS
 aSS
-aup
+quQ
 aSS
 aSS
-wEp
+iUd
 aSS
 aba
 aba
@@ -110680,7 +111281,7 @@ azO
 azO
 kxc
 arv
-hiR
+dHt
 bab
 bdc
 kjB
@@ -110906,7 +111507,7 @@ vPS
 joF
 qdD
 qEd
-bpD
+dJa
 kiO
 viO
 udf
@@ -110975,7 +111576,7 @@ bgS
 pPU
 aVk
 aWr
-aYx
+twK
 apD
 gzh
 gIS
@@ -111169,7 +111770,7 @@ jIY
 fAj
 fAj
 bRU
-djp
+lxT
 sxJ
 agt
 ade
@@ -111210,7 +111811,7 @@ aYh
 cBz
 imT
 pAJ
-aXg
+jwM
 asL
 aPp
 bdR
@@ -111496,8 +112097,8 @@ aXU
 epN
 aXU
 aXU
-aSB
-xWu
+jfv
+vPp
 aXU
 fkN
 fkN
@@ -112003,7 +112604,7 @@ bgV
 pPU
 aVA
 aGq
-aYy
+fiq
 xqm
 ouu
 aXU
@@ -112245,8 +112846,8 @@ aIm
 bbQ
 bbR
 bbN
-aLt
-bcI
+sID
+nrM
 bfO
 aeX
 aeX
@@ -112502,8 +113103,8 @@ bbO
 aLt
 bbS
 aLt
-aLt
-bcI
+sID
+nrM
 bfO
 aeX
 aeX
@@ -112698,9 +113299,9 @@ abx
 aeX
 exg
 exg
-yjW
+fAg
 exg
-rzB
+uMt
 aae
 aDj
 qEV
@@ -112745,7 +113346,7 @@ aOA
 atr
 atr
 atr
-aLk
+jvX
 aJh
 aJh
 avu
@@ -112754,11 +113355,11 @@ avu
 aJh
 aJh
 bcN
-aGJ
-bbP
+dbC
+nFo
 bcN
-bbT
-aMI
+fwl
+lzu
 bcN
 bcN
 aeX
@@ -112774,7 +113375,7 @@ bgZ
 pPU
 aVA
 aGq
-aZe
+eBF
 xqm
 gzh
 aXU
@@ -112998,7 +113599,7 @@ aOA
 aLC
 aHP
 aRY
-aEm
+rmy
 agK
 aNq
 bbp
@@ -113017,7 +113618,7 @@ aQl
 ayL
 wea
 aGc
-bcI
+nrM
 bfP
 aeX
 aeX
@@ -113210,12 +113811,12 @@ fkN
 fkN
 abx
 apQ
-yjW
+fAg
 qfH
 ogo
 dLV
 cuI
-ahP
+pav
 aAf
 aKn
 tLU
@@ -113274,7 +113875,7 @@ aJj
 aGJ
 aTX
 bbL
-bcI
+nrM
 bfO
 aeX
 aeX
@@ -113467,7 +114068,7 @@ fkN
 fkN
 abx
 apQ
-yjW
+fAg
 fGl
 ogo
 ogo
@@ -113531,7 +114132,7 @@ aGJ
 aGJ
 bch
 bcg
-bcL
+uAy
 bfQ
 aeX
 aeX
@@ -113733,7 +114334,7 @@ aae
 dqn
 dvp
 awM
-ahE
+msj
 aoc
 kai
 tyK
@@ -113755,7 +114356,7 @@ gbL
 arv
 arv
 arv
-ahI
+hWA
 arv
 arv
 arv
@@ -113788,7 +114389,7 @@ bdS
 aGJ
 aGJ
 bcG
-bcL
+uAy
 bfO
 aeX
 bfT
@@ -113981,7 +114582,7 @@ fkN
 fkN
 abx
 apQ
-yjW
+fAg
 fGl
 ogo
 ogo
@@ -114045,7 +114646,7 @@ aoQ
 aGJ
 aGJ
 bcF
-bcL
+uAy
 bfR
 aeX
 bfT
@@ -114238,20 +114839,20 @@ fkN
 fkN
 abx
 apQ
-yjW
+fAg
 tXm
 exg
 ykj
 fuM
 aae
 aae
-xQB
+oxo
 aae
 aSS
 aSS
-aoJ
-aoJ
-aoJ
+qlg
+qlg
+qlg
 aSS
 aSS
 asn
@@ -114260,16 +114861,16 @@ asn
 asn
 asn
 asn
-ats
-ats
-ats
+iWT
+iWT
+iWT
 arv
 arv
 arv
 arv
 arv
 arv
-aQq
+lcj
 arv
 arv
 arv
@@ -114302,7 +114903,7 @@ aJr
 bcf
 aGJ
 ahC
-bcL
+uAy
 bfO
 aeX
 bfT
@@ -114495,7 +115096,7 @@ fkN
 fkN
 abx
 apQ
-yjW
+fAg
 jFS
 wqk
 ogo
@@ -114559,7 +115160,7 @@ bcE
 bcE
 bcE
 aml
-bcL
+uAy
 bfS
 aeX
 bfT
@@ -114752,7 +115353,7 @@ fkN
 fkN
 abx
 apQ
-yjW
+fAg
 tdy
 kCD
 atj
@@ -114795,13 +115396,13 @@ bfH
 abx
 aOA
 aOA
-aZv
-aZv
+xSw
+xSw
 aOA
-ayu
-ayu
-ayu
-ayu
+naO
+naO
+naO
+naO
 aJh
 anK
 anK
@@ -114809,14 +115410,14 @@ bcX
 anK
 anK
 aJh
-bcI
-bcI
-bcI
-bcI
-bcI
-bcI
-bcI
-bcL
+nrM
+nrM
+nrM
+nrM
+nrM
+nrM
+nrM
+uAy
 bfO
 bdx
 bfV
@@ -115009,7 +115610,7 @@ fkN
 fkN
 abx
 apQ
-yjW
+fAg
 qfH
 exg
 ogo
@@ -115060,11 +115661,11 @@ bfM
 bfM
 bfM
 aQR
+gES
+gES
 aGZ
-aGZ
-aGZ
-aGZ
-aGZ
+gES
+gES
 aJh
 bfM
 bfM

--- a/_maps/map_files/Hammerhead/Hammerhead.dmm
+++ b/_maps/map_files/Hammerhead/Hammerhead.dmm
@@ -32273,15 +32273,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"gWt" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 6
-	},
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
-	target_temperature = 273.15
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/server)
 "gWx" = (
 /turf/open/floor/carpet/orange,
 /area/engine/break_room)
@@ -48034,6 +48025,15 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/tcommsat/computer)
+"sDC" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
+	target_temperature = 170
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/server)
 "sDT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -77648,7 +77648,7 @@ aUL
 aJB
 fkN
 aIZ
-gWt
+sDC
 nIE
 uwm
 xKF

--- a/_maps/map_files/Hammerhead/Hammerhead.dmm
+++ b/_maps/map_files/Hammerhead/Hammerhead.dmm
@@ -227,19 +227,6 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"aaN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/ship/command/glass{
-	name = "Chief Medical Officer";
-	req_one_access_txt = "40"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/cmo)
 "aaO" = (
 /turf/closed/wall/ship,
 /area/science/mixing)
@@ -688,12 +675,6 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/aft)
-"abW" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 28
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/storage)
 "abX" = (
 /obj/structure/rack,
 /obj/item/storage/firstaid/regular{
@@ -951,18 +932,6 @@
 /area/nsv/hanger/deck2/starboard{
 	name = "Launch tubes 1 and 2"
 	})
-"acD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/ship/security{
-	name = "Private Investigator's Office";
-	req_one_access_txt = "4"
-	},
-/turf/open/floor/plasteel,
-/area/security/detectives_office/private_investigators_office)
 "acE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -1606,17 +1575,6 @@
 /area/nsv/hanger/deck2/port{
 	name = "Launch tubes 3 and 4"
 	})
-"adY" = (
-/obj/machinery/door/airlock/ship/hatch{
-	name = "Air Control Left";
-	req_one_access_txt = "19;69"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/turf/open/floor/plasteel/ship,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
 "adZ" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -1674,17 +1632,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/nsv/weapons/fore)
-"aef" = (
-/obj/machinery/door/airlock/ship/hatch{
-	name = "Air Control Right";
-	req_one_access_txt = "19;69"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/turf/open/floor/plasteel/ship,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
 "aeg" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -28
@@ -1932,13 +1879,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/exit/departure_lounge)
-"aeG" = (
-/obj/machinery/door/airlock/ship/public{
-	id_tag = "cabin4";
-	name = "Cabin 4"
-	},
-/turf/open/floor/plasteel/ship,
-/area/crew_quarters/dorms)
 "aeH" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 4
@@ -2125,19 +2065,6 @@
 	},
 /turf/open/floor/plating,
 /area/nsv/hanger)
-"afk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/ship{
-	name = "Kitchen Coldroom";
-	req_one_access_txt = "35;28"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "afl" = (
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/port)
@@ -2727,25 +2654,6 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/heater,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"agE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Bridge-Ext";
-	location = "Fore-Weapons"
-	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	sortType = 15
-	},
-/turf/open/floor/plasteel/ship,
-/area/hallway/primary/fore)
 "agF" = (
 /obj/item/assembly/prox_sensor{
 	pixel_x = -4;
@@ -2852,12 +2760,6 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"agR" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
 "agS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/disposalpipe/segment{
@@ -3552,18 +3454,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/patients_rooms/room_c)
-"aix" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/security/prison)
 "aiz" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -3635,18 +3525,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"aiH" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/ship,
-/area/security/prison)
 "aiI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -4062,17 +3940,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/maintenance/department/science/central)
-"ajO" = (
-/obj/structure/plasticflaps,
-/obj/effect/turf_decal/loading_area/red{
-	dir = 8
-	},
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "atmos_belt"
-	},
-/turf/open/floor/plasteel/ship,
-/area/engine/atmos)
 "ajP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 8
@@ -4082,15 +3949,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"ajQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/mineral/ore_redemption,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/engine,
-/area/quartermaster/office)
 "ajR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 8
@@ -4463,21 +4321,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
-"akI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/security/prison)
 "akJ" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
 	dir = 4
@@ -4931,19 +4774,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/central)
-"alY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/door/firedoor/heavy,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/ship/command{
-	name = "Gravity Generator";
-	req_one_access_txt = "56"
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/engine/gravity_generator)
 "alZ" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/power/apc/auto_name/north{
@@ -5189,12 +5019,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/ship,
 /area/nsv/weapons/fore)
-"amz" = (
-/obj/machinery/door/airlock/ship/public{
-	name = "Quiet Room"
-	},
-/turf/open/floor/wood,
-/area/library/lounge)
 "amA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -5251,14 +5075,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"amH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel/ship,
-/area/hallway/primary/fore)
 "amI" = (
 /obj/machinery/power/apc/auto_name/west{
 	pixel_x = -24
@@ -5938,18 +5754,6 @@
 	name = "vibranium-reinforced wall"
 	},
 /area/science/test_area)
-"aou" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/security/prison)
 "aov" = (
 /obj/structure/window/plasma/reinforced/spawner/east,
 /obj/effect/turf_decal/tile/neutral,
@@ -6552,19 +6356,6 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"apO" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/westright{
-	name = "Chemistry Desk";
-	req_access_txt = "33"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "chem_desk_public";
-	name = "desk shutter"
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plating,
-/area/medical/medbay/lobby)
 "apP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -6766,21 +6557,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/security/warden)
-"aqo" = (
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 9
-	},
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "aqp" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/closed/wall/ship,
@@ -6832,14 +6608,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"aqw" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor/northleft{
-	name = "Security Desk";
-	req_one_access_txt = "63"
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "aqx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -6861,22 +6629,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/entry)
-"aqz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Construction Area";
-	req_one_access_txt = "32"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "aqA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 1
@@ -8888,11 +8640,6 @@
 "avr" = (
 /turf/open/floor/plasteel/dark,
 /area/science/server)
-"avs" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plasteel/dark,
-/area/science/storage)
 "avt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -8903,19 +8650,6 @@
 	},
 /turf/open/floor/plating,
 /area/bridge)
-"avu" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/machinery/door/airlock/ship/command/glass{
-	name = "War room";
-	req_one_access_txt = "19"
-	},
-/turf/open/floor/carpet/ship,
-/area/bridge/meeting_room)
 "avv" = (
 /obj/machinery/light_switch{
 	pixel_y = -22
@@ -8993,19 +8727,6 @@
 "avD" = (
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
-"avE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Surgery";
-	req_one_access_txt = "45"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/surgery)
 "avF" = (
 /turf/open/floor/plating,
 /area/quartermaster/storage)
@@ -9102,22 +8823,6 @@
 "avP" = (
 /turf/closed/wall/r_wall/ship,
 /area/tcommsat/server)
-"avQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Patient Room B";
-	req_one_access_txt = "5"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/patients_rooms/room_b)
 "avR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -9245,22 +8950,6 @@
 /obj/structure/overmap/fighter/utility/prebuilt/carrier,
 /turf/open/floor/plating,
 /area/nsv/hanger)
-"awj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Auxiliary Surgery";
-	req_one_access_txt = "45"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/surgery/aux)
 "awk" = (
 /obj/machinery/light{
 	dir = 1
@@ -9362,19 +9051,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/quartermaster/storage)
-"awy" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "chem_desk_med";
-	name = "desk shutter"
-	},
-/obj/machinery/door/window/northleft{
-	name = "Chemistry Desk";
-	req_one_access_txt = "33"
-	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plating,
-/area/medical/chemistry)
 "awz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -9656,22 +9332,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
-"axm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Patient Room A";
-	req_one_access_txt = "5"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/patients_rooms/room_a)
 "axn" = (
 /obj/machinery/conveyor{
 	id = "cmbelt"
@@ -10208,19 +9868,6 @@
 "ayy" = (
 /turf/closed/wall/ship,
 /area/crew_quarters/locker)
-"ayz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/ship/hatch{
-	name = "Crematorium";
-	req_one_access_txt = "27"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
 "ayA" = (
 /obj/machinery/button/door{
 	dir = 4;
@@ -11562,15 +11209,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"aBJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/science/storage)
 "aBK" = (
 /obj/machinery/gateway/centerstation,
 /turf/open/floor/plasteel/dark,
@@ -11603,14 +11241,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/exit)
-"aBP" = (
-/obj/machinery/power/apc/auto_name/south{
-	pixel_y = -24
-	},
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark,
-/area/science/storage)
 "aBQ" = (
 /obj/effect/landmark/start/librarian,
 /turf/open/floor/plasteel/cult,
@@ -11801,14 +11431,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
-"aCl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/ship,
-/area/security/prison)
 "aCm" = (
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/light,
@@ -12593,20 +12215,6 @@
 "aEi" = (
 /turf/closed/wall/ship,
 /area/medical/patients_rooms/room_a)
-"aEj" = (
-/obj/structure/sign/directions/medical{
-	dir = 4
-	},
-/obj/structure/sign/directions/evac{
-	dir = 1;
-	pixel_y = 8
-	},
-/obj/structure/sign/directions/supply{
-	dir = 8;
-	pixel_y = -8
-	},
-/turf/closed/wall/ship,
-/area/medical/chemistry)
 "aEk" = (
 /obj/machinery/power/apc/auto_name/west{
 	pixel_x = -24
@@ -13338,10 +12946,6 @@
 /obj/machinery/telecomms/message_server/preset,
 /turf/open/floor/circuit/red/telecomms,
 /area/tcommsat/server)
-"aGb" = (
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/plasteel,
-/area/science/storage)
 "aGc" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -13794,22 +13398,6 @@
 /obj/effect/turf_decal/stripes/red/line,
 /turf/open/floor/plasteel/ship,
 /area/quartermaster/storage)
-"aHh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Patient Room C";
-	req_one_access_txt = "5"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/patients_rooms/room_c)
 "aHi" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -13985,19 +13573,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar/atrium)
-"aHG" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Long-Term Confinement"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "cell1_ld";
-	name = "Cell 1 Lockdown"
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/security/prison)
 "aHI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 4
@@ -14114,22 +13689,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"aHV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
 "aHW" = (
 /obj/machinery/atmospherics/pipe/simple/brown/hidden{
 	dir = 9
@@ -14352,19 +13911,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"aIw" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Long-Term Confinement"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "cell2_ld";
-	name = "Cell 2 Lockdown"
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/security/prison)
 "aIx" = (
 /turf/closed/wall/ship,
 /area/maintenance/port/central)
@@ -14441,19 +13987,6 @@
 /obj/item/nullrod,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"aIG" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Long-Term Confinement"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "cell3_ld";
-	name = "Cell 3 Lockdown"
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/security/prison)
 "aIH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 9
@@ -14854,11 +14387,6 @@
 /obj/structure/chair/office,
 /turf/open/floor/plasteel/ship,
 /area/quartermaster/storage)
-"aJD" = (
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "aJE" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel/ship,
@@ -14953,13 +14481,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/engine/engineering/hangar)
-"aJU" = (
-/obj/machinery/door/airlock/ship/security/glass{
-	name = "Hangar armoury";
-	req_one_access_txt = "71"
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/nsv/hanger)
 "aJV" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -15066,6 +14587,21 @@
 "aKg" = (
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"aKh" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/public{
+	name = "Bar closet";
+	req_one_access_txt = "25"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "aKi" = (
 /obj/machinery/atmospherics/components/unary/portables_connector,
 /obj/machinery/light/small{
@@ -16123,9 +15659,6 @@
 "aMz" = (
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"aMA" = (
-/turf/open/floor/plasteel,
-/area/science/storage)
 "aMB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 10
@@ -16794,13 +16327,6 @@
 /obj/machinery/processor/slime,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"aOe" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/open/floor/plasteel/dark,
-/area/science/storage)
 "aOf" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible/layer3{
 	dir = 4
@@ -16875,24 +16401,6 @@
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
-"aOp" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/ship,
-/area/security/prison)
 "aOq" = (
 /obj/effect/turf_decal/stripes/red/corner{
 	dir = 8
@@ -17457,10 +16965,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/ai_monitored/security/armory/lockup)
-"aPI" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/turf/open/floor/plasteel/dark,
-/area/science/storage)
 "aPJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 8
@@ -17732,36 +17236,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
-"aQo" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor/northright{
-	name = "Warden's Desk";
-	req_one_access_txt = "3"
-	},
-/obj/machinery/door/window/brigdoor/southright{
-	name = "Warden's Desk";
-	req_one_access_txt = "3"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/security/warden)
 "aQr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
-"aQs" = (
-/obj/structure/plasticflaps,
-/obj/machinery/door/poddoor/shutters{
-	id = "cmbridge";
-	name = "Cargo Munitions Bridge Shutter"
-	},
-/obj/machinery/conveyor{
-	id = "cmbelt"
-	},
-/turf/open/floor/plating,
-/area/nsv/weapons/fore)
 "aQt" = (
 /obj/effect/mapping_helpers/airlock/unres,
 /obj/machinery/door/airlock/ship/public/glass{
@@ -17898,11 +17376,6 @@
 "aQL" = (
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/ai_monitored/turret_protected/ai)
-"aQM" = (
-/obj/structure/window/reinforced/fulltile/ship,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/library)
 "aQN" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -18590,20 +18063,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/toilet/restrooms)
-"aSw" = (
-/obj/effect/turf_decal/loading_area/red{
-	dir = 8
-	},
-/obj/machinery/door/airlock/ship/hatch{
-	name = "AI Upload Access";
-	req_one_access_txt = "16"
-	},
-/obj/machinery/door/poddoor{
-	id = "aiship_upload";
-	name = "AI Upload Security Door"
-	},
-/turf/open/floor/plasteel/ship,
-/area/ai_monitored/turret_protected/ai_upload)
 "aSx" = (
 /obj/effect/turf_decal/delivery/white,
 /obj/machinery/ship_weapon/pdc_mount,
@@ -18734,20 +18193,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"aSQ" = (
-/obj/machinery/door/window{
-	dir = 4;
-	name = "Mass Driver";
-	req_access_txt = "22"
-	},
-/obj/machinery/button/massdriver{
-	id = "chapelgun";
-	name = "Chapel Mass Driver";
-	pixel_x = -4;
-	pixel_y = -26
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
 "aSR" = (
 /obj/machinery/airalarm/directional/south,
 /obj/structure/cable{
@@ -19003,38 +18448,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/security)
-"aTs" = (
-/obj/effect/turf_decal/loading_area/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/door/airlock/ship/hatch{
-	name = "AI Upload Access";
-	req_one_access_txt = "16"
-	},
-/obj/machinery/door/poddoor{
-	id = "aiship_upload";
-	name = "AI Upload Security Door"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/ship,
-/area/ai_monitored/turret_protected/ai_upload)
-"aTt" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters{
-	id = "firingsquad";
-	name = "security shutters"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/security/execution/transfer)
 "aTv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 8
@@ -19089,15 +18502,6 @@
 /obj/machinery/light,
 /turf/open/floor/plating,
 /area/storage/tech)
-"aTA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/science/storage)
 "aTB" = (
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/plating,
@@ -19543,15 +18947,6 @@
 /obj/structure/extinguisher_cabinet/west,
 /turf/open/floor/plasteel/ship,
 /area/engine/gravity_generator)
-"aUK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plasteel/ship,
-/area/crew_quarters/dorms)
 "aUL" = (
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -19612,15 +19007,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/patients_rooms/room_b)
-"aUT" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 4
-	},
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
 "aUU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -19796,23 +19182,6 @@
 	},
 /turf/open/floor/plating,
 /area/hydroponics)
-"aVw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/ship/command{
-	dir = 4;
-	name = "Gravity Generator";
-	req_one_access_txt = "56"
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/engine/gravity_generator)
 "aVx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -19926,11 +19295,6 @@
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
-"aVI" = (
-/obj/structure/window/reinforced/fulltile/ship,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "aVJ" = (
 /obj/machinery/atmospherics/pipe/simple/brown/hidden{
 	dir = 6
@@ -20054,18 +19418,6 @@
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel/ship,
 /area/security/main)
-"aWa" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/ship,
-/area/hallway/primary/fore)
 "aWb" = (
 /obj/machinery/flasher{
 	id = "pw_2";
@@ -20129,11 +19481,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"aWi" = (
-/obj/structure/window/reinforced/fulltile/ship,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/library/lounge)
 "aWk" = (
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
@@ -20470,12 +19817,6 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"aWY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/bridge)
 "aWZ" = (
 /obj/structure/hull_plate/end{
 	dir = 8
@@ -21452,24 +20793,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/office)
-"aZC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Long-Term Confinement"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "cell4_ld";
-	name = "Cell 4 Lockdown"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/security/prison)
 "aZD" = (
 /obj/structure/kitchenspike,
 /obj/effect/turf_decal/box/red/corners{
@@ -22047,31 +21370,6 @@
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"baQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/door/airlock/ship/security/glass{
-	name = "Security Equipment";
-	req_one_access_txt = "1;4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plasteel/ship,
-/area/security/main)
 "bbb" = (
 /obj/machinery/door/airlock/ship{
 	name = "Server Access";
@@ -22092,6 +21390,17 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/hydroponics)
+"bbe" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "hos_privacy";
+	name = "privacy shutter"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hos)
 "bbf" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plasteel,
@@ -22235,12 +21544,6 @@
 /obj/structure/bed/dogbed/renault,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"bbx" = (
-/obj/machinery/door/poddoor/ship{
-	id = "engishuttle"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering/hangar)
 "bby" = (
 /obj/machinery/suit_storage_unit/security,
 /turf/open/floor/plasteel/dark,
@@ -22268,13 +21571,6 @@
 /obj/machinery/light/small{
 	brightness = 3;
 	dir = 8
-	},
-/turf/open/floor/plating,
-/area/engine/engineering/hangar)
-"bbD" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/poddoor/ship{
-	id = "engishuttle"
 	},
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
@@ -22494,19 +21790,6 @@
 	},
 /turf/open/floor/plating,
 /area/bridge)
-"bci" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/door/airlock/ship/public{
-	name = "Bar closet";
-	req_one_access_txt = "25"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "bcj" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/ship/public{
@@ -22928,20 +22211,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
-"bdc" = (
-/obj/structure/sign/directions/security,
-/turf/closed/wall/r_wall/ship,
-/area/nsv/weapons/fore)
-"bdd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/sign/directions/security{
-	dir = 4;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
 "bde" = (
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 8;
@@ -22962,12 +22231,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"bdg" = (
-/obj/structure/sign/directions/security{
-	dir = 4
-	},
-/turf/closed/wall/ship,
-/area/crew_quarters/dorms)
 "bdh" = (
 /obj/structure/sign/directions/security{
 	dir = 4
@@ -22980,12 +22243,6 @@
 	},
 /turf/closed/wall/ship,
 /area/security/checkpoint/customs)
-"bdk" = (
-/obj/structure/sign/directions/security{
-	dir = 4
-	},
-/turf/closed/wall/r_wall/ship,
-/area/ai_monitored/security/armory/lockup)
 "bdl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 10
@@ -23127,24 +22384,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/security/warden)
-"bdB" = (
-/obj/machinery/door/airlock/ship/public{
-	name = "Hydroponics Backroom";
-	req_one_access_txt = "35"
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
-"bdC" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/machinery/door/airlock/ship{
-	name = "Kitchen coldroom";
-	req_one_access_txt = "35;28"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/hallway/secondary/service)
 "bdD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -23155,27 +22394,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/crew_quarters/theatre)
-"bdE" = (
-/obj/machinery/door/airlock/ship/public{
-	id_tag = "cabin2";
-	name = "Cabin 2"
-	},
-/turf/open/floor/plasteel/ship,
-/area/crew_quarters/dorms)
-"bdF" = (
-/obj/machinery/door/airlock/ship/public{
-	id_tag = "cabin1";
-	name = "Cabin 1"
-	},
-/turf/open/floor/plasteel/ship,
-/area/crew_quarters/dorms)
-"bdG" = (
-/obj/machinery/door/airlock/ship/public{
-	id_tag = "cabin3";
-	name = "Cabin 3"
-	},
-/turf/open/floor/plasteel/ship,
-/area/crew_quarters/dorms)
 "bdH" = (
 /obj/item/disk/holodisk/hammerhead_cryo,
 /obj/structure/closet/secure_closet/personal,
@@ -23239,17 +22457,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"bdT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/door/airlock/ship/public{
-	name = "Quiet Room"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood,
-/area/library/lounge)
 "bdV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -23345,12 +22552,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
-/area/engine/engineering/hangar)
-"beg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/open/floor/plating,
 /area/engine/engineering/hangar)
 "beh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
@@ -23503,22 +22704,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"beA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Hangar Bay"
-	},
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	dir = 4;
-	id = "hang_storage"
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
 "beB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -23530,34 +22715,6 @@
 	name = "Hangar Bay"
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	dir = 4;
-	id = "hang_storage"
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
-"beC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Hangar Bay"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/door/poddoor/shutters/ship/preopen{
 	dir = 4;
 	id = "hang_storage"
@@ -23587,25 +22744,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	dir = 4;
-	id = "hang_storage"
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
-"beE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Hangar Bay"
-	},
 /obj/machinery/door/poddoor/shutters/ship/preopen{
 	dir = 4;
 	id = "hang_storage"
@@ -23675,18 +22813,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"beK" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
 "beL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -23868,13 +22994,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"bfe" = (
-/obj/item/storage/box/lights/mixed,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
 "bff" = (
 /obj/effect/landmark/start/medical_doctor,
 /obj/machinery/camera/autoname,
@@ -24072,32 +23191,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"bfw" = (
-/obj/item/assembly/mousetrap/armed,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
 "bfx" = (
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
 /area/science/xenobiology)
-"bfy" = (
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
 "bfz" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
@@ -24280,12 +23379,6 @@
 "bfZ" = (
 /turf/closed/wall/ship,
 /area/medical/virology)
-"bga" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
 "bgb" = (
 /obj/machinery/door/airlock/ship/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -24507,101 +23600,6 @@
 /area/maintenance/department/bridge)
 "bgJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/maintenance/department/bridge)
-"bgK" = (
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/bridge)
-"bgL" = (
-/obj/machinery/power/apc/auto_name/west{
-	pixel_x = -24
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/maintenance/department/bridge)
-"bgM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/bridge)
-"bgN" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/bridge)
-"bgO" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/maintenance/department/bridge)
-"bgQ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
-"bgR" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/bridge)
-"bgS" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/bridge)
-"bgT" = (
-/obj/machinery/light/small,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/bridge)
-"bgU" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "bgV" = (
@@ -25664,16 +24662,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"bjw" = (
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "bjx" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -25913,18 +24901,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/exit/departure_lounge)
-"bkb" = (
-/obj/machinery/door/airlock/ship/hatch{
-	name = "Telecomms Server Floor Access";
-	req_one_access_txt = "61;65"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/hallway/support_ship)
 "bkc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -26011,13 +24987,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/ai_monitored/turret_protected/aisat/hallway/support_ship)
-"bkn" = (
-/obj/machinery/door/airlock/ship/hatch{
-	name = "Telecomms Server Floor Access";
-	req_one_access_txt = "61;65"
-	},
-/turf/open/floor/plating,
-/area/tcommsat/server)
 "bko" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/components/binary/stormdrive_reactor{
@@ -26364,6 +25333,15 @@
 /obj/effect/turf_decal/delivery/white,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"blB" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "blW" = (
 /obj/machinery/door/poddoor{
 	id = "chapelgun";
@@ -26418,6 +25396,20 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/central)
+"bnO" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/westright{
+	name = "Hydroponics Desk";
+	req_one_access_txt = "35"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "bot_south";
+	name = "privacy shutter"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/hydroponics)
 "bog" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -26459,11 +25451,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
-"bqb" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plating,
-/area/nsv/hanger)
+"bpS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel/ship,
+/area/security/prison)
 "bqi" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -26477,15 +25475,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/ai_monitored/turret_protected/aisat/service/support_ship)
-"bqs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "bqI" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -26510,6 +25499,9 @@
 "brd" = (
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/hanger)
+"brg" = (
+/turf/open/floor/monotile/light,
+/area/science/storage)
 "brq" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
@@ -26530,37 +25522,28 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
+"brS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
+"brV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "brZ" = (
 /obj/machinery/light/built{
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/construction)
-"bsg" = (
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
-"bsr" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "xoprivacy";
-	name = "Privacy Shutters"
-	},
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hop)
 "bsP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -26604,6 +25587,13 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"buO" = (
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/monotile/light,
+/area/science/storage)
 "bva" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel/ship,
@@ -26644,6 +25634,29 @@
 /obj/machinery/light/broken,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"bwO" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/break_room)
+"bxg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/ship/command{
+	dir = 4;
+	name = "Gravity Generator";
+	req_one_access_txt = "56"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/engine/gravity_generator)
 "bxo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -26756,6 +25769,15 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"bAZ" = (
+/obj/machinery/door/airlock/virology/glass{
+	name = "Isolation A";
+	req_one_access_txt = "39"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "bBg" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
 	dir = 4
@@ -26851,16 +25873,11 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/lockup)
 "bGF" = (
-/obj/effect/landmark/secequipment,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/security/main)
+/obj/item/storage/box/lights/mixed,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/closet/crate,
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "bGN" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -26897,10 +25914,13 @@
 /obj/structure/closet/secure_closet/brig_phys,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"bLb" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plasteel/dark,
-/area/science/storage)
+"bJz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
 "bLk" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -26923,6 +25943,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar/atrium)
+"bLJ" = (
+/obj/machinery/door/airlock/ship/hatch{
+	name = "Air Control Right";
+	req_one_access_txt = "19;69"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plasteel/ship,
+/area/nsv/hanger/deck2/port{
+	name = "Launch tubes 3 and 4"
+	})
 "bLM" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -27035,6 +26068,9 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"bRj" = (
+/turf/open/floor/plasteel/dark,
+/area/maintenance/port/central)
 "bRn" = (
 /obj/effect/turf_decal/stripes/red/corner,
 /obj/structure/cable{
@@ -27100,16 +26136,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/patients_rooms/room_a)
-"bSP" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "ce_window";
-	name = "privacy shutter"
-	},
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/chief)
 "bSV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -27137,6 +26163,18 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/weapons/fore)
+"bTR" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "bTW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -27159,6 +26197,14 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/exit)
+"bUi" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "bUA" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -27269,6 +26315,10 @@
 /obj/machinery/vending/wardrobe/cargo_wardrobe,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"bXs" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "bXP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -27418,6 +26468,10 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/central)
+"ccS" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "ccX" = (
 /obj/structure/curtain/obscuring/grey,
 /turf/open/floor/plasteel/freezer,
@@ -27435,6 +26489,13 @@
 /obj/structure/closet/l3closet/scientist,
 /turf/open/floor/plasteel,
 /area/gateway)
+"cet" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/effect/spawner/room/threexthree,
+/turf/template_noop,
+/area/maintenance/department/bridge)
 "cgd" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 8
@@ -27448,6 +26509,13 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
+"cjf" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "cjk" = (
 /obj/machinery/airlock_sensor/incinerator_atmos{
 	pixel_x = 24;
@@ -27536,6 +26604,12 @@
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar/atrium)
+"clw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "clF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/cable{
@@ -27557,6 +26631,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"cmk" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "cne" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -27578,13 +26665,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
-"cpq" = (
-/obj/machinery/door/airlock/ship/hatch{
-	name = "Air Control Left";
-	req_one_access_txt = "19;69"
-	},
-/turf/open/floor/plasteel/ship/padded,
-/area/maintenance/starboard/central)
 "cpL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -27601,6 +26681,12 @@
 "cqh" = (
 /turf/open/floor/carpet/red,
 /area/security/detectives_office/private_investigators_office)
+"cqk" = (
+/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "cql" = (
 /obj/effect/turf_decal/bot_white,
 /obj/effect/spawner/lootdrop/maintenance/eight,
@@ -27692,15 +26778,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/fore)
-"ctY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/door/airlock/ship/hatch{
-	name = "Chaplain's Office";
-	req_one_access_txt = "22"
-	},
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/plasteel/dark,
-/area/chapel/main)
 "cut" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -27787,6 +26864,24 @@
 /obj/item/camera/detective,
 /turf/open/floor/wood,
 /area/security/detectives_office/private_investigators_office)
+"cyE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/security/glass{
+	name = "Riot Armory";
+	req_one_access_txt = "3"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/ship,
+/area/ai_monitored/security/armory/security)
 "cyJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/mech_bay_recharge_floor,
@@ -27845,6 +26940,10 @@
 /obj/machinery/vending/hydronutrients,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"cAb" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "cAd" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -27896,6 +26995,19 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"cBD" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/security/main)
 "cBX" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced/spawner/west,
@@ -27923,6 +27035,10 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"cCP" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/crew_quarters/heads/captain/private)
 "cDe" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -27953,15 +27069,6 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
-"cED" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "rd_window";
-	name = "privacy shutter"
-	},
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/science/lab)
 "cEN" = (
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
@@ -28017,6 +27124,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"cIo" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "xoprivacy";
+	name = "Privacy Shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hop)
 "cIx" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
@@ -28095,11 +27222,24 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/entry)
-"cNp" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/engine/gravity_generator)
+"cMr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Patient Room A";
+	req_one_access_txt = "5"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/white,
+/area/medical/patients_rooms/room_a)
 "cNO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -28121,10 +27261,6 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"cNX" = (
-/obj/machinery/light/floor,
-/turf/open/floor/plating,
-/area/engine/engineering/hangar)
 "cOm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -28177,11 +27313,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
-"cQp" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/security/execution/transfer)
 "cQr" = (
 /obj/structure/table/reinforced,
 /obj/item/pen/fourcolor,
@@ -28250,12 +27381,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/port/central)
-"cTY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/window,
-/obj/machinery/atmospherics/pipe/simple/brown/hidden,
-/turf/open/floor/plating,
-/area/engine/engine_room)
 "cUn" = (
 /obj/machinery/requests_console{
 	department = "Atmospherics";
@@ -28289,6 +27414,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"cVD" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship,
+/area/security/prison)
 "cXR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -28318,22 +27456,6 @@
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plasteel,
 /area/engine/storage)
-"cYR" = (
-/obj/machinery/door/airlock/virology/glass{
-	name = "Test Subject Supply";
-	req_one_access_txt = "39"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "cYS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28461,6 +27583,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"dcM" = (
+/obj/structure/railing,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/construction)
 "dcR" = (
 /obj/machinery/atmospherics/pipe/simple/dark/hidden/layer1{
 	dir = 8
@@ -28493,23 +27620,18 @@
 /obj/structure/closet/secure_closet/munitions_technician,
 /turf/open/floor/plasteel/ship,
 /area/nsv/weapons/fore)
-"deC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/ship,
-/area/hallway/primary/fore)
 "deM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/central)
+"deO" = (
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "dft" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -28534,16 +27656,13 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"dgc" = (
-/obj/machinery/button/door{
-	id = "ad_gun";
-	name = "Arms Dump Gun Storage";
-	pixel_x = 0;
-	pixel_y = 24;
-	req_one_access_txt = "3;58"
+"dgb" = (
+/obj/machinery/computer/ship/viewscreen,
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory/lockup)
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/fore)
 "dgl" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -28592,6 +27711,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"did" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "diq" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/structure/extinguisher_cabinet/west,
@@ -28650,6 +27780,18 @@
 	},
 /turf/open/floor/carpet/black,
 /area/crew_quarters/heads/hor)
+"dki" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "dkL" = (
 /obj/machinery/button/door{
 	dir = 8;
@@ -28719,6 +27861,27 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/quartermaster/storage)
+"dne" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/sorting/mail{
+	sortType = 7
+	},
+/turf/open/floor/plasteel/ship,
+/area/security/prison)
 "dnv" = (
 /obj/effect/landmark/start/master_at_arms,
 /turf/open/floor/plasteel/ship,
@@ -28892,6 +28055,23 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"drW" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "chem_privacy";
+	name = "privacy shutter"
+	},
+/obj/machinery/smartfridge/chemistry/preloaded,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/medical/medbay/lobby)
+"dsF" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "dtf" = (
 /obj/structure/grille,
 /obj/structure/cable,
@@ -28910,6 +28090,26 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/ai_monitored/turret_protected/ai)
+"dto" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Hangar Bay"
+	},
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "hang_storage"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/fore)
 "dtr" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -28954,6 +28154,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"dvc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/status_display/evac/west,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/port)
 "dvl" = (
 /obj/machinery/atmospherics/pipe/manifold/purple/visible{
 	dir = 4
@@ -29027,12 +28237,6 @@
 /obj/machinery/nanite_programmer,
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
-"dvV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
 "dvZ" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -29176,6 +28380,20 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
+"dDn" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
 "dDB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 1
@@ -29197,13 +28415,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"dEx" = (
-/obj/machinery/door/airlock/ship/hatch{
-	name = "Support Vessel Fore";
-	req_one_access_txt = "61;65"
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/ai_monitored/turret_protected/aisat/hallway/support_ship)
 "dEK" = (
 /obj/effect/turf_decal/bot_white,
 /obj/structure/disposalpipe/segment,
@@ -29280,30 +28491,11 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/ai_monitored/security/armory/lockup)
-"dHQ" = (
-/obj/machinery/door/airlock/ship/hatch{
-	name = "Air Control Right";
-	req_one_access_txt = "19;69"
-	},
-/turf/open/floor/plasteel/ship/padded,
-/area/maintenance/starboard/central)
 "dIv" = (
 /obj/machinery/modular_computer/console/preset/command{
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/crew_quarters/heads/hop)
-"dIH" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "xoprivacy";
-	name = "Privacy Shutters"
-	},
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
 /area/crew_quarters/heads/hop)
 "dIV" = (
 /obj/machinery/modular_computer/console/preset/research{
@@ -29327,18 +28519,6 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/fore)
-"dJu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/science/storage)
 "dJO" = (
 /obj/machinery/suit_storage_unit/pilot,
 /obj/structure/extinguisher_cabinet/south,
@@ -29414,10 +28594,29 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
+"dNI" = (
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "dOi" = (
 /obj/item/clothing/glasses/sunglasses/advanced,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"dOz" = (
+/obj/structure/sign/directions/evac{
+	dir = 1
+	},
+/obj/structure/sign/directions/supply{
+	dir = 1;
+	pixel_y = 8
+	},
+/obj/structure/sign/directions/engineering{
+	dir = 8;
+	pixel_y = -8
+	},
+/turf/closed/wall/ship,
+/area/hallway/secondary/service)
 "dOG" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
@@ -29439,6 +28638,11 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"dPc" = (
+/obj/structure/grille/broken,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "dPI" = (
 /obj/machinery/computer/teleporter{
 	dir = 8
@@ -29613,19 +28817,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"dVu" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/security/prison)
-"dVB" = (
-/obj/effect/spawner/lootdrop/grille_or_trash,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "dVO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/effect/turf_decal/tile/yellow{
@@ -29654,18 +28845,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
+"dWI" = (
+/obj/structure/railing,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plasteel,
+/area/construction)
 "dXj" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
-"dXI" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
 "dYf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -29682,6 +28872,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"dZx" = (
+/obj/machinery/door/airlock/virology/glass{
+	name = "Test Subject Supply";
+	req_one_access_txt = "39"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "dZQ" = (
 /obj/machinery/camera/autoname,
 /turf/open/floor/circuit,
@@ -29859,6 +29067,30 @@
 /obj/machinery/recharge_station,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
+"eiL" = (
+/obj/machinery/button/door{
+	id = "ad_gun";
+	name = "Arms Dump Gun Storage";
+	pixel_x = 0;
+	pixel_y = 24;
+	req_one_access_txt = "3;58"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory/lockup)
+"eiT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel/ship,
+/area/hallway/primary/fore)
 "eiW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 6
@@ -29939,13 +29171,10 @@
 /obj/item/mop,
 /turf/open/floor/plating,
 /area/maintenance/port/central)
-"emu" = (
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/engine/engineering/hangar)
+"ely" = (
+/obj/effect/landmark/blobstart,
+/turf/template_noop,
+/area/maintenance/department/electrical)
 "emx" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/ship/techfloor/alt,
@@ -29997,6 +29226,12 @@
 	},
 /turf/open/floor/plating,
 /area/security/warden)
+"epG" = (
+/obj/structure/closet/radiation,
+/obj/item/tank/internals/oxygen/yellow,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "epN" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -30033,11 +29268,6 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"eqM" = (
-/obj/machinery/light/small,
-/obj/machinery/portable_atmospherics/canister/toxins,
-/turf/open/floor/plasteel/dark,
-/area/science/storage)
 "eqW" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/wood,
@@ -30058,6 +29288,17 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/lockup)
+"erI" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "ce_window";
+	name = "privacy shutter"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/chief)
 "erO" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/red,
@@ -30094,13 +29335,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"esJ" = (
-/obj/machinery/door/airlock/ship/public{
-	name = "Bar closet";
-	req_one_access_txt = "25"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "etn" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/structure/extinguisher_cabinet/east,
@@ -30149,6 +29383,23 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
+"evj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/morgue{
+	name = "Private Study";
+	req_access_txt = "37"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/wood,
+/area/library)
+"evx" = (
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "ewW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -30188,11 +29439,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/weapons/fore)
-"ezq" = (
-/obj/machinery/light/small,
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/plasteel/dark,
-/area/science/storage)
 "eAd" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -30339,19 +29585,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
-"eGt" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
 "eGO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"eHb" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "eHs" = (
 /obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/ship/techfloor/alt,
@@ -30436,10 +29679,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
-"eKK" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
-/area/maintenance/department/bridge)
 "eKL" = (
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -30474,6 +29713,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/storage)
+"eMq" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/visible,
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "eMu" = (
 /obj/machinery/newscaster{
 	pixel_x = 30
@@ -30514,11 +29757,34 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"eNA" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor/northright{
+	name = "Warden's Desk";
+	req_one_access_txt = "3"
+	},
+/obj/machinery/door/window/brigdoor/southright{
+	name = "Warden's Desk";
+	req_one_access_txt = "3"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/security/warden)
 "eNE" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/ai_slipper,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"eNU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/turf/template_noop,
+/area/maintenance/port/central)
 "eNV" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -30556,34 +29822,19 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/fore)
-"ePu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/door/airlock/ship{
-	name = "Toxins Storage";
-	req_one_access_txt = "8"
-	},
-/obj/machinery/door/firedoor/heavy,
+"ePK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
-/area/science/storage)
-"ePS" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/open/floor/plasteel/dark,
-/area/science/storage)
-"eRf" = (
-/obj/machinery/door/airlock/virology/glass{
-	name = "Isolation A";
-	req_one_access_txt = "39"
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Brig-1";
+	location = "Brig-0"
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship,
+/area/hallway/primary/fore)
 "eRs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -30604,6 +29855,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"eRC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "eRN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -30846,11 +30109,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"fbm" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/crew_quarters/bar/atrium)
+"faw" = (
+/obj/structure/sign/directions/command{
+	dir = 4;
+	pixel_y = -8
+	},
+/obj/structure/sign/directions/security{
+	dir = 4
+	},
+/turf/closed/wall/ship,
+/area/nsv/hanger)
 "fcs" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -30874,6 +30142,14 @@
 /obj/item/storage/box/donkpockets,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"fdm" = (
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "fdA" = (
 /obj/effect/spawner/xmastree,
 /turf/open/floor/wood,
@@ -30881,10 +30157,6 @@
 "feC" = (
 /turf/closed/wall/ship,
 /area/maintenance/department/science/central)
-"feE" = (
-/obj/machinery/light/small,
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
 "feO" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/turf_decal/tile/yellow{
@@ -30974,6 +30246,10 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"fhl" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "fhB" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -31016,11 +30292,27 @@
 "fkN" = (
 /turf/open/space/basic,
 /area/space/nearstation)
-"flG" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/engine/engine_room)
+"flp" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/landmark/nuclear_waste_spawner/strong,
+/turf/open/floor/plasteel/ship,
+/area/engine/engineering/hangar)
+"flT" = (
+/obj/machinery/door/airlock/ship/security/glass{
+	id_tag = "pw_fd_inner";
+	name = "Brig";
+	req_one_access_txt = "63"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/security/prison)
 "fmb" = (
 /obj/effect/landmark/start/atmospheric_technician,
 /obj/machinery/camera/autoname{
@@ -31028,6 +30320,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"fmi" = (
+/obj/effect/spawner/room/fivexfour,
+/turf/template_noop,
+/area/maintenance/department/electrical)
 "fmX" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -31046,6 +30342,11 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
+"foD" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "fpf" = (
 /obj/machinery/modular_computer/console/preset/civilian,
 /obj/structure/cable{
@@ -31068,6 +30369,22 @@
 "fpL" = (
 /turf/open/floor/wood,
 /area/science/research)
+"fqj" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
+"fqn" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor/northleft{
+	name = "Security Desk";
+	req_one_access_txt = "63"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/security/prison)
 "fqz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31115,6 +30432,26 @@
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/dark,
+/area/security/prison)
+"fra" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Long-Term Confinement"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "cell4_ld";
+	name = "Cell 4 Lockdown"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/mineral/plastitanium/red/brig,
 /area/security/prison)
 "frx" = (
 /obj/machinery/door/poddoor/shutters{
@@ -31269,6 +30606,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/storage)
+"fxA" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "xoprivacy";
+	name = "Privacy Shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hop)
 "fxB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -31299,11 +30647,57 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"fyk" = (
+/obj/effect/turf_decal/loading_area/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/hatch{
+	name = "AI Upload Access";
+	req_one_access_txt = "16"
+	},
+/obj/machinery/door/poddoor{
+	id = "aiship_upload";
+	name = "AI Upload Security Door"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/ship,
+/area/ai_monitored/turret_protected/ai_upload)
+"fys" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
 "fyw" = (
 /obj/structure/table_frame/wood,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"fyJ" = (
+/obj/structure/sign/directions/medical{
+	dir = 4
+	},
+/obj/structure/sign/directions/evac{
+	dir = 4;
+	pixel_y = 8
+	},
+/obj/structure/sign/directions/supply{
+	dir = 4;
+	pixel_y = -8
+	},
+/turf/closed/wall/ship,
+/area/medical/chemistry)
 "fzR" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -31320,19 +30714,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"fAg" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/maintenance/disposal)
 "fAj" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"fAE" = (
-/obj/effect/landmark/nuclear_waste_spawner,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/secondary/exit)
 "fAI" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos{
 	dir = 4
@@ -31345,11 +30730,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
-"fBK" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/engine/atmos)
 "fBU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -31477,6 +30857,11 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
+"fES" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "fEY" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "12"
@@ -31504,6 +30889,27 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"fHR" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
+"fId" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship,
+/area/hallway/primary/fore)
 "fIp" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/ship/maintenance{
@@ -31516,6 +30922,30 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"fIA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "aicore_entrance";
+	name = "AI Core Entrance Shutters"
+	},
+/obj/machinery/door/airlock/ship/hatch{
+	name = "Intelligence Core";
+	req_one_access_txt = "16"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/ship,
+/area/ai_monitored/turret_protected/ai)
 "fIM" = (
 /obj/structure/chair/pew/right,
 /obj/effect/landmark/start/assistant,
@@ -31566,6 +30996,11 @@
 /area/nsv/hanger/deck2/port{
 	name = "Launch tubes 3 and 4"
 	})
+"fKv" = (
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "fKx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -31648,12 +31083,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"fLG" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/bridge)
 "fLL" = (
 /obj/structure/table/wood,
 /obj/structure/table/wood,
@@ -31807,6 +31236,15 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/entry)
+"fRz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
 "fSp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31820,6 +31258,10 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"fSJ" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/medical/virology)
 "fTe" = (
 /turf/closed/wall/r_wall/ship,
 /area/ai_monitored/turret_protected/aisat/service/support_ship)
@@ -31908,6 +31350,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"fYQ" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "fYU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -31984,15 +31432,6 @@
 /obj/machinery/atmospherics/pipe/simple/brown/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"gbc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/effect/spawner/lootdrop/grille_or_trash,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "gbL" = (
 /obj/structure/grille,
 /obj/structure/cable{
@@ -32016,18 +31455,26 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"gcK" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/nsv/hanger)
+"gdL" = (
+/obj/machinery/smartfridge/drinks,
+/obj/machinery/door/firedoor,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"get" = (
+/obj/structure/closet/radiation,
+/obj/item/tank/internals/oxygen/yellow,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "geE" = (
 /obj/structure/table/wood,
 /obj/machinery/microwave,
 /turf/open/floor/carpet/orange,
 /area/engine/break_room)
-"geQ" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
 "geX" = (
 /obj/machinery/light{
 	dir = 8
@@ -32038,11 +31485,6 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/hanger)
-"gft" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/hallway/secondary/exit)
 "gfK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 5
@@ -32129,6 +31571,16 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs/auxiliary)
+"gkX" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/obey{
+	pixel_x = -32
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/fore)
 "gln" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=CentHallCurv-1";
@@ -32183,6 +31635,10 @@
 /obj/item/stack/spacecash/c1,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"gnJ" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/security/main)
 "gnT" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -32228,22 +31684,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/exit)
-"goM" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor/northright{
-	name = "Security Desk";
-	req_one_access_txt = "63"
-	},
-/turf/open/floor/plating,
-/area/security/prison)
-"gpa" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor/eastright{
-	name = "Security Desk";
-	req_one_access_txt = "63"
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "gpm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -32280,11 +31720,6 @@
 /obj/effect/decal/cleanable/oil/streak,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
-"grF" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/engine/atmospherics_engine)
 "grQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
@@ -32292,6 +31727,18 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/nsv/hanger)
+"gsH" = (
+/obj/structure/plasticflaps,
+/obj/machinery/door/poddoor/shutters{
+	id = "cmbridge";
+	name = "Cargo Munitions Bridge Shutter"
+	},
+/obj/machinery/conveyor{
+	id = "cmbelt"
+	},
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/nsv/weapons/fore)
 "gsY" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -4
@@ -32304,6 +31751,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"gtr" = (
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/structure/cable,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "gtu" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 8
@@ -32331,6 +31786,12 @@
 "gtQ" = (
 /turf/template_noop,
 /area/maintenance/department/medical/morgue)
+"guj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "gum" = (
 /obj/effect/turf_decal/caution/white,
 /obj/structure/cable{
@@ -32454,11 +31915,6 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/plating,
 /area/crew_quarters/fitness)
-"gyg" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/security/checkpoint/customs/auxiliary)
 "gyv" = (
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/plasteel/white,
@@ -32498,10 +31954,16 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/ship,
 /area/security/prison)
-"gzQ" = (
-/obj/structure/railing,
-/turf/open/floor/plating,
-/area/construction)
+"gzJ" = (
+/obj/machinery/newscaster{
+	pixel_x = -32;
+	pixel_y = 32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/fore)
 "gzR" = (
 /obj/effect/landmark/start/flight_leader,
 /turf/open/floor/plasteel/ship,
@@ -32595,15 +32057,36 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/tcommsat/computer)
-"gES" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/bridge/meeting_room)
 "gEV" = (
 /obj/structure/tank_dispenser,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"gFe" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor/eastleft{
+	name = "Security Desk";
+	req_one_access_txt = "63"
+	},
+/obj/machinery/button/door{
+	id = "pw_fd_outer";
+	name = "Exterior Door Control";
+	normaldoorcontrol = 1;
+	pixel_x = 8;
+	pixel_y = 24;
+	req_one_access_txt = "63"
+	},
+/obj/machinery/button/door{
+	id = "pw_fd_inner";
+	name = "Interior Door Control";
+	normaldoorcontrol = 1;
+	pixel_x = -8;
+	pixel_y = 24;
+	req_one_access_txt = "63"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plating,
+/area/security/prison)
 "gFu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -32613,10 +32096,31 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"gGA" = (
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
+"gFI" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
+"gGZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/door/airlock/ship/hatch{
+	name = "Support Vessel Service";
+	req_one_access_txt = "65"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/ai_monitored/turret_protected/aisat/service/support_ship)
 "gHc" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -32626,6 +32130,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/gateway)
+"gHg" = (
+/obj/machinery/door/airlock/ship/hatch{
+	name = "Air Control Left";
+	req_one_access_txt = "19;69"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plasteel/ship,
+/area/nsv/hanger/deck2/starboard{
+	name = "Launch tubes 1 and 2"
+	})
 "gIK" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
@@ -32653,11 +32170,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
-"gJq" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "gJQ" = (
 /obj/structure/closet/wardrobe/white,
 /turf/open/floor/plasteel/white,
@@ -32717,6 +32229,15 @@
 "gMn" = (
 /turf/open/floor/wood,
 /area/maintenance/starboard/central)
+"gMv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 5
+	},
+/turf/open/floor/monotile/light,
+/area/science/storage)
 "gMA" = (
 /obj/machinery/light/broken{
 	dir = 4
@@ -32760,6 +32281,22 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plasteel/ship,
 /area/security/warden)
+"gOY" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/window{
+	req_one_access_txt = "11"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/construction)
+"gPi" = (
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/fore)
 "gRn" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -32822,6 +32359,25 @@
 /obj/item/storage/box/bodybags,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"gTe" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
+"gTJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship,
+/area/hallway/primary/fore)
 "gUr" = (
 /obj/structure/table/glass,
 /obj/effect/spawner/lootdrop/aimodule_neutral,
@@ -32836,6 +32392,28 @@
 /obj/item/grenade/barrier,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/security)
+"gUQ" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/computer/ship/viewscreen,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/central)
+"gUX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Surgery";
+	req_one_access_txt = "45"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plasteel/dark,
+/area/medical/surgery)
 "gVf" = (
 /obj/item/radio/intercom{
 	pixel_y = -26
@@ -33157,11 +32735,36 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
+"hdB" = (
+/obj/machinery/light/small,
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "hdT" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/storage)
+"hdY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Bridge-Ext";
+	location = "Fore-Weapons"
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	sortType = "7;8;15"
+	},
+/turf/open/floor/plasteel/ship,
+/area/hallway/primary/fore)
 "hew" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -33205,24 +32808,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/construction)
-"hfk" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plasteel/ship,
-/area/security/prison)
 "hfq" = (
 /obj/effect/turf_decal/delivery/white,
 /obj/structure/disposalpipe/segment{
@@ -33263,19 +32848,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
-"hfL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 10
-	},
-/obj/effect/landmark/blobstart,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "hfN" = (
 /obj/structure/hull_plate/end,
 /obj/structure/hull_plate/end,
@@ -33325,6 +32897,14 @@
 /obj/machinery/computer/secure_data/laptop,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/heads/hop)
+"hgm" = (
+/obj/machinery/door/airlock/ship/engineering{
+	name = "Engineering Cupboard";
+	req_one_access_txt = "10"
+	},
+/obj/effect/mapping_helpers/airlock/abandoned,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "hgn" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "12"
@@ -33346,6 +32926,12 @@
 /obj/effect/landmark/start/lawyer,
 /turf/open/floor/carpet,
 /area/security/courtroom)
+"hgV" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
+	},
+/turf/template_noop,
+/area/maintenance/department/electrical)
 "hht" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33365,6 +32951,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
+"hhI" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "hiT" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 8
@@ -33487,6 +33079,15 @@
 "hmw" = (
 /turf/open/floor/plasteel/ship,
 /area/nsv/hanger)
+"hmR" = (
+/obj/machinery/door/airlock/ship/public{
+	name = "Bar closet";
+	req_one_access_txt = "25"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "hmS" = (
 /obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/engine,
@@ -33569,6 +33170,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"hpp" = (
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
 "hpv" = (
 /obj/structure/sign/plaques/kiddie/library{
 	pixel_y = 32
@@ -33612,12 +33220,6 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/port/central)
-"hrR" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
 "hrY" = (
 /obj/machinery/door/airlock/ship/security/glass{
 	name = "Security Prison Wing Desk";
@@ -33705,11 +33307,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"huV" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/medical/virology)
 "hvo" = (
 /obj/machinery/vending/games,
 /obj/structure/extinguisher_cabinet/north,
@@ -33805,6 +33402,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"hyT" = (
+/obj/item/assembly/mousetrap/armed,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "hzO" = (
 /obj/structure/sign/poster/official/pda_ad{
 	pixel_x = -32
@@ -33825,6 +33435,11 @@
 	},
 /turf/open/floor/plasteel/ship/riveted,
 /area/maintenance/department/medical/morgue)
+"hAZ" = (
+/obj/structure/chair/office,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "hBa" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -33905,15 +33520,6 @@
 /obj/structure/extinguisher_cabinet/south,
 /turf/open/floor/plasteel/ship,
 /area/security/warden)
-"hEF" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
 "hEG" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/snacks/mint,
@@ -33978,11 +33584,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
-"hGy" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/engine/engine_room)
 "hGA" = (
 /obj/machinery/computer/security/mining{
 	dir = 4
@@ -34065,13 +33666,6 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"hIQ" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/storage)
 "hJp" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -34100,6 +33694,16 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/ai_monitored/turret_protected/ai_upload)
+"hLl" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "hLv" = (
 /obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/ship/techfloor/alt,
@@ -34129,6 +33733,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
+"hNo" = (
+/obj/structure/window,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/closet/crate/medical,
+/obj/item/stack/medical/gauze/improvised,
+/obj/item/stack/medical/ointment/one,
+/obj/item/stack/medical/bruise_pack/one,
+/obj/item/clothing/mask/surgical,
+/obj/item/reagent_containers/syringe/used,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "hNV" = (
 /obj/effect/turf_decal/bot_red/right,
 /obj/item/ammo_casing/a357{
@@ -34144,11 +33761,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
-"hOL" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/hallway/primary/fore)
 "hPq" = (
 /obj/machinery/light{
 	dir = 4
@@ -34194,6 +33806,10 @@
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"hQD" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "hRc" = (
 /obj/machinery/status_display/evac{
 	pixel_y = 32
@@ -34208,6 +33824,14 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/hanger)
+"hSk" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	id = "firingsquad";
+	name = "security shutters"
+	},
+/turf/open/floor/plating,
+/area/security/execution/transfer)
 "hSt" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/hydroponics/constructable,
@@ -34315,11 +33939,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"hWA" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/nsv/weapons/fore)
+"hWU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/template_noop,
+/area/maintenance/port/central)
 "hXb" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/candle_box,
@@ -34456,12 +34082,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/fore)
-"ibL" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
 "ibR" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/ship,
@@ -34470,6 +34090,11 @@
 /obj/machinery/vending/cola/random,
 /turf/open/floor/carpet/orange,
 /area/engine/break_room)
+"icH" = (
+/obj/structure/tank_dispenser/oxygen,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/nsv/hanger)
 "idC" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/donkpockets,
@@ -34525,6 +34150,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
+"ifD" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/brown/hidden{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/engine/engine_room)
 "ifE" = (
 /obj/machinery/light{
 	dir = 8
@@ -34577,14 +34209,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"igB" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "chem_privacy";
-	name = "privacy shutter"
-	},
-/obj/machinery/smartfridge/chemistry/preloaded,
-/turf/open/floor/plating,
-/area/medical/medbay/lobby)
 "igH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -34629,6 +34253,10 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/engine/plasma,
 /area/engine/atmos)
+"iie" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/chapel/office)
 "ikl" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/turf_decal/tile/blue{
@@ -34637,18 +34265,6 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"iky" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/science/storage)
 "ilk" = (
 /obj/structure/table/glass,
 /obj/item/stack/sheet/mineral/plasma,
@@ -34728,38 +34344,10 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/quartermaster/storage)
-"imr" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/door/airlock/ship/security/glass{
-	name = "Long-Term Confinement";
-	req_one_access_txt = "2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/security/prison)
 "imt" = (
 /obj/machinery/status_display/ai/west,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/ai_monitored/turret_protected/aisat/hallway/support_ship/aft)
-"imB" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "imF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -34856,10 +34444,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
-"ipV" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/turf/open/floor/plasteel/dark,
-/area/science/storage)
 "ipX" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
@@ -34867,6 +34451,24 @@
 "iqF" = (
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"irr" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship{
+	name = "Toxins Storage";
+	req_one_access_txt = "8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel,
+/area/science/storage)
 "irC" = (
 /obj/machinery/light/floor,
 /turf/open/floor/plasteel/ship/techfloor/alt,
@@ -34877,6 +34479,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"irQ" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "isl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -34898,15 +34510,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"isr" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "fab_window";
-	name = "privacy shutter"
-	},
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plating,
-/area/science/mixing)
 "isx" = (
 /obj/effect/turf_decal/bot_white,
 /obj/structure/closet/crate/internals,
@@ -34919,6 +34522,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/science/central)
+"isG" = (
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Long-Term Confinement"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "cell2_ld";
+	name = "Cell 2 Lockdown"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/security/prison)
 "itc" = (
 /turf/open/floor/carpet/black,
 /area/lawoffice)
@@ -35058,6 +34676,28 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"ixB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/security/prison)
+"ixJ" = (
+/obj/machinery/door/airlock/ship/public{
+	name = "Hydroponics Backroom";
+	req_one_access_txt = "35"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "ixK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 8
@@ -35095,15 +34735,6 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/port/central)
-"izt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/effect/landmark/nuclear_waste_spawner/strong,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "izF" = (
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/plating,
@@ -35133,22 +34764,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
-"iAg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/door/airlock/ship/hatch{
-	name = "Support Vessel Fore";
-	req_one_access_txt = "61;65"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/ai_monitored/turret_protected/aisat/hallway/support_ship)
 "iAi" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -35205,6 +34820,30 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/lockup)
+"iAZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/ship/hatch{
+	name = "Crematorium";
+	req_one_access_txt = "27"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
+"iBR" = (
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "iDr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -35245,6 +34884,14 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"iEU" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory/lockup)
 "iEX" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -35266,19 +34913,6 @@
 	dir = 6
 	},
 /area/chapel/main)
-"iFi" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/westright{
-	name = "Hydroponics Desk";
-	req_one_access_txt = "35"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "bot_south";
-	name = "privacy shutter"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plating,
-/area/hydroponics)
 "iFt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -35328,6 +34962,15 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/fore)
+"iGz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
 "iGB" = (
 /obj/machinery/food_cart,
 /obj/machinery/camera/autoname{
@@ -35393,24 +35036,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/security)
-"iIq" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/central)
-"iIr" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "hos_privacy";
-	name = "privacy shutter"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hos)
 "iIR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -35428,6 +35053,15 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"iJp" = (
+/obj/machinery/door/airlock/ship/public{
+	id_tag = "cabin3";
+	name = "Cabin 3"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/ship,
+/area/crew_quarters/dorms)
 "iJz" = (
 /obj/machinery/door/poddoor/ship{
 	id = "launchbay_access";
@@ -35516,10 +35150,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/service)
-"iNK" = (
-/obj/machinery/portable_atmospherics/canister,
-/turf/open/floor/plasteel/dark,
-/area/science/storage)
 "iNY" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -35586,11 +35216,15 @@
 "iSh" = (
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"iSl" = (
-/obj/structure/grille,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
+"iSq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "iSw" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -35671,6 +35305,13 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/hanger/storage)
+"iUF" = (
+/obj/machinery/status_display/ai{
+	pixel_x = -32
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/fore)
 "iVe" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -35707,11 +35348,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"iWT" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/hallway/primary/port)
 "iYh" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/ship/techfloor/alt,
@@ -35766,6 +35402,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"iZP" = (
+/obj/structure/sign/directions/evac{
+	dir = 8
+	},
+/obj/structure/sign/directions/supply{
+	dir = 4;
+	pixel_y = -8
+	},
+/turf/closed/wall/ship,
+/area/maintenance/department/crew_quarters/bar)
+"iZQ" = (
+/obj/structure/plasticflaps,
+/obj/effect/turf_decal/loading_area/red{
+	dir = 8
+	},
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "atmos_belt"
+	},
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plasteel/ship,
+/area/engine/atmos)
 "jaD" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/tile/red{
@@ -35801,6 +35459,24 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/ai_monitored/turret_protected/aisat/hallway/support_ship/aft)
+"jbi" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Patient Room B";
+	req_one_access_txt = "5"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/white,
+/area/medical/patients_rooms/room_b)
 "jbp" = (
 /obj/machinery/teleport/hub,
 /turf/open/floor/plasteel,
@@ -35852,6 +35528,16 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"jdZ" = (
+/obj/structure/sign/directions/command{
+	dir = 4;
+	pixel_y = -8
+	},
+/obj/structure/sign/directions/science{
+	dir = 8
+	},
+/turf/closed/wall/ship,
+/area/security/checkpoint/customs)
 "jep" = (
 /obj/machinery/door/airlock/ship/station/mining{
 	name = "Cargo Bay";
@@ -35883,23 +35569,21 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"jfv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
+"jfs" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/ship/security/glass{
-	name = "Riot Armory";
-	req_one_access_txt = "3"
+	id_tag = "pw_fd_outer";
+	name = "Brig";
+	req_one_access_txt = "63"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plasteel/ship,
-/area/ai_monitored/security/armory/security)
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/security/prison)
+"jfz" = (
+/turf/open/floor/plating,
+/area/space/nearstation)
 "jfD" = (
 /obj/machinery/cryopod,
 /obj/machinery/light{
@@ -35970,6 +35654,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"jhr" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "jhw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -36063,16 +35752,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/exit)
-"jkN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/engine/break_room)
 "jkW" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -36080,6 +35759,21 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/toilet/restrooms)
+"jlq" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	department = "Security";
+	departmentType = 7;
+	pixel_x = -32
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/security/prison)
 "jlH" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
@@ -36162,6 +35856,12 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
+"jpe" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer1,
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "jps" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -36273,6 +35973,16 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/fore)
+"jub" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor/northright{
+	name = "Security Desk";
+	req_one_access_txt = "63"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/security/prison)
 "jum" = (
 /obj/machinery/microwave,
 /obj/structure/table/wood,
@@ -36281,6 +35991,13 @@
 	},
 /turf/open/floor/wood,
 /area/science/research)
+"juF" = (
+/obj/structure/cable{
+	icon_state = "6-8"
+	},
+/obj/vehicle/sealed/car/realistic/medical,
+/turf/open/floor/plasteel/ship,
+/area/hallway/primary/central)
 "juJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -36376,6 +36093,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
+"jyi" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
 "jyB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -36405,6 +36127,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"jyH" = (
+/obj/machinery/door/airlock/ship/public{
+	name = "Quiet Room"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/wood,
+/area/library/lounge)
 "jzg" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
@@ -36512,16 +36242,6 @@
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"jDL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plasteel/ship,
-/area/hallway/primary/fore)
 "jEW" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -36613,6 +36333,10 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"jGF" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
 "jGG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -36693,6 +36417,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"jIB" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/science/mixing/chamber)
 "jIY" = (
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 1;
@@ -36706,6 +36434,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"jJy" = (
+/obj/machinery/door/airlock/ship/public{
+	id_tag = "cabin1";
+	name = "Cabin 1"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/ship,
+/area/crew_quarters/dorms)
 "jKl" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -36799,6 +36536,12 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai)
+"jMs" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 4
+	},
+/turf/template_noop,
+/area/maintenance/department/electrical)
 "jMw" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera/autoname{
@@ -36828,13 +36571,10 @@
 /obj/machinery/atmospherics/components/trinary/mixer,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"jNg" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
+"jML" = (
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "jNi" = (
 /obj/machinery/door/window/westright{
 	name = "Server Cage";
@@ -36843,18 +36583,6 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/circuit/telecomms/server,
 /area/science/server)
-"jNA" = (
-/obj/machinery/portable_atmospherics/scrubber/huge,
-/turf/open/floor/plasteel/dark,
-/area/science/storage)
-"jNK" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
 "jNO" = (
 /obj/machinery/newscaster{
 	pixel_x = 32
@@ -36921,26 +36649,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"jTl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/ship/security/glass{
-	name = "Hangar Bay";
-	req_one_access_txt = "69"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/nsv/hanger)
 "jTn" = (
 /obj/structure/table/wood,
 /obj/machinery/camera/autoname{
@@ -36978,6 +36686,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"jUl" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/ship,
+/area/nsv/hanger)
 "jUy" = (
 /obj/structure/sign/departments/evac{
 	pixel_x = -32
@@ -37023,6 +36746,10 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel,
 /area/storage/eva)
+"jVd" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "jVm" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1,
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible/layer3{
@@ -37036,6 +36763,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"jVC" = (
+/obj/machinery/door/airlock/ship/command{
+	name = "Master At Arms";
+	req_one_access_txt = "70"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/carpet/ship,
+/area/nsv/crew_quarters/heads/maa)
 "jVG" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
@@ -37079,6 +36827,30 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/security)
+"jXw" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/nsv/weapons/fore)
+"jXW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/central)
+"jZj" = (
+/turf/template_noop,
+/area/maintenance/port/central)
 "kac" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -37123,6 +36895,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
+"kaI" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
+"kbf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship,
+/area/hallway/primary/fore)
 "kbM" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/blue,
@@ -37146,10 +36931,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"kcz" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
 "kcR" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/purple,
@@ -37248,6 +37029,13 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/ai_monitored/turret_protected/aisat/hallway/support_ship/aft)
+"khU" = (
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
 "kie" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -37264,6 +37052,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"kiI" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "kiO" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -37292,6 +37085,19 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/ai_monitored/turret_protected/aisat/hallway/support_ship/aft)
+"kjy" = (
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "kjB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37324,13 +37130,6 @@
 	},
 /turf/open/floor/plasteel/ship/riveted,
 /area/maintenance/starboard/central)
-"kkv" = (
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "kkw" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -37341,6 +37140,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"kkG" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "chem_desk_med";
+	name = "desk shutter"
+	},
+/obj/machinery/door/window/northleft{
+	name = "Chemistry Desk";
+	req_one_access_txt = "33"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/medical/chemistry)
 "kkJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37390,17 +37203,21 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"kns" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/morgue{
-	name = "Private Study";
-	req_access_txt = "37"
+"knr" = (
+/obj/machinery/light/small,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/wood,
-/area/library)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "kpj" = (
 /obj/machinery/computer/warrant{
 	dir = 8
@@ -37433,6 +37250,15 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/quartermaster/storage)
+"kqs" = (
+/obj/machinery/door/airlock/ship/security/glass{
+	name = "Hangar armoury";
+	req_one_access_txt = "71"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/nsv/hanger)
 "kqt" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -37539,6 +37365,9 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/nsv/crew_quarters/heads/maa)
+"ksM" = (
+/turf/closed/wall/r_wall/ship,
+/area/space/nearstation)
 "ksP" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -37569,10 +37398,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"ktY" = (
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "kuY" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -37602,12 +37427,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"kwG" = (
-/obj/structure/window/reinforced/fulltile/ship,
-/obj/structure/grille,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/chapel/office)
 "kwH" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/AI,
@@ -37714,18 +37533,6 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"kyq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/port)
 "kyI" = (
 /obj/machinery/ship_weapon/mac{
 	dir = 4;
@@ -37782,6 +37589,15 @@
 /obj/machinery/autolathe,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/quartermaster/storage)
+"kAv" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/door/airlock/ship/external{
+	req_one_access_txt = "24;32"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "kAA" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/cafeteria,
@@ -37863,15 +37679,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs/auxiliary)
-"kDO" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/security/prison)
 "kEk" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3,
 /obj/structure/cable{
@@ -37895,19 +37702,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"kEM" = (
+"kEY" = (
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/machinery/light/floor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/engine/engineering/hangar)
 "kFl" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/structure/cable{
@@ -37946,6 +37753,19 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/fore)
+"kGo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/ship,
+/area/engine/engineering/hangar)
 "kGA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -37965,6 +37785,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"kHW" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/effect/mapping_helpers/airlock/abandoned,
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
 "kIp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38185,6 +38012,10 @@
 /obj/item/toy/cards/deck/cas/black,
 /turf/open/floor/wood,
 /area/library/lounge)
+"kSZ" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/hallway/primary/port)
 "kTo" = (
 /obj/effect/landmark/start/detective,
 /turf/open/floor/carpet/red,
@@ -38223,13 +38054,6 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
-"kUv" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
 "kUJ" = (
 /obj/machinery/door/poddoor{
 	id = "chapelgun";
@@ -38270,6 +38094,16 @@
 /obj/machinery/chem_dispenser,
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
+"kVQ" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "kWb" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
@@ -38289,11 +38123,6 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"kWS" = (
-/obj/machinery/smartfridge/drinks,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "kXx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38360,6 +38189,17 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"lab" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "lbb" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -38404,11 +38244,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
-"lcj" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/firedoor/window,
+"lcu" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plating,
-/area/nsv/weapons/fore)
+/area/maintenance/department/electrical)
 "lcD" = (
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/plasteel/white,
@@ -38446,6 +38296,15 @@
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
+"ldQ" = (
+/obj/machinery/door/airlock/ship/hatch{
+	name = "Support Vessel Fore";
+	req_one_access_txt = "61;65"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/ai_monitored/turret_protected/aisat/hallway/support_ship)
 "ldW" = (
 /turf/open/floor/plasteel/ship,
 /area/construction)
@@ -38492,10 +38351,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/ai_monitored/turret_protected/aisat/hallway/support_ship)
-"lhv" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/plasteel/dark,
-/area/science/storage)
 "lhx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -38525,6 +38380,14 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/entry)
+"lhF" = (
+/obj/structure/sign/directions/security,
+/obj/structure/sign/directions/command{
+	dir = 4;
+	pixel_y = -8
+	},
+/turf/closed/wall/r_wall/ship,
+/area/nsv/weapons/fore)
 "lio" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/disposalpipe/segment,
@@ -38555,15 +38418,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"ljw" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/structure/disposalpipe/segment,
-/obj/structure/barricade/wooden/crude,
-/turf/open/floor/plating,
-/area/maintenance/department/medical/morgue)
 "ljz" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -38573,6 +38427,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"ljB" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "lke" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -38620,19 +38483,6 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
-"lmM" = (
-/obj/machinery/status_display/ai{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
-"lmR" = (
-/obj/machinery/door/airlock/virology/glass{
-	name = "Isolation B";
-	req_one_access_txt = "39"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "lnt" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/snacks/donut/jelly/plain,
@@ -38668,16 +38518,32 @@
 /obj/machinery/modular_computer/console/preset/command,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
-"lpG" = (
+"lpu" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
+"lpJ" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 4
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical/morgue)
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/sorting/mail{
+	sortType = 8
+	},
+/turf/open/floor/plasteel/ship,
+/area/security/prison)
 "lqb" = (
 /obj/effect/landmark/start/munitions_tech,
 /turf/open/floor/plasteel/ship,
@@ -38686,11 +38552,10 @@
 /obj/machinery/atmospherics/pipe/manifold4w/general/visible,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"lqu" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plating,
-/area/science/mixing)
+"lqN" = (
+/obj/effect/spawner/room/tenxfive,
+/turf/template_noop,
+/area/maintenance/department/electrical)
 "lro" = (
 /obj/machinery/requests_console{
 	department = "Engineering";
@@ -38702,6 +38567,22 @@
 	},
 /turf/closed/wall/ship,
 /area/engine/engine_room)
+"lrs" = (
+/obj/effect/turf_decal/loading_area/red{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/hatch{
+	name = "AI Upload Access";
+	req_one_access_txt = "16"
+	},
+/obj/machinery/door/poddoor{
+	id = "aiship_upload";
+	name = "AI Upload Security Door"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/ship,
+/area/ai_monitored/turret_protected/ai_upload)
 "lrz" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 1
@@ -38729,6 +38610,9 @@
 /obj/effect/landmark/start/librarian,
 /turf/open/floor/wood,
 /area/library)
+"ltT" = (
+/turf/template_noop,
+/area/maintenance/department/bridge)
 "ltV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -38798,13 +38682,6 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"lvG" = (
-/obj/machinery/door/airlock/highsecurity/ship{
-	name = "Secure Tech Storage";
-	req_access_txt = "23;19"
-	},
-/turf/open/floor/plating,
-/area/storage/tech)
 "lvQ" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -38919,6 +38796,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
+"lyS" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "lzo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -39003,6 +38886,16 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/carpet/black,
 /area/crew_quarters/heads/chief)
+"lBi" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/landmark/nuclear_waste_spawner/strong,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "lCC" = (
 /obj/structure/mirror{
 	pixel_y = -32
@@ -39063,11 +38956,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo)
-"lDJ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plating,
-/area/nsv/hanger/storage)
 "lDW" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "5"
@@ -39076,18 +38964,6 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"lEb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/door/airlock/ship/hatch{
-	name = "Air Control Right";
-	req_one_access_txt = "19;69"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/ship/padded,
-/area/maintenance/starboard/central)
 "lEB" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -39155,15 +39031,6 @@
 /obj/item/bikehorn/rubberducky,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/toilet/restrooms)
-"lGT" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "fab_window";
-	name = "privacy shutter"
-	},
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/science/robotics/lab)
 "lHF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank{
@@ -39215,6 +39082,25 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/ai_monitored/turret_protected/aisat/hallway/support_ship)
+"lJI" = (
+/obj/machinery/light/floor,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/engine/engineering/hangar)
+"lKr" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "69"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "lLd" = (
 /obj/machinery/light,
 /obj/structure/cable{
@@ -39222,6 +39108,13 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/exit)
+"lLD" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "lLE" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/purple{
@@ -39230,6 +39123,14 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"lMm" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/template_noop,
+/area/maintenance/department/electrical)
 "lMH" = (
 /obj/structure/closet/secure_closet/CMO,
 /obj/item/screwdriver,
@@ -39245,6 +39146,27 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"lMO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/security/glass{
+	name = "Hangar Bay";
+	req_one_access_txt = "69"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/dark,
+/area/nsv/hanger)
 "lMR" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -39252,24 +39174,6 @@
 /obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/plasteel/dark,
 /area/science/server)
-"lMX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/security/prison)
 "lNC" = (
 /obj/structure/chair{
 	dir = 4
@@ -39310,6 +39214,10 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/exit/departure_lounge)
+"lPn" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/crew_quarters/heads/captain)
 "lPp" = (
 /obj/machinery/door/airlock/ship/external{
 	req_one_access_txt = "13"
@@ -39373,13 +39281,6 @@
 	},
 /turf/open/floor/plasteel/ship/riveted,
 /area/maintenance/starboard/central)
-"lSQ" = (
-/obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
 "lTP" = (
 /obj/effect/landmark/start/medical_doctor,
 /obj/effect/turf_decal/tile/blue{
@@ -39466,11 +39367,6 @@
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
-"lWu" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/engine/break_room)
 "lWA" = (
 /obj/machinery/light/small,
 /obj/structure/disposalpipe/segment{
@@ -39495,6 +39391,18 @@
 /obj/item/storage/firstaid/ancient,
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"lWR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "lYN" = (
 /obj/machinery/light{
 	dir = 4
@@ -39556,6 +39464,10 @@
 /obj/item/storage/lockbox/clusterbang,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/security)
+"maP" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/quartermaster/office)
 "maX" = (
 /obj/machinery/light{
 	dir = 4
@@ -39590,6 +39502,13 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/aft)
+"mcx" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/ship/external{
+	req_one_access_txt = "24;32"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "mdq" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -39646,18 +39565,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/construction)
-"men" = (
-/obj/machinery/light/small,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
-"mer" = (
-/obj/machinery/door/airlock/ship/hatch{
-	name = "Support Vessel Service";
-	req_one_access_txt = "65"
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/service/support_ship)
 "mes" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -39776,6 +39683,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"mha" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "rd_window";
+	name = "privacy shutter"
+	},
+/turf/open/floor/plating,
+/area/science/lab)
 "mhf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -39903,6 +39818,33 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/central)
+"mkQ" = (
+/obj/machinery/computer/security/console,
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/plasteel/dark,
+/area/maintenance/port/central)
+"mly" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -24
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/security/prison)
+"mlL" = (
+/obj/machinery/light/small,
+/obj/structure/closet/radiation,
+/obj/item/tank/internals/oxygen/yellow,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/dorms)
 "mlM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -40053,11 +39995,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/aft)
-"mqS" = (
-/obj/structure/grille/broken,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
 "mqX" = (
 /obj/machinery/computer/teleporter,
 /turf/open/floor/plasteel,
@@ -40081,6 +40018,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/lockup)
+"mrX" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/maintenance/port/central)
 "msf" = (
 /obj/machinery/door/poddoor/ship{
 	id = "launchbay_tube1";
@@ -40151,6 +40094,24 @@
 /obj/machinery/atmospherics/pipe/simple/brown/visible/layer1,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"mtL" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship,
+/area/hallway/primary/fore)
 "mtO" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -40198,6 +40159,21 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/ship,
 /area/security/prison)
+"mvc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "32"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "mvv" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -40236,6 +40212,15 @@
 /obj/machinery/light/floor,
 /turf/open/floor/plasteel/ship,
 /area/nsv/hanger/storage)
+"mxk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
 "mxv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40323,6 +40308,26 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/aft)
+"mAr" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/door/airlock/ship/security/glass{
+	name = "Long-Term Confinement";
+	req_one_access_txt = "2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/security/prison)
 "mAM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 1
@@ -40331,9 +40336,10 @@
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/aft)
 "mAT" = (
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/template_noop,
+/area/maintenance/port/central)
 "mBd" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Medbay-0";
@@ -40341,11 +40347,12 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/entry)
-"mBg" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/bar)
+"mBn" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 28
+	},
+/turf/open/floor/monotile/light,
+/area/science/storage)
 "mBN" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -40536,26 +40543,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"mIp" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plating,
-/area/maintenance/department/medical/morgue)
+"mHQ" = (
+/obj/effect/landmark/blobstart,
+/turf/template_noop,
+/area/maintenance/department/bridge)
 "mIE" = (
 /obj/machinery/vending/boozeomat/pubby_captain,
 /turf/closed/wall/r_wall/ship,
 /area/crew_quarters/heads/captain/private)
-"mIH" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "mJP" = (
 /obj/machinery/door/airlock/ship/hatch{
 	dir = 8;
@@ -40716,6 +40711,13 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"mQE" = (
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "mRh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40749,6 +40751,10 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/entry)
+"mTH" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/security/checkpoint/customs/auxiliary)
 "mUk" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/tile/purple{
@@ -40776,12 +40782,6 @@
 /obj/machinery/chem_heater,
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
-"mUy" = (
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
 "mUQ" = (
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
 /turf/open/floor/plasteel/white,
@@ -40795,25 +40795,40 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/engine/break_room)
-"mVC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "32"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
 "mVE" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"mWI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/security/glass{
+	name = "Security Equipment";
+	req_one_access_txt = "1;4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/ship,
+/area/security/main)
 "mXy" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable{
@@ -40858,6 +40873,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/central)
+"mYw" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "ce_window";
+	name = "privacy shutter"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/chief)
 "mYD" = (
 /obj/machinery/light{
 	dir = 1
@@ -40901,11 +40928,6 @@
 "mZW" = (
 /turf/open/floor/plating,
 /area/nsv/hanger)
-"naO" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/captain)
 "naW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -40968,30 +40990,16 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/port)
-"ndB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+"ndr" = (
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/machinery/suit_storage_unit/pilot,
+/obj/machinery/status_display/evac{
+	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/door/airlock/ship/security/glass{
-	name = "Long-Term Confinement";
-	req_one_access_txt = "2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/security/prison)
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/nsv/hanger)
 "ndC" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -41009,12 +41017,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"neU" = (
-/obj/structure/sign/directions/security{
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
 "neV" = (
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/camera/autoname{
@@ -41061,9 +41063,11 @@
 /turf/closed/wall/r_wall/ship,
 /area/engine/engine_room)
 "nhn" = (
-/obj/structure/closet/radiation,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "nif" = (
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/hanger/storage)
@@ -41159,6 +41163,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"njT" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "njY" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -41264,6 +41276,15 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/wood,
 /area/lawoffice)
+"npf" = (
+/obj/machinery/door/airlock/ship/public{
+	name = "Galley";
+	req_one_access_txt = "28"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "npk" = (
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 8;
@@ -41309,11 +41330,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"nrM" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/bridge)
 "nrV" = (
 /obj/machinery/light{
 	dir = 8
@@ -41369,6 +41385,19 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"nvI" = (
+/obj/machinery/door/airlock/ship/hatch{
+	name = "Air Control Right";
+	req_one_access_txt = "19;69"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plasteel/ship/padded,
+/area/maintenance/starboard/central)
+"nwm" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "nxc" = (
 /obj/effect/turf_decal/stripes/red/full,
 /obj/machinery/light/small{
@@ -41440,6 +41469,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"nAE" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/fore)
 "nBl" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
@@ -41447,15 +41486,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
-"nBs" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/security/prison)
 "nBK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 4
@@ -41463,12 +41493,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet/orange,
 /area/engine/break_room)
-"nBU" = (
-/obj/structure/sign/poster/official/obey{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
 "nBY" = (
 /obj/machinery/shower{
 	dir = 8
@@ -41630,6 +41654,12 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"nFv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
 "nFL" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8;
@@ -41752,6 +41782,21 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"nNj" = (
+/obj/structure/closet/radiation,
+/obj/item/clothing/mask/gas,
+/obj/item/tank/internals/oxygen/yellow,
+/turf/open/floor/plasteel/ship,
+/area/hallway/secondary/entry)
+"nNu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 8;
+	sortType = 15
+	},
+/turf/open/floor/plasteel/ship,
+/area/hallway/primary/fore)
 "nNA" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/green{
@@ -41840,6 +41885,27 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
+"nQk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/fore)
+"nQt" = (
+/obj/machinery/portable_atmospherics/scrubber/huge,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "nQJ" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "12"
@@ -41969,10 +42035,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/aft)
-"nUK" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
 "nUL" = (
 /obj/machinery/computer/security/hos{
 	dir = 4
@@ -42210,6 +42272,24 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/entry)
+"ock" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Construction Area";
+	req_one_access_txt = "32"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "ocu" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -42220,6 +42300,16 @@
 /obj/structure/closet/crate/internals,
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"ocA" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "odP" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -42295,6 +42385,15 @@
 /obj/effect/landmark/nuclear_waste_spawner,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/fore)
+"ogG" = (
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
@@ -42474,10 +42573,27 @@
 /obj/structure/closet/crate/trashcart,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"onu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "onx" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/hanger)
+"onC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/engine/engineering/hangar)
 "oob" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -42498,6 +42614,10 @@
 	},
 /turf/open/floor/carpet/red,
 /area/security/detectives_office/private_investigators_office)
+"ooO" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/maintenance/department/chapel)
 "ooU" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
 	dir = 5
@@ -42521,16 +42641,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"opv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/effect/landmark/start/scientist,
-/turf/open/floor/plasteel,
-/area/science/storage)
 "oqS" = (
 /obj/machinery/conveyor_switch{
 	id = "cmbelt";
@@ -42646,13 +42756,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
-"ovn" = (
-/obj/machinery/light/small{
-	dir = 1
+"ovy" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer1{
+	dir = 8
 	},
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/turf/open/floor/plasteel/dark,
-/area/science/storage)
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "ovP" = (
 /obj/machinery/light/floor,
 /turf/open/floor/plasteel/ship/techfloor/alt,
@@ -42928,6 +43038,15 @@
 /obj/effect/landmark/start/munitions_tech,
 /turf/open/floor/plasteel/ship,
 /area/nsv/weapons/fore)
+"oFf" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/advanced_airlock_controller/directional/west{
+	pixel_y = 24
+	},
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "oFm" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -43005,6 +43124,10 @@
 /obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"oIF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/template_noop,
+/area/maintenance/department/bridge)
 "oIJ" = (
 /obj/machinery/power/apc/auto_name/north{
 	dir = 2;
@@ -43024,6 +43147,19 @@
 /obj/structure/bed,
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
+"oKv" = (
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
+"oLF" = (
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "oLM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43056,11 +43192,43 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/central)
+"oMY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship{
+	name = "Kitchen Coldroom";
+	req_one_access_txt = "35;28"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "oNf" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
 /turf/open/floor/plasteel/white,
 /area/medical/patients_rooms/room_a)
+"oNr" = (
+/obj/structure/table/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/item/storage/fancy/donut_box,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "Serving Hatch"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "oNs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/components/binary/dp_vent_pump,
@@ -43071,19 +43239,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"oOb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/port)
+"oNL" = (
+/obj/machinery/computer/station_alert/console,
+/turf/open/floor/plasteel/dark,
+/area/maintenance/port/central)
 "oOe" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -43094,6 +43253,18 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"oOu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "oOO" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -43116,6 +43287,27 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
+"oPS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/turf/template_noop,
+/area/maintenance/department/electrical)
+"oQj" = (
+/obj/machinery/door/airlock/ship/security/glass{
+	name = "Riot Armory";
+	req_one_access_txt = "3"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/ship,
+/area/ai_monitored/security/armory/security)
 "oQz" = (
 /obj/effect/turf_decal/stripes/full,
 /obj/structure/overmap/fighter/heavy/prebuilt,
@@ -43363,22 +43555,6 @@
 "oZG" = (
 /turf/closed/wall/r_wall/ship,
 /area/crew_quarters/heads/hos)
-"oZV" = (
-/obj/structure/table/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/item/storage/fancy/donut_box,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "Serving Hatch"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "pav" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/ship/maintenance{
@@ -43391,12 +43567,6 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"pax" = (
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
 "paE" = (
 /obj/machinery/door_timer{
 	id = "pw_6";
@@ -43411,6 +43581,12 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/security/prison)
+"paV" = (
+/obj/machinery/light/small,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "pbr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 9
@@ -43459,6 +43635,11 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
 /area/construction)
+"pdt" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/brown/hidden,
+/turf/open/floor/plating,
+/area/engine/engine_room)
 "pdI" = (
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/plasteel/dark,
@@ -43480,6 +43661,21 @@
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"pgn" = (
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Long-Term Confinement"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "cell1_ld";
+	name = "Cell 1 Lockdown"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/security/prison)
 "pgK" = (
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
@@ -43595,6 +43791,26 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/service)
+"pkY" = (
+/obj/structure/sign/directions/medical{
+	dir = 8;
+	pixel_y = -8
+	},
+/obj/structure/sign/directions/science{
+	dir = 8
+	},
+/turf/closed/wall/ship,
+/area/hallway/secondary/service)
+"pkZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/door/airlock/ship/hatch{
+	name = "Chaplain's Office";
+	req_one_access_txt = "22"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plasteel/dark,
+/area/chapel/main)
 "plv" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -43616,10 +43832,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"pmm" = (
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/engine/engineering/hangar)
 "pmo" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -43636,10 +43848,6 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"pmz" = (
-/obj/structure/grille/broken,
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
 "pne" = (
 /obj/machinery/door/airlock/ship/external{
 	req_one_access_txt = "13"
@@ -43745,6 +43953,12 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/port)
+"ppC" = (
+/obj/structure/closet/radiation,
+/obj/item/tank/internals/oxygen/yellow,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/bar)
 "ppO" = (
 /obj/machinery/light{
 	dir = 4
@@ -43759,12 +43973,23 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/security/prison)
-"pqQ" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/structure/cable,
-/obj/machinery/door/firedoor/window,
+"prb" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plating,
-/area/security/prison)
+/area/maintenance/department/electrical)
 "prh" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -43801,12 +44026,20 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"ptk" = (
-/obj/machinery/camera/autoname{
-	dir = 4
+"ptw" = (
+/obj/machinery/door/airlock/ship/hatch{
+	name = "Telecomms Server Floor Access";
+	req_one_access_txt = "61;65"
 	},
-/turf/open/floor/plasteel/dark,
-/area/science/storage)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/ai_monitored/turret_protected/aisat/hallway/support_ship)
 "ptA" = (
 /obj/structure/grille,
 /obj/structure/cable{
@@ -43849,6 +44082,35 @@
 /obj/machinery/status_display/ai/north,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
+"pvE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Hangar Bay"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "hang_storage"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/fore)
 "pvW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -43883,25 +44145,6 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"pwp" = (
-/obj/machinery/door/airlock/ship/command{
-	name = "Master At Arms";
-	req_one_access_txt = "70"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/carpet/ship,
-/area/nsv/crew_quarters/heads/maa)
 "pwz" = (
 /obj/machinery/vending/boozeomat,
 /turf/closed/wall/ship,
@@ -43942,6 +44185,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"pzP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "pzS" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -43979,14 +44232,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"pAO" = (
-/obj/machinery/door/airlock/ship/public{
-	name = "Galley";
-	req_one_access_txt = "28"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "pAP" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -44085,18 +44330,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
-"pFf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/door/airlock/ship/hatch{
-	name = "Support Vessel Service";
-	req_one_access_txt = "65"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/service/support_ship)
 "pFp" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space/basic,
@@ -44171,16 +44404,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/construction)
-"pIR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "pJl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -44197,6 +44420,13 @@
 /obj/item/key/fighter_tug,
 /turf/open/floor/plating,
 /area/nsv/hanger)
+"pKb" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/monotile/light,
+/area/science/storage)
 "pKs" = (
 /obj/machinery/light{
 	dir = 8
@@ -44220,6 +44450,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/eva)
+"pKR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/mineral/ore_redemption,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/engine,
+/area/quartermaster/office)
 "pLc" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
 	dir = 9
@@ -44391,31 +44631,12 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
-"pTK" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "ce_window";
-	name = "privacy shutter"
-	},
-/obj/machinery/door/firedoor/window,
+"pTt" = (
+/obj/structure/closet/radiation,
+/obj/item/clothing/mask/gas,
+/obj/item/tank/internals/oxygen/yellow,
 /turf/open/floor/plating,
-/area/crew_quarters/heads/chief)
-"pTM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/ship,
-/area/security/main)
+/area/maintenance/central)
 "pUg" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/open/floor/plasteel,
@@ -44579,18 +44800,18 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
-"pYU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/door/airlock/ship/hatch{
-	name = "Air Control Left";
-	req_one_access_txt = "19;69"
-	},
+"pZq" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/ship/padded,
-/area/maintenance/starboard/central)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/turf/template_noop,
+/area/maintenance/department/electrical)
 "pZs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
 /turf/open/floor/plasteel/dark,
@@ -44615,10 +44836,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/lockup)
-"qbE" = (
-/obj/effect/landmark/nuclear_waste_spawner/strong,
-/turf/open/floor/plating,
-/area/engine/engineering/hangar)
 "qbH" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance/four,
@@ -44891,11 +45108,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
-"qlg" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/quartermaster/office)
 "qlj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 5
@@ -44936,6 +45148,20 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
+"qoP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/door/airlock/ship/hatch{
+	name = "Air Control Right";
+	req_one_access_txt = "19;69"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plasteel/ship/padded,
+/area/maintenance/starboard/central)
 "qoQ" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -44959,6 +45185,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs/auxiliary)
+"qpe" = (
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/fore)
 "qpE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45001,6 +45235,18 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
+"qrU" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 10
+	},
+/turf/template_noop,
+/area/maintenance/department/electrical)
 "qrX" = (
 /obj/effect/landmark/start/flight_leader,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -45061,6 +45307,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"qtr" = (
+/obj/machinery/door/airlock/ship/hatch{
+	name = "Support Vessel Service";
+	req_one_access_txt = "65"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plating,
+/area/ai_monitored/turret_protected/aisat/service/support_ship)
 "qtI" = (
 /obj/structure/closet/crate/engineering{
 	name = "pdc ammo crate"
@@ -45125,6 +45380,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"qwN" = (
+/obj/structure/closet/radiation,
+/obj/item/clothing/mask/gas,
+/obj/item/tank/internals/oxygen/yellow,
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "qxv" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 1
@@ -45147,20 +45408,6 @@
 /obj/item/clothing/glasses/sunglasses/advanced,
 /turf/open/floor/wood,
 /area/lawoffice)
-"qzh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "qzO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45175,6 +45422,15 @@
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
+"qAG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/break_room)
 "qAK" = (
 /obj/structure/mopbucket,
 /obj/item/mop,
@@ -45269,6 +45525,15 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
+"qEz" = (
+/obj/machinery/door/airlock/ship/hatch{
+	name = "Support Vessel Aft";
+	req_one_access_txt = "16;65"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/ai_monitored/turret_protected/aisat/hallway/support_ship/aft)
 "qEO" = (
 /obj/machinery/firealarm{
 	pixel_y = 30
@@ -45276,16 +45541,6 @@
 /obj/structure/reagent_dispensers/fueltank/aviation_fuel,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/hanger)
-"qES" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "qEV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -45339,16 +45594,51 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"qGO" = (
+/obj/machinery/door/airlock/ship/hatch{
+	name = "Telecomms Server Floor Access";
+	req_one_access_txt = "61;65"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plating,
+/area/tcommsat/server)
 "qHo" = (
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/entry)
-"qIs" = (
-/obj/structure/cable{
-	icon_state = "6-8"
+"qHp" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/advanced_airlock_controller/directional/west{
+	pixel_y = 24
 	},
-/turf/open/floor/plasteel/ship,
-/area/hallway/primary/central)
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
+"qHN" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
+/turf/template_noop,
+/area/maintenance/department/electrical)
+"qHP" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/westright{
+	name = "Chemistry Desk";
+	req_access_txt = "33"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "chem_desk_public";
+	name = "desk shutter"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plating,
+/area/medical/medbay/lobby)
+"qHW" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "qID" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -45358,10 +45648,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"qIT" = (
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "qJs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
 /turf/open/floor/plasteel/ship,
@@ -45436,18 +45722,6 @@
 /obj/machinery/light/runway/delay2,
 /turf/open/space/basic,
 /area/engine/engine_room)
-"qNG" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/ship,
-/area/nsv/hanger)
 "qNR" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -45464,16 +45738,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"qNV" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/snacks/pie/cream,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "Serving Hatch"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "qOk" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/donkpockets,
@@ -45502,6 +45766,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"qPZ" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=JaniCloset";
+	location = "HOP-Corner"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/fore)
 "qQu" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
@@ -45663,6 +45937,11 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/central)
+"qVf" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "qVq" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -45697,6 +45976,12 @@
 /area/nsv/hanger/deck2/starboard{
 	name = "Launch tubes 1 and 2"
 	})
+"qWT" = (
+/obj/structure/closet/radiation,
+/obj/item/tank/internals/oxygen/yellow,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "qWU" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -45819,6 +46104,15 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/tcommsat/computer)
+"raS" = (
+/obj/machinery/door/airlock/highsecurity/ship{
+	name = "Secure Tech Storage";
+	req_access_txt = "23;19"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plating,
+/area/storage/tech)
 "raV" = (
 /obj/machinery/newscaster{
 	pixel_x = 30
@@ -45901,6 +46195,12 @@
 	},
 /turf/closed/wall/r_wall/ship,
 /area/ai_monitored/turret_protected/ai_upload)
+"rdd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/template_noop,
+/area/maintenance/department/bridge)
 "rds" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -45961,6 +46261,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
+"rfV" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "rfX" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "8"
@@ -45983,11 +46294,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"rgj" = (
-/obj/structure/window/reinforced/fulltile/ship,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/science/mixing/chamber)
 "rgk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -46062,13 +46368,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"riS" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/open/floor/plasteel/dark,
-/area/science/storage)
 "rji" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -46136,30 +46435,19 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/entry)
-"rlF" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor/eastleft{
-	name = "Security Desk";
-	req_one_access_txt = "63"
+"rmj" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/machinery/door/airlock/ship{
+	name = "Kitchen coldroom";
+	req_one_access_txt = "35;28"
 	},
-/obj/machinery/button/door{
-	id = "pw_fd_outer";
-	name = "Exterior Door Control";
-	normaldoorcontrol = 1;
-	pixel_x = 8;
-	pixel_y = 24;
-	req_one_access_txt = "63"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/button/door{
-	id = "pw_fd_inner";
-	name = "Interior Door Control";
-	normaldoorcontrol = 1;
-	pixel_x = -8;
-	pixel_y = 24;
-	req_one_access_txt = "63"
-	},
-/turf/open/floor/plating,
-/area/security/prison)
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plasteel/cafeteria,
+/area/hallway/secondary/service)
 "rml" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -46174,20 +46462,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"rmy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/ship/command{
-	name = "Captain's Quarters";
-	req_one_access_txt = "20"
-	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/carpet/ship,
-/area/crew_quarters/heads/captain/private)
 "rmD" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/ship/techfloor/alt,
@@ -46225,6 +46499,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
+"roq" = (
+/obj/machinery/door/airlock/ship/hatch{
+	name = "Air Control Left";
+	req_one_access_txt = "19;69"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plasteel/ship/padded,
+/area/maintenance/starboard/central)
 "roR" = (
 /obj/effect/turf_decal/box/red/corners{
 	dir = 4
@@ -46244,6 +46527,16 @@
 /obj/structure/shuttle/engine/heater,
 /turf/closed/wall/ship,
 /area/maintenance/department/electrical)
+"rpX" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/security/prison)
 "rqN" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -46286,6 +46579,30 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
+"rsf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
+"rsq" = (
+/obj/structure/sign/directions/medical{
+	dir = 8;
+	pixel_y = -8
+	},
+/obj/structure/sign/directions/science{
+	dir = 8
+	},
+/turf/closed/wall/r_wall/ship,
+/area/ai_monitored/security/armory/lockup)
 "rsz" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -46361,6 +46678,21 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/exit)
+"rue" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/airlock/virology{
+	name = "Break Room";
+	req_one_access_txt = "39"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "rui" = (
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -46404,19 +46736,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"rwl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/door/airlock/virology{
-	name = "Break Room";
-	req_one_access_txt = "39"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "rwp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -46523,6 +46842,13 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/quartermaster/storage)
+"rzJ" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "rAf" = (
 /obj/structure/table/wood/poker,
 /obj/item/taperecorder/empty,
@@ -46581,6 +46907,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"rCZ" = (
+/obj/structure/sign/directions/evac{
+	dir = 8
+	},
+/obj/structure/sign/directions/engineering{
+	dir = 8;
+	pixel_y = -8
+	},
+/turf/closed/wall/ship,
+/area/maintenance/department/crew_quarters/dorms)
 "rDm" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
@@ -46616,13 +46952,6 @@
 /obj/structure/closet/secure_closet/fighter_pilot,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/hanger)
-"rFi" = (
-/obj/machinery/door/airlock/ship/hatch{
-	name = "Support Vessel Aft";
-	req_one_access_txt = "16;65"
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/ai_monitored/turret_protected/aisat/hallway/support_ship/aft)
 "rFw" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -46667,14 +46996,6 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
-"rHU" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/window,
-/obj/machinery/atmospherics/pipe/simple/brown/hidden{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/engine/engine_room)
 "rIu" = (
 /obj/effect/turf_decal/delivery/white,
 /obj/structure/reagent_dispensers/fueltank,
@@ -46709,6 +47030,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/lockup)
+"rJV" = (
+/obj/machinery/advanced_airlock_controller/directional/west{
+	pixel_y = 24
+	},
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "rKc" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /obj/machinery/firealarm{
@@ -46840,6 +47167,26 @@
 /obj/effect/landmark/start/munitions_tech,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/weapons/fore)
+"rPH" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/door/airlock/ship/security/glass{
+	name = "Long-Term Confinement";
+	req_one_access_txt = "2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/security/prison)
 "rPQ" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/drinkingglasses,
@@ -46872,6 +47219,23 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"rRV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Hangar Bay"
+	},
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "hang_storage"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/fore)
 "rSo" = (
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
@@ -46899,6 +47263,10 @@
 /obj/machinery/camera/motion,
 /turf/open/floor/plasteel/ship,
 /area/ai_monitored/turret_protected/ai)
+"rUq" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/nsv/weapons/fore)
 "rVd" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -47062,12 +47430,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"saF" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/bridge)
 "saW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/effect/landmark/start/medical_doctor,
@@ -47212,13 +47574,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"sie" = (
-/obj/structure/window,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "sim" = (
 /obj/machinery/door/airlock/vault/ship{
 	req_access_txt = "53"
@@ -47238,17 +47593,6 @@
 /obj/machinery/reagentgrinder,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"sjG" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/ship/security/glass{
-	id_tag = "pw_fd_outer";
-	name = "Brig";
-	req_one_access_txt = "63"
-	},
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/security/prison)
 "sll" = (
 /obj/machinery/porta_turret/ai,
 /obj/effect/turf_decal/stripes/box,
@@ -47376,14 +47720,6 @@
 "spY" = (
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/department/chapel)
-"sqe" = (
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer1{
-	dir = 8
-	},
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/engine/atmos)
 "sqF" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/airalarm/directional/west,
@@ -47471,6 +47807,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"svH" = (
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Long-Term Confinement"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "cell3_ld";
+	name = "Cell 3 Lockdown"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/security/prison)
 "svT" = (
 /obj/machinery/light{
 	dir = 4
@@ -47490,6 +47841,12 @@
 /obj/item/gun/ballistic/automatic/wt550,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/security)
+"swu" = (
+/obj/item/clothing/mask/gas,
+/obj/item/tank/internals/oxygen/yellow,
+/obj/structure/closet/radiation,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "swO" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/ship/public/glass{
@@ -47565,6 +47922,13 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/ship,
+/area/hallway/primary/fore)
+"syI" = (
+/obj/structure/sign/poster/official/obey{
+	pixel_x = -32
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
 "syY" = (
 /obj/structure/table/glass,
@@ -47657,12 +48021,30 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/exit)
+"sDV" = (
+/obj/machinery/door/airlock/ship/public{
+	id_tag = "cabin2";
+	name = "Cabin 2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/ship,
+/area/crew_quarters/dorms)
 "sEM" = (
 /obj/machinery/computer/operating{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"sFA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
 "sFF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -47707,6 +48089,10 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
+"sHD" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/crew_quarters/bar/atrium)
 "sIx" = (
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/construction)
@@ -47754,20 +48140,6 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
-"sJb" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/requests_console{
-	department = "Security";
-	departmentType = 7;
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/security/prison)
 "sJZ" = (
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/ship,
@@ -47776,21 +48148,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/ship/riveted,
 /area/maintenance/department/medical/morgue)
-"sLb" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 3
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "Serving Hatch"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "sLp" = (
 /obj/machinery/button/door{
 	id = "fab_window";
@@ -47841,6 +48198,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
+"sNR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/door/airlock/ship/public{
+	name = "Quiet Room"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/wood,
+/area/library/lounge)
 "sOb" = (
 /obj/machinery/igniter/incinerator_atmos,
 /turf/open/floor/engine/vacuum,
@@ -47922,6 +48292,9 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
+"sSo" = (
+/turf/template_noop,
+/area/maintenance/department/electrical)
 "sSp" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -47980,25 +48353,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"sUc" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/door/airlock/ship/security/glass{
-	name = "Long-Term Confinement";
-	req_one_access_txt = "2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/security/prison)
 "sUf" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel/ship/techfloor/alt,
@@ -48022,19 +48376,65 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/central)
+"sUA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/ship/command{
+	name = "Captain's Quarters";
+	req_one_access_txt = "20"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/heads/captain/private)
+"sUC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel/ship,
+/area/security/main)
+"sUN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/ship/command/glass{
+	name = "Chief Medical Officer";
+	req_one_access_txt = "40"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/cmo)
 "sVv" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/aft)
-"sWe" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+"sWa" = (
+/obj/structure/sign/directions/security{
+	pixel_y = 28
 	},
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/fore)
 "sWy" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -48063,6 +48463,31 @@
 /obj/machinery/status_display/ai/east,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/ai_monitored/turret_protected/aisat/hallway/support_ship)
+"sYh" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/door/airlock/ship/security/glass{
+	name = "Long-Term Confinement";
+	req_one_access_txt = "2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/security/prison)
 "sYA" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel/dark,
@@ -48072,11 +48497,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
-/area/engine/engineering)
-"sZu" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
 /area/engine/engineering)
 "sZR" = (
 /obj/effect/turf_decal/stripes/white/line{
@@ -48219,6 +48639,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"tda" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor/eastright{
+	name = "Security Desk";
+	req_one_access_txt = "63"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plating,
+/area/security/prison)
 "tdm" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -48386,6 +48816,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"tja" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/fore)
 "tju" = (
 /obj/item/stack/cable_coil,
 /turf/open/floor/plasteel/dark,
@@ -48602,6 +49042,12 @@
 /obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"ttR" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 8
+	},
+/turf/template_noop,
+/area/maintenance/port/central)
 "tuy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -48672,19 +49118,6 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/security/prison)
-"twS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "txc" = (
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -48734,6 +49167,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
+"tyZ" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "tzN" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -48819,11 +49258,6 @@
 	dir = 8
 	},
 /area/chapel/main)
-"tEP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plasteel/ship,
-/area/crew_quarters/dorms)
 "tEW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/cable{
@@ -48915,11 +49349,6 @@
 	},
 /turf/open/floor/plating,
 /area/hydroponics)
-"tIL" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/engine/engineering/hangar)
 "tJN" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -49140,6 +49569,18 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/port)
+"tSb" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/monotile/light,
+/area/science/storage)
 "tSc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/disposalpipe/junction{
@@ -49182,14 +49623,20 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
+"tSs" = (
+/obj/machinery/light/floor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/engine/engineering/hangar)
 "tSv" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/central)
-"tSD" = (
-/obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/nsv/hanger)
 "tSF" = (
 /obj/machinery/light,
 /obj/structure/table,
@@ -49221,6 +49668,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"tUu" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "tUx" = (
 /obj/structure/grille,
 /obj/structure/cable{
@@ -49255,6 +49706,22 @@
 /obj/effect/turf_decal/delivery/white,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"tVW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/port)
 "tWm" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Medbay Lobby";
@@ -49264,6 +49731,28 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"tWG" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 5
+	},
+/turf/template_noop,
+/area/maintenance/department/electrical)
+"tXl" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
+/turf/template_noop,
+/area/maintenance/department/electrical)
 "tXm" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -49379,6 +49868,10 @@
 /obj/item/clothing/head/helmet/alt,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/security)
+"uaR" = (
+/obj/effect/spawner/room/fivexfour,
+/turf/template_noop,
+/area/maintenance/port/central)
 "ubJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/cable{
@@ -49440,6 +49933,10 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/central)
+"ueA" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/bridge)
 "ufj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -49453,6 +49950,16 @@
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"ufp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/effect/landmark/start/scientist,
+/turf/open/floor/monotile/light,
+/area/science/storage)
 "ufF" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
 	dir = 4
@@ -49559,6 +50066,12 @@
 /obj/structure/chair,
 /turf/open/floor/plasteel/ship/riveted,
 /area/maintenance/department/medical/morgue)
+"umo" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "umK" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -49616,6 +50129,20 @@
 /obj/effect/spawner/lootdrop/maintenance/seven,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"uni" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/ship/command{
+	name = "Gravity Generator";
+	req_one_access_txt = "56"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/engine/gravity_generator)
 "unu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -49674,6 +50201,24 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hop)
+"uop" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/hatch{
+	name = "Support Vessel Aft";
+	req_one_access_txt = "16;65"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/ai_monitored/turret_protected/aisat/hallway/support_ship/aft)
 "uoB" = (
 /obj/machinery/iv_drip,
 /obj/item/radio/intercom{
@@ -49688,6 +50233,11 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
+"upv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "upJ" = (
 /turf/closed/wall/r_wall/ship,
 /area/security/warden)
@@ -49832,6 +50382,15 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"uwF" = (
+/obj/machinery/door/airlock/ship/public{
+	id_tag = "cabin4";
+	name = "Cabin 4"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/ship,
+/area/crew_quarters/dorms)
 "uwN" = (
 /obj/machinery/door/window{
 	dir = 8;
@@ -49883,22 +50442,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
-"uyq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/door/airlock/ship/hatch{
-	name = "Support Vessel Aft";
-	req_one_access_txt = "16;65"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/ai_monitored/turret_protected/aisat/hallway/support_ship/aft)
 "uyy" = (
 /obj/machinery/light/built{
 	dir = 8
@@ -49943,11 +50486,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"uAy" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "uAz" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -50028,6 +50566,10 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/quartermaster/storage)
+"uCy" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/library/lounge)
 "uCF" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -50047,19 +50589,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/toilet/restrooms)
-"uDi" = (
-/obj/machinery/door/airlock/ship/security/glass{
-	id_tag = "pw_fd_inner";
-	name = "Brig";
-	req_one_access_txt = "63"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/security/prison)
 "uEh" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -50123,6 +50652,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/storage)
+"uFL" = (
+/obj/structure/sign/directions/security{
+	dir = 4
+	},
+/obj/structure/sign/directions/command{
+	dir = 4;
+	pixel_y = -8
+	},
+/turf/closed/wall/ship,
+/area/hallway/secondary/service)
 "uFV" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -50209,28 +50748,6 @@
 /obj/structure/closet/secure_closet/master_at_arms,
 /turf/open/floor/carpet/ship,
 /area/nsv/crew_quarters/heads/maa)
-"uIO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 4;
-	id = "aicore_entrance";
-	name = "AI Core Entrance Shutters"
-	},
-/obj/machinery/door/airlock/ship/hatch{
-	name = "Intelligence Core";
-	req_one_access_txt = "16"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/ship,
-/area/ai_monitored/turret_protected/ai)
 "uJA" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
@@ -50410,6 +50927,25 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"uQq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/security/prison)
 "uQr" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -50426,6 +50962,15 @@
 /obj/item/stack/ducts/fifty,
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
+"uQv" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "ce_window";
+	name = "privacy shutter"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/chief)
 "uQA" = (
 /obj/effect/spawner/xmastree,
 /turf/open/floor/plasteel/ship,
@@ -50447,12 +50992,38 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
+"uSn" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
+"uSJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 1
+	},
+/turf/template_noop,
+/area/maintenance/port/central)
 "uST" = (
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"uSV" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "uTA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -50497,6 +51068,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"uYI" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/snacks/pie/cream,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "Serving Hatch"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "uYX" = (
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
@@ -50564,6 +51146,21 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
+"vbc" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/door/airlock/ship/command/glass{
+	name = "War room";
+	req_one_access_txt = "19"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/carpet/ship,
+/area/bridge/meeting_room)
 "vcn" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/machinery/button/door{
@@ -50595,15 +51192,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"vcW" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 4
-	},
-/obj/structure/sign/poster/official/obey{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
 "vdW" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -50619,15 +51207,17 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
-"veg" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+"veE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
-/obj/machinery/door/window{
-	req_one_access_txt = "11"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/construction)
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "veF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -50643,6 +51233,24 @@
 "vfy" = (
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"vfC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/hatch{
+	name = "Support Vessel Fore";
+	req_one_access_txt = "61;65"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/ai_monitored/turret_protected/aisat/hallway/support_ship)
 "vfV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -50652,6 +51260,24 @@
 	},
 /turf/open/floor/plating,
 /area/nsv/hanger)
+"vfW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Auxiliary Surgery";
+	req_one_access_txt = "45"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/white,
+/area/medical/surgery/aux)
 "vgq" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Command Hallway"
@@ -50666,6 +51292,17 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
+"vgw" = (
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "vgJ" = (
 /obj/structure/grille,
 /obj/structure/cable{
@@ -50786,17 +51423,6 @@
 /obj/item/stack/sheet/duranium/fifty,
 /turf/open/floor/plasteel,
 /area/engine/storage)
-"viM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/ship/security/glass{
-	name = "Hangar Bay";
-	req_one_access_txt = "69"
-	},
-/turf/open/floor/plasteel/dark,
-/area/nsv/hanger)
 "viO" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -50991,6 +51617,27 @@
 /obj/machinery/vending/engivend,
 /turf/open/floor/plasteel,
 /area/engine/storage)
+"vvw" = (
+/obj/machinery/door/window{
+	dir = 4;
+	name = "Mass Driver";
+	req_access_txt = "22"
+	},
+/obj/machinery/button/massdriver{
+	id = "chapelgun";
+	name = "Chapel Mass Driver";
+	pixel_x = -4;
+	pixel_y = -26
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
+"vvM" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/template_noop,
+/area/maintenance/department/electrical)
 "vvO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -51010,17 +51657,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"vvT" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plating,
-/area/maintenance/department/bridge)
 "vwk" = (
 /obj/structure/table/wood,
 /obj/item/paicard,
@@ -51070,6 +51706,10 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"vyb" = (
+/obj/effect/landmark/blobstart,
+/turf/template_noop,
+/area/maintenance/port/central)
 "vyU" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -28
@@ -51091,19 +51731,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"vzs" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/monotile/light,
+/area/science/storage)
 "vzz" = (
 /obj/machinery/door/airlock/ship/external{
 	req_one_access_txt = "13"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
-"vzL" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
@@ -51195,6 +51834,19 @@
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/service)
+"vCa" = (
+/obj/item/storage/box/lights/mixed,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "vCL" = (
 /obj/machinery/shieldwallgen/xenobiologyaccess,
 /obj/machinery/door/poddoor/preopen{
@@ -51206,6 +51858,10 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"vCO" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/plasteel/ship,
+/area/hallway/secondary/entry)
 "vDx" = (
 /obj/machinery/light{
 	dir = 1
@@ -51241,11 +51897,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"vFH" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/engine/atmos)
 "vFN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -51305,21 +51956,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
-"vIY" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "69"
+"vHT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
-"vJk" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
 /obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/plating,
-/area/maintenance/department/medical/morgue)
+/turf/open/floor/plasteel/ship,
+/area/crew_quarters/dorms)
 "vJy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -51336,6 +51982,18 @@
 /obj/item/gun/energy/ionrifle,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/security)
+"vJM" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/security/glass{
+	name = "Hangar Bay";
+	req_one_access_txt = "69"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/dark,
+/area/nsv/hanger)
 "vKa" = (
 /obj/structure/table,
 /obj/item/stamp/ce,
@@ -51428,6 +52086,33 @@
 	},
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
+"vNR" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship,
+/area/hallway/primary/fore)
+"vNT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/door/airlock/ship/hatch{
+	name = "Air Control Left";
+	req_one_access_txt = "19;69"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plasteel/ship/padded,
+/area/maintenance/starboard/central)
 "vOa" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
@@ -51439,24 +52124,11 @@
 	},
 /turf/open/floor/plating,
 /area/storage/primary)
-"vOF" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/security/main)
 "vPg" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/carpet/black,
 /area/science/research)
-"vPp" = (
-/obj/machinery/door/airlock/ship/security/glass{
-	name = "Riot Armory";
-	req_one_access_txt = "3"
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plasteel/ship,
-/area/ai_monitored/security/armory/security)
 "vPx" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel/white,
@@ -51480,12 +52152,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
-"vPY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/engine/atmos)
 "vQn" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -51588,6 +52254,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/service)
+"vRZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "vSR" = (
 /obj/machinery/button/massdriver{
 	id = "toxgun";
@@ -51602,19 +52274,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"vTi" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "ce_window";
-	name = "privacy shutter"
-	},
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/chief)
 "vTm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -51629,18 +52288,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/fore)
-"vTo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/door/airlock/ship/hatch{
-	name = "Network Administration";
-	req_one_access_txt = "61;65"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/ship,
-/area/tcommsat/computer)
 "vTt" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -51679,6 +52326,16 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
+"vTY" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/security/prison)
 "vUO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -51751,6 +52408,10 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"vYM" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/security/prison)
 "vYP" = (
 /obj/structure/railing,
 /turf/open/floor/plasteel,
@@ -51841,6 +52502,15 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/maintenance/starboard/central)
+"wbr" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/ship/external{
+	req_one_access_txt = "24;32"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "wbx" = (
 /obj/effect/landmark/blobstart,
 /obj/effect/decal/cleanable/cobweb,
@@ -51870,6 +52540,25 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"wdl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/security/prison)
 "wds" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -51990,6 +52679,13 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/construction)
+"wgv" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold/visible,
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "wgI" = (
 /obj/machinery/atmospherics/pipe/manifold/brown/visible{
 	dir = 8
@@ -52017,15 +52713,6 @@
 /obj/item/ship_weapon/ammunition/railgun_ammo,
 /turf/open/floor/plasteel/ship,
 /area/nsv/weapons/fore)
-"wiy" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	dir = 4;
-	id = "maashutter"
-	},
-/turf/open/floor/plating,
-/area/nsv/crew_quarters/heads/maa)
 "wiH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -52445,6 +53132,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"wzn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/fore)
 "wzp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -52454,6 +53150,11 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/exit)
+"wzG" = (
+/obj/structure/table,
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "wzY" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -52512,6 +53213,18 @@
 /obj/machinery/atmospherics/components/binary/pump,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"wDc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
+"wDk" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "wDs" = (
 /obj/machinery/light,
 /obj/structure/reagent_dispensers/fueltank,
@@ -52586,6 +53299,15 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/maintenance/department/crew_quarters/dorms)
+"wGH" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/template_noop,
+/area/maintenance/department/electrical)
 "wHc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/curtain/obscuring/grey,
@@ -52624,6 +53346,11 @@
 /obj/structure/table,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"wIn" = (
+/obj/structure/lattice,
+/obj/structure/filingcabinet,
+/turf/open/space/basic,
+/area/space/nearstation)
 "wJb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -52706,6 +53433,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"wNQ" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/space/basic,
+/area/crew_quarters/heads/captain)
 "wOo" = (
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -52771,6 +53502,10 @@
 	},
 /turf/open/floor/plating,
 /area/security/warden)
+"wRM" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/engine/gravity_generator)
 "wSj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -52810,6 +53545,11 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"wUS" = (
+/obj/structure/girder,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "wVa" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -52997,6 +53737,27 @@
 "xcC" = (
 /turf/closed/wall/r_wall/ship,
 /area/nsv/crew_quarters/heads/maa)
+"xdd" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/ship,
+/area/hallway/primary/fore)
+"xdL" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/status_display/evac/south,
+/turf/open/floor/plasteel/ship,
+/area/hallway/primary/fore)
 "xdN" = (
 /obj/structure/table/wood,
 /obj/item/taperecorder{
@@ -53105,13 +53866,6 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"xhL" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/storage)
 "xhO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -53157,6 +53911,28 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"xkz" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/library)
+"xkD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Patient Room C";
+	req_one_access_txt = "5"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/white,
+/area/medical/patients_rooms/room_c)
 "xkE" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_y = -30
@@ -53175,25 +53951,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"xlN" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/suit_storage_unit/pilot,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/nsv/hanger)
-"xmq" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plating,
-/area/maintenance/department/medical/morgue)
 "xmu" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -53284,23 +54041,15 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/security/prison)
-"xoq" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/ship,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/maintenance/department/chapel)
-"xov" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/structure/cable{
-	icon_state = "1-8"
+"xpg" = (
+/obj/machinery/door/airlock/virology/glass{
+	name = "Isolation B";
+	req_one_access_txt = "39"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/ship,
-/area/engine/engineering/hangar)
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "xpi" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/plasteel/ship,
@@ -53366,6 +54115,18 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"xrg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/template_noop,
+/area/maintenance/department/electrical)
 "xrE" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
@@ -53464,11 +54225,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"xux" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/hallway/secondary/exit/departure_lounge)
 "xuE" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 6
@@ -53558,6 +54314,18 @@
 	},
 /turf/open/floor/plating/airless,
 /area/ai_monitored/turret_protected/ai_upload)
+"xyL" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 5
+	},
+/turf/template_noop,
+/area/maintenance/department/electrical)
 "xzi" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light/runway/delay3,
@@ -53567,6 +54335,11 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
+"xzA" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "xzD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/light{
@@ -53576,6 +54349,12 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"xAb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plasteel/ship,
+/area/crew_quarters/dorms)
 "xAP" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -53586,6 +54365,20 @@
 /obj/machinery/recharge_station,
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
+"xBr" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/atmospherics_engine)
+"xBz" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "xBT" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -53642,6 +54435,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/security)
+"xDS" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "xEj" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -53739,13 +54536,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/quartermaster/storage)
-"xGE" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory/lockup)
 "xGJ" = (
 /obj/machinery/light,
 /obj/machinery/requests_console{
@@ -53773,6 +54563,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
+"xHC" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "fab_window";
+	name = "privacy shutter"
+	},
+/turf/open/floor/plating,
+/area/science/mixing)
 "xHO" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -53793,18 +54591,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
-"xIc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Brig-1";
-	location = "Brig-0"
-	},
-/turf/open/floor/plasteel/ship,
-/area/hallway/primary/fore)
 "xIM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -53918,6 +54704,20 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/hanger)
+"xNd" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/ship/security{
+	name = "Private Investigator's Office";
+	req_one_access_txt = "4"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plasteel,
+/area/security/detectives_office/private_investigators_office)
 "xND" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -53942,27 +54742,6 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"xNJ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/ship,
-/area/hallway/primary/fore)
 "xOb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53997,19 +54776,19 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"xQw" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=JaniCloset";
-	location = "HOP-Corner"
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
 "xQR" = (
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/ai_monitored/turret_protected/aisat/service/support_ship)
+"xQT" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -24
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/fore)
 "xRr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -54046,14 +54825,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/nsv/hanger)
-"xRN" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/storage)
 "xRZ" = (
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel/ship,
@@ -54064,11 +54835,6 @@
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/plasteel,
 /area/science/lab)
-"xSw" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/captain/private)
 "xSz" = (
 /obj/machinery/light{
 	dir = 8
@@ -54145,6 +54911,14 @@
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
+"xUn" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "xUx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -54187,11 +54961,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"xVu" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/firedoor/window,
+"xVE" = (
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/storage/tech)
+/area/chapel/office)
 "xVF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54216,6 +54989,15 @@
 	},
 /turf/open/floor/plating,
 /area/nsv/weapons/fore)
+"xWL" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
 "xWU" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -54292,6 +55074,11 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
+"xYH" = (
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "xYO" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
 /obj/effect/turf_decal/tile/yellow,
@@ -54466,6 +55253,12 @@
 /obj/item/paper_bin,
 /turf/open/floor/wood,
 /area/library/lounge)
+"yek" = (
+/obj/machinery/light/floor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "yeI" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
 /turf/open/floor/plating,
@@ -54546,6 +55339,11 @@
 /obj/structure/closet/secure_closet/munitions_technician,
 /turf/open/floor/plasteel/ship,
 /area/nsv/weapons/fore)
+"ygE" = (
+/obj/structure/table,
+/obj/item/disk/holodisk/hammerhead_cryo,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "ygR" = (
 /obj/structure/grille,
 /obj/structure/cable{
@@ -54556,6 +55354,22 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload)
+"yhc" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "Serving Hatch"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "yhA" = (
 /obj/structure/grille,
 /obj/structure/cable,
@@ -54603,6 +55417,18 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/plasteel/ship,
 /area/lawoffice)
+"yiC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/monotile/light,
+/area/science/storage)
 "yiU" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -54620,6 +55446,14 @@
 /obj/effect/spawner/structure/window/reinforced/ship,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"yjY" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "maashutter"
+	},
+/turf/open/floor/plating,
+/area/nsv/crew_quarters/heads/maa)
 "ykj" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "disposal_waste_eject"
@@ -54633,6 +55467,20 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/security/warden)
+"ykC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/door/airlock/ship/hatch{
+	name = "Network Administration";
+	req_one_access_txt = "61;65"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plasteel/ship,
+/area/tcommsat/computer)
 "ykO" = (
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -60224,7 +61072,7 @@ bgf
 aDf
 aRH
 aDf
-sqe
+ovy
 aDf
 aRH
 aDf
@@ -61231,7 +62079,7 @@ aEX
 asC
 fkN
 fkN
-xVu
+cPr
 kwH
 luQ
 nkV
@@ -61488,7 +62336,7 @@ aEX
 asC
 fkN
 fkN
-xVu
+cPr
 ldu
 aoa
 oms
@@ -61504,7 +62352,7 @@ vrW
 kkP
 kkP
 agJ
-vFH
+aiP
 bdl
 bdm
 bce
@@ -61535,7 +62383,7 @@ diq
 ako
 aBc
 aKU
-fBK
+hQD
 fkN
 aBl
 fkN
@@ -61747,18 +62595,18 @@ asC
 asC
 asC
 asC
-lvG
+raS
 asC
 aWl
 fkN
 fkN
 aPK
 aPK
-grF
-grF
+xBr
+xBr
 aPK
-grF
-grF
+xBr
+xBr
 aPK
 eEb
 aDf
@@ -61792,7 +62640,7 @@ xGt
 xGt
 nAm
 ask
-fBK
+hQD
 aar
 aBl
 fkN
@@ -62049,7 +62897,7 @@ aTL
 aTL
 ooU
 ymj
-fBK
+hQD
 fkN
 aBl
 fkN
@@ -62523,7 +63371,7 @@ qAn
 aWl
 aar
 aux
-fBK
+hQD
 aps
 aoT
 alk
@@ -62563,7 +63411,7 @@ fVK
 aHj
 bBg
 ymj
-fBK
+hQD
 fkN
 aBl
 fkN
@@ -62780,7 +63628,7 @@ aSY
 aWl
 fkN
 aar
-fBK
+hQD
 gEV
 aoT
 aoT
@@ -62789,7 +63637,7 @@ akF
 aoT
 aoT
 aoT
-vFH
+aiP
 aoT
 avX
 aGC
@@ -62820,7 +63668,7 @@ aqi
 nTi
 uZj
 ymj
-fBK
+hQD
 aar
 aBl
 fkN
@@ -63037,7 +63885,7 @@ ank
 aWl
 fkN
 fkN
-fBK
+hQD
 qcm
 aoT
 aoT
@@ -63046,7 +63894,7 @@ aUz
 aoT
 aoT
 aWp
-vFH
+aiP
 aoT
 aAH
 sbV
@@ -63077,7 +63925,7 @@ fVK
 cOm
 amu
 ymj
-fBK
+hQD
 fkN
 aBl
 fkN
@@ -63550,7 +64398,7 @@ aEG
 aTz
 aWl
 fkN
-fBK
+hQD
 ahr
 ahr
 ahr
@@ -63560,7 +64408,7 @@ aoT
 aoT
 aoT
 azP
-vFH
+aiP
 aoT
 aAH
 sbV
@@ -63807,7 +64655,7 @@ aEG
 aLs
 aWl
 fkN
-fBK
+hQD
 aoT
 aoT
 aoT
@@ -63817,7 +64665,7 @@ aoT
 eRN
 dkf
 esI
-vPY
+xzA
 dkf
 aiK
 xFt
@@ -63848,7 +64696,7 @@ tFt
 bmO
 uZj
 ymj
-fBK
+hQD
 aar
 aBl
 fkN
@@ -64064,7 +64912,7 @@ aEG
 aOo
 aWl
 fkN
-fBK
+hQD
 ahr
 ahr
 ahr
@@ -64105,7 +64953,7 @@ aUl
 tUJ
 amu
 ymj
-fBK
+hQD
 fkN
 aBl
 fkN
@@ -64156,9 +65004,9 @@ agh
 agh
 agh
 agh
-aSw
-aTs
-aSw
+lrs
+fyk
+lrs
 agh
 agh
 agh
@@ -64330,7 +65178,7 @@ aDf
 awC
 aiP
 aiP
-ajO
+iZQ
 aDf
 aDf
 qhT
@@ -64362,7 +65210,7 @@ apc
 apn
 amu
 ymj
-fBK
+hQD
 fkN
 aBl
 fkN
@@ -64876,7 +65724,7 @@ tFt
 okv
 pLc
 ymj
-fBK
+hQD
 fkN
 aHu
 aGt
@@ -65133,15 +65981,15 @@ aGf
 afM
 aCe
 ymj
-fBK
+hQD
 fkN
-cNp
+wRM
 aGt
 aBH
 avM
 aBw
 aGt
-cNp
+wRM
 fkN
 fkN
 bkD
@@ -65190,7 +66038,7 @@ aYD
 aYD
 aYD
 aYD
-mer
+qtr
 aYD
 aYD
 fTe
@@ -65390,15 +66238,15 @@ akk
 aMJ
 aLv
 akf
-fBK
+hQD
 aar
-cNp
+wRM
 aGt
 avM
 pcv
 akt
 aGt
-cNp
+wRM
 fkN
 fkN
 bkD
@@ -65649,13 +66497,13 @@ aRU
 eNw
 aYi
 bdq
-cNp
+wRM
 aGt
 aOL
 avM
 azu
 aGt
-cNp
+wRM
 fkN
 fkN
 bkD
@@ -65695,7 +66543,7 @@ aPA
 aEy
 ajc
 aiE
-pFf
+gGZ
 aId
 rWQ
 uqe
@@ -66165,7 +67013,7 @@ aYi
 bds
 aHu
 aHu
-aVw
+bxg
 aHu
 aHu
 aHu
@@ -66206,9 +67054,9 @@ fkN
 aar
 bkX
 aPA
-rFi
+qEz
 aPA
-uyq
+uop
 aYD
 aYD
 apb
@@ -66403,7 +67251,7 @@ aKD
 bco
 xAP
 bcu
-lWu
+bwO
 geE
 rsX
 aEh
@@ -66660,13 +67508,13 @@ aMj
 aMj
 aMj
 bcv
-lWu
+bwO
 idC
 gWx
 gWx
 hlo
 mzw
-tIL
+fhl
 alH
 aXx
 azR
@@ -66674,10 +67522,10 @@ aHR
 aHR
 aOl
 aHR
-xov
+kGo
 bdn
 bdu
-alY
+uni
 axs
 aRj
 aXa
@@ -66917,13 +67765,13 @@ aMj
 bcp
 aMj
 bcv
-lWu
+bwO
 mzw
 gWx
 nBK
 hlo
 mzw
-tIL
+fhl
 alH
 avA
 aJT
@@ -66931,7 +67779,7 @@ azJ
 agO
 amM
 agO
-agO
+onC
 bdo
 bef
 aHu
@@ -67174,7 +68022,7 @@ aSu
 bcq
 aSu
 bcw
-jkN
+qAG
 rNF
 aBt
 qTl
@@ -67188,15 +68036,15 @@ aCH
 awN
 amM
 aJo
-aYg
+guj
 bdp
-beg
-bbx
+tUu
+mcx
 aYg
-bbE
+qHp
 bbF
 aYg
-bbD
+wbr
 aux
 aux
 aux
@@ -67431,13 +68279,13 @@ bcm
 bcr
 bcs
 bcx
-lWu
+bwO
 ibY
 gWx
 gAB
 hlo
 mzw
-tIL
+fhl
 xZy
 tKN
 aTR
@@ -67445,15 +68293,15 @@ ajI
 aoX
 amM
 aJo
-aYg
-aYg
-aYg
-bbx
-bbz
-bbE
-bbE
-bbz
-bbD
+vRZ
+eHb
+blB
+kAv
+lpu
+umo
+lyS
+wgv
+wbr
 aux
 aux
 aux
@@ -67688,13 +68536,13 @@ aMj
 aMj
 bcs
 bcz
-lWu
+bwO
 ibY
 gWx
 gWx
 hlo
 mzw
-tIL
+fhl
 alH
 uWV
 aKt
@@ -67704,7 +68552,7 @@ rPV
 agO
 agO
 agO
-pmm
+tSs
 arQ
 arQ
 arQ
@@ -67961,13 +68809,13 @@ amM
 aJo
 aYg
 aYg
-aYg
-bbx
+brV
+mcx
 bbB
-aYg
+rJV
 aYg
 bbC
-bbD
+wbr
 aux
 aux
 aux
@@ -68210,7 +69058,7 @@ gWx
 mVm
 qNb
 alH
-uWV
+flp
 aUM
 ajI
 aoX
@@ -68218,13 +69066,13 @@ amM
 aJo
 aYg
 aYg
+brV
+mcx
 aYg
-bbx
-aYg
-bbE
-bbE
-aYg
-bbD
+kVQ
+lyS
+eMq
+wbr
 aux
 aux
 aux
@@ -68455,10 +69303,10 @@ aeJ
 ajk
 ahj
 ajk
-sZu
-sZu
-sZu
-sZu
+jVd
+jVd
+jVd
+jVd
 ajk
 atG
 atG
@@ -68475,13 +69323,13 @@ rPV
 agO
 agO
 agO
-pmm
-bbx
-cNX
-bbE
-bbE
-aYg
-bbD
+lJI
+kAv
+yek
+jpe
+lyS
+eMq
+wbr
 aar
 aar
 aar
@@ -68675,11 +69523,11 @@ adk
 aXH
 abq
 awB
-jNA
-ptk
-aGb
-xRN
-ipV
+nQt
+buO
+pKb
+fES
+nwm
 uPW
 gxb
 pEK
@@ -68717,7 +69565,7 @@ jsQ
 jsQ
 jsQ
 axa
-hGy
+tpl
 lwd
 hHo
 hHo
@@ -68730,15 +69578,15 @@ kWb
 awN
 amM
 aJo
-qbE
 aYg
 aYg
-bbx
+brV
+mcx
 aYg
-bbE
-bbE
-aYg
-bbD
+xBz
+lyS
+eMq
+wbr
 aux
 aux
 aux
@@ -68788,9 +69636,9 @@ dgQ
 dgQ
 dgQ
 dgQ
-iAg
+vfC
 bfq
-dEx
+ldQ
 oWV
 bkX
 aar
@@ -68932,11 +69780,11 @@ alc
 elf
 iTC
 awB
-lhv
-lhv
-aMA
-ipV
-ipV
+qVf
+hhI
+brg
+fES
+nwm
 uPW
 hjQ
 aPE
@@ -68974,7 +69822,7 @@ anC
 anC
 anC
 alQ
-hGy
+tpl
 dbm
 aEo
 aEo
@@ -68989,13 +69837,13 @@ amM
 aJo
 aYg
 aYg
+brV
+mcx
 aYg
-bbx
-aYg
-aYg
+jML
 aYg
 bbz
-bbD
+wbr
 aux
 aux
 aux
@@ -69189,11 +70037,11 @@ ckE
 awB
 xxX
 awB
-riS
-lhv
-aMA
-ipV
-eqM
+lLD
+jhr
+brg
+tyZ
+hdB
 uPW
 xXO
 aPE
@@ -69231,7 +70079,7 @@ iQe
 iQe
 mms
 aZo
-hGy
+tpl
 dbm
 aEo
 aEo
@@ -69246,7 +70094,7 @@ rPV
 agO
 agO
 agO
-emu
+kEY
 arQ
 arQ
 arQ
@@ -69446,11 +70294,11 @@ wjE
 jxt
 bRg
 amR
-ePS
-avs
-aTA
-aOe
-ePS
+ccS
+fqj
+gMv
+dsF
+ccS
 uPW
 aSj
 agL
@@ -69503,13 +70351,13 @@ amM
 aJo
 aYg
 aYg
-aYg
-bbx
-aYg
-bbE
-bbF
-aYg
-bbD
+iSq
+kAv
+upv
+oFf
+iBR
+eMq
+wbr
 aux
 aux
 aux
@@ -69703,11 +70551,11 @@ nTd
 jxt
 afp
 amR
-ipV
-aPI
-opv
-lhv
-lhv
+nwm
+dNI
+ufp
+nhn
+qVf
 uPW
 aVH
 auL
@@ -69761,12 +70609,12 @@ aJo
 aYg
 ajt
 aYg
-bbx
+mcx
 bbz
 bbE
 bbE
 bbz
-bbD
+wbr
 aux
 aux
 aux
@@ -69960,11 +70808,11 @@ jxt
 jxt
 bRg
 amR
-ovn
-bLb
-aBJ
-lhv
-ezq
+qHW
+wDk
+vzs
+fYQ
+paV
 uPW
 hcG
 auL
@@ -70003,14 +70851,14 @@ air
 aCt
 avV
 atG
-flG
 aTe
-flG
-flG
+aTe
+aTe
+aTe
 atG
-flG
-flG
-flG
+aTe
+aTe
+aTe
 atG
 tpl
 ayo
@@ -70072,7 +70920,7 @@ kIE
 lQi
 sDu
 hfs
-vTo
+ykC
 dhx
 hTE
 xuR
@@ -70217,11 +71065,11 @@ eIz
 eIz
 jAx
 amR
-bLb
-iNK
-iky
-xhL
-aBP
+foD
+cqk
+yiC
+oLF
+gtr
 uPW
 dvN
 amm
@@ -70474,11 +71322,11 @@ uwt
 aJB
 bRg
 amR
-jNA
-abW
-dJu
-aPI
-hIQ
+nQt
+mBn
+tSb
+oKv
+mQE
 uPW
 hUn
 oiF
@@ -70733,7 +71581,7 @@ bRg
 amR
 amR
 amR
-ePu
+irr
 amR
 amR
 uPW
@@ -71031,14 +71879,14 @@ aCt
 aCt
 ahb
 atG
-flG
-flG
 aTe
-flG
 aTe
-flG
-flG
-flG
+aTe
+aTe
+aTe
+aTe
+aTe
+aTe
 atG
 tpl
 aab
@@ -71351,7 +72199,7 @@ aPb
 aPb
 aEe
 aEe
-bkn
+qGO
 aPb
 aPb
 dgQ
@@ -71803,10 +72651,10 @@ jsQ
 wwa
 atG
 jUE
-rHU
-cTY
-cTY
-cTY
+ifD
+pdt
+pdt
+pdt
 nhh
 xHO
 qUo
@@ -71862,7 +72710,7 @@ bkX
 agH
 asS
 aHN
-bkb
+ptw
 bkc
 bke
 bkg
@@ -72019,7 +72867,7 @@ aaZ
 bMR
 aYO
 aYO
-rgj
+jIB
 aYO
 aYO
 apm
@@ -72072,7 +72920,7 @@ wCW
 dvl
 iua
 ckw
-izt
+nKX
 nKX
 nKX
 vFq
@@ -72325,7 +73173,7 @@ qtk
 qtk
 lWc
 kTD
-imB
+lBi
 sZr
 sZr
 aLc
@@ -72381,7 +73229,7 @@ auM
 auM
 auM
 auM
-uIO
+fIA
 auM
 auM
 auM
@@ -72563,10 +73411,10 @@ ajW
 aZN
 vqb
 avT
-pTK
-vTi
+erI
+mYw
 bxo
-bSP
+uQv
 axD
 vYV
 bNZ
@@ -72589,7 +73437,7 @@ anC
 uzn
 anv
 anv
-aqz
+ock
 kcU
 anv
 aJR
@@ -73338,7 +74186,7 @@ agZ
 uxS
 anE
 acX
-bSP
+uQv
 viJ
 auE
 alO
@@ -73572,7 +74420,7 @@ xSj
 aQV
 cnp
 rYW
-cED
+mha
 vFY
 awS
 anR
@@ -73595,7 +74443,7 @@ xso
 aGU
 aXD
 qlK
-bSP
+uQv
 bkp
 auE
 hdT
@@ -73820,7 +74668,7 @@ abZ
 eKt
 aza
 pWh
-lqu
+apm
 hew
 kGA
 aMD
@@ -73829,7 +74677,7 @@ dMa
 aOD
 rKF
 oTg
-cED
+mha
 xhr
 dRV
 bcA
@@ -73852,7 +74700,7 @@ lAM
 mYm
 orF
 vKa
-bSP
+uQv
 cXW
 pjs
 fxt
@@ -73865,14 +74713,14 @@ ajw
 ajw
 ajw
 kBF
-ata
+inv
 akX
 aye
 aye
 aJR
 aJR
 aJR
-gzQ
+dcM
 sIx
 mMR
 qCz
@@ -74077,7 +74925,7 @@ aaZ
 dgl
 rsR
 mft
-lqu
+apm
 but
 nDN
 aug
@@ -74115,7 +74963,7 @@ aam
 aam
 aam
 aam
-mVC
+mvc
 aam
 dSe
 bVr
@@ -74129,7 +74977,7 @@ mCn
 mCn
 mCn
 qNR
-veg
+gOY
 ifm
 iYr
 qCz
@@ -74386,7 +75234,7 @@ aye
 aye
 aye
 aye
-gzQ
+dcM
 sIx
 pYC
 mel
@@ -74591,7 +75439,7 @@ aaZ
 fst
 vPx
 wkZ
-isr
+xHC
 hnz
 acv
 aKC
@@ -74631,19 +75479,19 @@ aqA
 fIp
 jqp
 aho
-aho
-aho
-ata
-inv
-kBF
 tcP
+aho
+sSo
+sSo
+sSo
+fmi
 akX
 wPr
 aJR
 aJR
 aye
 aye
-vYP
+dWI
 sIx
 ntz
 xaC
@@ -74848,7 +75696,7 @@ aaZ
 xxo
 aaZ
 lRh
-isr
+xHC
 heQ
 lVZ
 aKC
@@ -74888,12 +75736,12 @@ kXQ
 aaf
 vHw
 aho
-kBF
-ata
-ata
-ata
-kBF
-feE
+wUS
+aho
+sSo
+sSo
+jMs
+sSo
 akX
 akX
 akX
@@ -75123,17 +75971,17 @@ aEZ
 aPo
 aUC
 aCL
-gJq
-gJq
+abo
+abo
 aaf
-gJq
-gJq
-gJq
-gJq
-gJq
+abo
+abo
+abo
+abo
+abo
 aaf
-gJq
-gJq
+abo
+abo
 aKL
 asE
 ays
@@ -75145,14 +75993,14 @@ mTA
 aaf
 iQX
 aho
-nZg
-ata
-ata
-ata
-ata
-ata
-jNK
-ata
+dSe
+rfV
+vvM
+vvM
+wGH
+sSo
+aho
+aho
 akX
 akX
 akX
@@ -75379,7 +76227,7 @@ aEZ
 aUO
 adc
 asY
-fbm
+sHD
 fkN
 fkN
 fkN
@@ -75391,7 +76239,7 @@ fkN
 fkN
 fkN
 fkN
-gyg
+mTH
 aEd
 kDM
 auK
@@ -75402,18 +76250,18 @@ aaj
 aaf
 vHw
 aho
-mAT
+vHw
 aho
+sSo
+qHN
+tWG
+sSo
 aho
-aho
-aho
-aho
-aho
-ata
-ata
-nZg
-ata
-wqP
+sSo
+sSo
+sSo
+sSo
+lqN
 aho
 bku
 aux
@@ -75628,7 +76476,7 @@ mhv
 aDq
 mhv
 abX
-lGT
+iaw
 aaj
 aIz
 aaj
@@ -75636,7 +76484,7 @@ aEZ
 ojZ
 adc
 asY
-fbm
+sHD
 fkN
 fkN
 fkN
@@ -75648,7 +76496,7 @@ fkN
 fkN
 fkN
 fkN
-gyg
+mTH
 aUB
 afZ
 arD
@@ -75659,18 +76507,18 @@ aaj
 aaf
 vHw
 aho
-ata
+vHw
 aho
-fkN
-fkN
-fkN
-fkN
-aho
-aho
-feE
-aho
-ata
-vqy
+sSo
+sSo
+qrU
+lMm
+uSV
+lMm
+lMm
+xyL
+sSo
+sSo
 rpQ
 aHd
 bkw
@@ -75885,7 +76733,7 @@ pRD
 aTZ
 hAT
 eUW
-lGT
+iaw
 aaj
 aIz
 aaj
@@ -75893,7 +76741,7 @@ aEZ
 pZy
 adc
 asY
-fbm
+sHD
 fkN
 fkN
 fkN
@@ -75905,7 +76753,7 @@ fkN
 fkN
 fkN
 fkN
-gyg
+mTH
 aBh
 azp
 bMn
@@ -75916,18 +76764,18 @@ aaj
 aaf
 vHw
 aho
-feE
+iQX
 aho
-fkN
-fkN
-fkN
-fkN
-fkN
 aho
-ata
+kaI
+kaI
 aho
-ibL
-rSF
+aho
+sSo
+sSo
+pZq
+sSo
+sSo
 rpQ
 aHd
 aHd
@@ -76142,7 +76990,7 @@ bFG
 axG
 mhv
 oHd
-lGT
+iaw
 aaj
 aIz
 aaj
@@ -76150,7 +76998,7 @@ aEZ
 ckT
 adc
 asY
-fbm
+sHD
 fkN
 fkN
 fkN
@@ -76162,7 +77010,7 @@ fkN
 fkN
 fkN
 fkN
-gyg
+mTH
 gkO
 atD
 eBE
@@ -76172,19 +77020,19 @@ aNQ
 aaj
 aaf
 vHw
+qwN
+vHw
 aho
-ata
-aho
-fkN
-fkN
-fkN
+ajz
+ajz
 fkN
 fkN
 aho
-ata
-aho
-ata
-ata
+sSo
+sSo
+pZq
+sSo
+sSo
 aho
 aux
 aux
@@ -76429,19 +77277,19 @@ aNQ
 vyU
 aaf
 vtn
-dXI
-ata
+fHR
+cjf
 aho
 fkN
-fkN
-fkN
-fkN
-fkN
-aho
-ata
-pmz
-ata
-ata
+hAZ
+wzG
+ajz
+kaI
+sSo
+sSo
+xrg
+sSo
+sSo
 rpQ
 aHd
 bkw
@@ -76689,16 +77537,16 @@ aaf
 vHw
 aho
 aho
-fkN
-fkN
-fkN
-fkN
-fkN
-aho
-ata
-kBF
-inv
-ata
+wIn
+ajz
+ygE
+jfz
+kaI
+sSo
+sSo
+xrg
+sSo
+sSo
 rpQ
 aHd
 aHd
@@ -76947,15 +77795,15 @@ vHw
 aho
 fkN
 fkN
-fkN
-fkN
-fkN
+ajz
+ajz
 fkN
 aho
-ata
-kBF
-ata
-rVd
+sSo
+qHN
+tXl
+sSo
+sSo
 aho
 aux
 aux
@@ -77179,7 +78027,7 @@ adc
 aGS
 biy
 aCL
-fbm
+sHD
 aCL
 fkN
 fkN
@@ -77208,11 +78056,11 @@ aho
 aho
 aho
 aho
-aho
-ata
-aho
-ata
-ata
+sSo
+ely
+oPS
+hgV
+sSo
 rpQ
 aHd
 bkw
@@ -77437,7 +78285,7 @@ aKH
 biA
 suo
 adc
-fbm
+sHD
 fkN
 fkN
 fkN
@@ -77455,7 +78303,7 @@ duW
 aaj
 aNQ
 aaj
-waq
+nNj
 aaf
 ahd
 aho
@@ -77464,12 +78312,12 @@ aho
 tLz
 rVd
 xpC
-kcz
 aho
-feE
-aho
-ata
-nUK
+sSo
+sSo
+xrg
+sSo
+sSo
 rpQ
 aHd
 aHd
@@ -77694,7 +78542,7 @@ aZw
 biA
 hTW
 puq
-fbm
+sHD
 fkN
 fkN
 fkN
@@ -77704,7 +78552,7 @@ fkN
 fkN
 fkN
 fkN
-gJq
+abo
 sWG
 uyM
 biN
@@ -77715,18 +78563,18 @@ aHQ
 aaf
 aaf
 vHw
-geQ
+njT
 ata
-ata
+nZg
 eki
 aho
 aho
 aho
-aho
-ata
-aho
-ibL
-urY
+sSo
+sSo
+xrg
+sSo
+sSo
 aho
 aux
 aux
@@ -77951,7 +78799,7 @@ aZw
 biA
 rPQ
 adc
-fbm
+sHD
 fkN
 fkN
 fkN
@@ -77961,7 +78809,7 @@ fkN
 fkN
 fkN
 fkN
-gJq
+abo
 sWG
 uyM
 biV
@@ -77969,7 +78817,7 @@ biQ
 biT
 biD
 aaj
-waq
+vCO
 aaf
 vHw
 aho
@@ -77978,12 +78826,12 @@ aho
 aho
 aho
 fkN
-fkN
 aho
-ata
-ata
-ata
-nUK
+aho
+aho
+prb
+aho
+aho
 rpQ
 aHd
 bkw
@@ -78208,7 +79056,7 @@ biw
 biA
 pSh
 adc
-fbm
+sHD
 fkN
 fkN
 fkN
@@ -78237,10 +79085,10 @@ fkN
 fkN
 fkN
 aho
+uSn
+oOu
 ata
-ata
-ata
-eki
+rSF
 rpQ
 aHd
 aHd
@@ -78464,7 +79312,7 @@ adc
 bix
 biF
 aCL
-fbm
+sHD
 aCL
 fkN
 fkN
@@ -78494,10 +79342,10 @@ fkN
 fkN
 fkN
 aho
+urY
+oOu
 ata
-ata
-ata
-ata
+wqP
 aho
 bku
 aux
@@ -78751,9 +79599,9 @@ fkN
 fkN
 fkN
 aho
-ata
-ata
-ata
+dki
+eRC
+bGF
 aho
 aho
 aux
@@ -78956,7 +79804,7 @@ aUL
 aUL
 aUL
 aUL
-aJD
+deO
 bhL
 bhR
 aST
@@ -78988,7 +79836,7 @@ fkN
 fkN
 fkN
 aaf
-gJq
+abo
 aaf
 aaf
 qhE
@@ -79008,8 +79856,8 @@ aar
 aar
 aar
 aho
-ata
-nUK
+oOu
+vqy
 aho
 aho
 aux
@@ -79265,7 +80113,7 @@ fkN
 fkN
 fkN
 aho
-men
+knr
 aho
 aho
 aux
@@ -79473,7 +80321,7 @@ fkN
 aIx
 bhP
 aIx
-kEM
+rsf
 aIx
 fkN
 aar
@@ -79522,7 +80370,7 @@ fkN
 fkN
 fkN
 aho
-ata
+oOu
 aho
 aux
 aux
@@ -79749,17 +80597,17 @@ aEZ
 aoO
 aqt
 avl
-gJq
-gJq
+abo
+abo
 aaf
-gJq
-gJq
-gJq
-gJq
-gJq
+abo
+abo
+abo
+abo
+abo
 aaf
-gJq
-gJq
+abo
+abo
 aaf
 aaf
 qhE
@@ -79771,7 +80619,7 @@ oyq
 aaf
 vHw
 aho
-aar
+ajz
 aar
 aar
 fkN
@@ -79779,7 +80627,7 @@ fkN
 aho
 aho
 aho
-ata
+oOu
 aho
 aux
 aar
@@ -80034,9 +80882,9 @@ fkN
 fkN
 fkN
 aho
-bfe
-hEF
-bga
+vCa
+cmk
+irQ
 aho
 aux
 aar
@@ -80291,7 +81139,7 @@ aho
 aho
 aho
 aho
-bfw
+hyT
 aqp
 bgb
 aho
@@ -80547,8 +81395,8 @@ bVr
 uEX
 bVr
 bVr
-beK
-bfy
+lcu
+kjy
 aho
 bgc
 aho
@@ -80780,11 +81628,11 @@ acB
 aEt
 aEt
 aEt
-acB
+jdZ
 acc
 azV
 aFC
-aEj
+fyJ
 aWP
 aWP
 aWP
@@ -81032,7 +81880,7 @@ aJL
 aJL
 tAb
 aJL
-aJL
+pTt
 acB
 aQc
 xqg
@@ -81568,7 +82416,7 @@ rcB
 cAU
 atF
 akT
-avE
+gUX
 aMp
 tAh
 apo
@@ -81818,7 +82666,7 @@ awQ
 qRf
 ttQ
 jjl
-awy
+kkG
 kXR
 apx
 hYg
@@ -82346,7 +83194,7 @@ axM
 axM
 axM
 axM
-qzh
+mvQ
 aWJ
 vLb
 dyX
@@ -82814,7 +83662,7 @@ aar
 aar
 aux
 aIx
-twS
+jXW
 aIx
 aIx
 aIx
@@ -82843,8 +83691,8 @@ aCS
 atV
 atV
 atV
-apO
-igB
+qHP
+drW
 aZy
 atV
 bfc
@@ -83107,7 +83955,7 @@ aQt
 fZW
 nOP
 rcB
-aaN
+sUN
 aiF
 aAa
 aKd
@@ -83629,7 +84477,7 @@ axR
 kXG
 jHE
 qsi
-sie
+hNo
 cYS
 muk
 aWJ
@@ -83848,7 +84696,7 @@ afB
 aJH
 apj
 ahp
-acD
+xNd
 aoP
 aZK
 abO
@@ -85637,9 +86485,9 @@ aar
 aar
 aIx
 aXu
-aub
+get
 aIx
-aub
+wHh
 aub
 ayG
 afB
@@ -85894,12 +86742,12 @@ fkN
 fkN
 aIx
 aXu
-aub
 aIx
-aub
-aub
+aIx
+hgm
+aIx
 ayG
-aIx
+oew
 afB
 afB
 sbD
@@ -86152,12 +87000,12 @@ aar
 aIx
 aIx
 aIx
+mkQ
+mrX
 aIx
-aIx
-aub
 ayG
-qIT
 aub
+cTJ
 afB
 afB
 cqh
@@ -86209,7 +87057,7 @@ ckb
 amF
 fzR
 asJ
-eRf
+bAZ
 asJ
 due
 ihG
@@ -86218,7 +87066,7 @@ dKj
 mUQ
 aOP
 oEi
-huV
+fSJ
 fkN
 bfF
 fkN
@@ -86409,13 +87257,13 @@ aux
 aux
 aIx
 aIx
-cTJ
-oew
-aub
+oNL
+bRj
+aIx
 ayG
 aIx
-iIq
-aub
+aIx
+aIx
 afB
 nkd
 afB
@@ -86475,7 +87323,7 @@ azK
 azK
 axN
 awO
-huV
+fSJ
 fkN
 bfF
 fkN
@@ -86669,12 +87517,12 @@ aIx
 aIx
 aIx
 aIx
-kEM
-aIx
-aub
-aub
-dVB
-aub
+bTR
+pzP
+mAT
+hWU
+uSJ
+uaR
 aIx
 dSy
 hga
@@ -86732,7 +87580,7 @@ dbp
 qwt
 jSG
 eGg
-huV
+fSJ
 fkN
 bfF
 fkN
@@ -86926,12 +87774,12 @@ aux
 aux
 aux
 aIx
-ayG
+lWR
 aIx
-aIx
-aIx
-aIx
-aub
+jZj
+eNU
+jZj
+jZj
 aIx
 ahx
 auu
@@ -86987,7 +87835,7 @@ asJ
 amF
 amF
 amF
-rwl
+rue
 amF
 amF
 fkN
@@ -87183,12 +88031,12 @@ aar
 aar
 aux
 aIx
-ayG
+lWR
 aIx
-aub
-aub
-aIx
-aub
+jZj
+eNU
+jZj
+jZj
 aIx
 pim
 auu
@@ -87237,7 +88085,7 @@ aMz
 amF
 fzR
 kRN
-lmR
+xpg
 ljc
 aTa
 asJ
@@ -87245,7 +88093,7 @@ amF
 due
 aCT
 aTa
-huV
+fSJ
 fkN
 fkN
 bfF
@@ -87440,12 +88288,12 @@ fkN
 aIx
 ctK
 aIx
-ayG
+lWR
 aIx
-aIx
-aIx
-aIx
-iIq
+jZj
+ttR
+jZj
+jZj
 aIx
 abP
 auu
@@ -87502,7 +88350,7 @@ amF
 baO
 asJ
 aTa
-huV
+fSJ
 aar
 aar
 bfF
@@ -87697,12 +88545,12 @@ fkN
 aIx
 bhK
 aIx
-hfL
-gbc
-aki
-aki
-aki
-gDS
+lWR
+aIx
+vyb
+jZj
+jZj
+jZj
 aIx
 abP
 auu
@@ -87759,7 +88607,7 @@ amF
 bWs
 asJ
 aTa
-huV
+fSJ
 fkN
 fkN
 bfF
@@ -87954,12 +88802,12 @@ fkN
 aIx
 bhC
 aIx
+lWR
 aIx
 aIx
+fdm
 aIx
-aub
-aub
-aRz
+aIx
 aIx
 abP
 auu
@@ -88016,7 +88864,7 @@ amF
 aUk
 aAP
 aFm
-huV
+fSJ
 fkN
 fkN
 bfF
@@ -88211,12 +89059,12 @@ aIx
 aIx
 bhD
 aIx
-sbd
-aki
-aki
-aki
-aki
-aqo
+lWR
+aIx
+aub
+aub
+aub
+aub
 aIx
 abP
 auu
@@ -88273,7 +89121,7 @@ amF
 asc
 asJ
 asP
-huV
+fSJ
 fkN
 fkN
 bfF
@@ -88472,7 +89320,7 @@ aRz
 aub
 aub
 aub
-aXu
+exc
 aIx
 aIx
 abP
@@ -88507,7 +89355,7 @@ aEi
 bRY
 aEi
 aEW
-avQ
+jbi
 aEW
 aEW
 jgj
@@ -88524,13 +89372,13 @@ amF
 amF
 amF
 fPA
-cYR
+dZx
 rVu
 amF
 aNT
 aPn
 aIS
-huV
+fSJ
 aar
 aar
 bfF
@@ -88722,7 +89570,7 @@ fkN
 fkN
 fkN
 aIx
-aub
+wHh
 bhF
 bhI
 aRz
@@ -88786,8 +89634,8 @@ aqF
 amF
 aSz
 fcQ
-huV
-huV
+fSJ
+fSJ
 fkN
 fkN
 bfF
@@ -89041,9 +89889,9 @@ xXf
 agw
 uyo
 amF
-huV
-huV
-huV
+fSJ
+fSJ
+fSJ
 fkN
 fkN
 fkN
@@ -89533,16 +90381,16 @@ wfW
 naW
 aEi
 aEi
-axm
+cMr
 aEi
 pvW
 aEW
 ajp
 ajp
-aHh
+xkD
 ajp
 aOX
-awj
+vfW
 aOX
 aWJ
 rbx
@@ -90283,7 +91131,7 @@ hwZ
 aVo
 adz
 abP
-qIs
+juF
 abO
 yeU
 ayy
@@ -90773,7 +91621,7 @@ fkN
 abx
 aeX
 apQ
-gft
+jGF
 acw
 acx
 wBH
@@ -90793,7 +91641,7 @@ aFX
 bet
 cAH
 aiM
-dQn
+mlL
 aVo
 tfb
 abO
@@ -90817,10 +91665,10 @@ oBW
 qFD
 qFD
 qFD
-xmq
+ljB
 qFD
+ocA
 qFD
-lpG
 qFD
 qFD
 qFD
@@ -90828,7 +91676,7 @@ qFD
 qFD
 qFD
 qlf
-xmq
+ljB
 qFD
 eVB
 tYx
@@ -91030,7 +91878,7 @@ fkN
 abx
 aeX
 apQ
-gft
+jGF
 acw
 aaF
 acw
@@ -91076,8 +91924,8 @@ arM
 arM
 dLA
 dLA
-oUs
 dLA
+oUs
 dLA
 dLA
 dLA
@@ -91286,7 +92134,7 @@ fkN
 fkN
 abx
 acT
-xux
+cAb
 acT
 xxc
 xnI
@@ -91338,7 +92186,7 @@ gtQ
 gtQ
 dqr
 dLA
-mIp
+vpo
 dLA
 dLA
 dLA
@@ -91541,7 +92389,7 @@ fkN
 fkN
 fkN
 acT
-xux
+cAb
 acT
 lNC
 aRr
@@ -91796,8 +92644,8 @@ fkN
 fkN
 fkN
 acT
-xux
-xux
+cAb
+cAb
 lNC
 lOK
 adR
@@ -92116,7 +92964,7 @@ jHX
 jHX
 dLA
 boH
-vJk
+xUn
 gtQ
 gtQ
 gtQ
@@ -92362,7 +93210,7 @@ lzy
 aVL
 ini
 iSh
-bsg
+evx
 iSh
 iSh
 iSh
@@ -92596,7 +93444,7 @@ axq
 lIT
 bdJ
 avI
-bdG
+iJp
 avI
 avI
 asl
@@ -92623,7 +93471,7 @@ aeR
 ioz
 lou
 aeR
-mIH
+gTe
 aeR
 gwD
 hVb
@@ -92824,7 +93672,7 @@ fkN
 fkN
 fkN
 acT
-xux
+cAb
 acT
 aMQ
 hnd
@@ -92856,7 +93704,7 @@ aQd
 aQd
 aQd
 avI
-bdF
+jJy
 avI
 avI
 avI
@@ -93082,7 +93930,7 @@ fkN
 fkN
 fkN
 fkN
-xux
+cAb
 pwI
 adR
 cjT
@@ -93108,7 +93956,7 @@ aFX
 aiM
 avI
 avI
-aeG
+uwF
 avI
 avI
 aYv
@@ -93116,7 +93964,7 @@ iYF
 aQd
 aHK
 aXj
-tEP
+xAb
 aRx
 edN
 sIE
@@ -93127,13 +93975,13 @@ miQ
 dAf
 lfk
 bMh
-xGE
+iEU
 aVL
 lzy
 aVL
 jru
 iSh
-bsg
+evx
 nZH
 jjT
 jHx
@@ -93142,7 +93990,7 @@ oNB
 fyw
 jHx
 jHx
-ljw
+hLl
 hkl
 vWS
 rMP
@@ -93339,7 +94187,7 @@ fkN
 fkN
 fkN
 fkN
-xux
+cAb
 pwI
 adR
 adR
@@ -93368,7 +94216,7 @@ avI
 aBr
 vcn
 avI
-bdE
+sDV
 avI
 avI
 tch
@@ -93380,7 +94228,7 @@ mql
 aVL
 aVL
 aVL
-dgc
+eiL
 ofi
 fVU
 lrz
@@ -93388,9 +94236,9 @@ oIJ
 aVL
 lzy
 aVL
-nhn
+qWT
 iSh
-bsg
+evx
 vHh
 iSh
 iSh
@@ -93596,7 +94444,7 @@ fkN
 fkN
 fkN
 fkN
-xux
+cAb
 pwI
 adR
 adR
@@ -93648,7 +94496,7 @@ xcC
 xcC
 xcC
 xcC
-kkv
+vHh
 aeR
 crk
 aeR
@@ -93852,7 +94700,7 @@ fkN
 fkN
 fkN
 acT
-xux
+cAb
 acT
 ban
 adR
@@ -93905,13 +94753,13 @@ nYE
 kVt
 bzk
 xcC
-bqs
+onu
 aeR
 aeR
 aeR
 iSh
 dor
-vzL
+gFI
 uGe
 lmv
 sxk
@@ -94144,7 +94992,7 @@ yhR
 avI
 aHs
 amT
-aUK
+vHT
 auo
 aCz
 xOb
@@ -94165,7 +95013,7 @@ xcC
 qsj
 viG
 itC
-sWe
+lab
 uGe
 umW
 aeR
@@ -94401,8 +95249,8 @@ avI
 avI
 avI
 avI
-bdg
-cto
+avI
+gUQ
 tQs
 ilH
 aVL
@@ -94659,7 +95507,7 @@ aiM
 aiM
 aiM
 aVo
-aPz
+abO
 tQs
 ayK
 aVL
@@ -94880,7 +95728,7 @@ fkN
 fkN
 fkN
 acT
-xux
+cAb
 acT
 lPa
 lPa
@@ -94915,11 +95763,11 @@ aVo
 aVo
 aVo
 aVo
-aVo
+rCZ
 acc
 azV
-aFC
-bdk
+acc
+rsq
 aVL
 aVL
 aVL
@@ -94928,9 +95776,9 @@ aVL
 aVL
 aVL
 xcC
-pwp
-wiy
-wiy
+jVC
+yjY
+yjY
 xcC
 xcC
 aeR
@@ -95139,9 +95987,9 @@ fkN
 fkN
 fkN
 acT
-xux
-xux
-xux
+cAb
+cAb
+cAb
 acT
 acw
 aod
@@ -95194,7 +96042,7 @@ arZ
 fNf
 dzc
 arC
-hOL
+aRk
 arC
 fkN
 fkN
@@ -95399,7 +96247,7 @@ fkN
 abx
 aeX
 apQ
-gft
+jGF
 tsA
 acw
 acw
@@ -95410,7 +96258,7 @@ acw
 acw
 acw
 acw
-fAE
+acw
 acw
 pgK
 acw
@@ -95656,7 +96504,7 @@ fkN
 abx
 aeX
 apQ
-gft
+jGF
 acx
 acx
 acx
@@ -95913,7 +96761,7 @@ fkN
 abx
 aeX
 apQ
-gft
+jGF
 acx
 acx
 acx
@@ -95943,10 +96791,11 @@ aYK
 aYK
 aYK
 aYK
-aYK
+iZP
 arW
 bcJ
 bcK
+faw
 kah
 kah
 kah
@@ -95956,9 +96805,8 @@ kah
 kah
 kah
 kah
-kah
-kah
-kah
+gcK
+gcK
 kah
 kah
 ejn
@@ -96170,7 +97018,7 @@ fkN
 abx
 aeX
 apQ
-gft
+jGF
 acx
 acx
 acx
@@ -96203,7 +97051,7 @@ aTo
 cZb
 arZ
 ecH
-bdd
+kjB
 kah
 aKA
 aKA
@@ -96213,10 +97061,10 @@ aKR
 pht
 aKv
 kah
-xlN
+ndr
 kyY
 iMz
-tSD
+icH
 kah
 nXx
 dpq
@@ -96685,7 +97533,7 @@ fkN
 abx
 aeX
 apQ
-gft
+jGF
 acx
 acx
 acx
@@ -96715,9 +97563,9 @@ aac
 vRf
 aac
 aac
-beA
-beC
-beE
+rRV
+pvE
+dto
 kah
 bbI
 hmw
@@ -96942,7 +97790,7 @@ fkN
 abx
 aeX
 apQ
-gft
+jGF
 acx
 acx
 acx
@@ -97199,7 +98047,7 @@ fkN
 abx
 aeX
 apQ
-gft
+jGF
 acx
 idJ
 acx
@@ -97217,7 +98065,7 @@ aJA
 unw
 aYK
 aTo
-lDJ
+bbX
 pPd
 wRi
 wRi
@@ -97236,19 +98084,19 @@ kah
 kah
 kah
 kah
-bqb
-bqb
-aJU
-bqb
+gcK
+gcK
+kqs
+gcK
 kah
 kah
-bqb
-bqb
-bqb
+gcK
+gcK
+gcK
 kah
-viM
-viM
-jTl
+vJM
+vJM
+lMO
 kah
 aeR
 kxL
@@ -97474,7 +98322,7 @@ amL
 ruM
 aYK
 aTo
-lDJ
+bbX
 wRi
 wRi
 wRi
@@ -97715,7 +98563,7 @@ aeX
 aeX
 aeX
 apQ
-gft
+jGF
 aED
 aOw
 aOw
@@ -97731,7 +98579,7 @@ aXk
 dbU
 aYK
 aTo
-lDJ
+bbX
 roR
 wRi
 wRi
@@ -97972,7 +98820,7 @@ aeX
 aeX
 aeX
 apQ
-gft
+jGF
 aAE
 ahq
 ahq
@@ -97988,7 +98836,7 @@ aiu
 dql
 aYK
 aTo
-lDJ
+bbX
 mxc
 aUY
 aUY
@@ -98245,7 +99093,7 @@ acx
 dql
 aRn
 aTo
-lDJ
+bbX
 pPd
 wRi
 wRi
@@ -98487,7 +99335,7 @@ aeX
 aeX
 aeX
 apQ
-gft
+jGF
 acx
 acx
 aFA
@@ -98502,7 +99350,7 @@ acx
 dql
 aRn
 aTo
-lDJ
+bbX
 wRi
 wRi
 wRi
@@ -98539,14 +99387,14 @@ aeR
 cIF
 aaW
 aaW
-kUv
-kUv
-kUv
-kUv
+ail
+ail
+ail
+ail
 aaW
 aaW
-kUv
-kUv
+ail
+ail
 aaW
 bfL
 bfK
@@ -98744,7 +99592,7 @@ aeX
 aeX
 aeX
 apQ
-gft
+jGF
 acx
 acx
 aaR
@@ -98759,7 +99607,7 @@ acx
 dql
 aRn
 aTo
-lDJ
+bbX
 roR
 wRi
 wRi
@@ -98790,9 +99638,9 @@ hmw
 hmw
 hmw
 vGE
-qNG
+jUl
 cSl
-pYU
+vNT
 lSz
 aaW
 abe
@@ -98804,7 +99652,7 @@ aaW
 adE
 aib
 acF
-kUv
+ail
 aux
 aux
 aux
@@ -99001,7 +99849,7 @@ aeX
 aeX
 aeX
 apQ
-gft
+jGF
 acx
 ddL
 aFA
@@ -99016,7 +99864,7 @@ acx
 dql
 aYK
 aTo
-lDJ
+bbX
 mxc
 aUY
 aUY
@@ -99057,11 +99905,11 @@ abN
 abN
 bdy
 acn
-adY
+gHg
 aej
 ahV
 acI
-kUv
+ail
 aux
 fkN
 fkN
@@ -99259,8 +100107,8 @@ bdx
 bdx
 bdx
 act
-gft
-gft
+jGF
+jGF
 aFA
 aFA
 hBz
@@ -99273,7 +100121,7 @@ iGa
 dql
 aYK
 aTo
-lDJ
+bbX
 pPd
 wRi
 wRi
@@ -99306,7 +100154,7 @@ hmw
 hmw
 nqC
 brd
-cpq
+roq
 bgw
 aaW
 abg
@@ -99567,14 +100415,14 @@ aeR
 bgx
 aaW
 aaW
-kUv
-kUv
 ail
-kUv
+ail
+ail
+ail
 aaW
 aaW
-kUv
-kUv
+ail
+ail
 aaW
 bfL
 bfK
@@ -100595,12 +101443,12 @@ aeR
 ckt
 aaW
 aaW
-kUv
 ail
-kUv
-kUv
-kUv
-kUv
+ail
+ail
+ail
+ail
+ail
 aaW
 aaW
 aaW
@@ -100848,7 +101696,7 @@ avB
 rIu
 bgs
 bgt
-vIY
+lKr
 bgC
 bgD
 bgE
@@ -101109,12 +101957,12 @@ aeR
 jsv
 adq
 adq
-eGt
-eGt
-eGt
-eGt
-eGt
-eGt
+adI
+adI
+adI
+adI
+adI
+adI
 adq
 adq
 adq
@@ -101327,7 +102175,7 @@ fkN
 abx
 aeX
 apQ
-mBg
+aIh
 aTo
 aHB
 hHj
@@ -101584,7 +102432,7 @@ fkN
 abx
 aeX
 apQ
-mBg
+aIh
 aTo
 aJQ
 aVq
@@ -101601,7 +102449,7 @@ bbV
 aOc
 amO
 teS
-bqb
+gcK
 brd
 afU
 afb
@@ -101841,7 +102689,7 @@ fkN
 abx
 aeX
 apQ
-mBg
+aIh
 aTo
 aJQ
 aVq
@@ -101858,7 +102706,7 @@ iQS
 arZ
 ecH
 kjB
-bqb
+gcK
 brd
 afV
 agk
@@ -102098,7 +102946,7 @@ fkN
 abx
 aeX
 apQ
-mBg
+aIh
 aTo
 aJQ
 aVq
@@ -102137,14 +102985,14 @@ aeR
 kkt
 adq
 adq
-eGt
-eGt
-eGt
-eGt
+adI
+adI
+adI
+adI
 adq
 adq
-eGt
-eGt
+adI
+adI
 adq
 bfL
 bfK
@@ -102355,7 +103203,7 @@ fkN
 abx
 aeX
 apQ
-mBg
+aIh
 aTo
 aJQ
 uHX
@@ -102372,7 +103220,7 @@ aHB
 mkc
 ecH
 kjB
-bqb
+gcK
 brd
 aeB
 aeE
@@ -102382,7 +103230,7 @@ ahM
 afU
 mZW
 afH
-vGE
+hmw
 brd
 hmw
 hmw
@@ -102390,7 +103238,7 @@ hmw
 hmw
 keD
 cSl
-lEb
+qoP
 pFN
 adq
 acl
@@ -102402,7 +103250,7 @@ adq
 aei
 aib
 aen
-eGt
+adI
 aux
 aux
 aux
@@ -102612,7 +103460,7 @@ fkN
 abx
 aeX
 apQ
-mBg
+aIh
 aTo
 aJQ
 jiW
@@ -102629,7 +103477,7 @@ aJQ
 arZ
 ecH
 kjB
-bqb
+gcK
 brd
 axc
 aDR
@@ -102655,7 +103503,7 @@ acd
 acd
 bdz
 acE
-aef
+bLJ
 aem
 ahW
 aeo
@@ -102869,7 +103717,7 @@ fkN
 abx
 aeX
 apQ
-mBg
+aIh
 aTo
 aJQ
 aYL
@@ -102886,7 +103734,7 @@ aJQ
 arZ
 ecH
 kjB
-bqb
+gcK
 brd
 aeD
 aeH
@@ -102904,7 +103752,7 @@ hmw
 hmw
 cOx
 brd
-dHQ
+nvI
 xXH
 adq
 adH
@@ -102916,7 +103764,7 @@ aii
 aek
 aid
 aer
-eGt
+adI
 aux
 aux
 aux
@@ -103165,14 +104013,14 @@ aeR
 xXH
 adq
 adq
-eGt
 adI
-eGt
-eGt
+adI
+adI
+adI
 adq
 adq
-eGt
-eGt
+adI
+adI
 adq
 bfL
 bfK
@@ -103383,24 +104231,24 @@ fkN
 abx
 aeX
 apQ
-mBg
+aIh
 aTo
 ama
-pAO
-oZV
-qNV
-sLb
+npf
+oNr
+uYI
+yhc
 ama
 ama
-kWS
-gGA
-pIR
-gGA
+gdL
+fKv
+veE
+fKv
 aJQ
 aoZ
 aKY
 akh
-bqb
+gcK
 brd
 afd
 aeY
@@ -103640,7 +104488,7 @@ fkN
 abx
 aeX
 apQ
-mBg
+aIh
 aTo
 ama
 oFZ
@@ -103657,7 +104505,7 @@ aJQ
 arZ
 ecH
 kjB
-bqb
+gcK
 brd
 afU
 aih
@@ -103897,7 +104745,7 @@ fkN
 abx
 aeX
 apQ
-mBg
+aIh
 aTo
 ama
 fwj
@@ -103914,7 +104762,7 @@ aJQ
 arZ
 ecH
 kjB
-bqb
+gcK
 brd
 afV
 agk
@@ -104422,7 +105270,7 @@ hDy
 ama
 aHB
 pwz
-bci
+aKh
 aHB
 aHB
 jrZ
@@ -104473,10 +105321,10 @@ aux
 aux
 aux
 aux
-fkN
-fkN
-fkN
-fkN
+ajz
+bkO
+bkO
+bkO
 fkN
 fkN
 fkN
@@ -104665,9 +105513,9 @@ bhp
 aVi
 fkN
 asn
-iWT
-iWT
-iWT
+kSZ
+kSZ
+kSZ
 aYK
 aTo
 ama
@@ -104708,7 +105556,7 @@ roi
 dOG
 dQI
 vEf
-xoq
+ooO
 bgi
 aeX
 bfT
@@ -104724,16 +105572,16 @@ dUV
 dUV
 dUV
 oZG
-cQp
-cQp
 aVb
-cQp
-cQp
-cQp
+aVb
+aVb
+aVb
+aVb
+aVb
 fkN
+ajz
 fkN
-fkN
-fkN
+bkO
 fkN
 fkN
 fkN
@@ -104986,11 +105834,11 @@ mna
 sZR
 avy
 avy
-cQp
-cQp
-fkN
-fkN
-fkN
+aVb
+aVb
+ajz
+ajz
+bkO
 fkN
 fkN
 fkN
@@ -105220,8 +106068,8 @@ aHY
 aHY
 nbz
 aHY
-kwG
-kwG
+xVE
+xVE
 aHY
 bgW
 bgW
@@ -105244,10 +106092,10 @@ sZR
 tNS
 avy
 avy
-cQp
-cQp
+aVb
+aVb
 fkN
-fkN
+bkO
 fkN
 fkN
 fkN
@@ -105473,13 +106321,13 @@ qdJ
 aYu
 pyc
 aZh
-ayz
+iAZ
 atl
 aqH
 lzv
 mpA
 tdr
-kwG
+iie
 bfO
 aeX
 bfT
@@ -105502,9 +106350,9 @@ mEY
 ozc
 avy
 avy
-cQp
+aVb
 fkN
-fkN
+bkO
 fkN
 fkN
 fkN
@@ -105688,7 +106536,7 @@ bhw
 bht
 bht
 bht
-bht
+clw
 bhz
 aoW
 aoW
@@ -105724,7 +106572,7 @@ aFR
 kwU
 aJz
 anh
-ctY
+pkZ
 anL
 aIF
 aGQ
@@ -105736,7 +106584,7 @@ aHS
 bHw
 aOT
 alK
-kwG
+iie
 bfO
 aeX
 bfT
@@ -105760,7 +106608,7 @@ avy
 avy
 pUG
 apq
-bkO
+ajz
 bkO
 bkO
 bkO
@@ -105945,7 +106793,7 @@ aoW
 aoW
 mgX
 aoW
-mgX
+kiI
 aoW
 xgQ
 aoW
@@ -105957,14 +106805,14 @@ aYK
 aTo
 ama
 ama
-afk
+oMY
 ama
 ama
 ama
 ama
 aVW
 aVW
-esJ
+hmR
 aVW
 aVW
 beP
@@ -105992,7 +106840,7 @@ aQY
 aHS
 alK
 alK
-aSQ
+vvw
 aHY
 aeX
 aeX
@@ -106006,11 +106854,11 @@ oZG
 oZG
 bWH
 oZG
-iIr
-iIr
+bbe
+bbe
 oZG
-aTt
-aTt
+hSk
+hSk
 apq
 apq
 mJP
@@ -106028,7 +106876,7 @@ aar
 fkN
 fkN
 fkN
-iSl
+bkO
 aaa
 aaa
 aaa
@@ -106202,7 +107050,7 @@ esh
 dbv
 dJX
 dEK
-esh
+bUi
 esh
 esh
 ghZ
@@ -106226,7 +107074,7 @@ kfy
 aVW
 arZ
 ecH
-fWk
+xdL
 aXq
 aKk
 iEX
@@ -106285,7 +107133,7 @@ aar
 fkN
 fkN
 fkN
-mqS
+dPc
 aaa
 aaa
 aaa
@@ -106520,11 +107368,11 @@ pPU
 pPU
 wrQ
 aVX
-vOF
-vOF
-vOF
-vOF
-vOF
+gnJ
+gnJ
+gnJ
+gnJ
+gnJ
 sAd
 asx
 mfO
@@ -106533,16 +107381,16 @@ pPU
 pPU
 pPU
 pPU
-dVu
-dVu
+rzJ
+rzJ
 pPU
 pPU
-dVu
-dVu
+rzJ
+rzJ
 pPU
 fkN
 fkN
-iSl
+bkO
 aaa
 aaa
 aaa
@@ -106732,7 +107580,7 @@ gmw
 axL
 slG
 rGG
-bdC
+rmj
 iNu
 bCM
 vRN
@@ -106764,8 +107612,8 @@ fkN
 ajz
 fkN
 fkN
-aVI
-hlW
+bXs
+epG
 aQg
 bar
 arc
@@ -106796,7 +107644,7 @@ aNW
 aQx
 aRu
 aSU
-pqQ
+jyi
 fkN
 fkN
 bkO
@@ -106964,9 +107812,9 @@ aVi
 bhq
 aVi
 aVi
-ktY
-bjw
-qES
+xYH
+vgw
+did
 aVi
 aVi
 aVi
@@ -106982,7 +107830,7 @@ vZG
 pRE
 tuV
 aYK
-aTo
+ppC
 aFT
 amN
 apz
@@ -106994,7 +107842,7 @@ vBI
 pWg
 iGB
 coj
-aVW
+pkY
 arZ
 ecH
 kjB
@@ -107009,20 +107857,20 @@ aqY
 aiB
 apV
 aiB
-amz
+jyH
 aIC
 aoh
 hqT
 aoh
 ydJ
 aPG
-aWi
+uCy
 fkN
 ajz
 fkN
 fkN
-aVI
-avU
+bXs
+hlW
 aQg
 aHL
 dJj
@@ -107043,17 +107891,17 @@ aOz
 ayF
 aCj
 aDz
-sUc
+mAr
 aGq
 aGq
-aHG
+pgn
 aJg
 aMi
 aOn
 aQF
 aRD
 aTb
-pqQ
+jyi
 fkN
 fkN
 bkO
@@ -107229,7 +108077,7 @@ lMN
 aoW
 aoW
 aoW
-aoW
+swu
 aVi
 aVi
 nGg
@@ -107250,9 +108098,9 @@ aFT
 aVW
 aVW
 aVW
-aVW
-aVW
-puZ
+uFL
+dOz
+arZ
 ecH
 kjB
 wmu
@@ -107266,14 +108114,14 @@ akg
 aHx
 avw
 jpt
-bdT
+sNR
 asU
 aoh
 pRx
 kSO
 aoh
 aPG
-aWi
+uCy
 fkN
 ajz
 fkN
@@ -107310,7 +108158,7 @@ aOW
 aGA
 aRI
 aTh
-pqQ
+jyi
 fkN
 fkN
 bkO
@@ -107497,7 +108345,7 @@ aeM
 gnX
 ppq
 ppq
-ppq
+dvc
 ppq
 ppq
 aGo
@@ -107506,8 +108354,8 @@ ppq
 aga
 ppq
 ppq
-kyq
-oOb
+tVW
+ppq
 qsO
 ohp
 aVF
@@ -107824,7 +108672,7 @@ aPC
 aGA
 aRI
 aTh
-pqQ
+jyi
 rny
 fIP
 pPU
@@ -108049,7 +108897,7 @@ fkN
 kte
 ajz
 fkN
-aVI
+bXs
 avU
 bwc
 aQg
@@ -108071,10 +108919,10 @@ aOz
 azU
 aCJ
 aDz
-imr
+rPH
 aGq
 aGq
-aIw
+isG
 aKI
 aGA
 aPD
@@ -108277,7 +109125,7 @@ eYE
 aIs
 aIs
 kTK
-iFi
+bnO
 kTK
 aIs
 own
@@ -108294,19 +109142,19 @@ aiB
 caC
 arL
 eDC
-kns
+evj
 ahA
 aJc
 aOV
 aBQ
 aos
 aVU
-aQM
+xkz
 fkN
 fkN
 ajz
 fkN
-aVI
+bXs
 avU
 xEI
 aQg
@@ -108852,7 +109700,7 @@ aPD
 aGA
 aRI
 aTh
-pqQ
+jyi
 fkN
 fkN
 bkO
@@ -109083,7 +109931,7 @@ dLK
 aQg
 jGO
 aGh
-aqw
+fqn
 rIP
 aoC
 hrY
@@ -109099,17 +109947,17 @@ aOz
 aAv
 aCJ
 aDz
-imr
+rPH
 aGq
 aGq
-aIG
+svH
 aKI
 aGA
 aPC
 aGA
 aRI
 aTh
-pqQ
+jyi
 fkN
 fkN
 bkO
@@ -109340,7 +110188,7 @@ avU
 rhf
 arc
 aGh
-goM
+jub
 qhv
 mgG
 aVX
@@ -109350,8 +110198,8 @@ aqU
 bcT
 mZS
 hbZ
-pTM
-bGF
+sUC
+cBD
 aOz
 aAQ
 aCQ
@@ -109366,7 +110214,7 @@ aPC
 aGA
 aRI
 aTh
-pqQ
+jyi
 fkN
 fkN
 bkO
@@ -109549,7 +110397,7 @@ aBx
 dUp
 aIs
 aIs
-bdB
+ixJ
 aIs
 aIs
 kxN
@@ -109598,8 +110446,8 @@ aQg
 fgL
 fvm
 aVX
-rlF
-gpa
+gFe
+tda
 aVX
 aMb
 xop
@@ -109607,7 +110455,7 @@ aVX
 aOz
 aOz
 baH
-baQ
+mWI
 aOz
 aOz
 aAU
@@ -109832,40 +110680,40 @@ aXm
 aNA
 sqK
 aQg
-aPy
-hrR
-arZ
-lmM
-arZ
-mUy
-hrR
-agR
-arZ
-pax
-jNg
-arZ
-arZ
-vcW
-pWp
-sSn
-nBU
-arZ
-arZ
-nBU
-arZ
-aHV
-sjG
-aLU
-aLU
-uDi
-kDO
-lMX
-nBs
-sJb
-nBs
-aix
-akI
-aou
+dgb
+tKa
+emD
+iUF
+emD
+oRT
+tKa
+xQT
+emD
+kyP
+jKA
+emD
+emD
+gkX
+gPi
+qpe
+syI
+emD
+emD
+syI
+emD
+nQk
+jfs
+vYM
+vYM
+flT
+vTY
+uQq
+rpX
+jlq
+rpX
+ixB
+wdl
+mly
 aiU
 aBj
 aCJ
@@ -109880,7 +110728,7 @@ aQa
 aGA
 aRI
 aTh
-pqQ
+jyi
 fkN
 fkN
 bkO
@@ -110089,55 +110937,55 @@ aNA
 aNA
 sqK
 aQg
-neU
+sWa
 aOZ
-azH
-azH
-deC
-deC
-deC
-deC
-deC
-deC
-azH
-azH
-alA
-aWa
-jDL
-azH
-azH
-azH
-azH
-azH
-xIc
-xNJ
+eiT
+kbf
+fId
+fId
+fId
+fId
+fId
+fId
+kbf
+kbf
+xdd
+vNR
+gTJ
+kbf
+kbf
+kbf
+kbf
+kbf
+ePK
+mtL
 kBd
 mLH
 mLH
 kBd
 muY
-hfk
-aCl
-aCl
-aCl
-aiH
-aOp
-aCl
+lpJ
+mLH
+mLH
+mLH
+cVD
+dne
+bpS
 aoK
 aBA
 aDb
 aEP
-ndB
+sYh
 aGG
 aGG
-aZC
+fra
 aLY
 aNd
 aQb
 aOn
 aSg
 aTh
-pqQ
+jyi
 aar
 aar
 bkO
@@ -110346,9 +111194,9 @@ kxW
 ias
 tpR
 aQg
-jrZ
+ogG
 aGh
-xQw
+qPZ
 gzW
 dzc
 dzc
@@ -110358,7 +111206,7 @@ dzc
 dzc
 arc
 sps
-dvV
+wzn
 arB
 pWp
 sps
@@ -110367,7 +111215,7 @@ jNO
 arZ
 bhM
 pTf
-bgQ
+nAE
 ujP
 cFc
 aLU
@@ -110394,7 +111242,7 @@ aQj
 aRm
 aSo
 aTp
-pqQ
+jyi
 fkN
 fkN
 bkO
@@ -110603,9 +111451,9 @@ aQg
 aQg
 aQg
 aQg
-arZ
+kjB
 aGh
-arZ
+kjB
 aKQ
 apH
 apH
@@ -110615,7 +111463,7 @@ apH
 bhg
 hTL
 aZT
-vvT
+dDn
 alw
 alw
 alw
@@ -110624,7 +111472,7 @@ alw
 alw
 alw
 alw
-bgR
+xWL
 pPU
 aVX
 aVX
@@ -110852,17 +111700,17 @@ azO
 hLX
 kjB
 jtI
-kjB
-arZ
-arZ
-jNg
-aUT
-arZ
-arZ
-arZ
-lSQ
+nbU
+emD
+emD
+jKA
+tja
+emD
+emD
+emD
+gzJ
 orz
-amH
+nNu
 ePt
 aBC
 ami
@@ -110872,7 +111720,7 @@ key
 aNK
 xZt
 aZT
-aWY
+mxk
 alw
 fLS
 rel
@@ -110881,7 +111729,7 @@ alw
 aqS
 tdF
 alw
-bgS
+nFv
 pPU
 aUZ
 aWo
@@ -111108,7 +111956,7 @@ beV
 azO
 arv
 baq
-agE
+hdY
 dvq
 azH
 aMV
@@ -111121,15 +111969,15 @@ azH
 asK
 bcb
 ati
-bsr
-dIH
-dIH
-dIH
-dIH
+cIo
+fxA
+fxA
+fxA
+fxA
 uoc
 ati
 ati
-aWY
+mxk
 alw
 alw
 alw
@@ -111138,7 +111986,7 @@ alw
 tdF
 jIn
 alw
-bgS
+nFv
 pPU
 aGq
 aVA
@@ -111363,7 +112211,7 @@ kxc
 arv
 dHt
 bab
-bdc
+lhF
 kjB
 dFC
 sFR
@@ -111386,23 +112234,23 @@ tLW
 bRM
 vqt
 ati
-aWY
-aqS
+sFA
+khU
 slK
-tdF
 eBM
-alw
+dcV
+kHW
 lAw
 dOi
 alw
-bgT
+hpp
 pPU
 aVX
 aVX
 aVX
 lhx
 gzh
-aQo
+eNA
 hnJ
 aLS
 bcW
@@ -111643,16 +112491,16 @@ hgj
 aVd
 aig
 ati
-bgI
+bJz
 bgJ
 bgJ
-bgJ
-bgK
+wDc
 alw
 alw
 alw
 alw
-bgS
+alw
+nFv
 pPU
 aVk
 aWr
@@ -111860,7 +112708,7 @@ aiV
 arK
 aKa
 tnb
-aQs
+gsH
 nXS
 axn
 tYd
@@ -111903,13 +112751,13 @@ ati
 aZT
 aZT
 aZT
-aZT
 bgI
-bgJ
-bgL
-bgM
-dcV
-bgS
+brS
+oIF
+oIF
+cet
+alw
+nFv
 pPU
 aVt
 aWs
@@ -112159,14 +113007,14 @@ rqV
 ati
 aeX
 aeX
-aeX
+ksM
 aZT
 aZT
-eKK
-fLG
-aWY
-dcV
-bgS
+ltT
+mHQ
+rdd
+fys
+fRz
 pPU
 aVX
 aVX
@@ -112177,8 +113025,8 @@ aXU
 epN
 aXU
 aXU
-jfv
-vPp
+cyE
+oQj
 aXU
 fkN
 fkN
@@ -112419,11 +113267,11 @@ aeX
 aeX
 bfT
 aZT
-aZT
-saF
-bgN
-bgO
-bgU
+ltT
+ltT
+ltT
+alw
+iGz
 pPU
 aUZ
 aWS
@@ -112675,7 +113523,7 @@ aeX
 aeX
 aeX
 bfT
-fkN
+ksM
 aZT
 aZT
 aZT
@@ -112927,7 +113775,7 @@ bbQ
 bbR
 bbN
 sID
-nrM
+ueA
 bfO
 aeX
 aeX
@@ -113184,7 +114032,7 @@ aLt
 bbS
 aLt
 sID
-nrM
+ueA
 bfO
 aeX
 aeX
@@ -113379,7 +114227,7 @@ abx
 aeX
 exg
 exg
-fAg
+yjW
 exg
 uMt
 aae
@@ -113429,9 +114277,9 @@ atr
 jvX
 aJh
 aJh
-avu
+vbc
 aCO
-avu
+vbc
 aJh
 aJh
 bcN
@@ -113679,7 +114527,7 @@ aOA
 aLC
 aHP
 aRY
-rmy
+sUA
 agK
 aNq
 bbp
@@ -113698,7 +114546,7 @@ aQl
 ayL
 wea
 aGc
-nrM
+ueA
 bfP
 aeX
 aeX
@@ -113891,7 +114739,7 @@ fkN
 fkN
 abx
 apQ
-fAg
+yjW
 qfH
 ogo
 dLV
@@ -113906,7 +114754,7 @@ aFN
 aIv
 aOU
 aWU
-ajQ
+pKR
 pXz
 aMr
 azh
@@ -113955,7 +114803,7 @@ aJj
 aGJ
 aTX
 bbL
-nrM
+ueA
 bfO
 aeX
 aeX
@@ -114148,7 +114996,7 @@ fkN
 fkN
 abx
 apQ
-fAg
+yjW
 fGl
 ogo
 ogo
@@ -114212,7 +115060,7 @@ aGJ
 aGJ
 bch
 bcg
-uAy
+xDS
 bfQ
 aeX
 aeX
@@ -114436,7 +115284,7 @@ gbL
 arv
 arv
 arv
-hWA
+rUq
 arv
 arv
 arv
@@ -114469,7 +115317,7 @@ bdS
 aGJ
 aGJ
 bcG
-uAy
+xDS
 bfO
 aeX
 bfT
@@ -114662,7 +115510,7 @@ fkN
 fkN
 abx
 apQ
-fAg
+yjW
 fGl
 ogo
 ogo
@@ -114726,7 +115574,7 @@ aoQ
 aGJ
 aGJ
 bcF
-uAy
+xDS
 bfR
 aeX
 bfT
@@ -114919,7 +115767,7 @@ fkN
 fkN
 abx
 apQ
-fAg
+yjW
 tXm
 exg
 ykj
@@ -114930,9 +115778,9 @@ oxo
 aae
 aSS
 aSS
-qlg
-qlg
-qlg
+maP
+maP
+maP
 aSS
 aSS
 asn
@@ -114941,16 +115789,16 @@ asn
 asn
 asn
 asn
-iWT
-iWT
-iWT
+kSZ
+kSZ
+kSZ
 arv
 arv
 arv
 arv
 arv
 arv
-lcj
+jXw
 arv
 arv
 arv
@@ -114983,7 +115831,7 @@ aJr
 bcf
 aGJ
 ahC
-uAy
+xDS
 bfO
 aeX
 bfT
@@ -115176,7 +116024,7 @@ fkN
 fkN
 abx
 apQ
-fAg
+yjW
 jFS
 wqk
 ogo
@@ -115240,7 +116088,7 @@ bcE
 bcE
 bcE
 aml
-uAy
+xDS
 bfS
 aeX
 bfT
@@ -115433,7 +116281,7 @@ fkN
 fkN
 abx
 apQ
-fAg
+yjW
 tdy
 kCD
 atj
@@ -115476,13 +116324,13 @@ bfH
 abx
 aOA
 aOA
-xSw
-xSw
+cCP
+cCP
 aOA
-naO
-naO
-naO
-naO
+lPn
+wNQ
+lPn
+lPn
 aJh
 anK
 anK
@@ -115490,14 +116338,14 @@ bcX
 anK
 anK
 aJh
-nrM
-nrM
-nrM
-nrM
-nrM
-nrM
-nrM
-uAy
+ueA
+ueA
+ueA
+ueA
+ueA
+ueA
+ueA
+xDS
 bfO
 bdx
 bfV
@@ -115690,7 +116538,7 @@ fkN
 fkN
 abx
 apQ
-fAg
+yjW
 qfH
 exg
 ogo
@@ -115741,11 +116589,11 @@ bfM
 bfM
 bfM
 aQR
-gES
-gES
 aGZ
-gES
-gES
+aGZ
+aGZ
+aGZ
+aGZ
 aJh
 bfM
 bfM

--- a/_maps/map_files/Hammerhead/Hammerhead.dmm
+++ b/_maps/map_files/Hammerhead/Hammerhead.dmm
@@ -516,12 +516,6 @@
 	},
 /turf/open/floor/wood,
 /area/security/courtroom)
-"abw" = (
-/obj/effect/turf_decal/stripes/white/line,
-/obj/structure/curtain/obscuring/grey,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plasteel/dark,
-/area/science/robotics/lab)
 "abx" = (
 /obj/structure/hull_plate/end{
 	dir = 1
@@ -5109,16 +5103,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar/atrium)
-"amp" = (
-/obj/machinery/airalarm/server{
-	dir = 8;
-	pixel_x = 22
-	},
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/science/server)
 "amq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 5
@@ -5430,12 +5414,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
-"amY" = (
-/obj/structure/window{
-	dir = 8
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/science/server)
 "amZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -5491,24 +5469,6 @@
 /obj/effect/landmark/start/chaplain,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
-"ani" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/ship,
-/area/security/prison)
 "anj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/door/airlock/ship/public/glass{
@@ -7672,19 +7632,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/nsv/weapons/fore)
-"asp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel/ship,
-/area/security/prison)
 "asq" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -11088,11 +11035,6 @@
 /obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
-"aAp" = (
-/obj/structure/window,
-/obj/machinery/rnd/server,
-/turf/open/floor/circuit/telecomms/server,
-/area/science/server)
 "aAq" = (
 /obj/machinery/light{
 	dir = 4
@@ -13530,13 +13472,6 @@
 /obj/structure/table/glass,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/heads/captain)
-"aGs" = (
-/obj/structure/window,
-/obj/structure/window{
-	dir = 8
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/science/server)
 "aGt" = (
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
@@ -20199,10 +20134,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/library/lounge)
-"aWj" = (
-/obj/structure/window,
-/turf/open/floor/circuit/telecomms/server,
-/area/science/server)
 "aWk" = (
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
@@ -20332,13 +20263,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"aWy" = (
-/obj/machinery/door/window/westright{
-	name = "Server Cage";
-	req_one_access_txt = "30"
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/science/server)
 "aWz" = (
 /obj/machinery/gateway{
 	dir = 8
@@ -24624,26 +24548,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
-"bgP" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer1,
-/turf/open/floor/plasteel/ship,
-/area/hallway/primary/fore)
 "bgQ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -26301,19 +26205,6 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
-"bkS" = (
-/obj/machinery/power/solar,
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/space/nearstation)
 "bkT" = (
 /obj/machinery/power/solar,
 /obj/structure/cable/yellow{
@@ -26464,17 +26355,6 @@
 	icon_state = "2-8"
 	},
 /turf/open/space,
-/area/space/nearstation)
-"blk" = (
-/obj/machinery/power/solar,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/space/nearstation)
-"bll" = (
-/obj/machinery/power/solar,
-/turf/open/floor/plasteel/airless/solarpanel,
 /area/space/nearstation)
 "bls" = (
 /obj/machinery/rnd/production/circuit_imprinter/department/science,
@@ -26640,6 +26520,16 @@
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/entry)
+"brF" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "brZ" = (
 /obj/machinery/light/built{
 	dir = 1
@@ -27110,6 +27000,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"bNZ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/storage)
 "bOf" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/newscaster{
@@ -27277,6 +27171,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"bVh" = (
+/obj/machinery/armour_plating_nanorepair_pump/forward_port{
+	apnw_id = "poolnoodles"
+	},
+/turf/open/floor/plasteel/ship,
+/area/construction)
 "bVq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -27336,6 +27236,28 @@
 /obj/item/stack/cable_coil,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"bWH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/security/glass{
+	dir = 8;
+	name = "Head of Security";
+	req_one_access_txt = "58"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hos)
 "bXo" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -27859,31 +27781,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"cye" = (
-/obj/machinery/button/door{
-	dir = 8;
-	id = "firingsquad";
-	name = "Firing Squad Shutters";
-	pixel_x = 22;
-	pixel_y = -8;
-	req_one_access_txt = "3"
-	},
-/obj/machinery/button/door{
-	dir = 8;
-	id = "hos_privacy";
-	name = "Privacy Shutters";
-	pixel_x = 22;
-	req_one_access_txt = "58"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/airalarm/directional/south,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "cyj" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/detective,
@@ -28262,6 +28159,10 @@
 	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
+"cPr" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/storage/tech)
 "cPT" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -29116,14 +29017,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"dvz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "dvN" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -29264,19 +29157,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"dzM" = (
-/obj/machinery/light,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Head of Security's Desk";
-	departmentType = 5;
-	name = "Head of Security RC";
-	pixel_x = 0;
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "dAf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
@@ -29346,6 +29226,25 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
+"dGm" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/ship,
+/area/security/prison)
 "dHt" = (
 /obj/machinery/camera/autoname,
 /obj/machinery/firealarm{
@@ -29691,6 +29590,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"dUV" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "hos_privacy";
+	name = "privacy shutter"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hos)
 "dVb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -29826,6 +29733,12 @@
 	},
 /turf/open/floor/plasteel/ship/riveted,
 /area/maintenance/starboard/central)
+"ecc" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/server)
 "ecH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -29990,6 +29903,14 @@
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"ekp" = (
+/obj/machinery/power/solar,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/space/nearstation)
 "elf" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -30808,23 +30729,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/crew_quarters/heads/hor)
-"eWc" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/landmark/start/brig_phys,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/ship,
-/area/security/prison)
 "eWo" = (
 /obj/item/bedsheet/random,
 /obj/structure/bed,
@@ -31010,12 +30914,6 @@
 /obj/effect/spawner/lootdrop/maintenance/five,
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
-"ffM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/science/mixing)
 "ffW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -31925,10 +31823,6 @@
 "fTe" = (
 /turf/closed/wall/r_wall/ship,
 /area/ai_monitored/turret_protected/aisat/service/support_ship)
-"fTu" = (
-/obj/machinery/armour_plating_nanorepair_pump/aft_port,
-/turf/open/floor/plasteel/ship,
-/area/construction)
 "fTE" = (
 /obj/machinery/door/airlock/ship{
 	name = "RD Bulk Storage";
@@ -31952,22 +31846,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/security/prison)
-"fUX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/ship,
 /area/security/prison)
 "fVK" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
@@ -32115,25 +31993,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/central)
-"gbq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/ship/security/glass{
-	dir = 8;
-	name = "Head of Security";
-	req_one_access_txt = "58"
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plasteel/ship,
-/area/security/prison)
 "gbL" = (
 /obj/structure/grille,
 /obj/structure/cable{
@@ -32343,6 +32202,11 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/port)
+"gof" = (
+/obj/machinery/power/solar,
+/obj/structure/cable/yellow,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/space/nearstation)
 "gon" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -32599,6 +32463,14 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"gyw" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "gyJ" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -32786,19 +32658,6 @@
 /obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"gJJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/armour_plating_nanorepair_pump/forward_starboard,
-/turf/open/floor/plasteel/ship,
-/area/construction)
 "gJQ" = (
 /obj/structure/closet/wardrobe/white,
 /turf/open/floor/plasteel/white,
@@ -33030,6 +32889,15 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"gWt" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
+	target_temperature = 273.15
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/server)
 "gWx" = (
 /turf/open/floor/carpet/orange,
 /area/engine/break_room)
@@ -33056,6 +32924,24 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
+"gXh" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/ship,
+/area/security/prison)
 "gXy" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -33276,26 +33162,6 @@
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/storage)
-"het" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/ship/security/glass{
-	dir = 8;
-	name = "Head of Security";
-	req_one_access_txt = "58"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hos)
 "hew" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -33339,6 +33205,24 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/construction)
+"hfk" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel/ship,
+/area/security/prison)
 "hfq" = (
 /obj/effect/turf_decal/delivery/white,
 /obj/structure/disposalpipe/segment{
@@ -33710,26 +33594,6 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/central)
-"hqD" = (
-/obj/machinery/keycard_auth{
-	pixel_y = 35
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/button/door{
-	id = "hos_window";
-	name = "Privacy Shutters";
-	pixel_x = 24;
-	pixel_y = 0;
-	req_one_access_txt = "58"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "hqT" = (
 /obj/structure/table/wood,
 /obj/item/toy/cards/deck/cas,
@@ -34159,6 +34023,12 @@
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"hHm" = (
+/obj/structure/window,
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/on,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/circuit/telecomms/server,
+/area/science/server)
 "hHo" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -34470,6 +34340,17 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/aft)
+"hXv" = (
+/obj/machinery/button/door{
+	dir = 8;
+	id = "firingsquad";
+	name = "Firing Squad Shutters";
+	pixel_x = 22;
+	pixel_y = -8;
+	req_one_access_txt = "3"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/transfer)
 "hXF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -34486,15 +34367,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /turf/open/floor/plasteel,
 /area/maintenance/department/science/central)
-"hYe" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/firedoor/window,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "hos_privacy";
-	name = "privacy shutter"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hos)
 "hYg" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -34729,13 +34601,6 @@
 /obj/machinery/atmospherics/pipe/simple/brown/visible,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"igP" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/landmark/nuclear_waste_spawner,
-/turf/open/floor/plasteel/dark,
-/area/science/server)
 "ihg" = (
 /obj/machinery/shower{
 	dir = 4
@@ -35075,6 +34940,16 @@
 	},
 /turf/template_noop,
 /area/maintenance/starboard/central)
+"itZ" = (
+/obj/structure/window{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/on{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/circuit/telecomms/server,
+/area/science/server)
 "iua" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -35233,6 +35108,25 @@
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"izL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/ship,
+/area/security/prison)
 "izP" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -35831,6 +35725,21 @@
 /obj/structure/closet/boxinggloves,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"iYr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/armour_plating_nanorepair_pump/forward_starboard{
+	apnw_id = "poolnoodles"
+	},
+/turf/open/floor/plasteel/ship,
+/area/construction)
 "iYF" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -36138,6 +36047,16 @@
 /obj/machinery/nuclearbomb/beer,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"jkf" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/airalarm/directional/south,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "jkt" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -36338,21 +36257,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"jtv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/security/prison)
 "jtI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -36563,11 +36467,6 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/central)
-"jBT" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/engine/storage)
 "jCp" = (
 /obj/effect/turf_decal/caution,
 /turf/open/floor/plasteel/ship,
@@ -36936,6 +36835,14 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
+"jNi" = (
+/obj/machinery/door/window/westright{
+	name = "Server Cage";
+	req_one_access_txt = "30"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/circuit/telecomms/server,
+/area/science/server)
 "jNA" = (
 /obj/machinery/portable_atmospherics/scrubber/huge,
 /turf/open/floor/plasteel/dark,
@@ -37172,17 +37079,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/security)
-"jXM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/engine/atmos)
 "kac" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -37221,6 +37117,12 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
+"kaA" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/server)
 "kbM" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/blue,
@@ -37531,6 +37433,29 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/quartermaster/storage)
+"kqt" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/landmark/start/brig_phys,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/ship,
+/area/security/prison)
 "kqz" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -37861,6 +37786,16 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"kBd" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/security/prison)
 "kBf" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/white/line,
@@ -38090,6 +38025,15 @@
 	},
 /turf/closed/wall/r_wall/ship,
 /area/medical/virology)
+"kKx" = (
+/obj/structure/window,
+/obj/structure/window{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/circuit/telecomms/server,
+/area/science/server)
 "kKz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -38131,6 +38075,19 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/quartermaster/storage)
+"kLX" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/medical/medbay/central)
 "kMJ" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/holopad{
@@ -38729,6 +38686,11 @@
 /obj/machinery/atmospherics/pipe/manifold4w/general/visible,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"lqu" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/science/mixing)
 "lro" = (
 /obj/machinery/requests_console{
 	department = "Engineering";
@@ -38756,11 +38718,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
-"lsu" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/science/mixing)
 "lsX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -39295,6 +39252,24 @@
 /obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/plasteel/dark,
 /area/science/server)
+"lMX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/security/prison)
 "lNC" = (
 /obj/structure/chair{
 	dir = 4
@@ -40204,6 +40179,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"muY" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship,
+/area/security/prison)
 "mvv" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -40379,12 +40373,41 @@
 /area/nsv/hanger/deck2/starboard{
 	name = "Launch tubes 1 and 2"
 	})
+"mCZ" = (
+/obj/machinery/airalarm/server{
+	dir = 8;
+	pixel_x = 22
+	},
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/machinery/rnd/server,
+/turf/open/floor/circuit/telecomms/server,
+/area/science/server)
 "mDq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
+"mDT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "mEb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -40560,6 +40583,15 @@
 /obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/plating,
 /area/storage/tech)
+"mLH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship,
+/area/security/prison)
 "mLP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -41329,6 +41361,10 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/security/prison)
+"nuY" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/hallway/primary/aft)
 "nvo" = (
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/white,
@@ -41650,6 +41686,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"nIE" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/visible,
+/turf/open/floor/plasteel/dark,
+/area/science/server)
 "nIG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
@@ -41789,6 +41829,15 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/firealarm/directional/east,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
+"nPQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "nQJ" = (
@@ -42180,15 +42229,6 @@
 /obj/item/stamp/law,
 /turf/open/floor/wood,
 /area/lawoffice)
-"odW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "oeu" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/hydroponics/constructable,
@@ -43219,11 +43259,6 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
-"oUA" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/hallway/primary/aft)
 "oUZ" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -43920,19 +43955,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"pzX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/armour_plating_nanorepair_pump/aft_starboard,
-/turf/open/floor/plasteel/ship,
-/area/construction)
 "pAj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /turf/open/floor/plating,
@@ -44143,6 +44165,12 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/port)
+"pIf" = (
+/obj/machinery/armour_plating_nanorepair_pump/aft_port{
+	apnw_id = "poolnoodles"
+	},
+/turf/open/floor/plasteel/ship,
+/area/construction)
 "pIR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -44633,6 +44661,26 @@
 	},
 /turf/open/floor/plating,
 /area/hydroponics)
+"qds" = (
+/obj/machinery/keycard_auth{
+	pixel_y = 35
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/button/door{
+	id = "hos_privacy";
+	name = "Privacy Shutters";
+	pixel_x = 24;
+	pixel_y = 0;
+	req_one_access_txt = "58"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "qdz" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -44775,6 +44823,13 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"qhT" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "qhU" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
@@ -44853,21 +44908,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/ai_monitored/turret_protected/aisat/service/support_ship)
-"qlq" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/ship,
-/area/security/prison)
 "qls" = (
 /obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/plating,
@@ -45318,6 +45358,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"qIT" = (
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "qJs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
 /turf/open/floor/plasteel/ship,
@@ -45689,14 +45733,6 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"qYP" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/engine/storage)
 "qYV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -45925,22 +45961,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
-"rfS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "rfX" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "8"
@@ -46603,6 +46623,26 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/ai_monitored/turret_protected/aisat/hallway/support_ship/aft)
+"rFw" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/landmark/start/brig_phys,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/ship,
+/area/security/prison)
 "rGF" = (
 /obj/structure/window{
 	dir = 1
@@ -46663,21 +46703,6 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload)
-"rJF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/ship,
-/area/security/prison)
 "rJN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
@@ -46778,6 +46803,23 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/engine/break_room)
+"rNT" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/ship,
+/area/security/prison)
 "rOt" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -47090,6 +47132,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"sdq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/armour_plating_nanorepair_pump/aft_starboard{
+	apnw_id = "poolnoodles"
+	},
+/turf/open/floor/plasteel/ship,
+/area/construction)
 "sdD" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -47371,11 +47428,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
-"stC" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/security/checkpoint/science/research)
 "stM" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -47419,10 +47471,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"svM" = (
-/obj/machinery/armour_plating_nanorepair_pump/forward_port,
-/turf/open/floor/plasteel/ship,
-/area/construction)
 "svT" = (
 /obj/machinery/light{
 	dir = 4
@@ -48444,6 +48492,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"tpl" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/engine_room)
 "tpK" = (
 /obj/structure/rack,
 /obj/item/stack/packageWrap,
@@ -48579,6 +48631,15 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"twi" = (
+/obj/machinery/armour_plating_nanorepair_well{
+	apnw_id = "poolnoodles"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/ship/padded,
+/area/construction)
 "twv" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
@@ -48882,14 +48943,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/engine/engineering/hangar)
-"tLc" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/engine/atmos)
 "tLg" = (
 /obj/machinery/light{
 	dir = 4
@@ -49333,20 +49386,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/exit)
-"ubM" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/ship,
-/area/security/prison)
 "ucs" = (
 /turf/open/floor/plasteel,
 /area/maintenance/department/science/central)
@@ -49401,12 +49440,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/central)
-"ueF" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/server)
 "ufj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -49778,6 +49811,14 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/exit)
+"uwm" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/landmark/nuclear_waste_spawner,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/plasteel/dark,
+/area/science/server)
 "uwn" = (
 /obj/machinery/light{
 	dir = 4
@@ -49938,20 +49979,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
-"uAY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plating,
-/area/medical/medbay/central)
 "uBv" = (
 /obj/machinery/door/airlock/vault/ship{
 	req_access_txt = "53"
@@ -50502,6 +50529,11 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"uZs" = (
+/obj/structure/window,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/circuit/telecomms/server,
+/area/science/server)
 "uZv" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -50905,11 +50937,6 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
-"vrk" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plating,
-/area/medical/medbay/central)
 "vrr" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -51219,6 +51246,22 @@
 /obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/engine/atmos)
+"vFN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/lattice/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "vFY" = (
 /obj/effect/turf_decal/stripes/white/line,
 /obj/effect/turf_decal/tile/brown{
@@ -51712,6 +51755,13 @@
 /obj/structure/railing,
 /turf/open/floor/plasteel,
 /area/construction)
+"vYV" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/storage)
 "vYZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -52158,6 +52208,28 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/ai_monitored/turret_protected/aisat/hallway/support_ship)
+"wrQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/ship/security/glass{
+	dir = 8;
+	name = "Head of Security";
+	req_one_access_txt = "58"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/ship,
+/area/security/prison)
 "wsa" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 1
@@ -52256,17 +52328,6 @@
 /obj/machinery/rnd/production/protolathe/department/science,
 /turf/open/floor/plasteel,
 /area/science/lab)
-"wud" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "wuv" = (
 /obj/effect/turf_decal/delivery/white,
 /obj/effect/landmark/start/flight_leader,
@@ -52476,26 +52537,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
-"wEc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/ship,
-/area/security/prison)
 "wEo" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -52665,32 +52706,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"wNv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
 "wOo" = (
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/ai_monitored/turret_protected/ai_upload)
-"wOC" = (
-/obj/machinery/armour_plating_nanorepair_well,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/ship/padded,
-/area/construction)
 "wOQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -52725,6 +52746,13 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/toilet/restrooms)
+"wPV" = (
+/obj/effect/turf_decal/stripes/white/line,
+/obj/structure/curtain/obscuring/grey,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plasteel/dark,
+/area/science/robotics/lab)
 "wQm" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Chapel"
@@ -53233,6 +53261,29 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/security/warden)
+"xop" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/ship,
+/area/security/prison)
 "xoq" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile/ship,
@@ -53695,6 +53746,21 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/lockup)
+"xGJ" = (
+/obj/machinery/light,
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Head of Security's Desk";
+	departmentType = 5;
+	name = "Head of Security RC";
+	pixel_x = 0;
+	pixel_y = -30
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "xHm" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -53760,6 +53826,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"xKF" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/server)
 "xKG" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/purple,
@@ -53867,6 +53942,27 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"xNJ" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship,
+/area/hallway/primary/fore)
 "xOb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54370,6 +54466,10 @@
 /obj/item/paper_bin,
 /turf/open/floor/wood,
 /area/library/lounge)
+"yeI" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/security/checkpoint/science/research)
 "yeU" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/ship/techfloor/alt,
@@ -54456,26 +54556,6 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload)
-"yhc" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/landmark/start/brig_phys,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/ship,
-/area/security/prison)
 "yhA" = (
 /obj/structure/grille,
 /obj/structure/cable,
@@ -63037,7 +63117,7 @@ fkN
 fkN
 bkQ
 bkR
-bkS
+bkQ
 bkR
 bkQ
 bkU
@@ -63059,11 +63139,11 @@ agh
 ygR
 agh
 blc
-blk
+ekp
 bkR
-blk
+ekp
 bkR
-bll
+gof
 fkN
 fkN
 fkN
@@ -63294,7 +63374,7 @@ fkN
 fkN
 bkQ
 bkR
-bkS
+bkQ
 bkR
 bkQ
 bkV
@@ -63316,11 +63396,11 @@ agh
 ygR
 agh
 bld
-blk
+ekp
 bkR
-blk
+ekp
 bkR
-bll
+gof
 fkN
 fkN
 fkN
@@ -63551,7 +63631,7 @@ fkN
 fkN
 bkQ
 bkR
-bkS
+bkQ
 bkR
 bkQ
 bkV
@@ -63573,11 +63653,11 @@ agh
 ygR
 agh
 ble
-blk
+ekp
 bkR
-blk
+ekp
 bkR
-bll
+gof
 fkN
 fkN
 fkN
@@ -63808,7 +63888,7 @@ fkN
 fkN
 bkQ
 bkR
-bkS
+bkQ
 bkR
 bkQ
 bkV
@@ -63830,11 +63910,11 @@ agh
 ygR
 agh
 ble
-blk
+ekp
 bkR
-blk
+ekp
 bkR
-bll
+gof
 fkN
 fkN
 fkN
@@ -64087,9 +64167,9 @@ agh
 hbS
 agh
 ble
-blk
+ekp
 bkR
-blk
+ekp
 fkN
 fkN
 fkN
@@ -64233,7 +64313,7 @@ rmw
 aEX
 awB
 aWl
-xVu
+cPr
 aWl
 aWl
 aWl
@@ -64242,22 +64322,22 @@ aWl
 aWl
 abA
 aDf
-vFH
-vFH
-vFH
+aiP
+aiP
+aiP
 aDf
 aDf
 awC
-vFH
-vFH
+aiP
+aiP
 ajO
 aDf
 aDf
-tLc
+qhT
 axQ
-jXM
+brF
 aDf
-vFH
+aiP
 aYi
 aDf
 aYi
@@ -64344,9 +64424,9 @@ aEy
 vYz
 aPA
 ble
-blk
+ekp
 bkR
-blk
+ekp
 fkN
 fkN
 fkN
@@ -64492,7 +64572,7 @@ awB
 fkN
 aar
 fkN
-oUA
+nuY
 abB
 aXy
 abB
@@ -64601,9 +64681,9 @@ mXy
 kjq
 aPA
 ble
-blk
+ekp
 bkR
-blk
+ekp
 fkN
 fkN
 fkN
@@ -64749,7 +64829,7 @@ awB
 aar
 aar
 aar
-oUA
+nuY
 abB
 axZ
 aYp
@@ -64858,9 +64938,9 @@ aEy
 aEy
 aPA
 ble
-blk
+ekp
 bkR
-blk
+ekp
 fkN
 fkN
 fkN
@@ -65006,7 +65086,7 @@ awB
 aar
 fkN
 fkN
-oUA
+nuY
 jEW
 aRZ
 jEW
@@ -65115,9 +65195,9 @@ aYD
 aYD
 fTe
 ble
-blk
+ekp
 bkR
-blk
+ekp
 fkN
 fkN
 fkN
@@ -65260,8 +65340,8 @@ aEX
 rmw
 aEX
 awB
-stC
-stC
+yeI
+yeI
 aKN
 aKN
 mYf
@@ -65372,7 +65452,7 @@ dlb
 dlb
 fTe
 ble
-bll
+gof
 fkN
 fkN
 fkN
@@ -65629,7 +65709,7 @@ wFV
 oyi
 fTe
 blf
-bll
+gof
 fkN
 fkN
 fkN
@@ -69932,9 +70012,9 @@ flG
 flG
 flG
 atG
-hGy
+tpl
 ayo
-hGy
+tpl
 atG
 arQ
 arQ
@@ -70179,7 +70259,7 @@ apM
 aCt
 avS
 aJy
-flG
+aTe
 aDB
 aDB
 aDB
@@ -70188,11 +70268,11 @@ aDB
 aDB
 aDB
 aDB
-flG
+aTe
 nFf
 aWt
 nFf
-flG
+aTe
 bjq
 bjq
 aux
@@ -70436,7 +70516,7 @@ ajS
 aGF
 avq
 amS
-flG
+aTe
 aTk
 mCc
 qNr
@@ -70445,11 +70525,11 @@ uxG
 oDR
 mCc
 aTk
-flG
+aTe
 aYU
 bko
 dnE
-flG
+aTe
 bjq
 bjq
 aux
@@ -70693,7 +70773,7 @@ aCt
 tju
 awf
 aoL
-flG
+aTe
 aDB
 aDB
 aDB
@@ -70702,11 +70782,11 @@ aDB
 aDB
 aDB
 aDB
-flG
+aTe
 nFf
 aQC
 nFf
-flG
+aTe
 bjq
 bjq
 aux
@@ -70960,9 +71040,9 @@ flG
 flG
 flG
 atG
-hGy
+tpl
 aab
-hGy
+tpl
 aSW
 ajk
 ajk
@@ -71416,7 +71496,7 @@ aJB
 aJB
 aJB
 bhY
-wud
+gyw
 aUL
 aaO
 aaO
@@ -72488,8 +72568,8 @@ vTi
 bxo
 bSP
 axD
-qYP
-jBT
+vYV
+bNZ
 aRf
 ryv
 qDZ
@@ -73280,11 +73360,11 @@ anv
 anv
 mZN
 sIx
-pzX
+sdq
 qCz
 phS
 qCz
-fTu
+pIf
 sIx
 aAn
 bkE
@@ -73596,7 +73676,7 @@ auM
 ajB
 auM
 blh
-bll
+gof
 fkN
 fkN
 fkN
@@ -73740,7 +73820,7 @@ abZ
 eKt
 aza
 pWh
-ffM
+lqu
 hew
 kGA
 aMD
@@ -73853,9 +73933,9 @@ auM
 ajB
 auM
 bli
-blk
+ekp
 bkR
-bll
+gof
 fkN
 fkN
 fkN
@@ -73988,7 +74068,7 @@ noG
 noG
 atd
 fkN
-lsu
+apW
 abl
 aaZ
 aaZ
@@ -73997,7 +74077,7 @@ aaZ
 dgl
 rsR
 mft
-ffM
+lqu
 but
 nDN
 aug
@@ -74051,11 +74131,11 @@ mCn
 qNR
 veg
 ifm
-gJJ
+iYr
 qCz
-wOC
+twi
 qCz
-svM
+bVh
 sIx
 akX
 aeX
@@ -74110,9 +74190,9 @@ auM
 ajB
 auM
 bli
-blk
+ekp
 bkR
-bll
+gof
 fkN
 fkN
 fkN
@@ -74245,7 +74325,7 @@ stV
 aUL
 atd
 fkN
-lsu
+apW
 aiT
 aaZ
 aSc
@@ -74345,7 +74425,7 @@ fkN
 fkN
 bkQ
 bkR
-bkS
+bkQ
 bkR
 bkQ
 bla
@@ -74367,11 +74447,11 @@ auM
 ajB
 auM
 bli
-blk
+ekp
 bkR
-blk
+ekp
 bkR
-bll
+gof
 fkN
 aaa
 aaa
@@ -74502,7 +74582,7 @@ aUL
 bia
 atd
 fkN
-lsu
+apW
 nTy
 aaZ
 aaZ
@@ -74602,7 +74682,7 @@ fkN
 fkN
 bkQ
 bkR
-bkS
+bkQ
 bkR
 bkQ
 bla
@@ -74624,11 +74704,11 @@ auM
 ajB
 auM
 bli
-blk
+ekp
 bkR
-blk
+ekp
 bkR
-bll
+gof
 fkN
 aaa
 aaa
@@ -74881,9 +74961,9 @@ yau
 dQw
 auM
 bli
-blk
+ekp
 bkR
-bll
+gof
 fkN
 fkN
 fkN
@@ -75138,7 +75218,7 @@ dQw
 auM
 auM
 blj
-bll
+gof
 fkN
 fkN
 fkN
@@ -76053,7 +76133,7 @@ aaO
 aaO
 aaO
 aTD
-abw
+wPV
 heQ
 aKw
 aEv
@@ -76310,7 +76390,7 @@ rrJ
 bbb
 xHr
 aTD
-abw
+wPV
 heQ
 fuZ
 arq
@@ -76559,10 +76639,10 @@ aUL
 aJB
 fkN
 aIZ
-avr
-avr
-igP
-ueF
+gWt
+nIE
+uwm
+xKF
 aYm
 aKC
 aTD
@@ -76816,10 +76896,10 @@ aUL
 aJB
 fkN
 aIZ
-amY
-aWy
-aGs
-avr
+itZ
+jNi
+kKx
+ecc
 dNc
 iaw
 aTD
@@ -77075,8 +77155,8 @@ fkN
 aIZ
 abd
 azk
-aWj
-avr
+uZs
+ecc
 lMR
 iaw
 aTD
@@ -77331,9 +77411,9 @@ aJB
 fkN
 aIZ
 aIZ
-amp
-aWj
-avr
+mCZ
+uZs
+ecc
 aHI
 aKC
 eSR
@@ -77589,8 +77669,8 @@ fkN
 fkN
 aIZ
 aIZ
-aAp
-avr
+hHm
+kaA
 aZX
 aKC
 aKC
@@ -80711,9 +80791,9 @@ aWP
 aWP
 aWP
 aWP
-vrk
-uAY
-vrk
+cze
+kLX
+cze
 axM
 axM
 axM
@@ -85819,7 +85899,7 @@ aIx
 aub
 aub
 ayG
-aub
+aIx
 afB
 afB
 sbD
@@ -86076,7 +86156,7 @@ aIx
 aIx
 aub
 ayG
-aub
+qIT
 aub
 afB
 afB
@@ -104638,11 +104718,11 @@ fkN
 fkN
 fkN
 fkN
-hYe
-hYe
-hYe
-hYe
-hYe
+dUV
+dUV
+dUV
+dUV
+dUV
 oZG
 cQp
 cQp
@@ -104894,8 +104974,8 @@ fkN
 fkN
 fkN
 fkN
-hYe
-hYe
+dUV
+dUV
 ecJ
 nUL
 xFh
@@ -105150,13 +105230,13 @@ bgW
 fkN
 fkN
 fkN
-hYe
-hYe
+dUV
+dUV
 cSY
 bGc
 aWk
 aWk
-dzM
+xGJ
 aym
 wwp
 hNV
@@ -105407,12 +105487,12 @@ bgW
 bgW
 fkN
 fkN
-hYe
+dUV
 iyP
 uXP
 moh
 lGq
-dvz
+nPQ
 xiD
 pGC
 mcm
@@ -105666,16 +105746,16 @@ bgW
 ajz
 oZG
 wdK
-hqD
-rfS
+qds
+mDT
 nPO
 oaN
-cye
+jkf
 oZG
 lzs
 njf
 uJA
-avy
+hXv
 avy
 avy
 pUG
@@ -105924,7 +106004,7 @@ fkN
 oZG
 oZG
 oZG
-het
+bWH
 oZG
 iIr
 iIr
@@ -106181,7 +106261,7 @@ aar
 kUJ
 ajz
 aIJ
-wNv
+vFN
 aIJ
 ajz
 yfL
@@ -106438,7 +106518,7 @@ pPU
 pPU
 pPU
 pPU
-gbq
+wrQ
 aVX
 vOF
 vOF
@@ -106695,7 +106775,7 @@ axt
 aVN
 jKL
 pWP
-yhc
+kqt
 aqU
 aKm
 fqA
@@ -106952,7 +107032,7 @@ aGq
 aVA
 pqx
 xqm
-eWc
+rFw
 aqU
 aNU
 ack
@@ -107209,7 +107289,7 @@ aVX
 aVX
 aVX
 mia
-ubM
+rNT
 aqU
 aNU
 ack
@@ -107466,7 +107546,7 @@ aUf
 aWb
 umU
 hPH
-rJF
+gXh
 aVX
 bcP
 ack
@@ -107723,7 +107803,7 @@ aUi
 aWc
 aqU
 xqm
-fUX
+izL
 aqU
 bcR
 ack
@@ -107980,7 +108060,7 @@ aVX
 aVX
 aVX
 xLX
-fUX
+izL
 aqU
 bcR
 ack
@@ -108237,7 +108317,7 @@ aUV
 aWe
 aqU
 xqm
-fUX
+izL
 aqU
 bcR
 ack
@@ -108494,7 +108574,7 @@ aGq
 aGq
 sof
 xqm
-fUX
+izL
 aVX
 bcS
 ack
@@ -108751,7 +108831,7 @@ aVX
 aVX
 aVX
 tnl
-asp
+dGm
 aqU
 bcR
 ggi
@@ -109008,7 +109088,7 @@ rIP
 aoC
 hrY
 xqm
-fUX
+izL
 aqU
 bcR
 ack
@@ -109265,7 +109345,7 @@ qhv
 mgG
 aVX
 bat
-fUX
+izL
 aqU
 bcT
 mZS
@@ -109522,7 +109602,7 @@ rlF
 gpa
 aVX
 aMb
-wEc
+xop
 aVX
 aOz
 aOz
@@ -109779,7 +109859,7 @@ aLU
 aLU
 uDi
 kDO
-jtv
+lMX
 nBs
 sJb
 nBs
@@ -110030,13 +110110,13 @@ azH
 azH
 azH
 xIc
-bgP
-odW
-aCl
-aCl
-odW
-ani
-qlq
+xNJ
+kBd
+mLH
+mLH
+kBd
+muY
+hfk
 aCl
 aCl
 aCl

--- a/_maps/map_files/Hammerhead/Hammerhead.dmm
+++ b/_maps/map_files/Hammerhead/Hammerhead.dmm
@@ -13342,10 +13342,6 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/bridge/meeting_room)
-"aGZ" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/bridge/meeting_room)
 "aHa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 9
@@ -14587,21 +14583,6 @@
 "aKg" = (
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"aKh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/door/airlock/ship/public{
-	name = "Bar closet";
-	req_one_access_txt = "25"
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "aKi" = (
 /obj/machinery/atmospherics/components/unary/portables_connector,
 /obj/machinery/light/small{
@@ -21390,17 +21371,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/hydroponics)
-"bbe" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "hos_privacy";
-	name = "privacy shutter"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hos)
 "bbf" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plasteel,
@@ -23602,6 +23572,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"bgL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
 "bgV" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -25333,15 +25309,15 @@
 /obj/effect/turf_decal/delivery/white,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"blB" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
+"blt" = (
+/obj/machinery/door/airlock/ship/public{
+	name = "Hydroponics Backroom";
+	req_one_access_txt = "35"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/engine/engineering/hangar)
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "blW" = (
 /obj/machinery/door/poddoor{
 	id = "chapelgun";
@@ -25389,6 +25365,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"bmQ" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "bnb" = (
 /obj/machinery/newscaster{
 	pixel_y = -30
@@ -25396,20 +25378,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/central)
-"bnO" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/westright{
-	name = "Hydroponics Desk";
-	req_one_access_txt = "35"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "bot_south";
-	name = "privacy shutter"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plating,
-/area/hydroponics)
 "bog" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -25451,17 +25419,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
-"bpS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plasteel/ship,
-/area/security/prison)
 "bqi" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -25499,9 +25456,6 @@
 "brd" = (
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/hanger)
-"brg" = (
-/turf/open/floor/monotile/light,
-/area/science/storage)
 "brq" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
@@ -25522,28 +25476,30 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
-"brS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/bridge)
-"brV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/engineering/hangar)
 "brZ" = (
 /obj/machinery/light/built{
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/construction)
+"bsB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/security/glass{
+	name = "Riot Armory";
+	req_one_access_txt = "3"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/ship,
+/area/ai_monitored/security/armory/security)
 "bsP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -25571,6 +25527,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"bup" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "but" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -25587,13 +25549,6 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"buO" = (
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/monotile/light,
-/area/science/storage)
 "bva" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel/ship,
@@ -25607,6 +25562,11 @@
 /obj/item/flashlight/lamp/bananalamp,
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
+"bvC" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "bvK" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -25630,33 +25590,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
+"bwA" = (
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "bwN" = (
 /obj/machinery/light/broken,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"bwO" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/break_room)
-"bxg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/ship/command{
-	dir = 4;
-	name = "Gravity Generator";
-	req_one_access_txt = "56"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/engine/gravity_generator)
 "bxo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -25769,15 +25719,6 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
-"bAZ" = (
-/obj/machinery/door/airlock/virology/glass{
-	name = "Isolation A";
-	req_one_access_txt = "39"
-	},
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "bBg" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
 	dir = 4
@@ -25836,6 +25777,9 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/crew_quarters/dorms)
+"bEf" = (
+/turf/open/floor/plating,
+/area/space/nearstation)
 "bFG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -25872,12 +25816,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/lockup)
-"bGF" = (
-/obj/item/storage/box/lights/mixed,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/closet/crate,
+"bGz" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
 /turf/open/floor/plating,
-/area/maintenance/department/electrical)
+/area/engine/gravity_generator)
+"bGF" = (
+/obj/structure/table,
+/obj/item/disk/holodisk/hammerhead_cryo,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "bGN" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -25885,6 +25832,16 @@
 /obj/effect/landmark/start/chief_medical_officer,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo)
+"bHb" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/fore)
 "bHn" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/closet/secure_closet/engineering_personal,
@@ -25914,13 +25871,10 @@
 /obj/structure/closet/secure_closet/brig_phys,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"bJz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/effect/spawner/lootdrop/maintenance,
+"bKR" = (
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/maintenance/department/bridge)
+/area/engine/engineering)
 "bLk" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -25943,19 +25897,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar/atrium)
-"bLJ" = (
-/obj/machinery/door/airlock/ship/hatch{
-	name = "Air Control Right";
-	req_one_access_txt = "19;69"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plasteel/ship,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
 "bLM" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -26021,6 +25962,24 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
+"bNg" = (
+/obj/machinery/door/airlock/virology/glass{
+	name = "Test Subject Supply";
+	req_one_access_txt = "39"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "bNx" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -26044,6 +26003,10 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"bOh" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/science/mixing/chamber)
 "bPL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /obj/machinery/light{
@@ -26068,9 +26031,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"bRj" = (
-/turf/open/floor/plasteel/dark,
-/area/maintenance/port/central)
 "bRn" = (
 /obj/effect/turf_decal/stripes/red/corner,
 /obj/structure/cable{
@@ -26136,6 +26096,24 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/patients_rooms/room_a)
+"bSL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/hatch{
+	name = "Support Vessel Fore";
+	req_one_access_txt = "61;65"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/ai_monitored/turret_protected/aisat/hallway/support_ship)
 "bSV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26154,6 +26132,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"bTw" = (
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/fore)
 "bTF" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/airlock/highsecurity/ship{
@@ -26163,18 +26150,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/weapons/fore)
-"bTR" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "bTW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26197,14 +26172,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/exit)
-"bUi" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "bUA" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -26217,6 +26184,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"bUL" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "32"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "bVh" = (
 /obj/machinery/armour_plating_nanorepair_pump/forward_port{
 	apnw_id = "poolnoodles"
@@ -26315,10 +26297,6 @@
 /obj/machinery/vending/wardrobe/cargo_wardrobe,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"bXs" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "bXP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -26468,14 +26446,23 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/central)
-"ccS" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/open/floor/monotile/dark,
-/area/science/storage)
 "ccX" = (
 /obj/structure/curtain/obscuring/grey,
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
+"cdq" = (
+/obj/item/storage/box/lights/mixed,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "cdZ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -26489,13 +26476,16 @@
 /obj/structure/closet/l3closet/scientist,
 /turf/open/floor/plasteel,
 /area/gateway)
-"cet" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
+"cfU" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
-/obj/effect/spawner/room/threexthree,
-/turf/template_noop,
-/area/maintenance/department/bridge)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/landmark/nuclear_waste_spawner/strong,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "cgd" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 8
@@ -26509,13 +26499,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
-"cjf" = (
-/obj/effect/spawner/lootdrop/grille_or_trash,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
 "cjk" = (
 /obj/machinery/airlock_sensor/incinerator_atmos{
 	pixel_x = 24;
@@ -26604,12 +26587,6 @@
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar/atrium)
-"clw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "clF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/cable{
@@ -26631,19 +26608,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"cmk" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
 "cne" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -26665,6 +26629,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
+"cpf" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/monotile/light,
+/area/science/storage)
 "cpL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -26681,12 +26652,6 @@
 "cqh" = (
 /turf/open/floor/carpet/red,
 /area/security/detectives_office/private_investigators_office)
-"cqk" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/monotile/dark,
-/area/science/storage)
 "cql" = (
 /obj/effect/turf_decal/bot_white,
 /obj/effect/spawner/lootdrop/maintenance/eight,
@@ -26748,6 +26713,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"csT" = (
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "cto" = (
 /obj/machinery/light{
 	dir = 1
@@ -26864,24 +26833,6 @@
 /obj/item/camera/detective,
 /turf/open/floor/wood,
 /area/security/detectives_office/private_investigators_office)
-"cyE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/door/airlock/ship/security/glass{
-	name = "Riot Armory";
-	req_one_access_txt = "3"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plasteel/ship,
-/area/ai_monitored/security/armory/security)
 "cyJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/mech_bay_recharge_floor,
@@ -26940,10 +26891,6 @@
 /obj/machinery/vending/hydronutrients,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"cAb" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/hallway/secondary/exit/departure_lounge)
 "cAd" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -26995,19 +26942,6 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"cBD" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/security/main)
 "cBX" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced/spawner/west,
@@ -27035,10 +26969,16 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"cCP" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
+"cCo" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor/eastright{
+	name = "Security Desk";
+	req_one_access_txt = "63"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plating,
-/area/crew_quarters/heads/captain/private)
+/area/security/prison)
 "cDe" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -27069,6 +27009,10 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"cEK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "cEN" = (
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
@@ -27118,32 +27062,27 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"cHy" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	department = "Security";
+	departmentType = 7;
+	pixel_x = -32
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/security/prison)
 "cIi" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
-"cIo" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "xoprivacy";
-	name = "Privacy Shutters"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hop)
 "cIx" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
@@ -27222,24 +27161,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/entry)
-"cMr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Patient Room A";
-	req_one_access_txt = "5"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plasteel/white,
-/area/medical/patients_rooms/room_a)
 "cNO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -27313,6 +27234,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
+"cQg" = (
+/obj/machinery/door/airlock/ship/hatch{
+	name = "Air Control Right";
+	req_one_access_txt = "19;69"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plasteel/ship/padded,
+/area/maintenance/starboard/central)
+"cQk" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/library)
 "cQr" = (
 /obj/structure/table/reinforced,
 /obj/item/pen/fourcolor,
@@ -27364,6 +27298,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
+"cTk" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "cTr" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -27414,19 +27354,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"cVD" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+"cWT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 8
-	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/ship,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "cXR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -27498,6 +27437,18 @@
 /obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"cZS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "daq" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -27571,6 +27522,24 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/exit)
+"dcg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/hatch{
+	name = "Support Vessel Aft";
+	req_one_access_txt = "16;65"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/ai_monitored/turret_protected/aisat/hallway/support_ship/aft)
 "dcq" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -27584,10 +27553,15 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "dcM" = (
-/obj/structure/railing,
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor/northright{
+	name = "Security Desk";
+	req_one_access_txt = "63"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plating,
-/area/construction)
+/area/security/prison)
 "dcR" = (
 /obj/machinery/atmospherics/pipe/simple/dark/hidden/layer1{
 	dir = 8
@@ -27626,12 +27600,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/central)
-"deO" = (
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "dft" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -27656,13 +27624,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"dgb" = (
-/obj/machinery/computer/ship/viewscreen,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
 "dgl" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -27711,17 +27672,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"did" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "diq" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/structure/extinguisher_cabinet/west,
@@ -27780,18 +27730,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/crew_quarters/heads/hor)
-"dki" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
 "dkL" = (
 /obj/machinery/button/door{
 	dir = 8;
@@ -27861,27 +27799,6 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/quartermaster/storage)
-"dne" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/sorting/mail{
-	sortType = 7
-	},
-/turf/open/floor/plasteel/ship,
-/area/security/prison)
 "dnv" = (
 /obj/effect/landmark/start/master_at_arms,
 /turf/open/floor/plasteel/ship,
@@ -28055,23 +27972,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"drW" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "chem_privacy";
-	name = "privacy shutter"
-	},
-/obj/machinery/smartfridge/chemistry/preloaded,
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plating,
-/area/medical/medbay/lobby)
-"dsF" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/monotile/dark,
-/area/science/storage)
 "dtf" = (
 /obj/structure/grille,
 /obj/structure/cable,
@@ -28090,26 +27990,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/ai_monitored/turret_protected/ai)
-"dto" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Hangar Bay"
-	},
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	dir = 4;
-	id = "hang_storage"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
 "dtr" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -28141,6 +28021,13 @@
 /obj/effect/turf_decal/delivery/white,
 /turf/open/floor/plasteel/ship,
 /area/nsv/hanger)
+"duA" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "duG" = (
 /obj/effect/spawner/lootdrop/costume,
 /obj/structure/rack,
@@ -28154,16 +28041,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"dvc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/status_display/evac/west,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/port)
 "dvl" = (
 /obj/machinery/atmospherics/pipe/manifold/purple/visible{
 	dir = 4
@@ -28339,6 +28216,21 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/hallway/support_ship)
+"dyU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/public{
+	name = "Bar closet";
+	req_one_access_txt = "25"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "dyX" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -28380,19 +28272,12 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
-"dDn" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
+"dDc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
+/obj/effect/spawner/room/threexthree,
+/turf/template_noop,
 /area/maintenance/department/bridge)
 "dDB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
@@ -28594,29 +28479,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
-"dNI" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/monotile/dark,
-/area/science/storage)
 "dOi" = (
 /obj/item/clothing/glasses/sunglasses/advanced,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
-"dOz" = (
-/obj/structure/sign/directions/evac{
-	dir = 1
-	},
-/obj/structure/sign/directions/supply{
-	dir = 1;
-	pixel_y = 8
-	},
-/obj/structure/sign/directions/engineering{
-	dir = 8;
-	pixel_y = -8
-	},
-/turf/closed/wall/ship,
-/area/hallway/secondary/service)
 "dOG" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
@@ -28638,11 +28504,16 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"dPc" = (
-/obj/structure/grille/broken,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
+"dPx" = (
+/obj/structure/sign/directions/evac{
+	dir = 8
+	},
+/obj/structure/sign/directions/engineering{
+	dir = 8;
+	pixel_y = -8
+	},
+/turf/closed/wall/ship,
+/area/maintenance/department/crew_quarters/dorms)
 "dPI" = (
 /obj/machinery/computer/teleporter{
 	dir = 8
@@ -28845,11 +28716,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
-"dWI" = (
-/obj/structure/railing,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plasteel,
-/area/construction)
 "dXj" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -28872,24 +28738,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"dZx" = (
-/obj/machinery/door/airlock/virology/glass{
-	name = "Test Subject Supply";
-	req_one_access_txt = "39"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "dZQ" = (
 /obj/machinery/camera/autoname,
 /turf/open/floor/circuit,
@@ -28995,6 +28843,18 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/central)
+"efj" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
+"efr" = (
+/obj/machinery/status_display/ai{
+	pixel_x = -32
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/fore)
 "efz" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	name = "Kitchen maintenance";
@@ -29022,6 +28882,11 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/exit)
+"egx" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "egP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -29067,30 +28932,6 @@
 /obj/machinery/recharge_station,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
-"eiL" = (
-/obj/machinery/button/door{
-	id = "ad_gun";
-	name = "Arms Dump Gun Storage";
-	pixel_x = 0;
-	pixel_y = 24;
-	req_one_access_txt = "3;58"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory/lockup)
-"eiT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel/ship,
-/area/hallway/primary/fore)
 "eiW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 6
@@ -29171,9 +29012,20 @@
 /obj/item/mop,
 /turf/open/floor/plating,
 /area/maintenance/port/central)
-"ely" = (
-/obj/effect/landmark/blobstart,
-/turf/template_noop,
+"elH" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "chem_privacy";
+	name = "privacy shutter"
+	},
+/obj/machinery/smartfridge/chemistry/preloaded,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/medical/medbay/lobby)
+"emv" = (
+/obj/structure/closet/radiation,
+/obj/item/clothing/mask/gas,
+/obj/item/tank/internals/oxygen/yellow,
+/turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "emx" = (
 /obj/machinery/light,
@@ -29226,12 +29078,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/warden)
-"epG" = (
-/obj/structure/closet/radiation,
-/obj/item/tank/internals/oxygen/yellow,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "epN" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -29272,6 +29118,32 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/wood,
 /area/science/research)
+"era" = (
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Long-Term Confinement"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "cell2_ld";
+	name = "Cell 2 Lockdown"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/security/prison)
+"erc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "ert" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/cable{
@@ -29288,17 +29160,6 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/lockup)
-"erI" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "ce_window";
-	name = "privacy shutter"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/chief)
 "erO" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/red,
@@ -29383,23 +29244,27 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
-"evj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/morgue{
-	name = "Private Study";
-	req_access_txt = "37"
+"eva" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/wood,
-/area/library)
-"evx" = (
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/security/glass{
+	name = "Hangar Bay";
+	req_one_access_txt = "69"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/dark,
+/area/nsv/hanger)
 "ewW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -29424,6 +29289,20 @@
 	},
 /turf/open/floor/plating,
 /area/nsv/weapons/fore)
+"eyQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/ship/security{
+	name = "Private Investigator's Office";
+	req_one_access_txt = "4"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plasteel,
+/area/security/detectives_office/private_investigators_office)
 "eza" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "12"
@@ -29451,6 +29330,12 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/quartermaster/storage)
+"eAW" = (
+/obj/structure/closet/radiation,
+/obj/item/tank/internals/oxygen/yellow,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "eAZ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -29495,6 +29380,24 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"eCj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Patient Room A";
+	req_one_access_txt = "5"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/white,
+/area/medical/patients_rooms/room_a)
 "eCU" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -29556,6 +29459,9 @@
 /obj/item/toy/plush/lizardplushie,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"eEG" = (
+/turf/template_noop,
+/area/maintenance/department/bridge)
 "eFd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -29591,10 +29497,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"eHb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/turf/open/floor/plating,
-/area/engine/engineering/hangar)
 "eHs" = (
 /obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/ship/techfloor/alt,
@@ -29651,6 +29553,42 @@
 /area/nsv/hanger/deck2/port{
 	name = "Launch tubes 3 and 4"
 	})
+"eJc" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/snacks/pie/cream,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "Serving Hatch"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"eJy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship,
+/area/hallway/primary/fore)
+"eJR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "eKt" = (
 /obj/machinery/button/door/incinerator_vent_toxmix{
 	pixel_x = -24
@@ -29713,10 +29651,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/storage)
-"eMq" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/visible,
-/turf/open/floor/plating,
-/area/engine/engineering/hangar)
 "eMu" = (
 /obj/machinery/newscaster{
 	pixel_x = 30
@@ -29757,34 +29691,11 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"eNA" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor/northright{
-	name = "Warden's Desk";
-	req_one_access_txt = "3"
-	},
-/obj/machinery/door/window/brigdoor/southright{
-	name = "Warden's Desk";
-	req_one_access_txt = "3"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plating,
-/area/security/warden)
 "eNE" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/ai_slipper,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
-"eNU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/turf/template_noop,
-/area/maintenance/port/central)
 "eNV" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -29810,6 +29721,24 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"ePb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
+"ePr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/break_room)
 "ePt" = (
 /obj/effect/turf_decal/arrows/red,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -29822,19 +29751,17 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/fore)
-"ePK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Brig-1";
-	location = "Brig-0"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/ship,
-/area/hallway/primary/fore)
+"ePC" = (
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
+"ePO" = (
+/obj/structure/closet/radiation,
+/obj/item/clothing/mask/gas,
+/obj/item/tank/internals/oxygen/yellow,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "eRs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -29855,18 +29782,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"eRC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
 "eRN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -29928,6 +29843,24 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"eTW" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship,
+/area/hallway/primary/fore)
 "eTX" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel/ship,
@@ -30004,6 +29937,16 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"eXO" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "eXV" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -30109,16 +30052,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"faw" = (
-/obj/structure/sign/directions/command{
-	dir = 4;
-	pixel_y = -8
-	},
-/obj/structure/sign/directions/security{
-	dir = 4
-	},
-/turf/closed/wall/ship,
-/area/nsv/hanger)
 "fcs" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -30142,18 +30075,19 @@
 /obj/item/storage/box/donkpockets,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"fdm" = (
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "fdA" = (
 /obj/effect/spawner/xmastree,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"fdW" = (
+/obj/machinery/door/airlock/ship/hatch{
+	name = "Air Control Left";
+	req_one_access_txt = "19;69"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plasteel/ship/padded,
+/area/maintenance/starboard/central)
 "feC" = (
 /turf/closed/wall/ship,
 /area/maintenance/department/science/central)
@@ -30186,6 +30120,9 @@
 /obj/effect/spawner/lootdrop/maintenance/five,
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
+"ffk" = (
+/turf/closed/wall/r_wall/ship,
+/area/space/nearstation)
 "ffW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -30197,6 +30134,19 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
+"fge" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/security/prison)
 "fgz" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/table/wood,
@@ -30246,10 +30196,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"fhl" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering/hangar)
 "fhB" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -30259,6 +30205,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
+"fhD" = (
+/obj/structure/sign/directions/evac{
+	dir = 1
+	},
+/obj/structure/sign/directions/supply{
+	dir = 1;
+	pixel_y = 8
+	},
+/obj/structure/sign/directions/engineering{
+	dir = 8;
+	pixel_y = -8
+	},
+/turf/closed/wall/ship,
+/area/hallway/secondary/service)
 "fiq" = (
 /obj/machinery/door/window/brigdoor/security/cell/southright{
 	id = "pw_6";
@@ -30279,6 +30239,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
+"fjy" = (
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
 "fkM" = (
 /obj/structure/bed/dogbed/runtime,
 /obj/structure/cable{
@@ -30292,27 +30259,6 @@
 "fkN" = (
 /turf/open/space/basic,
 /area/space/nearstation)
-"flp" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/landmark/nuclear_waste_spawner/strong,
-/turf/open/floor/plasteel/ship,
-/area/engine/engineering/hangar)
-"flT" = (
-/obj/machinery/door/airlock/ship/security/glass{
-	id_tag = "pw_fd_inner";
-	name = "Brig";
-	req_one_access_txt = "63"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/security/prison)
 "fmb" = (
 /obj/effect/landmark/start/atmospheric_technician,
 /obj/machinery/camera/autoname{
@@ -30320,10 +30266,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"fmi" = (
-/obj/effect/spawner/room/fivexfour,
-/turf/template_noop,
-/area/maintenance/department/electrical)
 "fmX" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -30342,8 +30284,9 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
-"foD" = (
-/obj/machinery/portable_atmospherics/canister/air,
+"fpd" = (
+/obj/machinery/light/small,
+/obj/machinery/portable_atmospherics/canister/toxins,
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/monotile/dark,
 /area/science/storage)
@@ -30369,13 +30312,7 @@
 "fpL" = (
 /turf/open/floor/wood,
 /area/science/research)
-"fqj" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/monotile/dark,
-/area/science/storage)
-"fqn" = (
+"fqh" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor/northleft{
 	name = "Security Desk";
@@ -30433,26 +30370,6 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"fra" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Long-Term Confinement"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "cell4_ld";
-	name = "Cell 4 Lockdown"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/security/prison)
 "frx" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "fab_storage";
@@ -30470,6 +30387,21 @@
 	},
 /turf/open/floor/wood,
 /area/security/detectives_office/private_investigators_office)
+"frX" = (
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Long-Term Confinement"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "cell1_ld";
+	name = "Cell 1 Lockdown"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/security/prison)
 "fsk" = (
 /obj/effect/turf_decal/stripes/red/corner{
 	dir = 4
@@ -30606,17 +30538,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/storage)
-"fxA" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "xoprivacy";
-	name = "Privacy Shutters"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hop)
 "fxB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -30647,57 +30568,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"fyk" = (
-/obj/effect/turf_decal/loading_area/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/door/airlock/ship/hatch{
-	name = "AI Upload Access";
-	req_one_access_txt = "16"
-	},
-/obj/machinery/door/poddoor{
-	id = "aiship_upload";
-	name = "AI Upload Security Door"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plasteel/ship,
-/area/ai_monitored/turret_protected/ai_upload)
-"fys" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/maintenance/department/bridge)
 "fyw" = (
 /obj/structure/table_frame/wood,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"fyJ" = (
-/obj/structure/sign/directions/medical{
-	dir = 4
-	},
-/obj/structure/sign/directions/evac{
-	dir = 4;
-	pixel_y = 8
-	},
-/obj/structure/sign/directions/supply{
-	dir = 4;
-	pixel_y = -8
-	},
-/turf/closed/wall/ship,
-/area/medical/chemistry)
 "fzR" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -30786,6 +30661,11 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
+"fDd" = (
+/obj/structure/table,
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "fDf" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -30857,11 +30737,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
-"fES" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/monotile/dark,
-/area/science/storage)
 "fEY" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "12"
@@ -30877,6 +30752,16 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"fFK" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "fGl" = (
 /obj/structure/window/reinforced,
 /obj/machinery/conveyor{
@@ -30889,27 +30774,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
-"fHR" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
-"fId" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/ship,
-/area/hallway/primary/fore)
 "fIp" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/ship/maintenance{
@@ -30922,30 +30786,6 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
-"fIA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 4;
-	id = "aicore_entrance";
-	name = "AI Core Entrance Shutters"
-	},
-/obj/machinery/door/airlock/ship/hatch{
-	name = "Intelligence Core";
-	req_one_access_txt = "16"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plasteel/ship,
-/area/ai_monitored/turret_protected/ai)
 "fIM" = (
 /obj/structure/chair/pew/right,
 /obj/effect/landmark/start/assistant,
@@ -30996,11 +30836,6 @@
 /area/nsv/hanger/deck2/port{
 	name = "Launch tubes 3 and 4"
 	})
-"fKv" = (
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "fKx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -31047,6 +30882,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/eva)
+"fKP" = (
+/obj/machinery/advanced_airlock_controller/directional/west{
+	pixel_y = 24
+	},
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "fKQ" = (
 /obj/machinery/power/apc/highcap/fifteen_k{
 	auto_name = 1;
@@ -31236,15 +31077,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/entry)
-"fRz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/bridge)
 "fSp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31258,10 +31090,6 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"fSJ" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/medical/virology)
 "fTe" = (
 /turf/closed/wall/r_wall/ship,
 /area/ai_monitored/turret_protected/aisat/service/support_ship)
@@ -31350,12 +31178,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"fYQ" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/monotile/dark,
-/area/science/storage)
 "fYU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -31432,6 +31254,11 @@
 /obj/machinery/atmospherics/pipe/simple/brown/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"gbJ" = (
+/obj/structure/girder,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "gbL" = (
 /obj/structure/grille,
 /obj/structure/cable{
@@ -31455,26 +31282,19 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"gcK" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/nsv/hanger)
-"gdL" = (
-/obj/machinery/smartfridge/drinks,
-/obj/machinery/door/firedoor,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"get" = (
-/obj/structure/closet/radiation,
-/obj/item/tank/internals/oxygen/yellow,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "geE" = (
 /obj/structure/table/wood,
 /obj/machinery/microwave,
 /turf/open/floor/carpet/orange,
 /area/engine/break_room)
+"geR" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "geX" = (
 /obj/machinery/light{
 	dir = 8
@@ -31571,16 +31391,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs/auxiliary)
-"gkX" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 4
-	},
-/obj/structure/sign/poster/official/obey{
-	pixel_x = -32
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
 "gln" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=CentHallCurv-1";
@@ -31635,10 +31445,6 @@
 /obj/item/stack/spacecash/c1,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"gnJ" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/security/main)
 "gnT" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -31711,6 +31517,15 @@
 /obj/structure/munitions_trolley,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/hanger)
+"gre" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/template_noop,
+/area/maintenance/department/electrical)
 "grs" = (
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
@@ -31727,18 +31542,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/nsv/hanger)
-"gsH" = (
-/obj/structure/plasticflaps,
-/obj/machinery/door/poddoor/shutters{
-	id = "cmbridge";
-	name = "Cargo Munitions Bridge Shutter"
-	},
-/obj/machinery/conveyor{
-	id = "cmbelt"
-	},
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plating,
-/area/nsv/weapons/fore)
 "gsY" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -4
@@ -31751,14 +31554,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"gtr" = (
-/obj/machinery/power/apc/auto_name/south{
-	pixel_y = -24
-	},
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/structure/cable,
-/turf/open/floor/monotile/dark,
-/area/science/storage)
 "gtu" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 8
@@ -31786,12 +31581,6 @@
 "gtQ" = (
 /turf/template_noop,
 /area/maintenance/department/medical/morgue)
-"guj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/engineering/hangar)
 "gum" = (
 /obj/effect/turf_decal/caution/white,
 /obj/structure/cable{
@@ -31954,16 +31743,6 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/ship,
 /area/security/prison)
-"gzJ" = (
-/obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 32
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
 "gzR" = (
 /obj/effect/landmark/start/flight_leader,
 /turf/open/floor/plasteel/ship,
@@ -31974,6 +31753,15 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
+"gAl" = (
+/obj/machinery/door/airlock/ship/security/glass{
+	name = "Riot Armory";
+	req_one_access_txt = "3"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/ship,
+/area/ai_monitored/security/armory/security)
 "gAB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 8
@@ -32061,32 +31849,6 @@
 /obj/structure/tank_dispenser,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"gFe" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor/eastleft{
-	name = "Security Desk";
-	req_one_access_txt = "63"
-	},
-/obj/machinery/button/door{
-	id = "pw_fd_outer";
-	name = "Exterior Door Control";
-	normaldoorcontrol = 1;
-	pixel_x = 8;
-	pixel_y = 24;
-	req_one_access_txt = "63"
-	},
-/obj/machinery/button/door{
-	id = "pw_fd_inner";
-	name = "Interior Door Control";
-	normaldoorcontrol = 1;
-	pixel_x = -8;
-	pixel_y = 24;
-	req_one_access_txt = "63"
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plating,
-/area/security/prison)
 "gFu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -32096,31 +31858,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"gFI" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
-"gGZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/door/airlock/ship/hatch{
-	name = "Support Vessel Service";
-	req_one_access_txt = "65"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/service/support_ship)
 "gHc" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -32130,19 +31867,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/gateway)
-"gHg" = (
-/obj/machinery/door/airlock/ship/hatch{
-	name = "Air Control Left";
-	req_one_access_txt = "19;69"
-	},
+"gHq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Brig-1";
+	location = "Brig-0"
+	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/ship,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
+/area/hallway/primary/fore)
+"gIH" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "gIK" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
@@ -32174,6 +31915,18 @@
 /obj/structure/closet/wardrobe/white,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
+"gKv" = (
+/obj/machinery/door/airlock/ship/engineering{
+	name = "Engineering Cupboard";
+	req_one_access_txt = "10"
+	},
+/obj/effect/mapping_helpers/airlock/abandoned,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
+"gLu" = (
+/obj/effect/landmark/blobstart,
+/turf/template_noop,
+/area/maintenance/port/central)
 "gLy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -32229,21 +31982,39 @@
 "gMn" = (
 /turf/open/floor/wood,
 /area/maintenance/starboard/central)
-"gMv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 6
-	},
+"gMp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 5
+	dir = 4
 	},
-/turf/open/floor/monotile/light,
-/area/science/storage)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/template_noop,
+/area/maintenance/department/electrical)
 "gMA" = (
 /obj/machinery/light/broken{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"gNq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/ship/command{
+	name = "Captain's Quarters";
+	req_one_access_txt = "20"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/heads/captain/private)
 "gNP" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -32281,22 +32052,33 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plasteel/ship,
 /area/security/warden)
-"gOY" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+"gPA" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/machinery/door/window{
-	req_one_access_txt = "11"
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plating,
-/area/construction)
-"gPi" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/door/airlock/ship/security/glass{
+	name = "Long-Term Confinement";
+	req_one_access_txt = "2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/security/prison)
+"gPF" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/brown/hidden{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/engine/engine_room)
 "gRn" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -32359,25 +32141,15 @@
 /obj/item/storage/box/bodybags,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"gTe" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
-"gTJ" = (
+"gSw" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/door/airlock/ship/external{
+	req_one_access_txt = "24;32"
 	},
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/ship,
-/area/hallway/primary/fore)
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "gUr" = (
 /obj/structure/table/glass,
 /obj/effect/spawner/lootdrop/aimodule_neutral,
@@ -32392,28 +32164,6 @@
 /obj/item/grenade/barrier,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/security)
-"gUQ" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/computer/ship/viewscreen,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/central)
-"gUX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Surgery";
-	req_one_access_txt = "45"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/plasteel/dark,
-/area/medical/surgery)
 "gVf" = (
 /obj/item/radio/intercom{
 	pixel_y = -26
@@ -32520,6 +32270,15 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/security/prison)
+"gXv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
 "gXy" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -32735,36 +32494,11 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
-"hdB" = (
-/obj/machinery/light/small,
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/monotile/dark,
-/area/science/storage)
 "hdT" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/storage)
-"hdY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Bridge-Ext";
-	location = "Fore-Weapons"
-	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	sortType = "7;8;15"
-	},
-/turf/open/floor/plasteel/ship,
-/area/hallway/primary/fore)
 "hew" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -32897,14 +32631,6 @@
 /obj/machinery/computer/secure_data/laptop,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/heads/hop)
-"hgm" = (
-/obj/machinery/door/airlock/ship/engineering{
-	name = "Engineering Cupboard";
-	req_one_access_txt = "10"
-	},
-/obj/effect/mapping_helpers/airlock/abandoned,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "hgn" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "12"
@@ -32926,12 +32652,6 @@
 /obj/effect/landmark/start/lawyer,
 /turf/open/floor/carpet,
 /area/security/courtroom)
-"hgV" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1
-	},
-/turf/template_noop,
-/area/maintenance/department/electrical)
 "hht" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -32951,12 +32671,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
-"hhI" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/monotile/dark,
-/area/science/storage)
 "hiT" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 8
@@ -33079,25 +32793,45 @@
 "hmw" = (
 /turf/open/floor/plasteel/ship,
 /area/nsv/hanger)
-"hmR" = (
-/obj/machinery/door/airlock/ship/public{
-	name = "Bar closet";
-	req_one_access_txt = "25"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "hmS" = (
 /obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"hmW" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "hnd" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/exit/departure_lounge)
+"hng" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/door/airlock/ship/security/glass{
+	name = "Long-Term Confinement";
+	req_one_access_txt = "2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/security/prison)
 "hnz" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -33138,6 +32872,21 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
+"hoX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/ship/hatch{
+	name = "Crematorium";
+	req_one_access_txt = "27"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "hpc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33170,13 +32919,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"hpp" = (
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/bridge)
 "hpv" = (
 /obj/structure/sign/plaques/kiddie/library{
 	pixel_y = 32
@@ -33227,6 +32969,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"hsp" = (
+/obj/structure/sign/directions/evac{
+	dir = 8
+	},
+/obj/structure/sign/directions/supply{
+	dir = 4;
+	pixel_y = -8
+	},
+/turf/closed/wall/ship,
+/area/maintenance/department/crew_quarters/bar)
 "hss" = (
 /obj/machinery/light,
 /obj/structure/table/glass,
@@ -33307,6 +33059,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"huJ" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/computer/ship/viewscreen,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/central)
 "hvo" = (
 /obj/machinery/vending/games,
 /obj/structure/extinguisher_cabinet/north,
@@ -33360,6 +33119,13 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/weapons/fore)
+"hxW" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/landmark/nuclear_waste_spawner/strong,
+/turf/open/floor/plasteel/ship,
+/area/engine/engineering/hangar)
 "hye" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -33402,19 +33168,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"hyT" = (
-/obj/item/assembly/mousetrap/armed,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
 "hzO" = (
 /obj/structure/sign/poster/official/pda_ad{
 	pixel_x = -32
@@ -33435,11 +33188,6 @@
 	},
 /turf/open/floor/plasteel/ship/riveted,
 /area/maintenance/department/medical/morgue)
-"hAZ" = (
-/obj/structure/chair/office,
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating,
-/area/space/nearstation)
 "hBa" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -33463,6 +33211,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
+"hBo" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
+/turf/template_noop,
+/area/maintenance/department/electrical)
 "hBz" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -33478,6 +33230,10 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
+"hCn" = (
+/obj/machinery/computer/station_alert/console,
+/turf/open/floor/plasteel/dark,
+/area/maintenance/port/central)
 "hCo" = (
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
@@ -33624,6 +33380,25 @@
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"hHk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/ship/command{
+	dir = 4;
+	name = "Gravity Generator";
+	req_one_access_txt = "56"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/engine/gravity_generator)
 "hHm" = (
 /obj/structure/window,
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/on,
@@ -33639,6 +33414,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"hHW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Bridge-Ext";
+	location = "Fore-Weapons"
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	sortType = "7;8;15"
+	},
+/turf/open/floor/plasteel/ship,
+/area/hallway/primary/fore)
 "hIz" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -33680,6 +33474,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"hJz" = (
+/obj/effect/landmark/blobstart,
+/turf/template_noop,
+/area/maintenance/department/electrical)
 "hJS" = (
 /obj/machinery/light,
 /obj/structure/closet/l3closet/scientist,
@@ -33694,16 +33492,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/ai_monitored/turret_protected/ai_upload)
-"hLl" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/plating,
-/area/maintenance/department/medical/morgue)
 "hLv" = (
 /obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/ship/techfloor/alt,
@@ -33724,6 +33512,14 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"hNh" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "hNn" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -33732,19 +33528,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/maintenance/department/medical)
-"hNo" = (
-/obj/structure/window,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/closet/crate/medical,
-/obj/item/stack/medical/gauze/improvised,
-/obj/item/stack/medical/ointment/one,
-/obj/item/stack/medical/bruise_pack/one,
-/obj/item/clothing/mask/surgical,
-/obj/item/reagent_containers/syringe/used,
-/turf/open/floor/plating,
 /area/maintenance/department/medical)
 "hNV" = (
 /obj/effect/turf_decal/bot_red/right,
@@ -33806,10 +33589,6 @@
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"hQD" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/engine/atmos)
 "hRc" = (
 /obj/machinery/status_display/evac{
 	pixel_y = 32
@@ -33824,14 +33603,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/hanger)
-"hSk" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters{
-	id = "firingsquad";
-	name = "security shutters"
-	},
-/turf/open/floor/plating,
-/area/security/execution/transfer)
 "hSt" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/hydroponics/constructable,
@@ -33844,6 +33615,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"hSR" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/chapel/office)
 "hSS" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -33939,13 +33714,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"hWU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 5
+"hWW" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/turf/template_noop,
-/area/maintenance/port/central)
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "ce_window";
+	name = "privacy shutter"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/chief)
 "hXb" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/candle_box,
@@ -33993,6 +33772,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /turf/open/floor/plasteel,
 /area/maintenance/department/science/central)
+"hXU" = (
+/obj/effect/spawner/room/tenxfive,
+/turf/template_noop,
+/area/maintenance/department/electrical)
 "hYg" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -34090,11 +33873,6 @@
 /obj/machinery/vending/cola/random,
 /turf/open/floor/carpet/orange,
 /area/engine/break_room)
-"icH" = (
-/obj/structure/tank_dispenser/oxygen,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/nsv/hanger)
 "idC" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/donkpockets,
@@ -34131,6 +33909,10 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/heads/captain/private)
+"ieE" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/medical/virology)
 "ieR" = (
 /obj/machinery/light{
 	dir = 4
@@ -34150,13 +33932,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
-"ifD" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/brown/hidden{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/engine/engine_room)
 "ifE" = (
 /obj/machinery/light{
 	dir = 8
@@ -34253,10 +34028,6 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/engine/plasma,
 /area/engine/atmos)
-"iie" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/chapel/office)
 "ikl" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/turf_decal/tile/blue{
@@ -34265,6 +34036,10 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"ikE" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/maintenance/department/chapel)
 "ilk" = (
 /obj/structure/table/glass,
 /obj/item/stack/sheet/mineral/plasma,
@@ -34444,6 +34219,15 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
+"ioN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/fore)
 "ipX" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
@@ -34451,24 +34235,6 @@
 "iqF" = (
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"irr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/door/airlock/ship{
-	name = "Toxins Storage";
-	req_one_access_txt = "8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plasteel,
-/area/science/storage)
 "irC" = (
 /obj/machinery/light/floor,
 /turf/open/floor/plasteel/ship/techfloor/alt,
@@ -34479,16 +34245,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"irQ" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
 "isl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -34522,21 +34278,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/science/central)
-"isG" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Long-Term Confinement"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "cell2_ld";
-	name = "Cell 2 Lockdown"
-	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/security/prison)
 "itc" = (
 /turf/open/floor/carpet/black,
 /area/lawoffice)
@@ -34551,6 +34292,14 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"itn" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "maashutter"
+	},
+/turf/open/floor/plating,
+/area/nsv/crew_quarters/heads/maa)
 "itC" = (
 /obj/effect/spawner/room/threexthree,
 /obj/structure/cable{
@@ -34676,28 +34425,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"ixB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/security/prison)
-"ixJ" = (
-/obj/machinery/door/airlock/ship/public{
-	name = "Hydroponics Backroom";
-	req_one_access_txt = "35"
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "ixK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 8
@@ -34820,30 +34547,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/lockup)
-"iAZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/ship/hatch{
-	name = "Crematorium";
-	req_one_access_txt = "27"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
-"iBR" = (
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/components/binary/dp_vent_pump,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/turf/open/floor/plating,
-/area/engine/engineering/hangar)
 "iDr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -34872,6 +34575,10 @@
 /obj/machinery/air_sensor/atmos/carbon_tank,
 /turf/open/floor/engine/co2,
 /area/engine/atmos)
+"iEB" = (
+/obj/machinery/portable_atmospherics/scrubber/huge,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "iEF" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -34884,14 +34591,6 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"iEU" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory/lockup)
 "iEX" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -34962,15 +34661,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/fore)
-"iGz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/bridge)
 "iGB" = (
 /obj/machinery/food_cart,
 /obj/machinery/camera/autoname{
@@ -35053,15 +34743,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"iJp" = (
-/obj/machinery/door/airlock/ship/public{
-	id_tag = "cabin3";
-	name = "Cabin 3"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plasteel/ship,
-/area/crew_quarters/dorms)
 "iJz" = (
 /obj/machinery/door/poddoor/ship{
 	id = "launchbay_access";
@@ -35072,6 +34753,12 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/maintenance/starboard/central)
+"iJU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "iJX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -35103,6 +34790,15 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"iMv" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "69"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "iMz" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -35169,6 +34865,15 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/nsv/hanger/storage)
+"iPL" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/engine/atmos)
+"iPW" = (
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "iQe" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -35176,6 +34881,16 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"iQn" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/fore)
 "iQS" = (
 /obj/structure/sign/barsign,
 /turf/closed/wall/ship,
@@ -35203,6 +34918,12 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/ship,
 /area/construction)
+"iRr" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/template_noop,
+/area/maintenance/department/electrical)
 "iRX" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -35216,15 +34937,18 @@
 "iSh" = (
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"iSq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
+"iSr" = (
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 10
+	dir = 5
 	},
-/turf/open/floor/plating,
-/area/engine/engineering/hangar)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 5
+	},
+/turf/template_noop,
+/area/maintenance/department/electrical)
 "iSw" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -35305,13 +35029,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/hanger/storage)
-"iUF" = (
-/obj/machinery/status_display/ai{
-	pixel_x = -32
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
 "iVe" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -35348,6 +35065,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"iWB" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "iYh" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/ship/techfloor/alt,
@@ -35402,28 +35123,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"iZP" = (
-/obj/structure/sign/directions/evac{
-	dir = 8
+"jak" = (
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/obj/structure/sign/directions/supply{
-	dir = 4;
-	pixel_y = -8
-	},
-/turf/closed/wall/ship,
-/area/maintenance/department/crew_quarters/bar)
-"iZQ" = (
-/obj/structure/plasticflaps,
-/obj/effect/turf_decal/loading_area/red{
-	dir = 8
-	},
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "atmos_belt"
-	},
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plasteel/ship,
-/area/engine/atmos)
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory/lockup)
 "jaD" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/tile/red{
@@ -35459,28 +35166,22 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/ai_monitored/turret_protected/aisat/hallway/support_ship/aft)
-"jbi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Patient Room B";
-	req_one_access_txt = "5"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plasteel/white,
-/area/medical/patients_rooms/room_b)
 "jbp" = (
 /obj/machinery/teleport/hub,
 /turf/open/floor/plasteel,
 /area/storage/eva)
+"jbw" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/template_noop,
+/area/maintenance/department/electrical)
+"jbD" = (
+/obj/effect/spawner/room/fivexfour,
+/turf/template_noop,
+/area/maintenance/port/central)
 "jbH" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -35513,6 +35214,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"jdh" = (
+/obj/structure/closet/radiation,
+/obj/item/tank/internals/oxygen/yellow,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "jdx" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -35528,16 +35235,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"jdZ" = (
-/obj/structure/sign/directions/command{
-	dir = 4;
-	pixel_y = -8
-	},
-/obj/structure/sign/directions/science{
-	dir = 8
-	},
-/turf/closed/wall/ship,
-/area/security/checkpoint/customs)
 "jep" = (
 /obj/machinery/door/airlock/ship/station/mining{
 	name = "Cargo Bay";
@@ -35569,21 +35266,6 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"jfs" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/ship/security/glass{
-	id_tag = "pw_fd_outer";
-	name = "Brig";
-	req_one_access_txt = "63"
-	},
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/security/prison)
-"jfz" = (
-/turf/open/floor/plating,
-/area/space/nearstation)
 "jfD" = (
 /obj/machinery/cryopod,
 /obj/machinery/light{
@@ -35654,11 +35336,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"jhr" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/monotile/dark,
-/area/science/storage)
 "jhw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -35759,21 +35436,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/toilet/restrooms)
-"jlq" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/requests_console{
-	department = "Security";
-	departmentType = 7;
-	pixel_x = -32
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/security/prison)
 "jlH" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
@@ -35803,6 +35465,15 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/ai_monitored/turret_protected/ai_upload)
+"jnj" = (
+/obj/structure/sign/directions/security{
+	pixel_y = 28
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/fore)
 "jnt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -35856,12 +35527,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
-"jpe" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer1,
-/turf/open/floor/plating,
-/area/engine/engineering/hangar)
 "jps" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -35879,6 +35544,13 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"jpA" = (
+/obj/structure/cable{
+	icon_state = "6-8"
+	},
+/obj/vehicle/sealed/car/realistic/medical,
+/turf/open/floor/plasteel/ship,
+/area/hallway/primary/central)
 "jpL" = (
 /obj/effect/landmark/blobstart,
 /turf/template_noop,
@@ -35927,6 +35599,26 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
+"jsn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Long-Term Confinement"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "cell4_ld";
+	name = "Cell 4 Lockdown"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/security/prison)
 "jsr" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
@@ -35973,16 +35665,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/fore)
-"jub" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor/northright{
-	name = "Security Desk";
-	req_one_access_txt = "63"
-	},
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plating,
-/area/security/prison)
 "jum" = (
 /obj/machinery/microwave,
 /obj/structure/table/wood,
@@ -35991,13 +35673,6 @@
 	},
 /turf/open/floor/wood,
 /area/science/research)
-"juF" = (
-/obj/structure/cable{
-	icon_state = "6-8"
-	},
-/obj/vehicle/sealed/car/realistic/medical,
-/turf/open/floor/plasteel/ship,
-/area/hallway/primary/central)
 "juJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -36093,11 +35768,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"jyi" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison)
 "jyB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -36127,14 +35797,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"jyH" = (
-/obj/machinery/door/airlock/ship/public{
-	name = "Quiet Room"
-	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/wood,
-/area/library/lounge)
 "jzg" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
@@ -36333,10 +35995,6 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"jGF" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/hallway/secondary/exit)
 "jGG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -36365,6 +36023,11 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/fore)
+"jHf" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
 "jHw" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -36417,10 +36080,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"jIB" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/science/mixing/chamber)
+"jIF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/door/airlock/ship/hatch{
+	name = "Chaplain's Office";
+	req_one_access_txt = "22"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plasteel/dark,
+/area/chapel/main)
 "jIY" = (
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 1;
@@ -36434,15 +36103,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"jJy" = (
-/obj/machinery/door/airlock/ship/public{
-	id_tag = "cabin1";
-	name = "Cabin 1"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plasteel/ship,
-/area/crew_quarters/dorms)
 "jKl" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -36536,12 +36196,6 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai)
-"jMs" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 4
-	},
-/turf/template_noop,
-/area/maintenance/department/electrical)
 "jMw" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera/autoname{
@@ -36571,9 +36225,15 @@
 /obj/machinery/atmospherics/components/trinary/mixer,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"jML" = (
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/plating,
+"jMU" = (
+/obj/machinery/light/floor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/ship/techfloor/alt,
 /area/engine/engineering/hangar)
 "jNi" = (
 /obj/machinery/door/window/westright{
@@ -36606,6 +36266,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"jOG" = (
+/obj/item/assembly/mousetrap/armed,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "jPy" = (
 /obj/machinery/keycard_auth{
 	pixel_y = -24
@@ -36635,6 +36308,21 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/engine/break_room)
+"jRY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/airlock/virology{
+	name = "Break Room";
+	req_one_access_txt = "39"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "jSD" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel,
@@ -36656,6 +36344,15 @@
 	},
 /turf/open/floor/wood,
 /area/science/research)
+"jTv" = (
+/obj/machinery/door/airlock/ship/public{
+	id_tag = "cabin3";
+	name = "Cabin 3"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/ship,
+/area/crew_quarters/dorms)
 "jTW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -36686,21 +36383,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"jUl" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/ship,
-/area/nsv/hanger)
 "jUy" = (
 /obj/structure/sign/departments/evac{
 	pixel_x = -32
@@ -36719,6 +36401,13 @@
 	},
 /turf/closed/wall/r_wall/ship,
 /area/engine/engine_room)
+"jUI" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold/visible,
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "jUN" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/camera/autoname{
@@ -36746,10 +36435,6 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel,
 /area/storage/eva)
-"jVd" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "jVm" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1,
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible/layer3{
@@ -36763,27 +36448,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"jVC" = (
-/obj/machinery/door/airlock/ship/command{
-	name = "Master At Arms";
-	req_one_access_txt = "70"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/carpet/ship,
-/area/nsv/crew_quarters/heads/maa)
 "jVG" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
@@ -36794,6 +36458,12 @@
 	},
 /turf/open/floor/plasteel/ship/riveted,
 /area/maintenance/starboard/central)
+"jVK" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 1
+	},
+/turf/template_noop,
+/area/maintenance/port/central)
 "jWq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -36827,30 +36497,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/security)
-"jXw" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/nsv/weapons/fore)
-"jXW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+"jXt" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/central)
-"jZj" = (
-/turf/template_noop,
-/area/maintenance/port/central)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship,
+/area/hallway/primary/fore)
 "kac" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -36895,19 +36554,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
-"kaI" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
-"kbf" = (
+"kbq" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/ship,
-/area/hallway/primary/fore)
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "kbM" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/blue,
@@ -37029,13 +36688,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/ai_monitored/turret_protected/aisat/hallway/support_ship/aft)
-"khU" = (
-/obj/machinery/power/apc/auto_name/west{
-	pixel_x = -24
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/bridge)
 "kie" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -37052,11 +36704,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"kiI" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "kiO" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -37085,19 +36732,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/ai_monitored/turret_protected/aisat/hallway/support_ship/aft)
-"kjy" = (
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
 "kjB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37141,19 +36775,18 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "kkG" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "chem_desk_med";
-	name = "desk shutter"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
 	},
-/obj/machinery/door/window/northleft{
-	name = "Chemistry Desk";
-	req_one_access_txt = "33"
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/plating,
-/area/medical/chemistry)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/ship,
+/area/engine/engineering/hangar)
 "kkJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37203,21 +36836,36 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"knr" = (
-/obj/machinery/light/small,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+"kng" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/security/main)
+"knt" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
-/area/maintenance/department/electrical)
+/area/maintenance/department/medical/morgue)
+"koK" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -24
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/fore)
 "kpj" = (
 /obj/machinery/computer/warrant{
 	dir = 8
@@ -37250,15 +36898,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/quartermaster/storage)
-"kqs" = (
-/obj/machinery/door/airlock/ship/security/glass{
-	name = "Hangar armoury";
-	req_one_access_txt = "71"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/nsv/hanger)
 "kqt" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -37345,10 +36984,18 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
+"ksg" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "ksk" = (
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"ksv" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/security/checkpoint/customs/auxiliary)
 "ksw" = (
 /obj/machinery/atmospherics/pipe/simple/brown/visible{
 	dir = 5
@@ -37365,9 +37012,6 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/nsv/crew_quarters/heads/maa)
-"ksM" = (
-/turf/closed/wall/r_wall/ship,
-/area/space/nearstation)
 "ksP" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -37386,6 +37030,11 @@
 /obj/effect/landmark/carpspawn,
 /turf/open/space/basic,
 /area/space/nearstation)
+"ktf" = (
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "ktA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -37589,15 +37238,6 @@
 /obj/machinery/autolathe,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/quartermaster/storage)
-"kAv" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/door/airlock/ship/external{
-	req_one_access_txt = "24;32"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering/hangar)
 "kAA" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/cafeteria,
@@ -37640,6 +37280,21 @@
 /obj/structure/closet/secure_closet/deck_technician,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/hanger)
+"kCc" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "kCD" = (
 /obj/machinery/mineral/stacking_machine{
 	input_dir = 1
@@ -37702,18 +37357,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"kEY" = (
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/obj/machinery/light/floor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+"kEz" = (
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plating,
 /area/engine/engineering/hangar)
 "kFl" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
@@ -37753,19 +37403,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/fore)
-"kGo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/ship,
-/area/engine/engineering/hangar)
 "kGA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -37785,13 +37422,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"kHW" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/effect/mapping_helpers/airlock/abandoned,
-/turf/open/floor/plating,
-/area/maintenance/department/bridge)
 "kIp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37841,6 +37471,20 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"kJk" = (
+/obj/machinery/door/airlock/ship/security/glass{
+	id_tag = "pw_fd_inner";
+	name = "Brig";
+	req_one_access_txt = "63"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/security/prison)
 "kJP" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -38007,15 +37651,16 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/aft)
+"kSB" = (
+/obj/structure/grille/broken,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "kSO" = (
 /obj/structure/table/wood,
 /obj/item/toy/cards/deck/cas/black,
 /turf/open/floor/wood,
 /area/library/lounge)
-"kSZ" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/hallway/primary/port)
 "kTo" = (
 /obj/effect/landmark/start/detective,
 /turf/open/floor/carpet/red,
@@ -38094,16 +37739,6 @@
 /obj/machinery/chem_dispenser,
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
-"kVQ" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/engine/engineering/hangar)
 "kWb" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
@@ -38189,17 +37824,30 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"lab" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+"kZV" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
+/obj/machinery/door/airlock/ship/command/glass{
+	name = "War room";
+	req_one_access_txt = "19"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/carpet/ship,
+/area/bridge/meeting_room)
+"laZ" = (
+/obj/machinery/door/airlock/ship/hatch{
+	name = "Support Vessel Fore";
+	req_one_access_txt = "61;65"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/ai_monitored/turret_protected/aisat/hallway/support_ship)
 "lbb" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -38238,27 +37886,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"lbN" = (
-/obj/machinery/atmospherics/pipe/simple/brown/hidden{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/engine_room)
-"lcu" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
 "lcD" = (
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/plasteel/white,
@@ -38271,6 +37898,15 @@
 	},
 /turf/open/floor/carpet/black,
 /area/crew_quarters/heads/hor)
+"lcM" = (
+/obj/machinery/door/airlock/ship/public{
+	name = "Galley";
+	req_one_access_txt = "28"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "ldt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -38296,15 +37932,6 @@
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
-"ldQ" = (
-/obj/machinery/door/airlock/ship/hatch{
-	name = "Support Vessel Fore";
-	req_one_access_txt = "61;65"
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/ai_monitored/turret_protected/aisat/hallway/support_ship)
 "ldW" = (
 /turf/open/floor/plasteel/ship,
 /area/construction)
@@ -38313,6 +37940,11 @@
 /obj/structure/closet/secure_closet/fighter_pilot,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/hanger)
+"lec" = (
+/obj/machinery/smartfridge/drinks,
+/obj/machinery/door/firedoor,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "leF" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -38380,14 +38012,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/entry)
-"lhF" = (
-/obj/structure/sign/directions/security,
-/obj/structure/sign/directions/command{
-	dir = 4;
-	pixel_y = -8
-	},
-/turf/closed/wall/r_wall/ship,
-/area/nsv/weapons/fore)
 "lio" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/disposalpipe/segment,
@@ -38427,15 +38051,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"ljB" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/plating,
-/area/maintenance/department/medical/morgue)
 "lke" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -38483,6 +38098,12 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
+"lnl" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "lnt" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/snacks/donut/jelly/plain,
@@ -38518,44 +38139,54 @@
 /obj/machinery/modular_computer/console/preset/command,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
-"lpu" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+"lpp" = (
+/obj/item/clothing/mask/gas,
+/obj/item/tank/internals/oxygen/yellow,
+/obj/structure/closet/radiation,
 /turf/open/floor/plating,
-/area/engine/engineering/hangar)
-"lpJ" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 4
-	},
+/area/maintenance/department/cargo)
+"lpU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/sorting/mail{
-	sortType = 8
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/plasteel/ship,
-/area/security/prison)
+/area/hallway/primary/fore)
 "lqb" = (
 /obj/effect/landmark/start/munitions_tech,
 /turf/open/floor/plasteel/ship,
 /area/nsv/weapons/fore)
+"lql" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel/ship,
+/area/security/prison)
 "lqo" = (
 /obj/machinery/atmospherics/pipe/manifold4w/general/visible,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"lqN" = (
-/obj/effect/spawner/room/tenxfive,
-/turf/template_noop,
-/area/maintenance/department/electrical)
+"lqM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/monotile/light,
+/area/science/storage)
 "lro" = (
 /obj/machinery/requests_console{
 	department = "Engineering";
@@ -38567,22 +38198,6 @@
 	},
 /turf/closed/wall/ship,
 /area/engine/engine_room)
-"lrs" = (
-/obj/effect/turf_decal/loading_area/red{
-	dir = 8
-	},
-/obj/machinery/door/airlock/ship/hatch{
-	name = "AI Upload Access";
-	req_one_access_txt = "16"
-	},
-/obj/machinery/door/poddoor{
-	id = "aiship_upload";
-	name = "AI Upload Security Door"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plasteel/ship,
-/area/ai_monitored/turret_protected/ai_upload)
 "lrz" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 1
@@ -38599,6 +38214,20 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
+"lsP" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/westright{
+	name = "Chemistry Desk";
+	req_access_txt = "33"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "chem_desk_public";
+	name = "desk shutter"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plating,
+/area/medical/medbay/lobby)
 "lsX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -38610,9 +38239,6 @@
 /obj/effect/landmark/start/librarian,
 /turf/open/floor/wood,
 /area/library)
-"ltT" = (
-/turf/template_noop,
-/area/maintenance/department/bridge)
 "ltV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -38768,6 +38394,15 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"lxU" = (
+/obj/machinery/door/airlock/ship/public{
+	name = "Bar closet";
+	req_one_access_txt = "25"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "lyj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -38789,6 +38424,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"lyk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
 "lyv" = (
 /obj/machinery/suit_storage_unit/ce,
 /obj/machinery/firealarm{
@@ -38796,12 +38440,33 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
-"lyS" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/components/binary/dp_vent_pump,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+"lzg" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
-/area/engine/engineering/hangar)
+/area/maintenance/department/electrical)
+"lzk" = (
+/obj/effect/turf_decal/loading_area/red{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/hatch{
+	name = "AI Upload Access";
+	req_one_access_txt = "16"
+	},
+/obj/machinery/door/poddoor{
+	id = "aiship_upload";
+	name = "AI Upload Security Door"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/ship,
+/area/ai_monitored/turret_protected/ai_upload)
 "lzo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -38886,16 +38551,23 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/carpet/black,
 /area/crew_quarters/heads/chief)
-"lBi" = (
-/obj/effect/turf_decal/tile/yellow{
+"lAO" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/nuclear_waste_spawner/strong,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship,
+/area/security/prison)
+"lCp" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "lCC" = (
 /obj/structure/mirror{
 	pixel_y = -32
@@ -38918,6 +38590,25 @@
 /area/nsv/hanger/deck2/port{
 	name = "Launch tubes 3 and 4"
 	})
+"lCV" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 28
+	},
+/turf/open/floor/monotile/light,
+/area/science/storage)
+"lDl" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "lDC" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 4
@@ -38956,6 +38647,12 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo)
+"lDO" = (
+/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "lDW" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "5"
@@ -39082,25 +38779,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/ai_monitored/turret_protected/aisat/hallway/support_ship)
-"lJI" = (
-/obj/machinery/light/floor,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 1
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/engine/engineering/hangar)
-"lKr" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "69"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "lLd" = (
 /obj/machinery/light,
 /obj/structure/cable{
@@ -39108,13 +38786,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/exit)
-"lLD" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/open/floor/monotile/dark,
-/area/science/storage)
 "lLE" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/purple{
@@ -39123,14 +38794,6 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"lMm" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/turf/template_noop,
-/area/maintenance/department/electrical)
 "lMH" = (
 /obj/structure/closet/secure_closet/CMO,
 /obj/item/screwdriver,
@@ -39146,27 +38809,6 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"lMO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/door/airlock/ship/security/glass{
-	name = "Hangar Bay";
-	req_one_access_txt = "69"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plasteel/dark,
-/area/nsv/hanger)
 "lMR" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -39180,6 +38822,16 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/exit/departure_lounge)
+"lOy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/status_display/evac/west,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/port)
 "lOK" = (
 /obj/structure/chair{
 	dir = 4
@@ -39214,10 +38866,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/exit/departure_lounge)
-"lPn" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/captain)
 "lPp" = (
 /obj/machinery/door/airlock/ship/external{
 	req_one_access_txt = "13"
@@ -39292,6 +38940,27 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"lUs" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/sorting/mail{
+	sortType = 7
+	},
+/turf/open/floor/plasteel/ship,
+/area/security/prison)
 "lUE" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/cigarettes,
@@ -39306,6 +38975,25 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/nsv/hanger)
+"lUN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship{
+	name = "Kitchen Coldroom";
+	req_one_access_txt = "35;28"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"lVr" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "lVU" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -39391,18 +39079,27 @@
 /obj/item/storage/firstaid/ancient,
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"lWR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
+"lYd" = (
+/obj/machinery/door/airlock/ship/command{
+	name = "Master At Arms";
+	req_one_access_txt = "70"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/central)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/carpet/ship,
+/area/nsv/crew_quarters/heads/maa)
 "lYN" = (
 /obj/machinery/light{
 	dir = 4
@@ -39464,10 +39161,6 @@
 /obj/item/storage/lockbox/clusterbang,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/security)
-"maP" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/quartermaster/office)
 "maX" = (
 /obj/machinery/light{
 	dir = 4
@@ -39502,13 +39195,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/aft)
-"mcx" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/ship/external{
-	req_one_access_txt = "24;32"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering/hangar)
 "mdq" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -39683,14 +39369,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"mha" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "rd_window";
-	name = "privacy shutter"
-	},
-/turf/open/floor/plating,
-/area/science/lab)
 "mhf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -39717,6 +39395,12 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/central)
+"mhr" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
+	},
+/turf/template_noop,
+/area/maintenance/department/electrical)
 "mhv" = (
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
@@ -39776,6 +39460,31 @@
 /obj/machinery/computer/message_monitor,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
+"mjZ" = (
+/obj/structure/sign/poster/official/obey{
+	pixel_x = -32
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/fore)
+"mkb" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/sorting/mail{
+	sortType = 8
+	},
+/turf/open/floor/plasteel/ship,
+/area/security/prison)
 "mkc" = (
 /obj/machinery/light{
 	dir = 1
@@ -39818,33 +39527,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/central)
-"mkQ" = (
-/obj/machinery/computer/security/console,
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/plasteel/dark,
-/area/maintenance/port/central)
-"mly" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/security/prison)
-"mlL" = (
-/obj/machinery/light/small,
-/obj/structure/closet/radiation,
-/obj/item/tank/internals/oxygen/yellow,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
 "mlM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -40018,12 +39700,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/lockup)
-"mrX" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/maintenance/port/central)
 "msf" = (
 /obj/machinery/door/poddoor/ship{
 	id = "launchbay_tube1";
@@ -40094,24 +39770,6 @@
 /obj/machinery/atmospherics/pipe/simple/brown/visible/layer1,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"mtL" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/ship,
-/area/hallway/primary/fore)
 "mtO" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -40140,6 +39798,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"muO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/door/airlock/ship/hatch{
+	name = "Support Vessel Service";
+	req_one_access_txt = "65"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/ai_monitored/turret_protected/aisat/service/support_ship)
 "muY" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 8
@@ -40159,21 +39831,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/ship,
 /area/security/prison)
-"mvc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "32"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
 "mvv" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -40201,6 +39858,13 @@
 /obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/weapons/fore)
+"mww" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
 "mwT" = (
 /obj/effect/turf_decal/stripes/red/corner{
 	dir = 8
@@ -40212,15 +39876,6 @@
 /obj/machinery/light/floor,
 /turf/open/floor/plasteel/ship,
 /area/nsv/hanger/storage)
-"mxk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/bridge)
 "mxv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40237,6 +39892,23 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/plasteel/ship,
 /area/ai_monitored/turret_protected/aisat/service/support_ship)
+"mxP" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor/northright{
+	name = "Warden's Desk";
+	req_one_access_txt = "3"
+	},
+/obj/machinery/door/window/brigdoor/southright{
+	name = "Warden's Desk";
+	req_one_access_txt = "3"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/security/warden)
 "mxS" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -40259,6 +39931,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
+"myU" = (
+/obj/structure/table/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/item/storage/fancy/donut_box,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "Serving Hatch"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "mzc" = (
 /obj/machinery/computer/upload/ai{
 	dir = 4
@@ -40308,26 +39997,6 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/aft)
-"mAr" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/door/airlock/ship/security/glass{
-	name = "Long-Term Confinement";
-	req_one_access_txt = "2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/security/prison)
 "mAM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 1
@@ -40335,11 +40004,11 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/aft)
-"mAT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/turf/template_noop,
-/area/maintenance/port/central)
+"mAY" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "mBd" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Medbay-0";
@@ -40347,12 +40016,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/entry)
-"mBn" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 28
-	},
-/turf/open/floor/monotile/light,
-/area/science/storage)
 "mBN" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -40374,6 +40037,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction)
+"mCs" = (
+/obj/machinery/door/airlock/ship/public{
+	id_tag = "cabin2";
+	name = "Cabin 2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/ship,
+/area/crew_quarters/dorms)
 "mCt" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plating,
@@ -40475,6 +40147,14 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"mGc" = (
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "mGn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40502,6 +40182,31 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"mGY" = (
+/obj/effect/turf_decal/loading_area/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/hatch{
+	name = "AI Upload Access";
+	req_one_access_txt = "16"
+	},
+/obj/machinery/door/poddoor{
+	id = "aiship_upload";
+	name = "AI Upload Security Door"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/ship,
+/area/ai_monitored/turret_protected/ai_upload)
 "mHm" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -40543,14 +40248,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"mHQ" = (
-/obj/effect/landmark/blobstart,
-/turf/template_noop,
-/area/maintenance/department/bridge)
 "mIE" = (
 /obj/machinery/vending/boozeomat/pubby_captain,
 /turf/closed/wall/r_wall/ship,
 /area/crew_quarters/heads/captain/private)
+"mJn" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "mJP" = (
 /obj/machinery/door/airlock/ship/hatch{
 	dir = 8;
@@ -40561,6 +40266,16 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plasteel/ship,
 /area/security/execution/transfer)
+"mKQ" = (
+/obj/structure/sign/directions/security{
+	dir = 4
+	},
+/obj/structure/sign/directions/command{
+	dir = 4;
+	pixel_y = -8
+	},
+/turf/closed/wall/ship,
+/area/hallway/secondary/service)
 "mKS" = (
 /obj/structure/chair/stool,
 /obj/effect/turf_decal/stripes/red/line{
@@ -40587,6 +40302,21 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/ship,
 /area/security/prison)
+"mLM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Surgery";
+	req_one_access_txt = "45"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plasteel/dark,
+/area/medical/surgery)
 "mLP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -40683,6 +40413,14 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"mOq" = (
+/obj/machinery/door/airlock/ship/public{
+	name = "Quiet Room"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/wood,
+/area/library/lounge)
 "mPo" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel,
@@ -40692,6 +40430,22 @@
 /obj/structure/closet/secure_closet/fighter_pilot,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/hanger)
+"mPF" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
+"mPY" = (
+/obj/structure/lattice,
+/obj/structure/filingcabinet,
+/turf/open/space/basic,
+/area/space/nearstation)
 "mQs" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -40711,13 +40465,18 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"mQE" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/machinery/camera/autoname{
-	dir = 8
+"mQT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 9
 	},
-/turf/open/floor/monotile/dark,
-/area/science/storage)
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "mRh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40751,10 +40510,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/entry)
-"mTH" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/security/checkpoint/customs/auxiliary)
 "mUk" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/tile/purple{
@@ -40782,6 +40537,11 @@
 /obj/machinery/chem_heater,
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
+"mUy" = (
+/obj/structure/tank_dispenser/oxygen,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/nsv/hanger)
 "mUQ" = (
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
 /turf/open/floor/plasteel/white,
@@ -40801,34 +40561,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"mWI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
+"mWo" = (
+/obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/door/airlock/ship/security/glass{
-	name = "Security Equipment";
-	req_one_access_txt = "1;4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/ship,
-/area/security/main)
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "mXy" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable{
@@ -40873,18 +40612,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/central)
-"mYw" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "ce_window";
-	name = "privacy shutter"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/chief)
 "mYD" = (
 /obj/machinery/light{
 	dir = 1
@@ -40990,16 +40717,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/port)
-"ndr" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/suit_storage_unit/pilot,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/nsv/hanger)
 "ndC" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -41017,6 +40734,21 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"nex" = (
+/obj/machinery/door/airlock/ship/public{
+	id_tag = "cabin1";
+	name = "Cabin 1"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/ship,
+/area/crew_quarters/dorms)
+"neL" = (
+/obj/item/storage/box/lights/mixed,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/closet/crate,
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "neV" = (
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/camera/autoname{
@@ -41062,12 +40794,6 @@
 /obj/machinery/atmospherics/pipe/simple/brown/hidden,
 /turf/closed/wall/r_wall/ship,
 /area/engine/engine_room)
-"nhn" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/monotile/dark,
-/area/science/storage)
 "nif" = (
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/hanger/storage)
@@ -41163,14 +40889,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"njT" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
 "njY" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -41237,6 +40955,18 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/port/central)
+"nmG" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 10
+	},
+/turf/template_noop,
+/area/maintenance/department/electrical)
 "nmN" = (
 /obj/effect/landmark/start/cook,
 /turf/open/floor/plasteel/cafeteria,
@@ -41276,15 +41006,6 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/wood,
 /area/lawoffice)
-"npf" = (
-/obj/machinery/door/airlock/ship/public{
-	name = "Galley";
-	req_one_access_txt = "28"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "npk" = (
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 8;
@@ -41298,6 +41019,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
+"npM" = (
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "npS" = (
 /obj/structure/table/optable,
 /turf/open/floor/plasteel/white,
@@ -41308,6 +41036,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
+"nqv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "nqC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -41385,17 +41125,10 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"nvI" = (
-/obj/machinery/door/airlock/ship/hatch{
-	name = "Air Control Right";
-	req_one_access_txt = "19;69"
-	},
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plasteel/ship/padded,
-/area/maintenance/starboard/central)
-"nwm" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
+"nwT" = (
+/obj/machinery/light/small,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/monotile/dark,
 /area/science/storage)
 "nxc" = (
@@ -41429,6 +41162,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
+"nxz" = (
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/structure/cable,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "nyw" = (
 /obj/machinery/light{
 	dir = 1
@@ -41460,6 +41201,20 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet/black,
 /area/science/research)
+"nAb" = (
+/obj/machinery/door/airlock/ship/hatch{
+	name = "Telecomms Server Floor Access";
+	req_one_access_txt = "61;65"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/ai_monitored/turret_protected/aisat/hallway/support_ship)
 "nAm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -41469,16 +41224,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"nAE" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
 "nBl" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
@@ -41527,6 +41272,24 @@
 /obj/structure/extinguisher_cabinet/west,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"nCm" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship{
+	name = "Toxins Storage";
+	req_one_access_txt = "8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel,
+/area/science/storage)
 "nCJ" = (
 /obj/structure/table/reinforced,
 /obj/item/kitchen/rollingpin,
@@ -41654,12 +41417,6 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"nFv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/bridge)
 "nFL" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8;
@@ -41701,6 +41458,16 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/ai_monitored/turret_protected/aisat/hallway/support_ship)
+"nHX" = (
+/obj/structure/sign/directions/medical{
+	dir = 8;
+	pixel_y = -8
+	},
+/obj/structure/sign/directions/science{
+	dir = 8
+	},
+/turf/closed/wall/r_wall/ship,
+/area/ai_monitored/security/armory/lockup)
 "nHZ" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 4
@@ -41772,6 +41539,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"nLn" = (
+/obj/structure/sign/directions/command{
+	dir = 4;
+	pixel_y = -8
+	},
+/obj/structure/sign/directions/science{
+	dir = 8
+	},
+/turf/closed/wall/ship,
+/area/security/checkpoint/customs)
 "nLs" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/machinery/requests_console{
@@ -41782,21 +41559,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
-"nNj" = (
-/obj/structure/closet/radiation,
-/obj/item/clothing/mask/gas,
-/obj/item/tank/internals/oxygen/yellow,
-/turf/open/floor/plasteel/ship,
-/area/hallway/secondary/entry)
-"nNu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 8;
-	sortType = 15
-	},
-/turf/open/floor/plasteel/ship,
-/area/hallway/primary/fore)
 "nNA" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/green{
@@ -41885,25 +41647,9 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
-"nQk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
-"nQt" = (
-/obj/machinery/portable_atmospherics/scrubber/huge,
+"nQs" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/monotile/dark,
 /area/science/storage)
 "nQJ" = (
@@ -41995,6 +41741,16 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"nTI" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/obey{
+	pixel_x = -32
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/fore)
 "nTO" = (
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -42019,6 +41775,30 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
+"nUs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "aicore_entrance";
+	name = "AI Core Entrance Shutters"
+	},
+/obj/machinery/door/airlock/ship/hatch{
+	name = "Intelligence Core";
+	req_one_access_txt = "16"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/ship,
+/area/ai_monitored/turret_protected/ai)
 "nUA" = (
 /obj/machinery/light/small,
 /obj/effect/turf_decal/tile/purple{
@@ -42041,6 +41821,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
+"nUP" = (
+/obj/machinery/newscaster{
+	pixel_x = -32;
+	pixel_y = 32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/fore)
 "nVw" = (
 /obj/item/paper_bin,
 /obj/item/stamp/cmo,
@@ -42212,6 +42002,19 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"oac" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/machinery/door/airlock/ship{
+	name = "Kitchen coldroom";
+	req_one_access_txt = "35;28"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plasteel/cafeteria,
+/area/hallway/secondary/service)
 "oaz" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -42272,24 +42075,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/entry)
-"ock" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Construction Area";
-	req_one_access_txt = "32"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "ocu" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -42300,16 +42085,12 @@
 /obj/structure/closet/crate/internals,
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"ocA" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/light/small{
-	dir = 4
+"odJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 10
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/medical/morgue)
+/area/engine/engineering/hangar)
 "odP" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -42370,6 +42151,16 @@
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
 /area/ai_monitored/turret_protected/ai)
+"ofY" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
+/turf/template_noop,
+/area/maintenance/department/electrical)
 "ogm" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "12"
@@ -42385,15 +42176,6 @@
 /obj/effect/landmark/nuclear_waste_spawner,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
-"ogG" = (
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
@@ -42573,27 +42355,10 @@
 /obj/structure/closet/crate/trashcart,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
-"onu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "onx" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/hanger)
-"onC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/engine/engineering/hangar)
 "oob" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -42614,10 +42379,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/security/detectives_office/private_investigators_office)
-"ooO" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/maintenance/department/chapel)
 "ooU" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
 	dir = 5
@@ -42698,6 +42459,23 @@
 /obj/item/clothing/head/helmet/alt,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/security)
+"orV" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/atmospherics_engine)
+"osz" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "bridge_blast"
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
+"osI" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 4
+	},
+/turf/template_noop,
+/area/maintenance/department/electrical)
 "osO" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -42756,13 +42534,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
-"ovy" = (
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer1{
-	dir = 8
-	},
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/engine/atmos)
 "ovP" = (
 /obj/machinery/light/floor,
 /turf/open/floor/plasteel/ship/techfloor/alt,
@@ -42912,6 +42683,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
+"ozO" = (
+/obj/structure/sign/directions/security,
+/obj/structure/sign/directions/command{
+	dir = 4;
+	pixel_y = -8
+	},
+/turf/closed/wall/r_wall/ship,
+/area/nsv/weapons/fore)
+"ozV" = (
+/turf/open/floor/plasteel/dark,
+/area/maintenance/port/central)
 "oAh" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Cloning Exit";
@@ -42956,6 +42738,11 @@
 /obj/structure/lattice,
 /turf/open/space,
 /area/ai_monitored/turret_protected/ai)
+"oBC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/template_noop,
+/area/maintenance/port/central)
 "oBE" = (
 /obj/machinery/computer/ship/viewscreen,
 /obj/machinery/computer/ship/munitions_computer{
@@ -43038,15 +42825,6 @@
 /obj/effect/landmark/start/munitions_tech,
 /turf/open/floor/plasteel/ship,
 /area/nsv/weapons/fore)
-"oFf" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/advanced_airlock_controller/directional/west{
-	pixel_y = 24
-	},
-/turf/open/floor/plating,
-/area/engine/engineering/hangar)
 "oFm" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -43065,6 +42843,13 @@
 /obj/item/pipe_dispenser,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"oFH" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer1{
+	dir = 8
+	},
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "oFZ" = (
 /obj/item/radio/intercom{
 	pixel_y = 26
@@ -43124,10 +42909,6 @@
 /obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"oIF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/template_noop,
-/area/maintenance/department/bridge)
 "oIJ" = (
 /obj/machinery/power/apc/auto_name/north{
 	dir = 2;
@@ -43147,19 +42928,6 @@
 /obj/structure/bed,
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
-"oKv" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/monotile/dark,
-/area/science/storage)
-"oLF" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/monotile/dark,
-/area/science/storage)
 "oLM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43192,43 +42960,11 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/central)
-"oMY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/ship{
-	name = "Kitchen Coldroom";
-	req_one_access_txt = "35;28"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "oNf" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
 /turf/open/floor/plasteel/white,
 /area/medical/patients_rooms/room_a)
-"oNr" = (
-/obj/structure/table/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/item/storage/fancy/donut_box,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "Serving Hatch"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "oNs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/components/binary/dp_vent_pump,
@@ -43239,10 +42975,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"oNL" = (
-/obj/machinery/computer/station_alert/console,
-/turf/open/floor/plasteel/dark,
-/area/maintenance/port/central)
 "oOe" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -43253,18 +42985,6 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"oOu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
 "oOO" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -43276,6 +42996,11 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar/atrium)
+"oPG" = (
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "oPO" = (
 /obj/machinery/light,
 /obj/effect/landmark/start/ai/secondary,
@@ -43287,27 +43012,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
-"oPS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 1
-	},
-/turf/template_noop,
-/area/maintenance/department/electrical)
-"oQj" = (
-/obj/machinery/door/airlock/ship/security/glass{
-	name = "Riot Armory";
-	req_one_access_txt = "3"
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plasteel/ship,
-/area/ai_monitored/security/armory/security)
 "oQz" = (
 /obj/effect/turf_decal/stripes/full,
 /obj/structure/overmap/fighter/heavy/prebuilt,
@@ -43536,6 +43240,13 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload)
+"oYO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/template_noop,
+/area/maintenance/port/central)
 "oZh" = (
 /obj/machinery/computer/operating{
 	dir = 8
@@ -43555,6 +43266,10 @@
 "oZG" = (
 /turf/closed/wall/r_wall/ship,
 /area/crew_quarters/heads/hos)
+"oZM" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/security/prison)
 "pav" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/ship/maintenance{
@@ -43581,12 +43296,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/security/prison)
-"paV" = (
-/obj/machinery/light/small,
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/monotile/dark,
-/area/science/storage)
 "pbr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 9
@@ -43635,15 +43344,17 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
 /area/construction)
-"pdt" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/brown/hidden,
-/turf/open/floor/plating,
-/area/engine/engine_room)
 "pdI" = (
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/plasteel/dark,
 /area/science/server)
+"pfm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/status_display/evac/south,
+/turf/open/floor/plasteel/ship,
+/area/hallway/primary/fore)
 "pfn" = (
 /obj/structure/closet/secure_closet/munitions_technician,
 /turf/open/floor/plasteel/dark,
@@ -43661,21 +43372,31 @@
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"pgn" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Long-Term Confinement"
+"pfQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 10
 	},
-/obj/machinery/door/poddoor/shutters{
-	id = "cell1_ld";
-	name = "Cell 1 Lockdown"
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
+"pgu" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/chapel/office)
+"pgy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/morgue{
+	name = "Private Study";
+	req_access_txt = "37"
 	},
-/obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/security/prison)
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/wood,
+/area/library)
 "pgK" = (
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
@@ -43701,6 +43422,23 @@
 	},
 /turf/open/floor/plating,
 /area/nsv/hanger)
+"phF" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "phS" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -43773,6 +43511,18 @@
 	dir = 1
 	},
 /area/engine/storage)
+"pjX" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/security/glass{
+	name = "Hangar Bay";
+	req_one_access_txt = "69"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/dark,
+/area/nsv/hanger)
 "pjY" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical,
@@ -43791,26 +43541,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/service)
-"pkY" = (
-/obj/structure/sign/directions/medical{
-	dir = 8;
-	pixel_y = -8
-	},
-/obj/structure/sign/directions/science{
-	dir = 8
-	},
-/turf/closed/wall/ship,
-/area/hallway/secondary/service)
-"pkZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/door/airlock/ship/hatch{
-	name = "Chaplain's Office";
-	req_one_access_txt = "22"
-	},
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plasteel/dark,
-/area/chapel/main)
 "plv" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -43904,6 +43634,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/aft)
+"poj" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/bridge)
 "pot" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -43953,12 +43687,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/port)
-"ppC" = (
-/obj/structure/closet/radiation,
-/obj/item/tank/internals/oxygen/yellow,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/bar)
 "ppO" = (
 /obj/machinery/light{
 	dir = 4
@@ -43973,23 +43701,6 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/security/prison)
-"prb" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
 "prh" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -43999,6 +43710,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"prS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship,
+/area/hallway/primary/fore)
 "psc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -44026,20 +43746,6 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"ptw" = (
-/obj/machinery/door/airlock/ship/hatch{
-	name = "Telecomms Server Floor Access";
-	req_one_access_txt = "61;65"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/hallway/support_ship)
 "ptA" = (
 /obj/structure/grille,
 /obj/structure/cable{
@@ -44080,35 +43786,6 @@
 /area/science/xenobiology)
 "puZ" = (
 /obj/machinery/status_display/ai/north,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
-"pvE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Hangar Bay"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	dir = 4;
-	id = "hang_storage"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
 "pvW" = (
@@ -44181,20 +43858,14 @@
 /obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/carpet/ship,
 /area/bridge/meeting_room)
+"pzC" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/security/main)
 "pzF" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"pzP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "pzS" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -44330,6 +44001,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"pEU" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/quartermaster/office)
 "pFp" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space/basic,
@@ -44404,6 +44079,12 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/construction)
+"pIj" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer1,
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "pJl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -44420,13 +44101,6 @@
 /obj/item/key/fighter_tug,
 /turf/open/floor/plating,
 /area/nsv/hanger)
-"pKb" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/open/floor/monotile/light,
-/area/science/storage)
 "pKs" = (
 /obj/machinery/light{
 	dir = 8
@@ -44450,16 +44124,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/eva)
-"pKR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/mineral/ore_redemption,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/engine,
-/area/quartermaster/office)
 "pLc" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
 	dir = 9
@@ -44487,6 +44151,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"pME" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
+"pNH" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "pNP" = (
 /obj/machinery/door/airlock/public/glass/incinerator/atmos_exterior,
 /obj/effect/mapping_helpers/airlock/locked,
@@ -44631,12 +44310,13 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
-"pTt" = (
-/obj/structure/closet/radiation,
-/obj/item/clothing/mask/gas,
-/obj/item/tank/internals/oxygen/yellow,
+"pTV" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/security/prison)
 "pUg" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/open/floor/plasteel,
@@ -44676,6 +44356,16 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/exit)
+"pVJ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/window{
+	req_one_access_txt = "11"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/construction)
 "pVN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -44771,6 +44461,10 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
+"pXN" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/visible,
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "pYy" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "12"
@@ -44800,18 +44494,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
-"pZq" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
-	},
-/turf/template_noop,
-/area/maintenance/department/electrical)
 "pZs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
 /turf/open/floor/plasteel/dark,
@@ -44943,6 +44625,12 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"qem" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/maintenance/port/central)
 "qeB" = (
 /obj/structure/table/wood,
 /obj/structure/window/reinforced/spawner/north,
@@ -44956,6 +44644,32 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/port)
+"qfd" = (
+/obj/machinery/door/airlock/ship/public{
+	id_tag = "cabin4";
+	name = "Cabin 4"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/ship,
+/area/crew_quarters/dorms)
+"qfk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "qfG" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light{
@@ -45141,6 +44855,19 @@
 /obj/machinery/vending/tool,
 /turf/open/floor/plasteel/ship/riveted,
 /area/maintenance/department/medical/morgue)
+"qor" = (
+/obj/machinery/door/airlock/ship/hatch{
+	name = "Air Control Right";
+	req_one_access_txt = "19;69"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plasteel/ship,
+/area/nsv/hanger/deck2/port{
+	name = "Launch tubes 3 and 4"
+	})
 "qoL" = (
 /obj/machinery/status_display/ai{
 	pixel_x = 32
@@ -45148,20 +44875,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
-"qoP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/door/airlock/ship/hatch{
-	name = "Air Control Right";
-	req_one_access_txt = "19;69"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plasteel/ship/padded,
-/area/maintenance/starboard/central)
 "qoQ" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -45185,14 +44898,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs/auxiliary)
-"qpe" = (
-/obj/machinery/airalarm/directional/west,
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
 "qpE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45222,6 +44927,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"qqA" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "hos_privacy";
+	name = "privacy shutter"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hos)
 "qqK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -45235,18 +44951,25 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
-"qrU" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
+"qrf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 10
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 10
+	dir = 8
 	},
-/turf/template_noop,
-/area/maintenance/department/electrical)
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/security/prison)
 "qrX" = (
 /obj/effect/landmark/start/flight_leader,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -45307,15 +45030,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"qtr" = (
-/obj/machinery/door/airlock/ship/hatch{
-	name = "Support Vessel Service";
-	req_one_access_txt = "65"
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/service/support_ship)
 "qtI" = (
 /obj/structure/closet/crate/engineering{
 	name = "pdc ammo crate"
@@ -45343,6 +45057,22 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel/ship,
+/area/hallway/primary/port)
+"qvl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/port)
 "qvI" = (
 /obj/machinery/light{
@@ -45380,12 +45110,9 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"qwN" = (
-/obj/structure/closet/radiation,
-/obj/item/clothing/mask/gas,
-/obj/item/tank/internals/oxygen/yellow,
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
+"qwI" = (
+/turf/open/floor/monotile/light,
+/area/science/storage)
 "qxv" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 1
@@ -45408,6 +45135,26 @@
 /obj/item/clothing/glasses/sunglasses/advanced,
 /turf/open/floor/wood,
 /area/lawoffice)
+"qyb" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "xoprivacy";
+	name = "Privacy Shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hop)
 "qzO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45422,15 +45169,6 @@
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
-"qAG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/engine/break_room)
 "qAK" = (
 /obj/structure/mopbucket,
 /obj/item/mop,
@@ -45446,6 +45184,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/service)
+"qBN" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/plasteel/ship,
+/area/hallway/secondary/entry)
 "qCt" = (
 /obj/effect/turf_decal/bot_red,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
@@ -45466,6 +45208,10 @@
 	dir = 9
 	},
 /area/chapel/main)
+"qCO" = (
+/obj/effect/spawner/room/fivexfour,
+/turf/template_noop,
+/area/maintenance/department/electrical)
 "qDa" = (
 /obj/effect/turf_decal/box/red/corners{
 	dir = 8
@@ -45525,15 +45271,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
-"qEz" = (
-/obj/machinery/door/airlock/ship/hatch{
-	name = "Support Vessel Aft";
-	req_one_access_txt = "16;65"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/ai_monitored/turret_protected/aisat/hallway/support_ship/aft)
 "qEO" = (
 /obj/machinery/firealarm{
 	pixel_y = 30
@@ -45594,51 +45331,21 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
-"qGO" = (
-/obj/machinery/door/airlock/ship/hatch{
-	name = "Telecomms Server Floor Access";
-	req_one_access_txt = "61;65"
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plating,
-/area/tcommsat/server)
 "qHo" = (
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/entry)
-"qHp" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/advanced_airlock_controller/directional/west{
-	pixel_y = 24
+"qIj" = (
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/engine/engineering/hangar)
-"qHN" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
-/turf/template_noop,
-/area/maintenance/department/electrical)
-"qHP" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/westright{
-	name = "Chemistry Desk";
-	req_access_txt = "33"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "chem_desk_public";
-	name = "desk shutter"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plating,
-/area/medical/medbay/lobby)
-"qHW" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/turf/open/floor/monotile/dark,
-/area/science/storage)
+/area/maintenance/department/cargo)
 "qID" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -45747,6 +45454,32 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"qPn" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor/eastleft{
+	name = "Security Desk";
+	req_one_access_txt = "63"
+	},
+/obj/machinery/button/door{
+	id = "pw_fd_outer";
+	name = "Exterior Door Control";
+	normaldoorcontrol = 1;
+	pixel_x = 8;
+	pixel_y = 24;
+	req_one_access_txt = "63"
+	},
+/obj/machinery/button/door{
+	id = "pw_fd_inner";
+	name = "Interior Door Control";
+	normaldoorcontrol = 1;
+	pixel_x = -8;
+	pixel_y = 24;
+	req_one_access_txt = "63"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plating,
+/area/security/prison)
 "qPr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -45766,16 +45499,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"qPZ" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=JaniCloset";
-	location = "HOP-Corner"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
 "qQu" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
@@ -45818,6 +45541,16 @@
 /obj/effect/spawner/room/threexthree,
 /turf/template_noop,
 /area/maintenance/department/medical/morgue)
+"qSO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/effect/landmark/start/scientist,
+/turf/open/floor/monotile/light,
+/area/science/storage)
 "qTb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -45831,6 +45564,14 @@
 	},
 /turf/open/floor/carpet/black,
 /area/crew_quarters/heads/hor)
+"qTf" = (
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/fore)
 "qTi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45937,11 +45678,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/central)
-"qVf" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/monotile/dark,
-/area/science/storage)
 "qVq" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -45976,12 +45712,6 @@
 /area/nsv/hanger/deck2/starboard{
 	name = "Launch tubes 1 and 2"
 	})
-"qWT" = (
-/obj/structure/closet/radiation,
-/obj/item/tank/internals/oxygen/yellow,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "qWU" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -46018,6 +45748,15 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"qYT" = (
+/obj/machinery/door/airlock/virology/glass{
+	name = "Isolation B";
+	req_one_access_txt = "39"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "qYV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -46104,15 +45843,16 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/tcommsat/computer)
-"raS" = (
-/obj/machinery/door/airlock/highsecurity/ship{
-	name = "Secure Tech Storage";
-	req_access_txt = "23;19"
+"raM" = (
+/obj/machinery/light/floor,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plating,
-/area/storage/tech)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/engine/engineering/hangar)
 "raV" = (
 /obj/machinery/newscaster{
 	pixel_x = 30
@@ -46195,12 +45935,6 @@
 	},
 /turf/closed/wall/r_wall/ship,
 /area/ai_monitored/turret_protected/ai_upload)
-"rdd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/template_noop,
-/area/maintenance/department/bridge)
 "rds" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -46239,6 +45973,16 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
+"rfg" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/security/prison)
 "rfD" = (
 /obj/structure/table,
 /obj/item/reagent_containers/spray/cleaner,
@@ -46261,17 +46005,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
-"rfV" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
 "rfX" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "8"
@@ -46435,19 +46168,6 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/entry)
-"rmj" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/machinery/door/airlock/ship{
-	name = "Kitchen coldroom";
-	req_one_access_txt = "35;28"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plasteel/cafeteria,
-/area/hallway/secondary/service)
 "rml" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -46499,15 +46219,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
-"roq" = (
-/obj/machinery/door/airlock/ship/hatch{
-	name = "Air Control Left";
-	req_one_access_txt = "19;69"
-	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/plasteel/ship/padded,
-/area/maintenance/starboard/central)
 "roR" = (
 /obj/effect/turf_decal/box/red/corners{
 	dir = 4
@@ -46527,16 +46238,22 @@
 /obj/structure/shuttle/engine/heater,
 /turf/closed/wall/ship,
 /area/maintenance/department/electrical)
-"rpX" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+"rqa" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
+"rqJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/monotile/light,
+/area/science/storage)
 "rqN" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -46579,30 +46296,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
-"rsf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
+"rrK" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/ship/security/glass{
+	id_tag = "pw_fd_outer";
+	name = "Brig";
+	req_one_access_txt = "63"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
-"rsq" = (
-/obj/structure/sign/directions/medical{
-	dir = 8;
-	pixel_y = -8
-	},
-/obj/structure/sign/directions/science{
-	dir = 8
-	},
-/turf/closed/wall/r_wall/ship,
-/area/ai_monitored/security/armory/lockup)
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/security/prison)
 "rsz" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -46678,21 +46383,6 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/exit)
-"rue" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/door/airlock/virology{
-	name = "Break Room";
-	req_one_access_txt = "39"
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "rui" = (
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -46718,6 +46408,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"rvK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "rvO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -46755,6 +46455,21 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/construction)
+"rwK" = (
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Long-Term Confinement"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "cell3_ld";
+	name = "Cell 3 Lockdown"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/security/prison)
 "rwT" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -46834,6 +46549,12 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/central)
+"rzn" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "rzF" = (
 /obj/machinery/light,
 /obj/machinery/firealarm{
@@ -46842,13 +46563,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/quartermaster/storage)
-"rzJ" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "rAf" = (
 /obj/structure/table/wood/poker,
 /obj/item/taperecorder/empty,
@@ -46895,6 +46609,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"rBA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/monotile/light,
+/area/science/storage)
 "rBB" = (
 /obj/machinery/newscaster{
 	pixel_y = -30
@@ -46907,16 +46630,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"rCZ" = (
-/obj/structure/sign/directions/evac{
+"rCy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
 	},
-/obj/structure/sign/directions/engineering{
-	dir = 8;
-	pixel_y = -8
-	},
-/turf/closed/wall/ship,
-/area/maintenance/department/crew_quarters/dorms)
+/turf/template_noop,
+/area/maintenance/port/central)
 "rDm" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
@@ -46952,6 +46671,20 @@
 /obj/structure/closet/secure_closet/fighter_pilot,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/hanger)
+"rFh" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/westright{
+	name = "Hydroponics Desk";
+	req_one_access_txt = "35"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "bot_south";
+	name = "privacy shutter"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/hydroponics)
 "rFw" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -46972,6 +46705,12 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/security/prison)
+"rGw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/template_noop,
+/area/maintenance/department/bridge)
 "rGF" = (
 /obj/structure/window{
 	dir = 1
@@ -46988,6 +46727,18 @@
 	},
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
+"rHu" = (
+/obj/structure/plasticflaps,
+/obj/effect/turf_decal/loading_area/red{
+	dir = 8
+	},
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "atmos_belt"
+	},
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plasteel/ship,
+/area/engine/atmos)
 "rHE" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "22"
@@ -47030,12 +46781,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/lockup)
-"rJV" = (
-/obj/machinery/advanced_airlock_controller/directional/west{
-	pixel_y = 24
-	},
-/turf/open/floor/plating,
-/area/engine/engineering/hangar)
 "rKc" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /obj/machinery/firealarm{
@@ -47048,6 +46793,10 @@
 /obj/structure/hull_plate,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"rKv" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/nsv/weapons/fore)
 "rKF" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -47083,6 +46832,15 @@
 /obj/item/stack/spacecash/c200,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"rMv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
 "rMz" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/ship/techfloor/alt,
@@ -47092,6 +46850,26 @@
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"rMK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/door/airlock/ship/hatch{
+	name = "Air Control Left";
+	req_one_access_txt = "19;69"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plasteel/ship/padded,
+/area/maintenance/starboard/central)
+"rMO" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "rMP" = (
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/department/medical/morgue)
@@ -47147,6 +46925,22 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/security/prison)
+"rOr" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "Serving Hatch"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "rOt" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -47167,26 +46961,6 @@
 /obj/effect/landmark/start/munitions_tech,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/weapons/fore)
-"rPH" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/door/airlock/ship/security/glass{
-	name = "Long-Term Confinement";
-	req_one_access_txt = "2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/security/prison)
 "rPQ" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/drinkingglasses,
@@ -47212,6 +46986,20 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"rQH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/ship,
+/area/hallway/primary/fore)
 "rRs" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable{
@@ -47219,23 +47007,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"rRV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Hangar Bay"
-	},
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	dir = 4;
-	id = "hang_storage"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
 "rSo" = (
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
@@ -47263,10 +47034,6 @@
 /obj/machinery/camera/motion,
 /turf/open/floor/plasteel/ship,
 /area/ai_monitored/turret_protected/ai)
-"rUq" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/nsv/weapons/fore)
 "rVd" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -47371,6 +47138,15 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
+"rYS" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
 "rYW" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -47378,6 +47154,15 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"rZe" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "ce_window";
+	name = "privacy shutter"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/chief)
 "rZm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -47430,6 +47215,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"saJ" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "captain_blast"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/captain/private)
 "saW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/effect/landmark/start/medical_doctor,
@@ -47494,6 +47286,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"scE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plasteel/ship,
+/area/crew_quarters/dorms)
 "sdq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -47625,6 +47423,12 @@
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/wood,
 /area/science/research)
+"snz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/engine/engineering/hangar)
 "snC" = (
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -47693,6 +47497,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"soT" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "sps" = (
 /obj/machinery/light{
 	dir = 4
@@ -47720,11 +47533,34 @@
 "spY" = (
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/department/chapel)
+"sqj" = (
+/obj/machinery/button/door{
+	id = "war_blast";
+	name = "blast doors";
+	pixel_y = 26
+	},
+/turf/open/floor/carpet/ship,
+/area/bridge/meeting_room)
 "sqF" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/carpet/ship,
 /area/nsv/crew_quarters/heads/maa)
+"sqI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/ship/command/glass{
+	name = "Chief Medical Officer";
+	req_one_access_txt = "40"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/cmo)
 "sqK" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -47735,6 +47571,20 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"srl" = (
+/obj/machinery/atmospherics/pipe/simple/brown/visible{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
+"srT" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "sse" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -47807,21 +47657,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"svH" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Long-Term Confinement"
+"svR" = (
+/obj/machinery/door/airlock/highsecurity/ship{
+	name = "Secure Tech Storage";
+	req_access_txt = "23;19"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "cell3_ld";
-	name = "Cell 3 Lockdown"
-	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/security/prison)
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plating,
+/area/storage/tech)
 "svT" = (
 /obj/machinery/light{
 	dir = 4
@@ -47841,12 +47685,25 @@
 /obj/item/gun/ballistic/automatic/wt550,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/security)
-"swu" = (
-/obj/item/clothing/mask/gas,
-/obj/item/tank/internals/oxygen/yellow,
-/obj/structure/closet/radiation,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+"swe" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"swx" = (
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "swO" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/ship/public/glass{
@@ -47923,13 +47780,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/fore)
-"syI" = (
-/obj/structure/sign/poster/official/obey{
-	pixel_x = -32
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
 "syY" = (
 /obj/structure/table/glass,
 /obj/structure/window/reinforced/spawner/east,
@@ -47952,6 +47802,13 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel,
 /area/maintenance/department/science/central)
+"sAp" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "sAU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -47963,6 +47820,24 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/central)
+"sAW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Auxiliary Surgery";
+	req_one_access_txt = "45"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/white,
+/area/medical/surgery/aux)
 "sBc" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -48009,6 +47884,16 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/tcommsat/computer)
+"sDO" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "sDT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -48021,30 +47906,12 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/exit)
-"sDV" = (
-/obj/machinery/door/airlock/ship/public{
-	id_tag = "cabin2";
-	name = "Cabin 2"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plasteel/ship,
-/area/crew_quarters/dorms)
 "sEM" = (
 /obj/machinery/computer/operating{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"sFA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/bridge)
 "sFF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -48076,6 +47943,16 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/central)
+"sHh" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/mineral/ore_redemption,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/engine,
+/area/quartermaster/office)
 "sHp" = (
 /obj/machinery/computer/upload/borg{
 	dir = 4
@@ -48083,16 +47960,25 @@
 /obj/machinery/status_display/ai/west,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"sHv" = (
+/obj/machinery/button/door{
+	id = "ad_gun";
+	name = "Arms Dump Gun Storage";
+	pixel_x = 0;
+	pixel_y = 24;
+	req_one_access_txt = "3;58"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory/lockup)
 "sHA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
-"sHD" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/crew_quarters/bar/atrium)
 "sIx" = (
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/construction)
@@ -48140,6 +48026,11 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
+"sJH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "sJZ" = (
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/ship,
@@ -48198,19 +48089,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
-"sNR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/door/airlock/ship/public{
-	name = "Quiet Room"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/wood,
-/area/library/lounge)
 "sOb" = (
 /obj/machinery/igniter/incinerator_atmos,
 /turf/open/floor/engine/vacuum,
@@ -48250,6 +48128,24 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"sPS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Patient Room C";
+	req_one_access_txt = "5"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/white,
+/area/medical/patients_rooms/room_c)
 "sQf" = (
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/ship/techfloor/alt,
@@ -48292,9 +48188,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
-"sSo" = (
-/turf/template_noop,
-/area/maintenance/department/electrical)
 "sSp" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -48303,6 +48196,21 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
+"sSF" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/ship,
+/area/nsv/hanger)
 "sSY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -48376,65 +48284,17 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/central)
-"sUA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
+"sUL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
 	},
-/obj/machinery/door/airlock/ship/command{
-	name = "Captain's Quarters";
-	req_one_access_txt = "20"
-	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/carpet/ship,
-/area/crew_quarters/heads/captain/private)
-"sUC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel/ship,
-/area/security/main)
-"sUN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/ship/command/glass{
-	name = "Chief Medical Officer";
-	req_one_access_txt = "40"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/cmo)
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
 "sVv" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/aft)
-"sWa" = (
-/obj/structure/sign/directions/security{
-	pixel_y = 28
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
 "sWy" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -48463,31 +48323,6 @@
 /obj/machinery/status_display/ai/east,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/ai_monitored/turret_protected/aisat/hallway/support_ship)
-"sYh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/door/airlock/ship/security/glass{
-	name = "Long-Term Confinement";
-	req_one_access_txt = "2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/security/prison)
 "sYA" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel/dark,
@@ -48567,6 +48402,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"tbH" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/brown/hidden,
+/turf/open/floor/plating,
+/area/engine/engine_room)
 "tbI" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/secure_data/laptop,
@@ -48639,16 +48479,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"tda" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor/eastright{
-	name = "Security Desk";
-	req_one_access_txt = "63"
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plating,
-/area/security/prison)
 "tdm" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -48659,6 +48489,16 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"tdo" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "tdr" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/candle_box{
@@ -48747,6 +48587,13 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/central)
+"tho" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/effect/mapping_helpers/airlock/abandoned,
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
 "thr" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -48816,20 +48663,24 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"tja" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 4
-	},
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
 "tju" = (
 /obj/item/stack/cable_coil,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
+"tjP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/ship/command{
+	name = "Gravity Generator";
+	req_one_access_txt = "56"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/engine/gravity_generator)
 "tkb" = (
 /obj/structure/closet/secure_closet/chemical,
 /obj/item/storage/box/beakers,
@@ -48945,6 +48796,15 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"tpP" = (
+/obj/machinery/door/airlock/ship/hatch{
+	name = "Telecomms Server Floor Access";
+	req_one_access_txt = "61;65"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plating,
+/area/tcommsat/server)
 "tpR" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -48970,6 +48830,28 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/entry)
+"tqV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/door/airlock/ship/public{
+	name = "Quiet Room"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/wood,
+/area/library/lounge)
+"tqZ" = (
+/obj/machinery/door/airlock/ship/hatch{
+	name = "Support Vessel Service";
+	req_one_access_txt = "65"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plating,
+/area/ai_monitored/turret_protected/aisat/service/support_ship)
 "trO" = (
 /obj/structure/sign/departments/restroom{
 	pixel_x = -32
@@ -49042,12 +48924,6 @@
 /obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"ttR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 8
-	},
-/turf/template_noop,
-/area/maintenance/port/central)
 "tuy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -49127,6 +49003,24 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/exit)
+"txh" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Patient Room B";
+	req_one_access_txt = "5"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/white,
+/area/medical/patients_rooms/room_b)
 "txZ" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -49167,12 +49061,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
-"tyZ" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/monotile/dark,
-/area/science/storage)
 "tzN" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -49218,6 +49106,22 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/security/main)
+"tBY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel/ship,
+/area/security/main)
 "tCl" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/start/bartender,
@@ -49248,6 +49152,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"tEa" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/nsv/hanger)
 "tEq" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/grown/harebell,
@@ -49366,6 +49274,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
+"tKC" = (
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "tKN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -49402,6 +49315,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"tLN" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "tLU" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -49569,18 +49487,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/port)
-"tSb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/monotile/light,
-/area/science/storage)
 "tSc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/disposalpipe/junction{
@@ -49623,16 +49529,6 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
-"tSs" = (
-/obj/machinery/light/floor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/engine/engineering/hangar)
 "tSv" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/ship,
@@ -49643,6 +49539,26 @@
 /obj/item/destTagger,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"tSM" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/door/airlock/ship/security/glass{
+	name = "Long-Term Confinement";
+	req_one_access_txt = "2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/security/prison)
 "tSU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -49668,10 +49584,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"tUu" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plating,
-/area/engine/engineering/hangar)
 "tUx" = (
 /obj/structure/grille,
 /obj/structure/cable{
@@ -49706,22 +49618,6 @@
 /obj/effect/turf_decal/delivery/white,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"tVW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/port)
 "tWm" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Medbay Lobby";
@@ -49731,28 +49627,6 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"tWG" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 5
-	},
-/turf/template_noop,
-/area/maintenance/department/electrical)
-"tXl" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
-/turf/template_noop,
-/area/maintenance/department/electrical)
 "tXm" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -49830,6 +49704,20 @@
 	},
 /turf/open/floor/plating,
 /area/nsv/weapons/fore)
+"tYp" = (
+/obj/structure/sign/directions/medical{
+	dir = 4
+	},
+/obj/structure/sign/directions/evac{
+	dir = 4;
+	pixel_y = 8
+	},
+/obj/structure/sign/directions/supply{
+	dir = 4;
+	pixel_y = -8
+	},
+/turf/closed/wall/ship,
+/area/medical/chemistry)
 "tYx" = (
 /obj/machinery/airalarm/directional/south,
 /obj/structure/disposalpipe/segment{
@@ -49868,10 +49756,10 @@
 /obj/item/clothing/head/helmet/alt,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/security)
-"uaR" = (
-/obj/effect/spawner/room/fivexfour,
+"uaT" = (
+/obj/effect/landmark/blobstart,
 /turf/template_noop,
-/area/maintenance/port/central)
+/area/maintenance/department/bridge)
 "ubJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/cable{
@@ -49933,10 +49821,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/central)
-"ueA" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/bridge)
 "ufj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -49950,16 +49834,6 @@
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"ufp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/effect/landmark/start/scientist,
-/turf/open/floor/monotile/light,
-/area/science/storage)
 "ufF" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
 	dir = 4
@@ -50066,12 +49940,6 @@
 /obj/structure/chair,
 /turf/open/floor/plasteel/ship/riveted,
 /area/maintenance/department/medical/morgue)
-"umo" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/turf/open/floor/plating,
-/area/engine/engineering/hangar)
 "umK" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -50129,20 +49997,10 @@
 /obj/effect/spawner/lootdrop/maintenance/seven,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"uni" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/ship/command{
-	name = "Gravity Generator";
-	req_one_access_txt = "56"
-	},
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/engine/gravity_generator)
+"ung" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/template_noop,
+/area/maintenance/department/bridge)
 "unu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -50201,24 +50059,6 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hop)
-"uop" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/door/airlock/ship/hatch{
-	name = "Support Vessel Aft";
-	req_one_access_txt = "16;65"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/ai_monitored/turret_protected/aisat/hallway/support_ship/aft)
 "uoB" = (
 /obj/machinery/iv_drip,
 /obj/item/radio/intercom{
@@ -50233,11 +50073,13 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
-"upv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/turf/open/floor/plating,
-/area/engine/engineering/hangar)
+"upy" = (
+/obj/machinery/computer/ship/viewscreen,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/fore)
 "upJ" = (
 /turf/closed/wall/r_wall/ship,
 /area/security/warden)
@@ -50262,6 +50104,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"urC" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/hallway/primary/port)
 "urY" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -50310,6 +50156,28 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"uuv" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
+"uuP" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -24
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/security/prison)
 "uve" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -50382,15 +50250,6 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"uwF" = (
-/obj/machinery/door/airlock/ship/public{
-	id_tag = "cabin4";
-	name = "Cabin 4"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plasteel/ship,
-/area/crew_quarters/dorms)
 "uwN" = (
 /obj/machinery/door/window{
 	dir = 8;
@@ -50486,6 +50345,14 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"uAp" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "rd_window";
+	name = "privacy shutter"
+	},
+/turf/open/floor/plating,
+/area/science/lab)
 "uAz" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -50550,6 +50417,26 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"uBY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Hangar Bay"
+	},
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "hang_storage"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/fore)
 "uCd" = (
 /obj/machinery/light,
 /obj/structure/disposalpipe/segment{
@@ -50566,10 +50453,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/quartermaster/storage)
-"uCy" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/library/lounge)
 "uCF" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -50596,6 +50479,20 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"uEz" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
 "uER" = (
 /obj/machinery/newscaster{
 	dir = 4;
@@ -50652,16 +50549,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/storage)
-"uFL" = (
-/obj/structure/sign/directions/security{
-	dir = 4
-	},
-/obj/structure/sign/directions/command{
-	dir = 4;
-	pixel_y = -8
-	},
-/turf/closed/wall/ship,
-/area/hallway/secondary/service)
 "uFV" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -50678,6 +50565,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"uGI" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/suit_storage_unit/pilot,
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/nsv/hanger)
 "uHa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -50773,6 +50670,18 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"uJI" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 5
+	},
+/turf/template_noop,
+/area/maintenance/department/electrical)
 "uJO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -50908,6 +50817,11 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"uPL" = (
+/obj/structure/railing,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plasteel,
+/area/construction)
 "uPO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -50927,25 +50841,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"uQq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/security/prison)
 "uQr" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -50962,19 +50857,17 @@
 /obj/item/stack/ducts/fifty,
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
-"uQv" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "ce_window";
-	name = "privacy shutter"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/chief)
 "uQA" = (
 /obj/effect/spawner/xmastree,
 /turf/open/floor/plasteel/ship,
 /area/ai_monitored/turret_protected/ai)
+"uRj" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/advanced_airlock_controller/directional/west{
+	pixel_y = 24
+	},
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "uRC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/effect/turf_decal/tile/purple{
@@ -50985,6 +50878,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"uRF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 8;
+	sortType = 15
+	},
+/turf/open/floor/plasteel/ship,
+/area/hallway/primary/fore)
 "uRX" = (
 /obj/machinery/atmospherics/pipe/simple/brown/hidden,
 /obj/structure/cable{
@@ -50992,38 +50894,19 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
-"uSn" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/closet/emcloset,
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
-"uSJ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 1
-	},
-/turf/template_noop,
-/area/maintenance/port/central)
 "uST" = (
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"uSV" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
+"uTw" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "bridge_blast"
 	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plating,
-/area/maintenance/department/electrical)
+/area/bridge)
 "uTA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -51045,6 +50928,27 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/engine/engineering/hangar)
+"uWY" = (
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
+"uXF" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "chem_desk_med";
+	name = "desk shutter"
+	},
+/obj/machinery/door/window/northleft{
+	name = "Chemistry Desk";
+	req_one_access_txt = "33"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/medical/chemistry)
 "uXJ" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "12"
@@ -51068,17 +50972,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"uYI" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/snacks/pie/cream,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "Serving Hatch"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "uYX" = (
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
@@ -51111,6 +51004,13 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"uZq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
 "uZs" = (
 /obj/structure/window,
 /obj/machinery/door/firedoor/border_only/directional/south,
@@ -51146,21 +51046,12 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
-"vbc" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/machinery/door/airlock/ship/command/glass{
-	name = "War room";
-	req_one_access_txt = "19"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/carpet/ship,
-/area/bridge/meeting_room)
+"vbl" = (
+/obj/structure/closet/radiation,
+/obj/item/tank/internals/oxygen/yellow,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "vcn" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/machinery/button/door{
@@ -51207,17 +51098,11 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
-"veE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
+"vdZ" = (
+/obj/machinery/computer/security/console,
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/plasteel/dark,
+/area/maintenance/port/central)
 "veF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51233,24 +51118,6 @@
 "vfy" = (
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"vfC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/door/airlock/ship/hatch{
-	name = "Support Vessel Fore";
-	req_one_access_txt = "61;65"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/ai_monitored/turret_protected/aisat/hallway/support_ship)
 "vfV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -51267,17 +51134,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
 	},
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Auxiliary Surgery";
-	req_one_access_txt = "45"
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
+/obj/effect/turf_decal/tile/red,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plasteel/white,
-/area/medical/surgery/aux)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/fore)
 "vgq" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Command Hallway"
@@ -51292,17 +51158,6 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
-"vgw" = (
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "vgJ" = (
 /obj/structure/grille,
 /obj/structure/cable{
@@ -51435,6 +51290,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"vjj" = (
+/obj/structure/sign/directions/command{
+	dir = 4;
+	pixel_y = -8
+	},
+/obj/structure/sign/directions/security{
+	dir = 4
+	},
+/turf/closed/wall/ship,
+/area/nsv/hanger)
 "vjD" = (
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/plasteel/white,
@@ -51461,6 +51326,32 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/lockup)
+"vlb" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/ship/external{
+	req_one_access_txt = "24;32"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
+"vlm" = (
+/obj/machinery/door/airlock/ship/hatch{
+	name = "Air Control Left";
+	req_one_access_txt = "19;69"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plasteel/ship,
+/area/nsv/hanger/deck2/starboard{
+	name = "Launch tubes 1 and 2"
+	})
+"vlA" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/break_room)
 "vlV" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -51546,6 +51437,31 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"vpw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"vpO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/door/airlock/ship/hatch{
+	name = "Network Administration";
+	req_one_access_txt = "61;65"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plasteel/ship,
+/area/tcommsat/computer)
 "vqb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -51563,6 +51479,20 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"vqC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/door/airlock/ship/hatch{
+	name = "Air Control Right";
+	req_one_access_txt = "19;69"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plasteel/ship/padded,
+/area/maintenance/starboard/central)
 "vrr" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -51585,6 +51515,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"vti" = (
+/obj/structure/railing,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/construction)
 "vtn" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -51617,27 +51552,6 @@
 /obj/machinery/vending/engivend,
 /turf/open/floor/plasteel,
 /area/engine/storage)
-"vvw" = (
-/obj/machinery/door/window{
-	dir = 4;
-	name = "Mass Driver";
-	req_access_txt = "22"
-	},
-/obj/machinery/button/massdriver{
-	id = "chapelgun";
-	name = "Chapel Mass Driver";
-	pixel_x = -4;
-	pixel_y = -26
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
-"vvM" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/template_noop,
-/area/maintenance/department/electrical)
 "vvO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -51694,6 +51608,15 @@
 	},
 /turf/open/floor/carpet/black,
 /area/security/courtroom)
+"vxA" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/advanced_airlock_controller/directional/west{
+	pixel_y = 24
+	},
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "vxH" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Atmospherics Incinerator";
@@ -51706,10 +51629,6 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"vyb" = (
-/obj/effect/landmark/blobstart,
-/turf/template_noop,
-/area/maintenance/port/central)
 "vyU" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -28
@@ -51731,15 +51650,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"vzs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/turf/open/floor/monotile/light,
-/area/science/storage)
 "vzz" = (
 /obj/machinery/door/airlock/ship/external{
 	req_one_access_txt = "13"
@@ -51757,6 +51667,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"vAH" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "vAJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
@@ -51834,19 +51752,6 @@
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/service)
-"vCa" = (
-/obj/item/storage/box/lights/mixed,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
 "vCL" = (
 /obj/machinery/shieldwallgen/xenobiologyaccess,
 /obj/machinery/door/poddoor/preopen{
@@ -51858,10 +51763,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"vCO" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/plasteel/ship,
-/area/hallway/secondary/entry)
 "vDx" = (
 /obj/machinery/light{
 	dir = 1
@@ -51950,22 +51851,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"vHu" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "vHw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
-"vHT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/plasteel/ship,
-/area/crew_quarters/dorms)
+"vHO" = (
+/obj/structure/chair/office,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "vJy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -51982,18 +51883,6 @@
 /obj/item/gun/energy/ionrifle,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/security)
-"vJM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/airlock/ship/security/glass{
-	name = "Hangar Bay";
-	req_one_access_txt = "69"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plasteel/dark,
-/area/nsv/hanger)
 "vKa" = (
 /obj/structure/table,
 /obj/item/stamp/ce,
@@ -52004,6 +51893,21 @@
 /obj/item/paper/monitorkey,
 /turf/open/floor/carpet/black,
 /area/crew_quarters/heads/chief)
+"vKz" = (
+/obj/machinery/door/window{
+	dir = 4;
+	name = "Mass Driver";
+	req_access_txt = "22"
+	},
+/obj/machinery/button/massdriver{
+	id = "chapelgun";
+	name = "Chapel Mass Driver";
+	pixel_x = -4;
+	pixel_y = -26
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "vKA" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plating,
@@ -52038,6 +51942,10 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/exit)
+"vLL" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/nsv/weapons/fore)
 "vLM" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -52077,6 +51985,18 @@
 /obj/structure/window/reinforced/spawner,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"vNc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship,
+/area/hallway/primary/fore)
 "vNr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -52086,33 +52006,6 @@
 	},
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
-"vNR" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/ship,
-/area/hallway/primary/fore)
-"vNT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/door/airlock/ship/hatch{
-	name = "Air Control Left";
-	req_one_access_txt = "19;69"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/plasteel/ship/padded,
-/area/maintenance/starboard/central)
 "vOa" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
@@ -52174,6 +52067,34 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"vQr" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/security/glass{
+	name = "Security Equipment";
+	req_one_access_txt = "1;4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/ship,
+/area/security/main)
 "vQy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
@@ -52254,12 +52175,47 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/service)
-"vRZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 10
+"vRU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/engine/engineering/hangar)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/turf/template_noop,
+/area/maintenance/department/electrical)
+"vSA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Hangar Bay"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "hang_storage"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/fore)
 "vSR" = (
 /obj/machinery/button/massdriver{
 	id = "toxgun";
@@ -52304,6 +52260,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science/research)
+"vTA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Hangar Bay"
+	},
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "hang_storage"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/fore)
 "vTT" = (
 /obj/effect/turf_decal/stripes/white/line,
 /obj/effect/turf_decal/arrows/white{
@@ -52326,16 +52299,19 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
-"vTY" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+"vUw" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/library/lounge)
+"vUM" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "vUO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -52358,6 +52334,12 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
+"vVw" = (
+/obj/machinery/light/floor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "vVy" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/blue,
@@ -52408,10 +52390,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"vYM" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/security/prison)
 "vYP" = (
 /obj/structure/railing,
 /turf/open/floor/plasteel,
@@ -52502,15 +52480,6 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/maintenance/starboard/central)
-"wbr" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/airlock/ship/external{
-	req_one_access_txt = "24;32"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering/hangar)
 "wbx" = (
 /obj/effect/landmark/blobstart,
 /obj/effect/decal/cleanable/cobweb,
@@ -52540,25 +52509,6 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"wdl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/security/prison)
 "wds" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -52679,13 +52629,6 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/construction)
-"wgv" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold/visible,
-/turf/open/floor/plating,
-/area/engine/engineering/hangar)
 "wgI" = (
 /obj/machinery/atmospherics/pipe/manifold/brown/visible{
 	dir = 8
@@ -52723,6 +52666,15 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/central)
+"wiW" = (
+/obj/machinery/door/airlock/ship/security/glass{
+	name = "Hangar armoury";
+	req_one_access_txt = "71"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/nsv/hanger)
 "wjB" = (
 /obj/machinery/air_sensor/atmos/incinerator_tank{
 	pixel_y = 32
@@ -53053,6 +53005,12 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
+"wwo" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "wwp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
@@ -53132,15 +53090,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"wzn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
 "wzp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -53150,11 +53099,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/exit)
-"wzG" = (
-/obj/structure/table,
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plating,
-/area/space/nearstation)
 "wzY" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -53201,6 +53145,12 @@
 	},
 /turf/open/floor/carpet/black,
 /area/security/courtroom)
+"wCK" = (
+/obj/structure/closet/radiation,
+/obj/item/clothing/mask/gas,
+/obj/item/tank/internals/oxygen/yellow,
+/turf/open/floor/plasteel/ship,
+/area/hallway/secondary/entry)
 "wCW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -53213,18 +53163,6 @@
 /obj/machinery/atmospherics/components/binary/pump,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"wDc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/machinery/light/small,
-/turf/open/floor/plating,
-/area/maintenance/department/bridge)
-"wDk" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/monotile/dark,
-/area/science/storage)
 "wDs" = (
 /obj/machinery/light,
 /obj/structure/reagent_dispensers/fueltank,
@@ -53244,6 +53182,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"wDE" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "ce_window";
+	name = "privacy shutter"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/chief)
 "wDN" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -53299,15 +53249,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/maintenance/department/crew_quarters/dorms)
-"wGH" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/turf/template_noop,
-/area/maintenance/department/electrical)
 "wHc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/curtain/obscuring/grey,
@@ -53329,6 +53270,9 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
+"wHE" = (
+/turf/template_noop,
+/area/maintenance/port/central)
 "wHH" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/yellow,
@@ -53346,11 +53290,12 @@
 /obj/structure/table,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"wIn" = (
-/obj/structure/lattice,
-/obj/structure/filingcabinet,
-/turf/open/space/basic,
-/area/space/nearstation)
+"wIy" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 8
+	},
+/turf/template_noop,
+/area/maintenance/port/central)
 "wJb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53359,6 +53304,14 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/central)
+"wJj" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	id = "firingsquad";
+	name = "security shutters"
+	},
+/turf/open/floor/plating,
+/area/security/execution/transfer)
 "wKp" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -53384,6 +53337,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"wLs" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=JaniCloset";
+	location = "HOP-Corner"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/fore)
 "wLF" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Fitness Room"
@@ -53392,6 +53355,15 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"wLQ" = (
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "wMz" = (
 /obj/machinery/light{
 	dir = 4
@@ -53425,6 +53397,16 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/port)
+"wNb" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plasteel/ship,
+/area/crew_quarters/dorms)
 "wNf" = (
 /obj/structure/disposalpipe/trunk,
 /obj/structure/window/reinforced,
@@ -53433,10 +53415,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"wNQ" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/space/basic,
-/area/crew_quarters/heads/captain)
 "wOo" = (
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -53492,6 +53470,12 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
+"wQF" = (
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "wRi" = (
 /turf/open/floor/plating,
 /area/nsv/hanger/storage)
@@ -53502,10 +53486,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/warden)
-"wRM" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/engine/gravity_generator)
 "wSj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53523,6 +53503,17 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/central)
+"wSF" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "wTa" = (
 /obj/structure/table/wood,
 /obj/structure/mirror{
@@ -53539,17 +53530,24 @@
 /obj/item/lipstick/black,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/theatre)
+"wTk" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "wUk" = (
 /obj/structure/sink/kitchen{
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"wUS" = (
-/obj/structure/girder,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
 "wVa" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -53737,27 +53735,6 @@
 "xcC" = (
 /turf/closed/wall/r_wall/ship,
 /area/nsv/crew_quarters/heads/maa)
-"xdd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/ship,
-/area/hallway/primary/fore)
-"xdL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/status_display/evac/south,
-/turf/open/floor/plasteel/ship,
-/area/hallway/primary/fore)
 "xdN" = (
 /obj/structure/table/wood,
 /obj/item/taperecorder{
@@ -53800,6 +53777,15 @@
 	},
 /turf/open/floor/plating,
 /area/nsv/weapons/fore)
+"xfH" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "xgc" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -53822,6 +53808,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"xgM" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/monotile/dark,
+/area/science/storage)
 "xgQ" = (
 /obj/effect/decal/cleanable/oil/streak,
 /turf/open/floor/plating,
@@ -53911,28 +53903,6 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"xkz" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/library)
-"xkD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Patient Room C";
-	req_one_access_txt = "5"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plasteel/white,
-/area/medical/patients_rooms/room_c)
 "xkE" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_y = -30
@@ -53951,6 +53921,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"xmk" = (
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/monotile/light,
+/area/science/storage)
 "xmu" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -53981,6 +53958,9 @@
 /obj/machinery/computer/atmos_control/tank/incinerator,
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
+"xmP" = (
+/turf/template_noop,
+/area/maintenance/department/electrical)
 "xnj" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/computer/ship/munitions_computer{
@@ -54012,6 +53992,12 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/exit)
+"xnL" = (
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/hallway/primary/fore)
 "xoh" = (
 /obj/machinery/computer/security{
 	dir = 8
@@ -54041,15 +54027,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/security/prison)
-"xpg" = (
-/obj/machinery/door/airlock/virology/glass{
-	name = "Isolation B";
-	req_one_access_txt = "39"
-	},
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "xpi" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/plasteel/ship,
@@ -54115,18 +54092,31 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"xrg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
+"xqJ" = (
+/obj/structure/plasticflaps,
+/obj/machinery/door/poddoor/shutters{
+	id = "cmbridge";
+	name = "Cargo Munitions Bridge Shutter"
 	},
+/obj/machinery/conveyor{
+	id = "cmbelt"
+	},
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/nsv/weapons/fore)
+"xrw" = (
+/obj/structure/window,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/turf/template_noop,
-/area/maintenance/department/electrical)
+/obj/structure/closet/crate/medical,
+/obj/item/stack/medical/gauze/improvised,
+/obj/item/stack/medical/ointment/one,
+/obj/item/stack/medical/bruise_pack/one,
+/obj/item/clothing/mask/surgical,
+/obj/item/reagent_containers/syringe/used,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "xrE" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
@@ -54136,6 +54126,21 @@
 	},
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
+"xsl" = (
+/obj/machinery/light/small,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "xso" = (
 /obj/machinery/computer/card/minor/ce,
 /obj/machinery/requests_console{
@@ -54314,18 +54319,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/ai_monitored/turret_protected/ai_upload)
-"xyL" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 5
-	},
-/turf/template_noop,
-/area/maintenance/department/electrical)
 "xzi" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light/runway/delay3,
@@ -54335,11 +54328,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
-"xzA" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/engine/atmos)
 "xzD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/light{
@@ -54349,12 +54337,25 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"xAb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/plasteel/ship,
-/area/crew_quarters/dorms)
+"xzN" = (
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/machinery/light/floor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/engine/engineering/hangar)
+"xzV" = (
+/obj/structure/closet/radiation,
+/obj/item/tank/internals/oxygen/yellow,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/bar)
 "xAP" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -54365,20 +54366,6 @@
 /obj/machinery/recharge_station,
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
-"xBr" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/atmospherics_engine)
-"xBz" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/engine/engineering/hangar)
 "xBT" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -54413,6 +54400,18 @@
 /obj/machinery/telecomms/server/presets/command,
 /turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
+"xCZ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/turf/template_noop,
+/area/maintenance/department/electrical)
 "xDx" = (
 /obj/structure/rack,
 /obj/item/gun/ballistic/automatic/pistol/m1911/no_mag,
@@ -54435,10 +54434,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/security)
-"xDS" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "xEj" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -54563,14 +54558,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
-"xHC" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "fab_window";
-	name = "privacy shutter"
-	},
-/turf/open/floor/plating,
-/area/science/mixing)
 "xHO" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -54601,6 +54588,13 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/central)
+"xJF" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "captain_blast"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/captain)
 "xKf" = (
 /obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/ship/techfloor/alt,
@@ -54612,6 +54606,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"xKs" = (
+/obj/machinery/door/airlock/ship/hatch{
+	name = "Support Vessel Aft";
+	req_one_access_txt = "16;65"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/ai_monitored/turret_protected/aisat/hallway/support_ship/aft)
 "xKF" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -54646,6 +54649,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"xKW" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "war_blast"
+	},
+/turf/open/floor/plating,
+/area/bridge/meeting_room)
+"xLs" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "xoprivacy";
+	name = "Privacy Shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hop)
 "xLX" = (
 /obj/machinery/door_timer{
 	id = "pw_2";
@@ -54704,20 +54725,6 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/hanger)
-"xNd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/ship/security{
-	name = "Private Investigator's Office";
-	req_one_access_txt = "4"
-	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/plasteel,
-/area/security/detectives_office/private_investigators_office)
 "xND" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -54742,6 +54749,24 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"xNK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Construction Area";
+	req_one_access_txt = "32"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "xOb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54782,13 +54807,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/ai_monitored/turret_protected/aisat/service/support_ship)
-"xQT" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/ship/techfloor/alt,
-/area/hallway/primary/fore)
 "xRr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -54911,14 +54929,6 @@
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
-"xUn" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plating,
-/area/maintenance/department/medical/morgue)
 "xUx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
@@ -54936,6 +54946,25 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
+"xUC" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/security/prison)
+"xUI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 5
+	},
+/turf/open/floor/monotile/light,
+/area/science/storage)
 "xUX" = (
 /obj/machinery/computer/crew,
 /obj/machinery/computer/security/telescreen/cmo{
@@ -54961,10 +54990,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"xVE" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/chapel/office)
+"xVx" = (
+/obj/machinery/door/airlock/virology/glass{
+	name = "Isolation A";
+	req_one_access_txt = "39"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "xVF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54975,6 +55009,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"xWo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "xWt" = (
 /obj/structure/table/glass,
 /turf/open/floor/wood,
@@ -54989,15 +55032,6 @@
 	},
 /turf/open/floor/plating,
 /area/nsv/weapons/fore)
-"xWL" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/bridge)
 "xWU" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -55074,11 +55108,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
-"xYH" = (
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "xYO" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
 /obj/effect/turf_decal/tile/yellow,
@@ -55142,6 +55171,23 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/engine/engineering/hangar)
+"xZL" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/ship/external{
+	req_one_access_txt = "24;32"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
+"xZR" = (
+/obj/structure/sign/directions/medical{
+	dir = 8;
+	pixel_y = -8
+	},
+/obj/structure/sign/directions/science{
+	dir = 8
+	},
+/turf/closed/wall/ship,
+/area/hallway/secondary/service)
 "xZW" = (
 /obj/structure/sign/poster/contraband/hacking_guide{
 	pixel_y = -32
@@ -55253,16 +55299,29 @@
 /obj/item/paper_bin,
 /turf/open/floor/wood,
 /area/library/lounge)
-"yek" = (
-/obj/machinery/light/floor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/turf/open/floor/plating,
-/area/engine/engineering/hangar)
 "yeI" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
 /turf/open/floor/plating,
 /area/security/checkpoint/science/research)
+"yeJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/ship/techfloor/alt,
+/area/security/prison)
 "yeU" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/ship/techfloor/alt,
@@ -55339,11 +55398,6 @@
 /obj/structure/closet/secure_closet/munitions_technician,
 /turf/open/floor/plasteel/ship,
 /area/nsv/weapons/fore)
-"ygE" = (
-/obj/structure/table,
-/obj/item/disk/holodisk/hammerhead_cryo,
-/turf/open/floor/plating,
-/area/space/nearstation)
 "ygR" = (
 /obj/structure/grille,
 /obj/structure/cable{
@@ -55354,22 +55408,6 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload)
-"yhc" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 3
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "Serving Hatch"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "yhA" = (
 /obj/structure/grille,
 /obj/structure/cable,
@@ -55417,18 +55455,6 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/plasteel/ship,
 /area/lawoffice)
-"yiC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/monotile/light,
-/area/science/storage)
 "yiU" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -55442,18 +55468,18 @@
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"yjQ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "fab_window";
+	name = "privacy shutter"
+	},
+/turf/open/floor/plating,
+/area/science/mixing)
 "yjW" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"yjY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	dir = 4;
-	id = "maashutter"
-	},
-/turf/open/floor/plating,
-/area/nsv/crew_quarters/heads/maa)
 "ykj" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "disposal_waste_eject"
@@ -55467,26 +55493,16 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/security/warden)
-"ykC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/door/airlock/ship/hatch{
-	name = "Network Administration";
-	req_one_access_txt = "61;65"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plasteel/ship,
-/area/tcommsat/computer)
 "ykO" = (
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/port)
+"ykQ" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/crew_quarters/bar/atrium)
 "ylf" = (
 /obj/machinery/status_display/ai/west,
 /turf/open/floor/plasteel/ship/techfloor/alt,
@@ -55524,6 +55540,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"ymo" = (
+/obj/machinery/light/small,
+/obj/structure/closet/radiation,
+/obj/item/tank/internals/oxygen/yellow,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/dorms)
 
 (1,1,1) = {"
 aaa
@@ -61072,7 +61095,7 @@ bgf
 aDf
 aRH
 aDf
-ovy
+oFH
 aDf
 aRH
 aDf
@@ -62383,7 +62406,7 @@ diq
 ako
 aBc
 aKU
-hQD
+iPL
 fkN
 aBl
 fkN
@@ -62595,18 +62618,18 @@ asC
 asC
 asC
 asC
-raS
+svR
 asC
 aWl
 fkN
 fkN
 aPK
 aPK
-xBr
-xBr
+orV
+orV
 aPK
-xBr
-xBr
+orV
+orV
 aPK
 eEb
 aDf
@@ -62640,7 +62663,7 @@ xGt
 xGt
 nAm
 ask
-hQD
+iPL
 aar
 aBl
 fkN
@@ -62897,7 +62920,7 @@ aTL
 aTL
 ooU
 ymj
-hQD
+iPL
 fkN
 aBl
 fkN
@@ -63371,7 +63394,7 @@ qAn
 aWl
 aar
 aux
-hQD
+iPL
 aps
 aoT
 alk
@@ -63411,7 +63434,7 @@ fVK
 aHj
 bBg
 ymj
-hQD
+iPL
 fkN
 aBl
 fkN
@@ -63628,7 +63651,7 @@ aSY
 aWl
 fkN
 aar
-hQD
+iPL
 gEV
 aoT
 aoT
@@ -63668,7 +63691,7 @@ aqi
 nTi
 uZj
 ymj
-hQD
+iPL
 aar
 aBl
 fkN
@@ -63885,7 +63908,7 @@ ank
 aWl
 fkN
 fkN
-hQD
+iPL
 qcm
 aoT
 aoT
@@ -63925,7 +63948,7 @@ fVK
 cOm
 amu
 ymj
-hQD
+iPL
 fkN
 aBl
 fkN
@@ -64398,7 +64421,7 @@ aEG
 aTz
 aWl
 fkN
-hQD
+iPL
 ahr
 ahr
 ahr
@@ -64655,7 +64678,7 @@ aEG
 aLs
 aWl
 fkN
-hQD
+iPL
 aoT
 aoT
 aoT
@@ -64665,7 +64688,7 @@ aoT
 eRN
 dkf
 esI
-xzA
+tLN
 dkf
 aiK
 xFt
@@ -64696,7 +64719,7 @@ tFt
 bmO
 uZj
 ymj
-hQD
+iPL
 aar
 aBl
 fkN
@@ -64912,7 +64935,7 @@ aEG
 aOo
 aWl
 fkN
-hQD
+iPL
 ahr
 ahr
 ahr
@@ -64953,7 +64976,7 @@ aUl
 tUJ
 amu
 ymj
-hQD
+iPL
 fkN
 aBl
 fkN
@@ -65004,9 +65027,9 @@ agh
 agh
 agh
 agh
-lrs
-fyk
-lrs
+lzk
+mGY
+lzk
 agh
 agh
 agh
@@ -65178,7 +65201,7 @@ aDf
 awC
 aiP
 aiP
-iZQ
+rHu
 aDf
 aDf
 qhT
@@ -65210,7 +65233,7 @@ apc
 apn
 amu
 ymj
-hQD
+iPL
 fkN
 aBl
 fkN
@@ -65724,7 +65747,7 @@ tFt
 okv
 pLc
 ymj
-hQD
+iPL
 fkN
 aHu
 aGt
@@ -65981,15 +66004,15 @@ aGf
 afM
 aCe
 ymj
-hQD
+iPL
 fkN
-wRM
+bGz
 aGt
 aBH
 avM
 aBw
 aGt
-wRM
+bGz
 fkN
 fkN
 bkD
@@ -66038,7 +66061,7 @@ aYD
 aYD
 aYD
 aYD
-qtr
+tqZ
 aYD
 aYD
 fTe
@@ -66238,15 +66261,15 @@ akk
 aMJ
 aLv
 akf
-hQD
+iPL
 aar
-wRM
+bGz
 aGt
 avM
 pcv
 akt
 aGt
-wRM
+bGz
 fkN
 fkN
 bkD
@@ -66497,13 +66520,13 @@ aRU
 eNw
 aYi
 bdq
-wRM
+bGz
 aGt
 aOL
 avM
 azu
 aGt
-wRM
+bGz
 fkN
 fkN
 bkD
@@ -66543,7 +66566,7 @@ aPA
 aEy
 ajc
 aiE
-gGZ
+muO
 aId
 rWQ
 uqe
@@ -67013,7 +67036,7 @@ aYi
 bds
 aHu
 aHu
-bxg
+hHk
 aHu
 aHu
 aHu
@@ -67054,9 +67077,9 @@ fkN
 aar
 bkX
 aPA
-qEz
+xKs
 aPA
-uop
+dcg
 aYD
 aYD
 apb
@@ -67251,7 +67274,7 @@ aKD
 bco
 xAP
 bcu
-bwO
+vlA
 geE
 rsX
 aEh
@@ -67508,13 +67531,13 @@ aMj
 aMj
 aMj
 bcv
-bwO
+vlA
 idC
 gWx
 gWx
 hlo
 mzw
-fhl
+lCp
 alH
 aXx
 azR
@@ -67522,10 +67545,10 @@ aHR
 aHR
 aOl
 aHR
-kGo
+kkG
 bdn
 bdu
-uni
+tjP
 axs
 aRj
 aXa
@@ -67765,13 +67788,13 @@ aMj
 bcp
 aMj
 bcv
-bwO
+vlA
 mzw
 gWx
 nBK
 hlo
 mzw
-fhl
+lCp
 alH
 avA
 aJT
@@ -67779,7 +67802,7 @@ azJ
 agO
 amM
 agO
-onC
+snz
 bdo
 bef
 aHu
@@ -68022,7 +68045,7 @@ aSu
 bcq
 aSu
 bcw
-qAG
+ePr
 rNF
 aBt
 qTl
@@ -68036,15 +68059,15 @@ aCH
 awN
 amM
 aJo
-guj
+wwo
 bdp
-tUu
-mcx
+ksg
+xZL
 aYg
-qHp
+uRj
 bbF
 aYg
-wbr
+vlb
 aux
 aux
 aux
@@ -68279,13 +68302,13 @@ bcm
 bcr
 bcs
 bcx
-bwO
+vlA
 ibY
 gWx
 gAB
 hlo
 mzw
-fhl
+lCp
 xZy
 tKN
 aTR
@@ -68293,15 +68316,15 @@ ajI
 aoX
 amM
 aJo
-vRZ
-eHb
-blB
-kAv
-lpu
-umo
-lyS
-wgv
-wbr
+odJ
+cEK
+vUM
+gSw
+kEz
+bmQ
+bup
+jUI
+vlb
 aux
 aux
 aux
@@ -68536,13 +68559,13 @@ aMj
 aMj
 bcs
 bcz
-bwO
+vlA
 ibY
 gWx
 gWx
 hlo
 mzw
-fhl
+lCp
 alH
 uWV
 aKt
@@ -68552,7 +68575,7 @@ rPV
 agO
 agO
 agO
-tSs
+jMU
 arQ
 arQ
 arQ
@@ -68809,13 +68832,13 @@ amM
 aJo
 aYg
 aYg
-brV
-mcx
+xWo
+xZL
 bbB
-rJV
+fKP
 aYg
 bbC
-wbr
+vlb
 aux
 aux
 aux
@@ -69058,7 +69081,7 @@ gWx
 mVm
 qNb
 alH
-flp
+hxW
 aUM
 ajI
 aoX
@@ -69066,13 +69089,13 @@ amM
 aJo
 aYg
 aYg
-brV
-mcx
+xWo
+xZL
 aYg
-kVQ
-lyS
-eMq
-wbr
+fFK
+bup
+pXN
+vlb
 aux
 aux
 aux
@@ -69303,10 +69326,10 @@ aeJ
 ajk
 ahj
 ajk
-jVd
-jVd
-jVd
-jVd
+bKR
+bKR
+bKR
+bKR
 ajk
 atG
 atG
@@ -69323,13 +69346,13 @@ rPV
 agO
 agO
 agO
-lJI
-kAv
-yek
-jpe
-lyS
-eMq
-wbr
+raM
+gSw
+vVw
+pIj
+bup
+pXN
+vlb
 aar
 aar
 aar
@@ -69523,11 +69546,11 @@ adk
 aXH
 abq
 awB
-nQt
-buO
-pKb
-fES
-nwm
+iEB
+xmk
+cpf
+efj
+gIH
 uPW
 gxb
 pEK
@@ -69580,13 +69603,13 @@ amM
 aJo
 aYg
 aYg
-brV
-mcx
+xWo
+xZL
 aYg
-xBz
-lyS
-eMq
-wbr
+tdo
+bup
+pXN
+vlb
 aux
 aux
 aux
@@ -69636,9 +69659,9 @@ dgQ
 dgQ
 dgQ
 dgQ
-vfC
+bSL
 bfq
-ldQ
+laZ
 oWV
 bkX
 aar
@@ -69780,11 +69803,11 @@ alc
 elf
 iTC
 awB
-qVf
-hhI
-brg
-fES
-nwm
+mAY
+rMO
+qwI
+efj
+gIH
 uPW
 hjQ
 aPE
@@ -69837,13 +69860,13 @@ amM
 aJo
 aYg
 aYg
-brV
-mcx
+xWo
+xZL
 aYg
-jML
+csT
 aYg
 bbz
-wbr
+vlb
 aux
 aux
 aux
@@ -70037,11 +70060,11 @@ ckE
 awB
 xxX
 awB
-lLD
-jhr
-brg
-tyZ
-hdB
+mWo
+nQs
+qwI
+xgM
+fpd
 uPW
 xXO
 aPE
@@ -70094,7 +70117,7 @@ rPV
 agO
 agO
 agO
-kEY
+xzN
 arQ
 arQ
 arQ
@@ -70294,11 +70317,11 @@ wjE
 jxt
 bRg
 amR
-ccS
-fqj
-gMv
-dsF
-ccS
+hmW
+lnl
+xUI
+srT
+hmW
 uPW
 aSj
 agL
@@ -70351,13 +70374,13 @@ amM
 aJo
 aYg
 aYg
-iSq
-kAv
-upv
-oFf
-iBR
-eMq
-wbr
+pfQ
+gSw
+sJH
+vxA
+wLQ
+pXN
+vlb
 aux
 aux
 aux
@@ -70551,11 +70574,11 @@ nTd
 jxt
 afp
 amR
-nwm
-dNI
-ufp
-nhn
-qVf
+gIH
+iPW
+qSO
+cTk
+mAY
 uPW
 aVH
 auL
@@ -70609,12 +70632,12 @@ aJo
 aYg
 ajt
 aYg
-mcx
+xZL
 bbz
 bbE
 bbE
 bbz
-wbr
+vlb
 aux
 aux
 aux
@@ -70808,11 +70831,11 @@ jxt
 jxt
 bRg
 amR
-qHW
-wDk
-vzs
-fYQ
-paV
+duA
+bvC
+rBA
+rzn
+nwT
 uPW
 hcG
 auL
@@ -70920,7 +70943,7 @@ kIE
 lQi
 sDu
 hfs
-ykC
+vpO
 dhx
 hTE
 xuR
@@ -71065,11 +71088,11 @@ eIz
 eIz
 jAx
 amR
-foD
-cqk
-yiC
-oLF
-gtr
+vHu
+lDO
+lqM
+swx
+nxz
 uPW
 dvN
 amm
@@ -71322,11 +71345,11 @@ uwt
 aJB
 bRg
 amR
-nQt
-mBn
-tSb
-oKv
-mQE
+iEB
+lCV
+rqJ
+ktf
+npM
 uPW
 hUn
 oiF
@@ -71581,7 +71604,7 @@ bRg
 amR
 amR
 amR
-irr
+nCm
 amR
 amR
 uPW
@@ -72199,7 +72222,7 @@ aPb
 aPb
 aEe
 aEe
-qGO
+tpP
 aPb
 aPb
 dgQ
@@ -72395,7 +72418,7 @@ lro
 atG
 aIA
 nBl
-lbN
+srl
 jjm
 aIj
 byc
@@ -72651,10 +72674,10 @@ jsQ
 wwa
 atG
 jUE
-ifD
-pdt
-pdt
-pdt
+gPF
+tbH
+tbH
+tbH
 nhh
 xHO
 qUo
@@ -72710,7 +72733,7 @@ bkX
 agH
 asS
 aHN
-ptw
+nAb
 bkc
 bke
 bkg
@@ -72867,7 +72890,7 @@ aaZ
 bMR
 aYO
 aYO
-jIB
+bOh
 aYO
 aYO
 apm
@@ -73173,7 +73196,7 @@ qtk
 qtk
 lWc
 kTD
-lBi
+cfU
 sZr
 sZr
 aLc
@@ -73229,7 +73252,7 @@ auM
 auM
 auM
 auM
-fIA
+nUs
 auM
 auM
 auM
@@ -73411,10 +73434,10 @@ ajW
 aZN
 vqb
 avT
-erI
-mYw
+hWW
+wDE
 bxo
-uQv
+rZe
 axD
 vYV
 bNZ
@@ -73437,7 +73460,7 @@ anC
 uzn
 anv
 anv
-ock
+xNK
 kcU
 anv
 aJR
@@ -74186,7 +74209,7 @@ agZ
 uxS
 anE
 acX
-uQv
+rZe
 viJ
 auE
 alO
@@ -74420,7 +74443,7 @@ xSj
 aQV
 cnp
 rYW
-mha
+uAp
 vFY
 awS
 anR
@@ -74443,7 +74466,7 @@ xso
 aGU
 aXD
 qlK
-uQv
+rZe
 bkp
 auE
 hdT
@@ -74677,7 +74700,7 @@ dMa
 aOD
 rKF
 oTg
-mha
+uAp
 xhr
 dRV
 bcA
@@ -74700,7 +74723,7 @@ lAM
 mYm
 orF
 vKa
-uQv
+rZe
 cXW
 pjs
 fxt
@@ -74720,7 +74743,7 @@ aye
 aJR
 aJR
 aJR
-dcM
+vti
 sIx
 mMR
 qCz
@@ -74963,7 +74986,7 @@ aam
 aam
 aam
 aam
-mvc
+bUL
 aam
 dSe
 bVr
@@ -74977,7 +75000,7 @@ mCn
 mCn
 mCn
 qNR
-gOY
+pVJ
 ifm
 iYr
 qCz
@@ -75234,7 +75257,7 @@ aye
 aye
 aye
 aye
-dcM
+vti
 sIx
 pYC
 mel
@@ -75439,7 +75462,7 @@ aaZ
 fst
 vPx
 wkZ
-xHC
+yjQ
 hnz
 acv
 aKC
@@ -75481,17 +75504,17 @@ jqp
 aho
 tcP
 aho
-sSo
-sSo
-sSo
-fmi
+xmP
+xmP
+xmP
+qCO
 akX
 wPr
 aJR
 aJR
 aye
 aye
-dWI
+uPL
 sIx
 ntz
 xaC
@@ -75696,7 +75719,7 @@ aaZ
 xxo
 aaZ
 lRh
-xHC
+yjQ
 heQ
 lVZ
 aKC
@@ -75736,12 +75759,12 @@ kXQ
 aaf
 vHw
 aho
-wUS
+gbJ
 aho
-sSo
-sSo
-jMs
-sSo
+xmP
+xmP
+osI
+xmP
 akX
 akX
 akX
@@ -75994,11 +76017,11 @@ aaf
 iQX
 aho
 dSe
-rfV
-vvM
-vvM
-wGH
-sSo
+lzg
+iRr
+iRr
+gre
+xmP
 aho
 aho
 akX
@@ -76227,7 +76250,7 @@ aEZ
 aUO
 adc
 asY
-sHD
+ykQ
 fkN
 fkN
 fkN
@@ -76239,7 +76262,7 @@ fkN
 fkN
 fkN
 fkN
-mTH
+ksv
 aEd
 kDM
 auK
@@ -76252,16 +76275,16 @@ vHw
 aho
 vHw
 aho
-sSo
-qHN
-tWG
-sSo
+xmP
+hBo
+uJI
+xmP
 aho
-sSo
-sSo
-sSo
-sSo
-lqN
+xmP
+xmP
+xmP
+xmP
+hXU
 aho
 bku
 aux
@@ -76484,7 +76507,7 @@ aEZ
 ojZ
 adc
 asY
-sHD
+ykQ
 fkN
 fkN
 fkN
@@ -76496,7 +76519,7 @@ fkN
 fkN
 fkN
 fkN
-mTH
+ksv
 aUB
 afZ
 arD
@@ -76509,16 +76532,16 @@ vHw
 aho
 vHw
 aho
-sSo
-sSo
-qrU
-lMm
-uSV
-lMm
-lMm
-xyL
-sSo
-sSo
+xmP
+xmP
+nmG
+jbw
+lDl
+jbw
+jbw
+iSr
+xmP
+xmP
 rpQ
 aHd
 bkw
@@ -76741,7 +76764,7 @@ aEZ
 pZy
 adc
 asY
-sHD
+ykQ
 fkN
 fkN
 fkN
@@ -76753,7 +76776,7 @@ fkN
 fkN
 fkN
 fkN
-mTH
+ksv
 aBh
 azp
 bMn
@@ -76767,15 +76790,15 @@ aho
 iQX
 aho
 aho
-kaI
-kaI
+iWB
+iWB
 aho
 aho
-sSo
-sSo
-pZq
-sSo
-sSo
+xmP
+xmP
+xCZ
+xmP
+xmP
 rpQ
 aHd
 aHd
@@ -76998,7 +77021,7 @@ aEZ
 ckT
 adc
 asY
-sHD
+ykQ
 fkN
 fkN
 fkN
@@ -77010,7 +77033,7 @@ fkN
 fkN
 fkN
 fkN
-mTH
+ksv
 gkO
 atD
 eBE
@@ -77020,7 +77043,7 @@ aNQ
 aaj
 aaf
 vHw
-qwN
+emv
 vHw
 aho
 ajz
@@ -77028,11 +77051,11 @@ ajz
 fkN
 fkN
 aho
-sSo
-sSo
-pZq
-sSo
-sSo
+xmP
+xmP
+xCZ
+xmP
+xmP
 aho
 aux
 aux
@@ -77277,19 +77300,19 @@ aNQ
 vyU
 aaf
 vtn
-fHR
-cjf
+soT
+uuv
 aho
 fkN
-hAZ
-wzG
+vHO
+fDd
 ajz
-kaI
-sSo
-sSo
-xrg
-sSo
-sSo
+iWB
+xmP
+xmP
+gMp
+xmP
+xmP
 rpQ
 aHd
 bkw
@@ -77537,16 +77560,16 @@ aaf
 vHw
 aho
 aho
-wIn
+mPY
 ajz
-ygE
-jfz
-kaI
-sSo
-sSo
-xrg
-sSo
-sSo
+bGF
+bEf
+iWB
+xmP
+xmP
+gMp
+xmP
+xmP
 rpQ
 aHd
 aHd
@@ -77799,11 +77822,11 @@ ajz
 ajz
 fkN
 aho
-sSo
-qHN
-tXl
-sSo
-sSo
+xmP
+hBo
+ofY
+xmP
+xmP
 aho
 aux
 aux
@@ -78027,7 +78050,7 @@ adc
 aGS
 biy
 aCL
-sHD
+ykQ
 aCL
 fkN
 fkN
@@ -78056,11 +78079,11 @@ aho
 aho
 aho
 aho
-sSo
-ely
-oPS
-hgV
-sSo
+xmP
+hJz
+vRU
+mhr
+xmP
 rpQ
 aHd
 bkw
@@ -78285,7 +78308,7 @@ aKH
 biA
 suo
 adc
-sHD
+ykQ
 fkN
 fkN
 fkN
@@ -78303,7 +78326,7 @@ duW
 aaj
 aNQ
 aaj
-nNj
+wCK
 aaf
 ahd
 aho
@@ -78313,11 +78336,11 @@ tLz
 rVd
 xpC
 aho
-sSo
-sSo
-xrg
-sSo
-sSo
+xmP
+xmP
+gMp
+xmP
+xmP
 rpQ
 aHd
 aHd
@@ -78542,7 +78565,7 @@ aZw
 biA
 hTW
 puq
-sHD
+ykQ
 fkN
 fkN
 fkN
@@ -78563,18 +78586,18 @@ aHQ
 aaf
 aaf
 vHw
-njT
+pNH
 ata
 nZg
 eki
 aho
 aho
 aho
-sSo
-sSo
-xrg
-sSo
-sSo
+xmP
+xmP
+gMp
+xmP
+xmP
 aho
 aux
 aux
@@ -78799,7 +78822,7 @@ aZw
 biA
 rPQ
 adc
-sHD
+ykQ
 fkN
 fkN
 fkN
@@ -78817,7 +78840,7 @@ biQ
 biT
 biD
 aaj
-vCO
+qBN
 aaf
 vHw
 aho
@@ -78829,7 +78852,7 @@ fkN
 aho
 aho
 aho
-prb
+phF
 aho
 aho
 rpQ
@@ -79056,7 +79079,7 @@ biw
 biA
 pSh
 adc
-sHD
+ykQ
 fkN
 fkN
 fkN
@@ -79085,8 +79108,8 @@ fkN
 fkN
 fkN
 aho
-uSn
-oOu
+sAp
+cWT
 ata
 rSF
 rpQ
@@ -79312,7 +79335,7 @@ adc
 bix
 biF
 aCL
-sHD
+ykQ
 aCL
 fkN
 fkN
@@ -79343,7 +79366,7 @@ fkN
 fkN
 aho
 urY
-oOu
+cWT
 ata
 wqP
 aho
@@ -79599,9 +79622,9 @@ fkN
 fkN
 fkN
 aho
-dki
-eRC
-bGF
+nqv
+mQT
+neL
 aho
 aho
 aux
@@ -79804,7 +79827,7 @@ aUL
 aUL
 aUL
 aUL
-deO
+wQF
 bhL
 bhR
 aST
@@ -79856,7 +79879,7 @@ aar
 aar
 aar
 aho
-oOu
+cWT
 vqy
 aho
 aho
@@ -80113,7 +80136,7 @@ fkN
 fkN
 fkN
 aho
-knr
+xsl
 aho
 aho
 aux
@@ -80321,7 +80344,7 @@ fkN
 aIx
 bhP
 aIx
-rsf
+eJR
 aIx
 fkN
 aar
@@ -80370,7 +80393,7 @@ fkN
 fkN
 fkN
 aho
-oOu
+cWT
 aho
 aux
 aux
@@ -80627,7 +80650,7 @@ fkN
 aho
 aho
 aho
-oOu
+cWT
 aho
 aux
 aar
@@ -80882,9 +80905,9 @@ fkN
 fkN
 fkN
 aho
-vCa
-cmk
-irQ
+cdq
+kbq
+eXO
 aho
 aux
 aar
@@ -81139,7 +81162,7 @@ aho
 aho
 aho
 aho
-hyT
+jOG
 aqp
 bgb
 aho
@@ -81395,8 +81418,8 @@ bVr
 uEX
 bVr
 bVr
-lcu
-kjy
+kCc
+bwA
 aho
 bgc
 aho
@@ -81628,11 +81651,11 @@ acB
 aEt
 aEt
 aEt
-jdZ
+nLn
 acc
 azV
 aFC
-fyJ
+tYp
 aWP
 aWP
 aWP
@@ -81880,7 +81903,7 @@ aJL
 aJL
 tAb
 aJL
-pTt
+ePO
 acB
 aQc
 xqg
@@ -82416,7 +82439,7 @@ rcB
 cAU
 atF
 akT
-gUX
+mLM
 aMp
 tAh
 apo
@@ -82666,7 +82689,7 @@ awQ
 qRf
 ttQ
 jjl
-kkG
+uXF
 kXR
 apx
 hYg
@@ -83662,7 +83685,7 @@ aar
 aar
 aux
 aIx
-jXW
+qfk
 aIx
 aIx
 aIx
@@ -83691,8 +83714,8 @@ aCS
 atV
 atV
 atV
-qHP
-drW
+lsP
+elH
 aZy
 atV
 bfc
@@ -83955,7 +83978,7 @@ aQt
 fZW
 nOP
 rcB
-sUN
+sqI
 aiF
 aAa
 aKd
@@ -84477,7 +84500,7 @@ axR
 kXG
 jHE
 qsi
-hNo
+xrw
 cYS
 muk
 aWJ
@@ -84696,7 +84719,7 @@ afB
 aJH
 apj
 ahp
-xNd
+eyQ
 aoP
 aZK
 abO
@@ -86485,7 +86508,7 @@ aar
 aar
 aIx
 aXu
-get
+vbl
 aIx
 wHh
 aub
@@ -86744,7 +86767,7 @@ aIx
 aXu
 aIx
 aIx
-hgm
+gKv
 aIx
 ayG
 oew
@@ -87000,8 +87023,8 @@ aar
 aIx
 aIx
 aIx
-mkQ
-mrX
+vdZ
+qem
 aIx
 ayG
 aub
@@ -87057,7 +87080,7 @@ ckb
 amF
 fzR
 asJ
-bAZ
+xVx
 asJ
 due
 ihG
@@ -87066,7 +87089,7 @@ dKj
 mUQ
 aOP
 oEi
-fSJ
+ieE
 fkN
 bfF
 fkN
@@ -87257,8 +87280,8 @@ aux
 aux
 aIx
 aIx
-oNL
-bRj
+hCn
+ozV
 aIx
 ayG
 aIx
@@ -87323,7 +87346,7 @@ azK
 azK
 axN
 awO
-fSJ
+ieE
 fkN
 bfF
 fkN
@@ -87517,12 +87540,12 @@ aIx
 aIx
 aIx
 aIx
-bTR
-pzP
-mAT
-hWU
-uSJ
-uaR
+wTk
+rvK
+oBC
+oYO
+jVK
+jbD
 aIx
 dSy
 hga
@@ -87580,7 +87603,7 @@ dbp
 qwt
 jSG
 eGg
-fSJ
+ieE
 fkN
 bfF
 fkN
@@ -87774,12 +87797,12 @@ aux
 aux
 aux
 aIx
-lWR
+cZS
 aIx
-jZj
-eNU
-jZj
-jZj
+wHE
+rCy
+wHE
+wHE
 aIx
 ahx
 auu
@@ -87835,7 +87858,7 @@ asJ
 amF
 amF
 amF
-rue
+jRY
 amF
 amF
 fkN
@@ -88031,12 +88054,12 @@ aar
 aar
 aux
 aIx
-lWR
+cZS
 aIx
-jZj
-eNU
-jZj
-jZj
+wHE
+rCy
+wHE
+wHE
 aIx
 pim
 auu
@@ -88085,7 +88108,7 @@ aMz
 amF
 fzR
 kRN
-xpg
+qYT
 ljc
 aTa
 asJ
@@ -88093,7 +88116,7 @@ amF
 due
 aCT
 aTa
-fSJ
+ieE
 fkN
 fkN
 bfF
@@ -88288,12 +88311,12 @@ fkN
 aIx
 ctK
 aIx
-lWR
+cZS
 aIx
-jZj
-ttR
-jZj
-jZj
+wHE
+wIy
+wHE
+wHE
 aIx
 abP
 auu
@@ -88350,7 +88373,7 @@ amF
 baO
 asJ
 aTa
-fSJ
+ieE
 aar
 aar
 bfF
@@ -88545,12 +88568,12 @@ fkN
 aIx
 bhK
 aIx
-lWR
+cZS
 aIx
-vyb
-jZj
-jZj
-jZj
+gLu
+wHE
+wHE
+wHE
 aIx
 abP
 auu
@@ -88607,7 +88630,7 @@ amF
 bWs
 asJ
 aTa
-fSJ
+ieE
 fkN
 fkN
 bfF
@@ -88802,10 +88825,10 @@ fkN
 aIx
 bhC
 aIx
-lWR
+cZS
 aIx
 aIx
-fdm
+mGc
 aIx
 aIx
 aIx
@@ -88864,7 +88887,7 @@ amF
 aUk
 aAP
 aFm
-fSJ
+ieE
 fkN
 fkN
 bfF
@@ -89059,7 +89082,7 @@ aIx
 aIx
 bhD
 aIx
-lWR
+cZS
 aIx
 aub
 aub
@@ -89121,7 +89144,7 @@ amF
 asc
 asJ
 asP
-fSJ
+ieE
 fkN
 fkN
 bfF
@@ -89355,7 +89378,7 @@ aEi
 bRY
 aEi
 aEW
-jbi
+txh
 aEW
 aEW
 jgj
@@ -89372,13 +89395,13 @@ amF
 amF
 amF
 fPA
-dZx
+bNg
 rVu
 amF
 aNT
 aPn
 aIS
-fSJ
+ieE
 aar
 aar
 bfF
@@ -89634,8 +89657,8 @@ aqF
 amF
 aSz
 fcQ
-fSJ
-fSJ
+ieE
+ieE
 fkN
 fkN
 bfF
@@ -89889,9 +89912,9 @@ xXf
 agw
 uyo
 amF
-fSJ
-fSJ
-fSJ
+ieE
+ieE
+ieE
 fkN
 fkN
 fkN
@@ -90381,16 +90404,16 @@ wfW
 naW
 aEi
 aEi
-cMr
+eCj
 aEi
 pvW
 aEW
 ajp
 ajp
-xkD
+sPS
 ajp
 aOX
-vfW
+sAW
 aOX
 aWJ
 rbx
@@ -91131,7 +91154,7 @@ hwZ
 aVo
 adz
 abP
-juF
+jpA
 abO
 yeU
 ayy
@@ -91621,7 +91644,7 @@ fkN
 abx
 aeX
 apQ
-jGF
+rqa
 acw
 acx
 wBH
@@ -91641,7 +91664,7 @@ aFX
 bet
 cAH
 aiM
-mlL
+ymo
 aVo
 tfb
 abO
@@ -91665,9 +91688,9 @@ oBW
 qFD
 qFD
 qFD
-ljB
+xfH
 qFD
-ocA
+knt
 qFD
 qFD
 qFD
@@ -91676,7 +91699,7 @@ qFD
 qFD
 qFD
 qlf
-ljB
+xfH
 qFD
 eVB
 tYx
@@ -91878,7 +91901,7 @@ fkN
 abx
 aeX
 apQ
-jGF
+rqa
 acw
 aaF
 acw
@@ -92134,7 +92157,7 @@ fkN
 fkN
 abx
 acT
-cAb
+mJn
 acT
 xxc
 xnI
@@ -92389,7 +92412,7 @@ fkN
 fkN
 fkN
 acT
-cAb
+mJn
 acT
 lNC
 aRr
@@ -92644,8 +92667,8 @@ fkN
 fkN
 fkN
 acT
-cAb
-cAb
+mJn
+mJn
 lNC
 lOK
 adR
@@ -92964,7 +92987,7 @@ jHX
 jHX
 dLA
 boH
-xUn
+hNh
 gtQ
 gtQ
 gtQ
@@ -93210,7 +93233,7 @@ lzy
 aVL
 ini
 iSh
-evx
+ePC
 iSh
 iSh
 iSh
@@ -93444,7 +93467,7 @@ axq
 lIT
 bdJ
 avI
-iJp
+jTv
 avI
 avI
 asl
@@ -93471,7 +93494,7 @@ aeR
 ioz
 lou
 aeR
-gTe
+geR
 aeR
 gwD
 hVb
@@ -93672,7 +93695,7 @@ fkN
 fkN
 fkN
 acT
-cAb
+mJn
 acT
 aMQ
 hnd
@@ -93704,7 +93727,7 @@ aQd
 aQd
 aQd
 avI
-jJy
+nex
 avI
 avI
 avI
@@ -93930,7 +93953,7 @@ fkN
 fkN
 fkN
 fkN
-cAb
+mJn
 pwI
 adR
 cjT
@@ -93956,7 +93979,7 @@ aFX
 aiM
 avI
 avI
-uwF
+qfd
 avI
 avI
 aYv
@@ -93964,7 +93987,7 @@ iYF
 aQd
 aHK
 aXj
-xAb
+scE
 aRx
 edN
 sIE
@@ -93975,13 +93998,13 @@ miQ
 dAf
 lfk
 bMh
-iEU
+jak
 aVL
 lzy
 aVL
 jru
 iSh
-evx
+ePC
 nZH
 jjT
 jHx
@@ -93990,7 +94013,7 @@ oNB
 fyw
 jHx
 jHx
-hLl
+sDO
 hkl
 vWS
 rMP
@@ -94187,7 +94210,7 @@ fkN
 fkN
 fkN
 fkN
-cAb
+mJn
 pwI
 adR
 adR
@@ -94216,7 +94239,7 @@ avI
 aBr
 vcn
 avI
-sDV
+mCs
 avI
 avI
 tch
@@ -94228,7 +94251,7 @@ mql
 aVL
 aVL
 aVL
-eiL
+sHv
 ofi
 fVU
 lrz
@@ -94236,9 +94259,9 @@ oIJ
 aVL
 lzy
 aVL
-qWT
+jdh
 iSh
-evx
+ePC
 vHh
 iSh
 iSh
@@ -94444,7 +94467,7 @@ fkN
 fkN
 fkN
 fkN
-cAb
+mJn
 pwI
 adR
 adR
@@ -94700,7 +94723,7 @@ fkN
 fkN
 fkN
 acT
-cAb
+mJn
 acT
 ban
 adR
@@ -94753,13 +94776,13 @@ nYE
 kVt
 bzk
 xcC
-onu
+erc
 aeR
 aeR
 aeR
 iSh
 dor
-gFI
+mPF
 uGe
 lmv
 sxk
@@ -94992,7 +95015,7 @@ yhR
 avI
 aHs
 amT
-vHT
+wNb
 auo
 aCz
 xOb
@@ -95013,7 +95036,7 @@ xcC
 qsj
 viG
 itC
-lab
+wSF
 uGe
 umW
 aeR
@@ -95250,7 +95273,7 @@ avI
 avI
 avI
 avI
-gUQ
+huJ
 tQs
 ilH
 aVL
@@ -95728,7 +95751,7 @@ fkN
 fkN
 fkN
 acT
-cAb
+mJn
 acT
 lPa
 lPa
@@ -95763,11 +95786,11 @@ aVo
 aVo
 aVo
 aVo
-rCZ
+dPx
 acc
 azV
 acc
-rsq
+nHX
 aVL
 aVL
 aVL
@@ -95776,9 +95799,9 @@ aVL
 aVL
 aVL
 xcC
-jVC
-yjY
-yjY
+lYd
+itn
+itn
 xcC
 xcC
 aeR
@@ -95987,9 +96010,9 @@ fkN
 fkN
 fkN
 acT
-cAb
-cAb
-cAb
+mJn
+mJn
+mJn
 acT
 acw
 aod
@@ -96247,7 +96270,7 @@ fkN
 abx
 aeX
 apQ
-jGF
+rqa
 tsA
 acw
 acw
@@ -96504,7 +96527,7 @@ fkN
 abx
 aeX
 apQ
-jGF
+rqa
 acx
 acx
 acx
@@ -96761,7 +96784,7 @@ fkN
 abx
 aeX
 apQ
-jGF
+rqa
 acx
 acx
 acx
@@ -96791,11 +96814,11 @@ aYK
 aYK
 aYK
 aYK
-iZP
+hsp
 arW
 bcJ
 bcK
-faw
+vjj
 kah
 kah
 kah
@@ -96805,8 +96828,8 @@ kah
 kah
 kah
 kah
-gcK
-gcK
+tEa
+tEa
 kah
 kah
 ejn
@@ -97018,7 +97041,7 @@ fkN
 abx
 aeX
 apQ
-jGF
+rqa
 acx
 acx
 acx
@@ -97061,10 +97084,10 @@ aKR
 pht
 aKv
 kah
-ndr
+uGI
 kyY
 iMz
-icH
+mUy
 kah
 nXx
 dpq
@@ -97533,7 +97556,7 @@ fkN
 abx
 aeX
 apQ
-jGF
+rqa
 acx
 acx
 acx
@@ -97563,9 +97586,9 @@ aac
 vRf
 aac
 aac
-rRV
-pvE
-dto
+vTA
+vSA
+uBY
 kah
 bbI
 hmw
@@ -97790,7 +97813,7 @@ fkN
 abx
 aeX
 apQ
-jGF
+rqa
 acx
 acx
 acx
@@ -98047,7 +98070,7 @@ fkN
 abx
 aeX
 apQ
-jGF
+rqa
 acx
 idJ
 acx
@@ -98084,19 +98107,19 @@ kah
 kah
 kah
 kah
-gcK
-gcK
-kqs
-gcK
+tEa
+tEa
+wiW
+tEa
 kah
 kah
-gcK
-gcK
-gcK
+tEa
+tEa
+tEa
 kah
-vJM
-vJM
-lMO
+pjX
+pjX
+eva
 kah
 aeR
 kxL
@@ -98563,7 +98586,7 @@ aeX
 aeX
 aeX
 apQ
-jGF
+rqa
 aED
 aOw
 aOw
@@ -98820,7 +98843,7 @@ aeX
 aeX
 aeX
 apQ
-jGF
+rqa
 aAE
 ahq
 ahq
@@ -99335,7 +99358,7 @@ aeX
 aeX
 aeX
 apQ
-jGF
+rqa
 acx
 acx
 aFA
@@ -99592,7 +99615,7 @@ aeX
 aeX
 aeX
 apQ
-jGF
+rqa
 acx
 acx
 aaR
@@ -99638,9 +99661,9 @@ hmw
 hmw
 hmw
 vGE
-jUl
+sSF
 cSl
-vNT
+rMK
 lSz
 aaW
 abe
@@ -99849,7 +99872,7 @@ aeX
 aeX
 aeX
 apQ
-jGF
+rqa
 acx
 ddL
 aFA
@@ -99905,7 +99928,7 @@ abN
 abN
 bdy
 acn
-gHg
+vlm
 aej
 ahV
 acI
@@ -100107,8 +100130,8 @@ bdx
 bdx
 bdx
 act
-jGF
-jGF
+rqa
+rqa
 aFA
 aFA
 hBz
@@ -100154,7 +100177,7 @@ hmw
 hmw
 nqC
 brd
-roq
+fdW
 bgw
 aaW
 abg
@@ -101696,7 +101719,7 @@ avB
 rIu
 bgs
 bgt
-lKr
+iMv
 bgC
 bgD
 bgE
@@ -102449,7 +102472,7 @@ bbV
 aOc
 amO
 teS
-gcK
+tEa
 brd
 afU
 afb
@@ -102706,7 +102729,7 @@ iQS
 arZ
 ecH
 kjB
-gcK
+tEa
 brd
 afV
 agk
@@ -103220,7 +103243,7 @@ aHB
 mkc
 ecH
 kjB
-gcK
+tEa
 brd
 aeB
 aeE
@@ -103238,7 +103261,7 @@ hmw
 hmw
 keD
 cSl
-qoP
+vqC
 pFN
 adq
 acl
@@ -103477,7 +103500,7 @@ aJQ
 arZ
 ecH
 kjB
-gcK
+tEa
 brd
 axc
 aDR
@@ -103503,7 +103526,7 @@ acd
 acd
 bdz
 acE
-bLJ
+qor
 aem
 ahW
 aeo
@@ -103734,7 +103757,7 @@ aJQ
 arZ
 ecH
 kjB
-gcK
+tEa
 brd
 aeD
 aeH
@@ -103752,7 +103775,7 @@ hmw
 hmw
 cOx
 brd
-nvI
+cQg
 xXH
 adq
 adH
@@ -104234,21 +104257,21 @@ apQ
 aIh
 aTo
 ama
-npf
-oNr
-uYI
-yhc
+lcM
+myU
+eJc
+rOr
 ama
 ama
-gdL
-fKv
-veE
-fKv
+lec
+oPG
+swe
+oPG
 aJQ
 aoZ
 aKY
 akh
-gcK
+tEa
 brd
 afd
 aeY
@@ -104505,7 +104528,7 @@ aJQ
 arZ
 ecH
 kjB
-gcK
+tEa
 brd
 afU
 aih
@@ -104762,7 +104785,7 @@ aJQ
 arZ
 ecH
 kjB
-gcK
+tEa
 brd
 afV
 agk
@@ -105270,7 +105293,7 @@ hDy
 ama
 aHB
 pwz
-aKh
+dyU
 aHB
 aHB
 jrZ
@@ -105513,9 +105536,9 @@ bhp
 aVi
 fkN
 asn
-kSZ
-kSZ
-kSZ
+urC
+urC
+urC
 aYK
 aTo
 ama
@@ -105556,7 +105579,7 @@ roi
 dOG
 dQI
 vEf
-ooO
+ikE
 bgi
 aeX
 bfT
@@ -106068,8 +106091,8 @@ aHY
 aHY
 nbz
 aHY
-xVE
-xVE
+hSR
+hSR
 aHY
 bgW
 bgW
@@ -106321,13 +106344,13 @@ qdJ
 aYu
 pyc
 aZh
-iAZ
+hoX
 atl
 aqH
 lzv
 mpA
 tdr
-iie
+pgu
 bfO
 aeX
 bfT
@@ -106536,7 +106559,7 @@ bhw
 bht
 bht
 bht
-clw
+iJU
 bhz
 aoW
 aoW
@@ -106572,7 +106595,7 @@ aFR
 kwU
 aJz
 anh
-pkZ
+jIF
 anL
 aIF
 aGQ
@@ -106584,7 +106607,7 @@ aHS
 bHw
 aOT
 alK
-iie
+pgu
 bfO
 aeX
 bfT
@@ -106793,7 +106816,7 @@ aoW
 aoW
 mgX
 aoW
-kiI
+egx
 aoW
 xgQ
 aoW
@@ -106805,14 +106828,14 @@ aYK
 aTo
 ama
 ama
-oMY
+lUN
 ama
 ama
 ama
 ama
 aVW
 aVW
-hmR
+lxU
 aVW
 aVW
 beP
@@ -106840,7 +106863,7 @@ aQY
 aHS
 alK
 alK
-vvw
+vKz
 aHY
 aeX
 aeX
@@ -106854,11 +106877,11 @@ oZG
 oZG
 bWH
 oZG
-bbe
-bbe
+qqA
+qqA
 oZG
-hSk
-hSk
+wJj
+wJj
 apq
 apq
 mJP
@@ -107050,7 +107073,7 @@ esh
 dbv
 dJX
 dEK
-bUi
+vAH
 esh
 esh
 ghZ
@@ -107074,7 +107097,7 @@ kfy
 aVW
 arZ
 ecH
-xdL
+pfm
 aXq
 aKk
 iEX
@@ -107133,7 +107156,7 @@ aar
 fkN
 fkN
 fkN
-dPc
+kSB
 aaa
 aaa
 aaa
@@ -107368,11 +107391,11 @@ pPU
 pPU
 wrQ
 aVX
-gnJ
-gnJ
-gnJ
-gnJ
-gnJ
+pzC
+pzC
+pzC
+pzC
+pzC
 sAd
 asx
 mfO
@@ -107381,12 +107404,12 @@ pPU
 pPU
 pPU
 pPU
-rzJ
-rzJ
+pTV
+pTV
 pPU
 pPU
-rzJ
-rzJ
+pTV
+pTV
 pPU
 fkN
 fkN
@@ -107580,7 +107603,7 @@ gmw
 axL
 slG
 rGG
-rmj
+oac
 iNu
 bCM
 vRN
@@ -107612,8 +107635,8 @@ fkN
 ajz
 fkN
 fkN
-bXs
-epG
+lVr
+eAW
 aQg
 bar
 arc
@@ -107644,7 +107667,7 @@ aNW
 aQx
 aRu
 aSU
-jyi
+jHf
 fkN
 fkN
 bkO
@@ -107812,9 +107835,9 @@ aVi
 bhq
 aVi
 aVi
-xYH
-vgw
-did
+tKC
+qIj
+vpw
 aVi
 aVi
 aVi
@@ -107830,7 +107853,7 @@ vZG
 pRE
 tuV
 aYK
-ppC
+xzV
 aFT
 amN
 apz
@@ -107842,7 +107865,7 @@ vBI
 pWg
 iGB
 coj
-pkY
+xZR
 arZ
 ecH
 kjB
@@ -107857,19 +107880,19 @@ aqY
 aiB
 apV
 aiB
-jyH
+mOq
 aIC
 aoh
 hqT
 aoh
 ydJ
 aPG
-uCy
+vUw
 fkN
 ajz
 fkN
 fkN
-bXs
+lVr
 hlW
 aQg
 aHL
@@ -107891,17 +107914,17 @@ aOz
 ayF
 aCj
 aDz
-mAr
+gPA
 aGq
 aGq
-pgn
+frX
 aJg
 aMi
 aOn
 aQF
 aRD
 aTb
-jyi
+jHf
 fkN
 fkN
 bkO
@@ -108077,7 +108100,7 @@ lMN
 aoW
 aoW
 aoW
-swu
+lpp
 aVi
 aVi
 nGg
@@ -108098,8 +108121,8 @@ aFT
 aVW
 aVW
 aVW
-uFL
-dOz
+mKQ
+fhD
 arZ
 ecH
 kjB
@@ -108114,14 +108137,14 @@ akg
 aHx
 avw
 jpt
-sNR
+tqV
 asU
 aoh
 pRx
 kSO
 aoh
 aPG
-uCy
+vUw
 fkN
 ajz
 fkN
@@ -108158,7 +108181,7 @@ aOW
 aGA
 aRI
 aTh
-jyi
+jHf
 fkN
 fkN
 bkO
@@ -108345,7 +108368,7 @@ aeM
 gnX
 ppq
 ppq
-dvc
+lOy
 ppq
 ppq
 aGo
@@ -108354,7 +108377,7 @@ ppq
 aga
 ppq
 ppq
-tVW
+qvl
 ppq
 qsO
 ohp
@@ -108672,7 +108695,7 @@ aPC
 aGA
 aRI
 aTh
-jyi
+jHf
 rny
 fIP
 pPU
@@ -108897,7 +108920,7 @@ fkN
 kte
 ajz
 fkN
-bXs
+lVr
 avU
 bwc
 aQg
@@ -108919,10 +108942,10 @@ aOz
 azU
 aCJ
 aDz
-rPH
+tSM
 aGq
 aGq
-isG
+era
 aKI
 aGA
 aPD
@@ -109125,7 +109148,7 @@ eYE
 aIs
 aIs
 kTK
-bnO
+rFh
 kTK
 aIs
 own
@@ -109142,19 +109165,19 @@ aiB
 caC
 arL
 eDC
-evj
+pgy
 ahA
 aJc
 aOV
 aBQ
 aos
 aVU
-xkz
+cQk
 fkN
 fkN
 ajz
 fkN
-bXs
+lVr
 avU
 xEI
 aQg
@@ -109700,7 +109723,7 @@ aPD
 aGA
 aRI
 aTh
-jyi
+jHf
 fkN
 fkN
 bkO
@@ -109931,7 +109954,7 @@ dLK
 aQg
 jGO
 aGh
-fqn
+fqh
 rIP
 aoC
 hrY
@@ -109947,17 +109970,17 @@ aOz
 aAv
 aCJ
 aDz
-rPH
+tSM
 aGq
 aGq
-svH
+rwK
 aKI
 aGA
 aPC
 aGA
 aRI
 aTh
-jyi
+jHf
 fkN
 fkN
 bkO
@@ -110188,7 +110211,7 @@ avU
 rhf
 arc
 aGh
-jub
+dcM
 qhv
 mgG
 aVX
@@ -110198,8 +110221,8 @@ aqU
 bcT
 mZS
 hbZ
-sUC
-cBD
+tBY
+kng
 aOz
 aAQ
 aCQ
@@ -110214,7 +110237,7 @@ aPC
 aGA
 aRI
 aTh
-jyi
+jHf
 fkN
 fkN
 bkO
@@ -110397,7 +110420,7 @@ aBx
 dUp
 aIs
 aIs
-ixJ
+blt
 aIs
 aIs
 kxN
@@ -110446,8 +110469,8 @@ aQg
 fgL
 fvm
 aVX
-gFe
-tda
+qPn
+cCo
 aVX
 aMb
 xop
@@ -110455,7 +110478,7 @@ aVX
 aOz
 aOz
 baH
-mWI
+vQr
 aOz
 aOz
 aAU
@@ -110680,40 +110703,40 @@ aXm
 aNA
 sqK
 aQg
-dgb
+upy
 tKa
 emD
-iUF
+efr
 emD
 oRT
 tKa
-xQT
+koK
 emD
 kyP
 jKA
 emD
 emD
-gkX
-gPi
-qpe
-syI
+nTI
+xnL
+qTf
+mjZ
 emD
 emD
-syI
+mjZ
 emD
-nQk
-jfs
-vYM
-vYM
-flT
-vTY
-uQq
-rpX
-jlq
-rpX
-ixB
-wdl
-mly
+vfW
+rrK
+oZM
+oZM
+kJk
+xUC
+qrf
+rfg
+cHy
+rfg
+fge
+yeJ
+uuP
 aiU
 aBj
 aCJ
@@ -110728,7 +110751,7 @@ aQa
 aGA
 aRI
 aTh
-jyi
+jHf
 fkN
 fkN
 bkO
@@ -110937,55 +110960,55 @@ aNA
 aNA
 sqK
 aQg
-sWa
+jnj
 aOZ
-eiT
-kbf
-fId
-fId
-fId
-fId
-fId
-fId
-kbf
-kbf
-xdd
-vNR
-gTJ
-kbf
-kbf
-kbf
-kbf
-kbf
-ePK
-mtL
+lpU
+prS
+vNc
+vNc
+vNc
+vNc
+vNc
+vNc
+prS
+prS
+rQH
+jXt
+eJy
+prS
+prS
+prS
+prS
+prS
+gHq
+eTW
 kBd
 mLH
 mLH
 kBd
 muY
-lpJ
+mkb
 mLH
 mLH
 mLH
-cVD
-dne
-bpS
+lAO
+lUs
+lql
 aoK
 aBA
 aDb
 aEP
-sYh
+hng
 aGG
 aGG
-fra
+jsn
 aLY
 aNd
 aQb
 aOn
 aSg
 aTh
-jyi
+jHf
 aar
 aar
 bkO
@@ -111194,9 +111217,9 @@ kxW
 ias
 tpR
 aQg
-ogG
+bTw
 aGh
-qPZ
+wLs
 gzW
 dzc
 dzc
@@ -111206,7 +111229,7 @@ dzc
 dzc
 arc
 sps
-wzn
+ioN
 arB
 pWp
 sps
@@ -111215,7 +111238,7 @@ jNO
 arZ
 bhM
 pTf
-nAE
+iQn
 ujP
 cFc
 aLU
@@ -111242,7 +111265,7 @@ aQj
 aRm
 aSo
 aTp
-jyi
+jHf
 fkN
 fkN
 bkO
@@ -111463,7 +111486,7 @@ apH
 bhg
 hTL
 aZT
-dDn
+uEz
 alw
 alw
 alw
@@ -111472,7 +111495,7 @@ alw
 alw
 alw
 alw
-xWL
+rYS
 pPU
 aVX
 aVX
@@ -111704,13 +111727,13 @@ nbU
 emD
 emD
 jKA
-tja
+bHb
 emD
 emD
 emD
-gzJ
+nUP
 orz
-nNu
+uRF
 ePt
 aBC
 ami
@@ -111720,7 +111743,7 @@ key
 aNK
 xZt
 aZT
-mxk
+lyk
 alw
 fLS
 rel
@@ -111729,7 +111752,7 @@ alw
 aqS
 tdF
 alw
-nFv
+bgL
 pPU
 aUZ
 aWo
@@ -111956,7 +111979,7 @@ beV
 azO
 arv
 baq
-hdY
+hHW
 dvq
 azH
 aMV
@@ -111969,15 +111992,15 @@ azH
 asK
 bcb
 ati
-cIo
-fxA
-fxA
-fxA
-fxA
+qyb
+xLs
+xLs
+xLs
+xLs
 uoc
 ati
 ati
-mxk
+lyk
 alw
 alw
 alw
@@ -111986,7 +112009,7 @@ alw
 tdF
 jIn
 alw
-nFv
+bgL
 pPU
 aGq
 aVA
@@ -112211,7 +112234,7 @@ kxc
 arv
 dHt
 bab
-lhF
+ozO
 kjB
 dFC
 sFR
@@ -112234,23 +112257,23 @@ tLW
 bRM
 vqt
 ati
-sFA
-khU
+ePb
+uWY
 slK
 eBM
 dcV
-kHW
+tho
 lAw
 dOi
 alw
-hpp
+fjy
 pPU
 aVX
 aVX
 aVX
 lhx
 gzh
-eNA
+mxP
 hnJ
 aLS
 bcW
@@ -112491,16 +112514,16 @@ hgj
 aVd
 aig
 ati
-bJz
+mww
 bgJ
 bgJ
-wDc
+uZq
 alw
 alw
 alw
 alw
 alw
-nFv
+bgL
 pPU
 aVk
 aWr
@@ -112708,7 +112731,7 @@ aiV
 arK
 aKa
 tnb
-gsH
+xqJ
 nXS
 axn
 tYd
@@ -112752,12 +112775,12 @@ aZT
 aZT
 aZT
 bgI
-brS
-oIF
-oIF
-cet
+sUL
+ung
+ung
+dDc
 alw
-nFv
+bgL
 pPU
 aVt
 aWs
@@ -113007,14 +113030,14 @@ rqV
 ati
 aeX
 aeX
-ksM
+ffk
 aZT
 aZT
-ltT
-mHQ
-rdd
-fys
-fRz
+eEG
+uaT
+rGw
+pME
+gXv
 pPU
 aVX
 aVX
@@ -113025,8 +113048,8 @@ aXU
 epN
 aXU
 aXU
-cyE
-oQj
+bsB
+gAl
 aXU
 fkN
 fkN
@@ -113267,11 +113290,11 @@ aeX
 aeX
 bfT
 aZT
-ltT
-ltT
-ltT
+eEG
+eEG
+eEG
 alw
-iGz
+rMv
 pPU
 aUZ
 aWS
@@ -113523,7 +113546,7 @@ aeX
 aeX
 aeX
 bfT
-ksM
+ffk
 aZT
 aZT
 aZT
@@ -113775,7 +113798,7 @@ bbQ
 bbR
 bbN
 sID
-ueA
+poj
 bfO
 aeX
 aeX
@@ -114032,7 +114055,7 @@ aLt
 bbS
 aLt
 sID
-ueA
+poj
 bfO
 aeX
 aeX
@@ -114277,9 +114300,9 @@ atr
 jvX
 aJh
 aJh
-vbc
+kZV
 aCO
-vbc
+kZV
 aJh
 aJh
 bcN
@@ -114527,7 +114550,7 @@ aOA
 aLC
 aHP
 aRY
-sUA
+gNq
 agK
 aNq
 bbp
@@ -114546,7 +114569,7 @@ aQl
 ayL
 wea
 aGc
-ueA
+uTw
 bfP
 aeX
 aeX
@@ -114754,7 +114777,7 @@ aFN
 aIv
 aOU
 aWU
-pKR
+sHh
 pXz
 aMr
 azh
@@ -114803,7 +114826,7 @@ aJj
 aGJ
 aTX
 bbL
-ueA
+uTw
 bfO
 aeX
 aeX
@@ -115060,7 +115083,7 @@ aGJ
 aGJ
 bch
 bcg
-xDS
+osz
 bfQ
 aeX
 aeX
@@ -115284,7 +115307,7 @@ gbL
 arv
 arv
 arv
-rUq
+vLL
 arv
 arv
 arv
@@ -115317,7 +115340,7 @@ bdS
 aGJ
 aGJ
 bcG
-xDS
+osz
 bfO
 aeX
 bfT
@@ -115574,7 +115597,7 @@ aoQ
 aGJ
 aGJ
 bcF
-xDS
+osz
 bfR
 aeX
 bfT
@@ -115778,9 +115801,9 @@ oxo
 aae
 aSS
 aSS
-maP
-maP
-maP
+pEU
+pEU
+pEU
 aSS
 aSS
 asn
@@ -115789,16 +115812,16 @@ asn
 asn
 asn
 asn
-kSZ
-kSZ
-kSZ
+urC
+urC
+urC
 arv
 arv
 arv
 arv
 arv
 arv
-jXw
+rKv
 arv
 arv
 arv
@@ -115831,7 +115854,7 @@ aJr
 bcf
 aGJ
 ahC
-xDS
+osz
 bfO
 aeX
 bfT
@@ -116088,7 +116111,7 @@ bcE
 bcE
 bcE
 aml
-xDS
+osz
 bfS
 aeX
 bfT
@@ -116324,28 +116347,28 @@ bfH
 abx
 aOA
 aOA
-cCP
-cCP
+saJ
+saJ
 aOA
-lPn
-wNQ
-lPn
-lPn
+xJF
+xJF
+xJF
+xJF
 aJh
-anK
+sqj
 anK
 bcX
 anK
 anK
 aJh
-ueA
-ueA
-ueA
-ueA
-ueA
-ueA
-ueA
-xDS
+uTw
+uTw
+uTw
+uTw
+uTw
+uTw
+uTw
+osz
 bfO
 bdx
 bfV
@@ -116589,11 +116612,11 @@ bfM
 bfM
 bfM
 aQR
-aGZ
-aGZ
-aGZ
-aGZ
-aGZ
+xKW
+xKW
+xKW
+xKW
+xKW
 aJh
 bfM
 bfM

--- a/_maps/map_files/Hammerhead/Hammerhead.dmm
+++ b/_maps/map_files/Hammerhead/Hammerhead.dmm
@@ -9347,6 +9347,9 @@
 	dir = 1
 	},
 /area/chapel/main)
+"axp" = (
+/turf/open/floor/plasteel,
+/area/maintenance/fore)
 "axq" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -25792,6 +25795,18 @@
 /obj/effect/landmark/start/roboticist,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"bFX" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "bGc" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -26685,6 +26700,18 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"crn" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 10
+	},
+/turf/template_noop,
+/area/maintenance/starboard/central)
 "crT" = (
 /obj/structure/disposaloutlet{
 	dir = 8
@@ -27077,6 +27104,19 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/security/prison)
+"cHE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "cIi" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 5
@@ -27873,6 +27913,10 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/central)
+"doW" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "dpq" = (
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
@@ -27921,11 +27965,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"dqG" = (
-/obj/item/radio/intercom/directional/west,
-/obj/machinery/computer/monitor/console,
-/turf/open/floor/plasteel/dark,
-/area/maintenance/port/central)
 "dqL" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/structure/closet/secure_closet/engineering_personal,
@@ -28006,6 +28045,14 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
+"dts" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "duc" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -28258,6 +28305,13 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"dzQ" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "dAf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
@@ -28327,6 +28381,17 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/fore)
+"dGa" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "dGm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -28428,15 +28493,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"dKc" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/plating,
-/area/maintenance/department/medical/morgue)
 "dKj" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder{
@@ -28477,10 +28533,6 @@
 /obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/plasteel,
 /area/science/lab)
-"dMn" = (
-/obj/structure/chair,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "dMT" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -28570,11 +28622,6 @@
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
-"dQU" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance/four,
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "dRb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -28866,6 +28913,10 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/central)
+"edV" = (
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "efj" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/machinery/door/firedoor/border_only/directional/north,
@@ -28950,6 +29001,11 @@
 /obj/machinery/recharge_station,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
+"eiH" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "eiW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 6
@@ -28960,19 +29016,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/exit)
-"eiX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "ejn" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Hangar Bay"
@@ -29534,13 +29577,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"eHH" = (
-/obj/machinery/mecha_part_fabricator/maint{
-	name = "forgotten exosuit fabricator"
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/circuit/green,
-/area/maintenance/fore)
 "eHR" = (
 /obj/item/wrench,
 /obj/item/stack/sheet/glass{
@@ -29902,6 +29938,11 @@
 /obj/machinery/reagentgrinder,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"eUR" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "eUW" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/electrical{
@@ -30599,6 +30640,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"fzo" = (
+/obj/item/radio/intercom/directional/west,
+/obj/machinery/computer/monitor/console,
+/turf/open/floor/plasteel/dark,
+/area/maintenance/port/central)
 "fzR" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -30615,21 +30661,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"fzX" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 5
-	},
-/turf/template_noop,
-/area/maintenance/starboard/central)
 "fAj" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
@@ -31272,15 +31303,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/ship,
 /area/ai_monitored/turret_protected/aisat/hallway/support_ship)
-"gan" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "gaw" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	dir = 4;
@@ -31457,6 +31479,19 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/nsv/hanger/storage)
+"gmt" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "gmu" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
@@ -31523,10 +31558,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/secondary/exit)
-"goT" = (
-/obj/structure/table_frame,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "gpm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31549,17 +31580,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
-"gqw" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "gqM" = (
 /obj/machinery/computer/ship/viewscreen,
 /obj/structure/munitions_trolley,
@@ -31666,14 +31686,6 @@
 /obj/item/book/manual/wiki/security_space_law,
 /turf/open/floor/carpet/red,
 /area/security/detectives_office/private_investigators_office)
-"gvE" = (
-/obj/machinery/door/airlock/ship/engineering{
-	name = "Engineering Post";
-	req_one_access_txt = "10"
-	},
-/obj/effect/mapping_helpers/airlock/abandoned,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "gvH" = (
 /obj/structure/table/reinforced,
 /obj/item/airlock_painter,
@@ -31869,11 +31881,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
-"gCv" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance/four,
-/turf/open/floor/plating,
-/area/maintenance/department/medical/morgue)
 "gCY" = (
 /obj/machinery/light,
 /turf/open/floor/carpet/ship,
@@ -33279,6 +33286,12 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
+"hCb" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "hCn" = (
 /obj/machinery/computer/station_alert/console,
 /turf/open/floor/plasteel/dark,
@@ -33523,6 +33536,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"hJE" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "hJS" = (
 /obj/machinery/light,
 /obj/structure/closet/l3closet/scientist,
@@ -34277,14 +34295,16 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/construction)
+"iqb" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "iqF" = (
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"iqZ" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/mechanical,
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "irC" = (
 /obj/machinery/light/floor,
 /turf/open/floor/plasteel/ship/techfloor/alt,
@@ -34603,6 +34623,11 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/weapons/fore)
+"iEc" = (
+/obj/structure/grille/broken,
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "iEr" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -34903,8 +34928,8 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/toilet/restrooms)
-"iPd" = (
-/obj/structure/grille,
+"iOD" = (
+/obj/structure/table_frame,
 /turf/open/floor/plating,
 /area/maintenance/port/central)
 "iPn" = (
@@ -35056,10 +35081,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"iTH" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
 "iUd" = (
 /obj/machinery/door/airlock/ship/station/mining{
 	name = "Cargo Shipping";
@@ -35399,21 +35420,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/port)
-"jhI" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
-"jhL" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/airalarm/directional/west,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "jhZ" = (
 /obj/machinery/computer/telecomms/server,
 /turf/open/floor/plasteel/grimy,
@@ -35606,31 +35612,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"jpA" = (
-/obj/structure/cable{
-	icon_state = "6-8"
-	},
-/obj/vehicle/sealed/car/realistic/medical,
-/turf/open/floor/plasteel/ship,
-/area/hallway/primary/central)
-"jpB" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/ship,
-/area/hallway/primary/fore)
 "jqp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -36749,23 +36730,6 @@
 /obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/plating,
 /area/nsv/hanger)
-"khC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "khN" = (
 /obj/machinery/turretid{
 	control_area = "/area/ai_monitored/turret_protected/ai_upload";
@@ -37509,12 +37473,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"kHP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/obj/item/robot_suit,
-/turf/open/floor/plasteel,
-/area/maintenance/fore)
 "kIp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38897,11 +38855,6 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"lMP" = (
-/obj/structure/grille/broken,
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "lMR" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -39217,10 +39170,6 @@
 "lYW" = (
 /turf/open/floor/plating/airless,
 /area/ai_monitored/turret_protected/ai)
-"lZa" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "lZe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39538,19 +39487,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/lockup)
-"miZ" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "mjD" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -39761,11 +39697,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
-"moi" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance/three,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "mpA" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/holywater{
@@ -40202,26 +40133,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
-"mDV" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "mEb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -40565,6 +40476,15 @@
 /obj/structure/closet/secure_closet/fighter_pilot,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/hanger)
+"mPD" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "mPF" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "12"
@@ -40645,6 +40565,11 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/entry)
+"mTY" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/four,
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "mUk" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/tile/purple{
@@ -40690,6 +40615,15 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/engine/break_room)
+"mVo" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/four,
+/turf/open/floor/plating,
+/area/maintenance/fore)
+"mVA" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "mVE" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -41242,6 +41176,15 @@
 /obj/effect/spawner/structure/window/reinforced/ship,
 /turf/open/floor/plating/airless,
 /area/maintenance/department/medical/morgue)
+"nuh" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "nuA" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -41359,6 +41302,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"nBb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/obj/item/robot_suit,
+/turf/open/floor/plasteel,
+/area/maintenance/fore)
 "nBl" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
@@ -41552,6 +41501,21 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"nFy" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/template_noop,
+/area/maintenance/starboard/central)
 "nFL" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8;
@@ -41876,18 +41840,6 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"nTA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 10
-	},
-/turf/template_noop,
-/area/maintenance/starboard/central)
 "nTI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 4
@@ -42542,6 +42494,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"opY" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 5
+	},
+/turf/template_noop,
+/area/maintenance/starboard/central)
 "oqS" = (
 /obj/machinery/conveyor_switch{
 	id = "cmbelt";
@@ -42752,23 +42719,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"oxA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "oxE" = (
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -42782,10 +42732,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/entry)
-"oyM" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "oyO" = (
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -43061,6 +43007,10 @@
 	},
 /turf/open/floor/plating,
 /area/nsv/hanger)
+"oHX" = (
+/obj/structure/chair,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "oIl" = (
 /obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/wood,
@@ -43131,14 +43081,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"oNC" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "oOe" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -43247,6 +43189,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"oRz" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "oRR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -43391,12 +43337,6 @@
 /obj/structure/closet/secure_closet/hydroponics,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"oXY" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "oYa" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -44016,6 +43956,23 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"pyU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "pzg" = (
 /obj/structure/table/glass,
 /obj/effect/landmark/nuclear_waste_spawner,
@@ -44168,6 +44125,23 @@
 /obj/effect/spawner/structure/window/reinforced/ship,
 /turf/open/floor/plating,
 /area/quartermaster/office)
+"pFh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "pFp" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space/basic,
@@ -44270,18 +44244,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/hanger)
-"pKA" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "pKD" = (
 /obj/machinery/atmospherics/pipe/manifold4w/general/visible,
 /turf/open/floor/plating,
@@ -44333,6 +44295,21 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"pMU" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/ship,
+/area/hallway/primary/fore)
 "pNH" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "12"
@@ -44698,6 +44675,15 @@
 /obj/effect/spawner/lootdrop/maintenance/four,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"qbW" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "qcm" = (
 /obj/machinery/suit_storage_unit/atmos,
 /turf/open/floor/plasteel,
@@ -44953,11 +44939,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/science/research)
-"qjO" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/three,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "qki" = (
 /obj/machinery/door/airlock/public/glass/incinerator/atmos_interior,
 /obj/effect/mapping_helpers/airlock/locked,
@@ -45193,11 +45174,6 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/primary/port)
-"qtd" = (
-/obj/structure/closet/cardboard,
-/obj/effect/spawner/lootdrop/maintenance/seven,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "qtk" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -46924,6 +46900,13 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/aft)
+"rIH" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "rIP" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -46937,6 +46920,24 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload)
+"rJf" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/ship,
+/area/hallway/primary/fore)
 "rJN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
@@ -47469,6 +47470,11 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/construction)
+"sdr" = (
+/obj/structure/closet/cardboard,
+/obj/effect/spawner/lootdrop/maintenance/seven,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "sdD" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -47776,10 +47782,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
-"stj" = (
-/obj/effect/spawner/lootdrop/grille_or_trash,
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "stM" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -48446,9 +48448,6 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
-"sWN" = (
-/turf/open/floor/plasteel,
-/area/maintenance/fore)
 "sXM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 4
@@ -48727,6 +48726,18 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/central)
+"tfo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "tho" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "12"
@@ -48871,6 +48882,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"tmt" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
+"tmy" = (
+/obj/machinery/mecha_part_fabricator/maint{
+	name = "forgotten exosuit fabricator"
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/circuit/green,
+/area/maintenance/fore)
 "tmM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -49076,10 +49102,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/ai_monitored/turret_protected/aisat/hallway/support_ship)
-"tuE" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "tuV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -49379,13 +49401,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
-"tHR" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "tIa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -49752,13 +49767,6 @@
 /obj/machinery/computer/atmos_control/tank/nitrous_tank,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"tUR" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "tVy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 4
@@ -49890,15 +49898,6 @@
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/hallway/secondary/entry)
-"tYY" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/structure/barricade/wooden/crude,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "tZd" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -50323,6 +50322,26 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"utZ" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "uuv" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/structure/cable{
@@ -50868,6 +50887,14 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/central)
+"uKD" = (
+/obj/machinery/door/airlock/ship/engineering{
+	name = "Engineering Post";
+	req_one_access_txt = "10"
+	},
+/obj/effect/mapping_helpers/airlock/abandoned,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "uLd" = (
 /obj/machinery/power/turbine{
 	dir = 1
@@ -50937,18 +50964,6 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
-"uMT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "uMU" = (
 /obj/machinery/air_sensor/atmos/nitrous_tank,
 /turf/open/floor/engine/n2o,
@@ -51523,6 +51538,10 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
+"vlW" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "vmf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -51664,21 +51683,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"vrs" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/turf/template_noop,
-/area/maintenance/starboard/central)
 "vrL" = (
 /obj/machinery/suit_storage_unit/security,
 /obj/effect/landmark/nuclear_waste_spawner,
@@ -51924,21 +51928,6 @@
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/service)
-"vBY" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/ship,
-/area/hallway/primary/fore)
 "vCL" = (
 /obj/machinery/shieldwallgen/xenobiologyaccess,
 /obj/machinery/door/poddoor/preopen{
@@ -52226,6 +52215,10 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
+"vQl" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "vQn" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -53708,6 +53701,12 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"wVp" = (
+/obj/structure/cable{
+	icon_state = "6-8"
+	},
+/turf/open/floor/plasteel/ship,
+/area/hallway/primary/central)
 "wWE" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -74304,7 +74303,7 @@ aar
 aJB
 cCm
 aJB
-lZa
+mVA
 aJB
 fkN
 aaO
@@ -75330,9 +75329,9 @@ aux
 fkN
 aEn
 acb
-lZa
-lZa
-lMP
+mVA
+mVA
+iEc
 atd
 fkN
 apW
@@ -79506,7 +79505,7 @@ fkN
 aho
 urY
 cWT
-iTH
+edV
 wqP
 aho
 bku
@@ -86906,7 +86905,7 @@ aIx
 aXu
 aIx
 aIx
-gvE
+uKD
 aIx
 ayG
 oew
@@ -87162,7 +87161,7 @@ aar
 aIx
 aIx
 aIx
-dqG
+fzo
 qem
 aIx
 ayG
@@ -87679,7 +87678,7 @@ aIx
 aIx
 aIx
 aIx
-pKA
+bFX
 pwe
 wHE
 wHE
@@ -88450,7 +88449,7 @@ fkN
 aIx
 ctK
 aIx
-eiX
+cHE
 aIx
 wHE
 wHE
@@ -89221,12 +89220,12 @@ aIx
 aIx
 bhD
 aIx
-oxA
+pFh
 aIx
-qtd
+sdr
 aub
 aub
-moi
+hJE
 aIx
 abP
 auu
@@ -89738,7 +89737,7 @@ bhI
 aRz
 aub
 aub
-iPd
+vlW
 aIx
 aIx
 vJy
@@ -89993,8 +89992,8 @@ sbd
 bhG
 bhJ
 vQU
-dMn
-goT
+oHX
+iOD
 exc
 aIx
 aYF
@@ -91272,7 +91271,7 @@ aeX
 aeX
 aeX
 aIx
-iPd
+vlW
 sbd
 vQU
 axS
@@ -91293,7 +91292,7 @@ hwZ
 aVo
 adz
 abP
-jpA
+wVp
 abO
 yeU
 ayy
@@ -92083,7 +92082,7 @@ ngq
 dLA
 arM
 arM
-gCv
+mTY
 dLA
 dLA
 dLA
@@ -93631,9 +93630,9 @@ hTn
 iSh
 aeR
 ioz
-qjO
+eUR
 aeR
-tYY
+mPD
 aeR
 gwD
 hVb
@@ -94144,15 +94143,15 @@ aVL
 jru
 iSh
 ePC
-miZ
-jhL
-jhI
-tHR
+gmt
+rIH
+tmt
+iqb
 oNB
 fyw
 jHx
 jHx
-dKc
+nuh
 hkl
 vWS
 rMP
@@ -94401,9 +94400,9 @@ aVL
 jdh
 iSh
 ePC
-uMT
+tfo
 iSh
-oXY
+hCb
 fvQ
 rAf
 bHx
@@ -94658,7 +94657,7 @@ xcC
 xcC
 xcC
 xcC
-uMT
+tfo
 aeR
 crk
 aeR
@@ -94915,7 +94914,7 @@ nYE
 kVt
 bzk
 xcC
-khC
+pyU
 aeR
 aeR
 aeR
@@ -95172,8 +95171,8 @@ epl
 kbM
 oUk
 xcC
-nTA
-fzX
+crn
+opY
 itC
 wSF
 uGe
@@ -95430,7 +95429,7 @@ ieh
 gCY
 xcC
 jHX
-vrs
+nFy
 jHX
 aeR
 aeR
@@ -95687,7 +95686,7 @@ epl
 uIM
 xcC
 jHX
-vrs
+nFy
 jHX
 aeR
 fkN
@@ -95944,7 +95943,7 @@ itn
 xcC
 xcC
 aeR
-mDV
+utZ
 aeR
 aeR
 fkN
@@ -96201,7 +96200,7 @@ arZ
 sSn
 arZ
 arZ
-vBY
+pMU
 dzc
 arC
 aRk
@@ -96458,7 +96457,7 @@ aOC
 aOC
 aOC
 alA
-jpB
+rJf
 fgY
 bjc
 bjd
@@ -110074,19 +110073,19 @@ aQg
 aQg
 aQg
 aQg
-tUR
+dzQ
 avU
 rhf
-gqw
-sWN
-iqZ
+dGa
+axp
+eiH
 aQg
-dQU
+mVo
 avU
 bQp
 avU
 avU
-oNC
+dts
 avU
 avU
 dLK
@@ -110334,17 +110333,17 @@ wyM
 avU
 avU
 aQg
-eHH
-kHP
-oyM
-gan
+tmy
+nBb
+doW
+qbW
 avU
 avU
 hlW
-stj
-tuE
+vQl
+oRz
 aQg
-tUR
+dzQ
 avU
 avU
 rhf

--- a/nsv13/code/modules/overmap/types.dm
+++ b/nsv13/code/modules/overmap/types.dm
@@ -229,7 +229,7 @@
 	max_integrity = 500
 	integrity_failure = 500
 	starting_system = "Wolf 359"
-	use_armour_quadrants = FALSE //TODO: Mappers map in the pump setup.
+	use_armour_quadrants = TRUE
 	armour_quadrants = list("forward_port" = list("name" = "Forward Port", "max_armour" = 1250, "current_armour" = 1250),\
 							"forward_starboard" = list("name" = "Forward Starboard", "max_armour" = 1250, "current_armour" = 1250),\
 							"aft_port" = list("name" = "Aft Port", "max_armour" = 750, "current_armour" = 750),\


### PR DESCRIPTION
## About The Pull Request
Adds munitions lockers, armour pumps, a new arms dump and changed atmos to be more stormdrive compatible and even less friendly to anyone who doesn't wanna use the stormdrive.

## Changelog
:cl:
add: Added Armour Pumps to the Hammerhead
add: Added Random Maints to Hammerhead
add: Adds lockers for munitions and bridge staff to Hammerhead
tweak: Re-piped a few parts of the stormdrive to make adding interesting mixes easier
balance: Overhauled the Arms Dump and moved the HoS Office
/:cl: