### PR TITLE
Fixes ghosts being able to use the astrometrics computer + Roci's Dradis is no longer useable by all

### DIFF
--- a/nsv13/code/modules/overmap/components.dm
+++ b/nsv13/code/modules/overmap/components.dm
@@ -52,17 +52,17 @@ GLOBAL_LIST_INIT(computer_beeps, list('nsv13/sound/effects/computer/beep.ogg','n
 		var/sound = pick('nsv13/sound/effects/computer/error.ogg','nsv13/sound/effects/computer/error2.ogg','nsv13/sound/effects/computer/error3.ogg')
 		playsound(src, sound, 100, 1)
 		to_chat(user, "<span class='warning'>Access denied</span>")
-		return
+		return FALSE
 	if(!isliving(user))
-		return
+		return FALSE
 	if(!has_overmap())
 		var/sound = pick('nsv13/sound/effects/computer/error.ogg','nsv13/sound/effects/computer/error2.ogg','nsv13/sound/effects/computer/error3.ogg')
 		playsound(src, sound, 100, 1)
 		to_chat(user, "<span class='warning'>A warning flashes across [src]'s screen: Unable to locate thrust parameters, no registered ship stored in microprocessor.</span>")
-		return
-	if(!position)
-		return
+		return FALSE
 	playsound(src, 'nsv13/sound/effects/computer/startup.ogg', 75, 1)
+	if(!position)
+		return TRUE
 	return linked.start_piloting(user, position)
 
 /datum/techweb_node/ship_circuits
@@ -141,7 +141,10 @@ GLOBAL_LIST_INIT(computer_beeps, list('nsv13/sound/effects/computer/beep.ogg','n
 		ui.open()
 
 /obj/machinery/computer/ship/tactical/ui_act(action, params, datum/tgui/ui)
-	if(..() || !linked)
+	. = ..()
+	if(.)
+		return
+	if(!linked)
 		return
 	switch(action)
 		if("target_lock")

--- a/nsv13/code/modules/overmap/ftl.dm
+++ b/nsv13/code/modules/overmap/ftl.dm
@@ -373,7 +373,8 @@ A way for syndies to track where the player ship is going in advance, so they ca
 		ui.open()
 
 /obj/machinery/computer/ship/ftl_computer/ui_act(action, params, datum/tgui/ui)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	if(!has_overmap())
 		return

--- a/nsv13/code/modules/overmap/radar.dm
+++ b/nsv13/code/modules/overmap/radar.dm
@@ -91,7 +91,8 @@
 
 /obj/machinery/computer/ship/dradis/attack_hand(mob/user)
 	. = ..()
-	ui_interact(user)
+	if(.)
+		ui_interact(user)
 
 /obj/machinery/computer/ship/dradis/can_interact(mob/user) //Override this code to allow people to use consoles when flying the ship.
 	if(locate(user) in linked?.operators)
@@ -114,7 +115,8 @@
 		ui.open()
 
 /obj/machinery/computer/ship/dradis/ui_act(action, params, datum/tgui/ui)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	if(!has_overmap())
 		return

--- a/nsv13/code/modules/overmap/starmap.dm
+++ b/nsv13/code/modules/overmap/starmap.dm
@@ -33,7 +33,8 @@
 		ui.open()
 
 /obj/machinery/computer/ship/navigation/ui_act(action, params, datum/tgui/ui)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	if(!has_overmap())
 		return

--- a/nsv13/code/modules/research/astrometrics.dm
+++ b/nsv13/code/modules/research/astrometrics.dm
@@ -86,7 +86,8 @@ Clean override of the navigation computer to provide scan functionality.
 	return LAZYFIND(scanned, system.name)
 
 /obj/machinery/computer/ship/navigation/astrometrics/ui_act(action, params, datum/tgui/ui)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	if(!has_overmap())
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes ghosts being able to stop/start scans. Also fixes the Roci's dradis opening if you don't have access

Added in additional . = ..() on other computer/ship subtypes just to be safe

## Why It's Good For The Game

fixes #822 and #884 

## Changelog
:cl:TMTIME
fix: Ghosts can no longer start/stop scans via the astrometrics computer
fix: Roci Dradis console no longer always lets you open it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
