### PR TITLE
Disables AI torpedo firing and bombers temporarily

### DIFF
--- a/nsv13/code/modules/overmap/ai-skynet2.dm
+++ b/nsv13/code/modules/overmap/ai-skynet2.dm
@@ -751,7 +751,7 @@ GLOBAL_LIST_EMPTY(ai_goals)
 		//Heavy weapons take ammo, stuff like PDC and gauss do NOT for AI ships. We make decisions on the fly as to which gun we get to shoot. If we've run out of ammo, we have to resort to PDCs only.
 		for(var/I = FIRE_MODE_PDC; I <= MAX_POSSIBLE_FIREMODE; I++) //We should ALWAYS default to PDCs.
 			var/datum/ship_weapon/SW = weapon_types[I]
-			if(!SW)
+			if(!SW || (I == FIRE_MODE_TORPEDO))
 				continue
 			var/distance = target_range - SW.range_modifier //How close to the effective range of the given weapon are we?
 			if(distance < best_distance)

--- a/nsv13/code/modules/overmap/types.dm
+++ b/nsv13/code/modules/overmap/types.dm
@@ -405,8 +405,8 @@
 	icon_state = "carrier"
 	mass = MASS_LARGE
 	ai_can_launch_fighters = TRUE //AI variable. Allows your ai ships to spawn fighter craft
-	ai_fighter_type = list(/obj/structure/overmap/syndicate/ai/fighter,
-							/obj/structure/overmap/syndicate/ai/bomber)
+	ai_fighter_type = list(/obj/structure/overmap/syndicate/ai/fighter)//,
+							///obj/structure/overmap/syndicate/ai/bomber)
 	sprite_size = 48
 	damage_states = TRUE
 	pixel_z = -96
@@ -588,6 +588,7 @@
 	armor = list("overmap_light" = 5, "overmap_heavy" = 5)
 	ai_trait = AI_TRAIT_ANTI_FIGHTER
 
+/**
 /obj/structure/overmap/syndicate/ai/bomber //need custom AI behaviour to target capitals only
 	name = "Syndicate Bomber"
 	desc = "A space faring fighter craft."
@@ -608,6 +609,7 @@
 	bounty = 250
 	armor = list("overmap_light" = 15, "overmap_heavy" = 0)
 	ai_trait = AI_TRAIT_DESTROYER
+*/
 
 /obj/structure/overmap/syndicate/ai/fighter/Initialize()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes AIs not shoot torpedos to see if it nerfs lag

## Why It's Good For The Game


## Changelog
:cl:
del: enemy torpedoes and bombers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
