### PR TITLE
Tiny PR - Tiny Fans

### DIFF
--- a/_maps/map_files/Pegasus/pegasus2.dmm
+++ b/_maps/map_files/Pegasus/pegasus2.dmm
@@ -7502,7 +7502,7 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/unres,
-/obj/structure/holosign/barrier/atmos,
+/obj/structure/fans/tiny,
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/frame1/central)
 "fXO" = (
@@ -19154,7 +19154,7 @@
 	name = "Arrival Shuttle Dock";
 	req_one_access_txt = "13"
 	},
-/obj/structure/holosign/barrier/atmos,
+/obj/structure/fans/tiny,
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/frame1/central)
 "oTi" = (

--- a/_maps/shuttles/ferry_fancy.dmm
+++ b/_maps/shuttles/ferry_fancy.dmm
@@ -11,6 +11,7 @@
 /area/shuttle/transport)
 "d" = (
 /obj/machinery/door/airlock/external,
+/obj/structure/fans/tiny,
 /turf/open/floor/pod/dark,
 /area/shuttle/transport)
 "e" = (
@@ -74,6 +75,7 @@
 	preferred_direction = 4;
 	width = 5
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/pod/light,
 /area/shuttle/transport)
 "o" = (
@@ -98,6 +100,7 @@
 /area/shuttle/transport)
 "r" = (
 /obj/machinery/door/airlock/external,
+/obj/structure/fans/tiny,
 /turf/open/floor/pod/light,
 /area/shuttle/transport)
 


### PR DESCRIPTION
## About The Pull Request

This PR does two things:
-Replaces holofans on Pegasus with tiny fans
-Adds tiny fans to the CentCom ferry

## Why It's Good For The Game

Why would you put holofans on your map instead of tiny fans in the first place?
Also, CentCom ferry suffers from too many depressurisation accidents, when someone accidentally bumps into the doors, so tiny fans should fix that.

## Changelog
:cl:
add: Added tiny fans to CentCom ferry
del: Removed holofans from arrivals on Pegasus
add: Added tiny fans in place of those holofans in arrivals on Pegasus
/:cl:
