### PR TITLE
lets the rest of the crew know when you are talking shit to other ships

### DIFF
--- a/nsv13/code/modules/overmap/ai-skynet2.dm
+++ b/nsv13/code/modules/overmap/ai-skynet2.dm
@@ -251,17 +251,24 @@ GLOBAL_LIST_EMPTY(ai_goals)
 	curr?.remove_ship(src)
 	jump(SS, FALSE)
 
-/obj/structure/overmap/proc/try_hail(mob/living/user)
+/obj/structure/overmap/proc/try_hail(mob/living/user, var/obj/structure/overmap/source_ship)
 	if(!isliving(user))
+		return FALSE
+	if(!source_ship)
 		return FALSE
 	var/text = stripped_input(user, "What do you want to say?", "Hailing")
 	if(text)
-		hail(text, user)
+		hail(text, user, source_ship)
 
-/obj/structure/overmap/proc/hail(text, sender)
-	if(!text || !sender)
+/obj/structure/overmap/proc/hail(text, sender, var/obj/structure/overmap/source_ship)
+	if(!text)
 		return
-	relay('nsv13/sound/effects/ship/freespace2/computer/textdraw.wav', "<h1>Incoming hail from: [sender]</h1><hr><br><span class='userdanger'>[text]</span>")
+	if(!sender)
+		return
+	if(!source_ship)
+		return
+	source_ship.relay('nsv13/sound/effects/ship/freespace2/computer/textdraw.wav', "<h3>Outbound hail to: [src.name] (Sent by [sender])</h3><hr><span class='danger'>[text]</span><br>")
+	relay('nsv13/sound/effects/ship/freespace2/computer/textdraw.wav', "<h1>Incoming hail from: [source_ship.name] (Sent by [sender])</h1><hr><span class='userdanger'>[text]</span><br>")
 
 /proc/get_internet_sound(web_sound_input)
 	if(!web_sound_input)

--- a/nsv13/code/modules/overmap/ai-skynet2.dm
+++ b/nsv13/code/modules/overmap/ai-skynet2.dm
@@ -258,17 +258,22 @@ GLOBAL_LIST_EMPTY(ai_goals)
 		return FALSE
 	var/text = stripped_input(user, "What do you want to say?", "Hailing")
 	if(text)
-		hail(text, user, source_ship)
+		source_ship.hail(text, name, user.name, TRUE) // Let the crew on the source ship know an Outbound message was sent
+		hail(text, source_ship.name, user.name)
 
-/obj/structure/overmap/proc/hail(text, sender, var/obj/structure/overmap/source_ship)
+/obj/structure/overmap/proc/hail(var/text, var/ship_name, var/player_name, var/outbound = FALSE)
 	if(!text)
 		return
-	if(!sender)
+	if(!ship_name)
 		return
-	if(!source_ship)
-		return
-	source_ship.relay('nsv13/sound/effects/ship/freespace2/computer/textdraw.wav', "<h3>Outbound hail to: [src.name] (Sent by [sender])</h3><hr><span class='danger'>[text]</span><br>")
-	relay('nsv13/sound/effects/ship/freespace2/computer/textdraw.wav', "<h1>Incoming hail from: [source_ship.name] (Sent by [sender])</h1><hr><span class='userdanger'>[text]</span><br>")
+	var/player_string = ""	
+	if(player_name) // No sender means AI ship
+		player_string = " (Sent by [player_name])"
+		
+	if(outbound)
+		relay('nsv13/sound/effects/ship/freespace2/computer/textdraw.wav', "<h3>Outbound hail to: [ship_name][player_string]</h3><hr><span class='danger'>[text]</span><br>")
+	else
+		relay('nsv13/sound/effects/ship/freespace2/computer/textdraw.wav', "<h1>Incoming hail from: [ship_name][player_string]</h1><hr><span class='userdanger'>[text]</span><br>")
 
 /proc/get_internet_sound(web_sound_input)
 	if(!web_sound_input)

--- a/nsv13/code/modules/overmap/radar.dm
+++ b/nsv13/code/modules/overmap/radar.dm
@@ -154,9 +154,11 @@
 				return
 			if(world.time < next_hail)
 				return
+			if(target == linked)
+				return
 			next_hail = world.time + 10 SECONDS //I hate that I need to do this, but yeah.
 			if(get_dist(target, linked) <= hail_range)
-				target.try_hail(usr)
+				target.try_hail(usr, linked)
 
 /obj/machinery/computer/ship/dradis/attackby(obj/item/I, mob/user) //Allows you to upgrade dradis consoles to show asteroids, as well as revealing more valuable ones.
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Lets the crew on the ship see outbound hails

## Why It's Good For The Game

After that one round where we had the Zorn helping the player ship out, it was jank as hell:

- not having feedback about sent hails
- knowing the crew is confused as to why someone is suggesting to use cargo torps to send pizza

so this fixes that. also fixes crew hailing themselves as I think that was an issue?

one thing to be aware of is sending a hail to the main ship will also go to its launched fighters, as they remain in the main ship's mobs_in_ship  

## Changelog
:cl:TMTIME
add: Outbound hails are now shown to the crew
fix: You now cant hail yourself
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
