### PR TITLE
Mapps

### DIFF
--- a/_maps/map_files/Aetherwhisp/Aetherwhisp2.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp2.dmm
@@ -10634,13 +10634,6 @@
 	name = "nanoweave carpet (bluer)"
 	},
 /area/crew_quarters/heads/xo)
-"hWC" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/carpet/ship/beige_carpet{
-	color = "#CC8899";
-	name = "nanoweave carpet (puce)"
-	},
-/area/nsv/hanger/storage)
 "hWE" = (
 /obj/effect/landmark/start/geneticist,
 /turf/open/floor/carpet/ship/purple_carpet,
@@ -15718,13 +15711,13 @@
 /turf/open/floor/plating,
 /area/nsv/weapons/port)
 "mkK" = (
-/obj/structure/table,
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/camera/autoname{
 	dir = 8
 	},
-/obj/item/storage/fancy/cigarettes/cigars,
-/obj/item/lighter,
+/obj/machinery/computer/ship/ordnance{
+	dir = 1
+	},
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
@@ -17163,6 +17156,13 @@
 	name = "nanoweave carpet (bluer)"
 	},
 /area/ai_monitored/nuke_storage)
+"nkQ" = (
+/obj/machinery/vending/wardrobe/muni_wardrobe,
+/turf/open/floor/carpet/ship/beige_carpet{
+	color = "#CC8899";
+	name = "nanoweave carpet (puce)"
+	},
+/area/nsv/hanger/storage)
 "nkV" = (
 /obj/machinery/atmospherics/components/binary/pump/layer1{
 	dir = 1;
@@ -17827,6 +17827,8 @@
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen,
+/obj/item/lighter,
+/obj/item/storage/fancy/cigarettes/cigars,
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
@@ -22341,6 +22343,7 @@
 /area/maintenance/department/science/central)
 "rdY" = (
 /obj/machinery/firealarm/directional/east,
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
@@ -71770,8 +71773,8 @@ nuK
 lSx
 vNI
 rdY
-hWC
 pOB
+nkQ
 nkW
 tlN
 bjL

--- a/_maps/map_files/Hammerhead/Hammerhead.dmm
+++ b/_maps/map_files/Hammerhead/Hammerhead.dmm
@@ -26800,7 +26800,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/structure/closet/secure_closet/munitions_technician,
+/obj/machinery/vending/wardrobe/muni_wardrobe,
 /turf/open/floor/plasteel/ship,
 /area/nsv/weapons/fore)
 "dHw" = (
@@ -30516,6 +30516,9 @@
 /area/maintenance/department/chapel)
 "gCY" = (
 /obj/machinery/light,
+/obj/machinery/computer/ship/ordnance{
+	dir = 1
+	},
 /turf/open/floor/carpet/ship,
 /area/nsv/crew_quarters/heads/maa)
 "gDS" = (

--- a/_maps/map_files/Jeppison/Jeppison1.dmm
+++ b/_maps/map_files/Jeppison/Jeppison1.dmm
@@ -8610,6 +8610,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "sx" = (
@@ -13364,6 +13365,10 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger)
+"Pb" = (
+/obj/effect/landmark/nuclear_waste_spawner,
+/turf/open/floor/monotile,
+/area/nsv/hanger)
 "Pe" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	name = "Escape Airlock"
@@ -14045,6 +14050,10 @@
 	},
 /turf/open/floor/plating,
 /area/nsv/hanger)
+"ZB" = (
+/obj/effect/landmark/nuclear_waste_spawner,
+/turf/open/floor/plasteel/ship,
+/area/hallway/primary/port)
 "ZU" = (
 /obj/structure/fighter_launcher/launch_only{
 	dir = 1
@@ -34489,7 +34498,7 @@ qu
 PO
 fL
 fL
-fL
+Pb
 UR
 fL
 fL
@@ -45026,7 +45035,7 @@ xq
 xq
 fE
 sE
-Ez
+ZB
 eD
 ik
 OF

--- a/_maps/map_files/Jeppison/Jeppison2.dmm
+++ b/_maps/map_files/Jeppison/Jeppison2.dmm
@@ -10059,10 +10059,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "ul" = (
-/obj/machinery/nuclearbomb/beer,
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
+/obj/structure/closet/secure_closet/master_at_arms,
 /turf/open/floor/plasteel,
 /area/nsv/crew_quarters/heads/maa)
 "um" = (
@@ -11402,7 +11402,9 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "wT" = (
-/obj/structure/closet/secure_closet/master_at_arms,
+/obj/machinery/computer/ship/ordnance{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/nsv/crew_quarters/heads/maa)
 "wU" = (
@@ -13202,6 +13204,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/vending/wardrobe/muni_wardrobe,
 /turf/open/floor/monotile/dark,
 /area/nsv/magazine)
 "At" = (
@@ -17700,6 +17703,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/cmo)
+"KD" = (
+/obj/effect/landmark/nuclear_waste_spawner,
+/turf/open/floor/plasteel/ship/padded,
+/area/engine/atmos)
 "KE" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19110,6 +19117,10 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/break_room)
+"RW" = (
+/obj/machinery/nuclearbomb/beer,
+/turf/open/floor/plasteel,
+/area/nsv/crew_quarters/heads/maa)
 "RZ" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -19191,6 +19202,23 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"Sq" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4;
+	icon_state = "pipe11-1"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/landmark/nuclear_waste_spawner,
+/turf/open/floor/plasteel,
+/area/hallway/nsv/deck2/aft)
 "Sv" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -20031,6 +20059,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
+"Xe" = (
+/obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "Xf" = (
@@ -42261,7 +42293,7 @@ Un
 Un
 IC
 at
-aP
+KD
 bf
 bF
 cc
@@ -46650,7 +46682,7 @@ Ea
 Eh
 Eh
 im
-DY
+Xe
 Ew
 im
 EV
@@ -50754,7 +50786,7 @@ lZ
 mq
 pg
 lA
-Qx
+Sq
 Yh
 BZ
 mi
@@ -58737,7 +58769,7 @@ Um
 xU
 Mi
 CX
-AE
+RW
 DS
 xU
 bP

--- a/_maps/map_files/Pegasus/pegasus2.dmm
+++ b/_maps/map_files/Pegasus/pegasus2.dmm
@@ -2867,10 +2867,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
-"cha" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/carpet/purple,
-/area/nsv/crew_quarters/heads/maa)
 "chk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -8081,6 +8077,10 @@
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/chapel/main)
+"gxY" = (
+/obj/machinery/computer/ship/ordnance,
+/turf/open/floor/carpet/purple,
+/area/nsv/crew_quarters/heads/maa)
 "gyk" = (
 /obj/machinery/vending/hydroseeds{
 	slogan_delay = 700
@@ -9180,6 +9180,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/library)
+"hpo" = (
+/obj/machinery/vending/wardrobe/muni_wardrobe,
+/obj/effect/turf_decal/ship/delivery/yellow,
+/turf/open/floor/noslip/dark,
+/area/nsv/weapons/fore)
 "hpr" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -57676,7 +57681,7 @@ sGL
 tQb
 wzl
 bam
-gYA
+hpo
 lgs
 bPb
 ovG
@@ -58960,7 +58965,7 @@ jfd
 uts
 oAZ
 biO
-cha
+pEC
 jNn
 uBw
 fCI
@@ -59215,7 +59220,7 @@ tzq
 fCI
 oYt
 uts
-pEC
+gxY
 tVX
 vEW
 jNn

--- a/_maps/map_files/Tycoon/Tycoon2.dmm
+++ b/_maps/map_files/Tycoon/Tycoon2.dmm
@@ -102,10 +102,11 @@
 /obj/structure/sign/nanotrasen{
 	pixel_y = 26
 	},
+/obj/structure/chair/comfy/black,
 /turf/open/floor/carpet/ship,
 /area/nsv/crew_quarters/heads/maa)
 "aaq" = (
-/obj/structure/chair/comfy/black,
+/obj/structure/table/reinforced,
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/carpet/ship,
 /area/nsv/crew_quarters/heads/maa)
@@ -225,7 +226,9 @@
 /turf/closed/wall/ship,
 /area/medical/surgery)
 "aaL" = (
-/obj/structure/table/reinforced,
+/obj/machinery/computer/ship/ordnance{
+	dir = 1
+	},
 /turf/open/floor/carpet/ship,
 /area/nsv/crew_quarters/heads/maa)
 "aaM" = (
@@ -2482,6 +2485,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/machinery/vending/wardrobe/muni_wardrobe,
 /turf/open/floor/monotile,
 /area/nsv/hanger/deck2)
 "agh" = (

--- a/_maps/map_files/jollysausage/todger.dmm
+++ b/_maps/map_files/jollysausage/todger.dmm
@@ -5837,6 +5837,7 @@
 /area/chapel/main)
 "aoy" = (
 /obj/structure/table/wood,
+/obj/item/toy/plush/awakenedplushie,
 /turf/open/floor/wood,
 /area/nsv/crew_quarters/heads/maa)
 "aoz" = (
@@ -8987,11 +8988,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "avd" = (
-/obj/structure/table/wood,
 /obj/structure/cable{
 	icon_state = "6-9"
 	},
-/obj/item/toy/plush/awakenedplushie,
+/obj/machinery/computer/ship/ordnance{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/nsv/crew_quarters/heads/maa)
 "ave" = (
@@ -9003,6 +9005,7 @@
 /area/nsv/hanger)
 "avf" = (
 /obj/machinery/airalarm/directional/north,
+/obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "avg" = (
@@ -34158,6 +34161,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"fMJ" = (
+/obj/effect/landmark/nuclear_waste_spawner,
+/turf/open/floor/plasteel/dark,
+/area/chapel/main)
 "fOV" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -34202,6 +34209,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"fRt" = (
+/obj/effect/landmark/nuclear_waste_spawner,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "fSY" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -34807,6 +34818,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"hTS" = (
+/obj/effect/landmark/nuclear_waste_spawner,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "hZd" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -36616,6 +36631,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/landmark/nuclear_waste_spawner/strong,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
 "ran" = (
@@ -36897,6 +36913,11 @@
 /mob/living/simple_animal/pet/hamster/vector,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"sDR" = (
+/obj/structure/hull_plate,
+/obj/machinery/vending/wardrobe/muni_wardrobe,
+/turf/open/floor/plating/airless,
+/area/nsv/weapons/gauss)
 "sDS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/orange/visible/layer1{
@@ -37620,6 +37641,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"vKU" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/landmark/nuclear_waste_spawner,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "vLi" = (
 /obj/machinery/door/airlock/ship/medical{
 	name = "Virology";
@@ -37702,6 +37733,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"wfu" = (
+/obj/effect/landmark/nuclear_waste_spawner,
+/turf/open/floor/plasteel/dark,
+/area/medical/morgue)
 "wgY" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/bar{
@@ -53312,7 +53347,7 @@ jWY
 abs
 gSL
 jeG
-jeG
+wfu
 jeG
 mww
 aeb
@@ -54103,7 +54138,7 @@ kgN
 fUz
 hbv
 cMY
-wbb
+vKU
 hua
 lxH
 wXj
@@ -59769,7 +59804,7 @@ avs
 aNe
 aBX
 aFJ
-ahL
+fRt
 aDK
 ahH
 ahH
@@ -63118,7 +63153,7 @@ afe
 afe
 afe
 afe
-afe
+hTS
 bjL
 aMk
 acq
@@ -67966,7 +68001,7 @@ aao
 abz
 adj
 aao
-aao
+fMJ
 aao
 aao
 aao
@@ -79533,7 +79568,7 @@ agF
 aRN
 abl
 abM
-aAw
+sDR
 bqA
 ano
 abo


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR adds Munidrobes and ORDs to the maps that are in rotation.
Resolves Pegasus having Fighters 2.0 components.
Also replaces stripped landmarks from Jeppison and Jolly Sausage post rework.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More content.
Fixes a Pegasus problem.
Fixes #907
Fixes #906
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added Munidrobes to munitions departments
add: Added ORDs to MAA's offices
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
