### PR TITLE
Makes you unable to toggle munitions trolley brakes from a distance

### DIFF
--- a/nsv13/code/modules/munitions/munitions_trolley.dm
+++ b/nsv13/code/modules/munitions/munitions_trolley.dm
@@ -17,6 +17,8 @@
 
 /obj/structure/munitions_trolley/AltClick(mob/user)
 	. = ..()
+	if(!in_range(src, usr))
+		return
 	add_fingerprint(user)
 	if(!anchored)
 		to_chat(user, "<span class='notice'>You toggle the brakes on [src], fixing it in place.</span>")


### PR DESCRIPTION
## About The Pull Request

fixes #439 

## Changelog
:cl:
fix: Fixes munitions trolley breaks being togglable from a distance
/:cl:
