### PR TITLE
Balatant FTL Buffs

### DIFF
--- a/nsv13/code/modules/overmap/ftl.dm
+++ b/nsv13/code/modules/overmap/ftl.dm
@@ -141,7 +141,7 @@
 		relay(ftl_drive.ftl_loop, "<span class='warning'>You feel the ship lurch forward</span>", loop=TRUE, channel = CHANNEL_SHIP_ALERT)
 		var/datum/star_system/curr = SSstar_system.ships[src]["current_system"]
 		curr.remove_ship(src)
-		var/speed = (curr.dist(target_system) / (ftl_drive.jump_speed_factor*10)) //TODO: FTL drive speed upgrades.
+		var/speed = (curr.dist(target_system) / (ftl_drive.jump_speed_factor*50)) //TODO: FTL drive speed upgrades.
 		SSstar_system.ships[src]["to_time"] = world.time + speed MINUTES
 		SEND_SIGNAL(src, COMSIG_FTL_STATE_CHANGE)
 		if(role == MAIN_OVERMAP) //Scuffed please fix
@@ -229,7 +229,7 @@
 	var/active = FALSE
 	var/progress = 0 SECONDS
 	var/progress_rate = 1 SECONDS
-	var/spoolup_time = 1 MINUTES //Make sure this is always longer than the ftl_startup_time, or you can seriously bug the ship out with cancel jump spam.
+	var/spoolup_time = 45 SECONDS //Make sure this is always longer than the ftl_startup_time, or you can seriously bug the ship out with cancel jump spam.
 	var/screen = 1
 	var/can_cancel_jump = TRUE //Defaults to true. TODO: Make emagging disable this
 	var/max_range = 100 //max jump range. This is _very_ long distance

--- a/nsv13/code/modules/overmap/ftl.dm
+++ b/nsv13/code/modules/overmap/ftl.dm
@@ -238,7 +238,7 @@
 	var/ftl_start = 'nsv13/sound/effects/ship/FTL_long.ogg'
 	var/ftl_exit = 'nsv13/sound/effects/ship/freespace2/warp_close.wav'
 	var/ftl_startup_time = 30 SECONDS
-	var/auto_spool = FALSE //For lazy admins
+	var/auto_spool = TRUE //For lazy admins
 
 /obj/machinery/computer/ship/ftl_computer/attackby(obj/item/I, mob/user) //Allows you to upgrade dradis consoles to show asteroids, as well as revealing more valuable ones.
 	. = ..()
@@ -274,7 +274,6 @@
 			ftl_exit = 'nsv13/sound/effects/ship/warp_exit.ogg'
 			ftl_startup_time = 5 SECONDS
 			spoolup_time = 10 SECONDS
-			auto_spool = TRUE
 			jump_speed_factor = 5
 			max_range = 300
 


### PR DESCRIPTION
FTL works faster now and automatically spools after each use.

## Why it's good for the game

Auto spooling removes the need to stop whatever you're doing, run all the way to the FTL drive, and press a single button.

As Starmap 2 has made the universe bigger, It now takes less time to travel between systems, It took the crew around an hour to even reach combat on the first shift.

These changes hope to improve the quality of current rounds and get the ship into action faster so that pilots, bridge assistants and munitions can do their thing without as much needless waiting. Auto spooling can safely be removed when the FTL drive update comes, but it could be some time until it's finished.