### PR TITLE
Add missing categories to the techfab

### DIFF
--- a/code/modules/research/machinery/techfab.dm
+++ b/code/modules/research/machinery/techfab.dm
@@ -28,11 +28,13 @@
 								"Misc. Machinery",
 								"Computer Parts",
 								"Advanced Munitions",
-								"Ship Components"
+								"Asteroid Mining",
+								"Ship Components",
+								"Vehicles"
 								)
 	console_link = FALSE
 	production_animation = "protolathe_n"
 	requires_console = FALSE
 	consoleless_interface = TRUE
 	allowed_buildtypes = PROTOLATHE | IMPRINTER
-//nsv13 added Advanced Munitions, Ship Components list above
+//nsv13 added Advanced Munitions, Ship Components, Vehicles and Asteroid Mining to list above


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the missing categories 'Asteroid Mining' and 'Vehicles' to techfabs which were left out when they were added to protolathes meaning that mining upgrades and such weren't able to be found without being searched for.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Being able to make things is good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Techfabs have all the correct categories
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
