### PR TITLE
Shield Gen now shows all the needed components

### DIFF
--- a/nsv13/code/modules/overmap/shieldgen.dm
+++ b/nsv13/code/modules/overmap/shieldgen.dm
@@ -11,7 +11,7 @@
 /obj/structure/shieldgen_frame
 {
 	name = "Shield Generator Frame";
-	desc = "The beginnings of a shield generator. It requires 2 cooling fans, 4 flux"
+	desc = "The beginnings of a shield generator. It requires 2 cooling fans, 4 flux, 1 crystal interface, and 4 modulators."
 	icon = 'nsv13/icons/obj/machinery/shieldgen.dmi';
 	icon_state = "shieldgen_build1";
 	pixel_x = -32;


### PR DESCRIPTION
Hopefully alleviates some confusion when building shields by including all the needed parts in the frame examine text.