### PR TITLE
Nuke summoning device no longer spawns in the syndie captain's backpack

### DIFF
--- a/_maps/map_files/PVP/Hammurabi.dmm
+++ b/_maps/map_files/PVP/Hammurabi.dmm
@@ -1356,17 +1356,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
-"ga" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/west{
-	req_access = null;
-	req_one_access_txt = "150"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/hammurabi/medbay)
 "gb" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -1550,17 +1539,6 @@
 /obj/effect/spawner/structure/window/reinforced/ship,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
-"gO" = (
-/obj/effect/turf_decal/box,
-/obj/structure/closet/firecloset,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/hammurabi/hangar)
 "gP" = (
 /obj/item/ship_weapon/ammunition/torpedo,
 /obj/effect/turf_decal/delivery,
@@ -2325,16 +2303,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/hammurabi)
-"kh" = (
-/obj/structure/railing{
-	dir = 8;
-	icon_state = "railing0"
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/bridge)
 "kG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/mineral/plastitanium/red,
@@ -2520,6 +2488,19 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
+"mJ" = (
+/obj/effect/turf_decal/box,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/closet/syndicate{
+	name = "suspicious closet"
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi/hangar)
 "mT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -2680,6 +2661,12 @@
 	},
 /turf/open/floor/plating,
 /area/hammurabi)
+"oU" = (
+/obj/structure/chair/office,
+/obj/machinery/firealarm/directional/north,
+/obj/effect/landmark/start/nukeop/syndi_crew_leader,
+/turf/open/floor/carpet/red,
+/area/hammurabi/bridge)
 "oW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -2791,10 +2778,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/hangar)
-"pT" = (
-/obj/structure/chair/office,
-/turf/open/floor/carpet/red,
-/area/hammurabi/bridge)
 "pW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/carpet/red,
@@ -3068,6 +3051,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/monotile/dark,
 /area/hammurabi/medbay)
+"sS" = (
+/obj/structure/table/reinforced,
+/obj/item/pvp_nuke_spawner,
+/turf/open/floor/carpet/red,
+/area/hammurabi/bridge)
 "sZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -3255,6 +3243,12 @@
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
+"uY" = (
+/obj/structure/railing{
+	dir = 10
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/bridge)
 "uZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -3553,6 +3547,12 @@
 "yi" = (
 /obj/structure/bed,
 /obj/item/bedsheet/syndie,
+/turf/open/floor/carpet/red,
+/area/hammurabi/bridge)
+"yn" = (
+/obj/machinery/door/airlock/vault/ship{
+	name = "Nuclear Summoning Device Storage"
+	},
 /turf/open/floor/carpet/red,
 /area/hammurabi/bridge)
 "yo" = (
@@ -4200,10 +4200,6 @@
 /obj/item/stack/sheet/iron/twenty,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/maintenance)
-"Fn" = (
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/carpet/red,
-/area/hammurabi/bridge)
 "Fo" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -4335,6 +4331,15 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi)
+"GH" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/carpet/red,
+/area/hammurabi)
 "GI" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
 /obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
@@ -4415,16 +4420,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/carpet/red,
 /area/hammurabi)
-"HP" = (
-/obj/structure/railing{
-	dir = 9
-	},
-/obj/structure/railing{
-	dir = 9;
-	icon_state = "railing0"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/bridge)
 "HQ" = (
 /obj/structure/extinguisher_cabinet/east,
 /turf/open/floor/plasteel/tech/grid,
@@ -4523,6 +4518,12 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
+"IT" = (
+/obj/structure/railing{
+	dir = 9
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/bridge)
 "Jp" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
@@ -4675,16 +4676,6 @@
 	icon_state = "stairs-m"
 	},
 /area/hammurabi/bridge)
-"Lt" = (
-/obj/effect/landmark/nuclear_waste_spawner,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/turf/open/floor/carpet/red,
-/area/hammurabi)
 "LF" = (
 /obj/item/gun/ballistic/automatic/c20r/toy/unrestricted/riot,
 /obj/structure/table/reinforced,
@@ -4729,6 +4720,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi)
+"MN" = (
+/obj/structure/closet/crate/freezer/blood,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/west{
+	req_access = null;
+	req_one_access_txt = "150"
+	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone,
+/turf/open/floor/plasteel/tech/grid,
+/area/hammurabi/medbay)
 "MS" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5339,16 +5342,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/mineral/plastitanium/red,
 /area/hammurabi)
-"Sq" = (
-/obj/structure/railing{
-	dir = 10
-	},
-/obj/structure/railing{
-	dir = 10;
-	icon_state = "railing0"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/hammurabi/bridge)
 "Sv" = (
 /obj/structure/sign/warning/vacuum/external,
 /turf/closed/wall/ship,
@@ -5392,6 +5385,17 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hammurabi/hangar)
+"SV" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/landmark/nuclear_waste_spawner,
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/armoury)
 "Tl" = (
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi/maintenance)
@@ -5746,6 +5750,12 @@
 /obj/structure/extinguisher_cabinet/east,
 /turf/open/floor/plasteel/tech/grid,
 /area/hammurabi/medbay)
+"XG" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/hammurabi/bridge)
 "XI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -30228,7 +30238,7 @@ ab
 gV
 ro
 cM
-ga
+MN
 cR
 cZ
 fW
@@ -34595,7 +34605,7 @@ Wh
 ha
 hd
 he
-gO
+mJ
 hf
 hj
 aJ
@@ -37948,7 +37958,7 @@ yv
 pF
 tZ
 xf
-Lt
+GH
 KT
 bT
 Hx
@@ -38725,7 +38735,7 @@ an
 ca
 eH
 gF
-wN
+SV
 gg
 bP
 aY
@@ -39995,10 +40005,10 @@ cp
 cp
 dY
 ec
-ec
-ec
 ae
-Fn
+sS
+yn
+in
 SC
 in
 bX
@@ -40255,7 +40265,7 @@ aG
 aG
 aG
 ae
-pT
+oU
 iP
 Cx
 GX
@@ -40774,9 +40784,9 @@ it
 uw
 XB
 Lr
-HP
-kh
-Sq
+IT
+XG
+uY
 Lr
 ab
 ab

--- a/nsv13/code/game/gamemodes/pvp/pvp.dm
+++ b/nsv13/code/game/gamemodes/pvp/pvp.dm
@@ -230,8 +230,7 @@ Method to assign a job, in order of descending priority. We REALLY need people t
 	head = /obj/item/clothing/head/beret/durathread
 	suit = /obj/item/clothing/suit/space/officer
 	backpack_contents = list(/obj/item/storage/box/syndie=1,\
-	/obj/item/kitchen/knife/combat/survival=1,\
-	/obj/item/pvp_nuke_spawner)
+	/obj/item/kitchen/knife/combat/survival=1,)
 	command_radio = TRUE
 	implants = list()
 


### PR DESCRIPTION
Moves the spawn location of the Nuke Summoning Device to a small vault (accessible by anyone) in the back of the Syndicate Captain's room.

Also adds a locker to the hangar bay that's definitely not there to be put in a boarding craft.

fixes #604 

## Why It's Good For The Game

Issue 604 has more details but sometimes the captain forgets he has it and doesn't give it away.

## Changelog
:cl:
tweak: Moved the PVP nuke out of the captain's backpack.
/:cl: