### PR TITLE
Adds a dectective spawnpoint on the jeppison

### DIFF
--- a/_maps/map_files/Jeppison/Jeppison1.dmm
+++ b/_maps/map_files/Jeppison/Jeppison1.dmm
@@ -1037,6 +1037,7 @@
 	dir = 1
 	},
 /obj/machinery/firealarm/directional/north,
+/obj/effect/landmark/start/detective,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "cw" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a detective spawnpoint onto the jeppy.

## Why It's Good For The Game

So the detective spawns in security.
Fixes #861 

## Changelog
:cl:
add: Detective spawnpoint on jeppison
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
