### PR TITLE
updates ethereals to TG high demand high compensation dynamic

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -188,6 +188,7 @@
 //Used as an upper limit for species that continuously gain nutriment
 #define NUTRITION_LEVEL_ALMOST_FULL 535
 
+//NSV13 changed charge levels to tg kind up to full
 //Charge levels for Ethereals
 #define ETHEREAL_CHARGE_NONE 0
 #define ETHEREAL_CHARGE_LOWPOWER 400
@@ -288,6 +289,7 @@
 #define DOOR_CRUSH_DAMAGE	15	//! the amount of damage that airlocks deal when they crush you
 
 #define	HUNGER_FACTOR		0.1	//! factor at which mob nutrition decreases
+//NSV13 charge factor increased from 0.1 to 1.6
 #define	ETHEREAL_CHARGE_FACTOR	1.6 //! factor at which ethereal's charge decreases
 #define	HYGIENE_FACTOR  0.1	//! factor at which mob hygiene decreases
 #define	REAGENTS_METABOLISM 0.4	//! How many units of reagent are consumed per tick, by default.

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -190,10 +190,10 @@
 
 //Charge levels for Ethereals
 #define ETHEREAL_CHARGE_NONE 0
-#define ETHEREAL_CHARGE_LOWPOWER 20
-#define ETHEREAL_CHARGE_NORMAL 50
-#define ETHEREAL_CHARGE_ALMOSTFULL 75
-#define ETHEREAL_CHARGE_FULL 100
+#define ETHEREAL_CHARGE_LOWPOWER 400
+#define ETHEREAL_CHARGE_NORMAL 1000
+#define ETHEREAL_CHARGE_ALMOSTFULL 1500
+#define ETHEREAL_CHARGE_FULL 2000
 
 //Slime evolution threshold. Controls how fast slimes can split/grow
 #define SLIME_EVOLUTION_THRESHOLD 10
@@ -288,7 +288,7 @@
 #define DOOR_CRUSH_DAMAGE	15	//! the amount of damage that airlocks deal when they crush you
 
 #define	HUNGER_FACTOR		0.1	//! factor at which mob nutrition decreases
-#define	ETHEREAL_CHARGE_FACTOR	0.1 //! factor at which ethereal's charge decreases
+#define	ETHEREAL_CHARGE_FACTOR	1.6 //! factor at which ethereal's charge decreases
 #define	HYGIENE_FACTOR  0.1	//! factor at which mob hygiene decreases
 #define	REAGENTS_METABOLISM 0.4	//! How many units of reagent are consumed per tick, by default.
 #define REAGENTS_EFFECT_MULTIPLIER (REAGENTS_METABOLISM / 0.4)	//! By defining the effect multiplier this way, it'll exactly adjust all effects according to how they originally were with the 0.4 metabolism

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -38,6 +38,9 @@
 #define APC_CHARGING 1
 #define APC_FULLY_CHARGED 2
 
+#define APC_DRAIN_TIME 75
+#define APC_POWER_GAIN 200
+
 // the Area Power Controller (APC), formerly Power Distribution Unit (PDU)
 // one per area, needs wire connection to power network through a terminal
 
@@ -783,15 +786,15 @@
 			if(stomach.crystal_charge >= ETHEREAL_CHARGE_FULL)
 				to_chat(H, "<span class='warning'>Your charge is full!</span>")
 				return
-			E.drain_time = world.time + 75
+			E.drain_time = world.time + APC_DRAIN_TIME
 			to_chat(H, "<span class='notice'>You start channeling some power through the APC into your body.</span>")
-			if(do_after(user, 75, target = src))
+			if(do_after(user, APC_DRAIN_TIME, target = src))
 				if(cell.charge <= (cell.maxcharge / 2) || (stomach.crystal_charge >= ETHEREAL_CHARGE_FULL))
 					to_chat(H, "<span class='warning'>You can't receive more charge from the APC.</span>")
 					return
 				to_chat(H, "<span class='notice'>You receive some charge from the APC.</span>")
-				stomach.adjust_charge(10)
-				cell.charge -= 10
+				stomach.adjust_charge(APC_POWER_GAIN)
+				cell.charge -= APC_POWER_GAIN
 			else
 				to_chat(H, "<span class='warning'>You fail to receive charge from the APC!</span>")
 			return
@@ -803,18 +806,18 @@
 			if(!istype(stomach))
 				to_chat(H, "<span class='warning'>You can't transfer charge!</span>")
 				return
-			if(stomach.crystal_charge < 10)
+			if(stomach.crystal_charge < APC_POWER_GAIN)
 				to_chat(H, "<span class='warning'>Your charge is too low!</span>")
 				return
-			E.drain_time = world.time + 75
+			E.drain_time = world.time + APC_DRAIN_TIME
 			to_chat(H, "<span class='notice'>You start channeling power through your body into the APC.</span>")
-			if(cell.charge == cell.maxcharge || (stomach.crystal_charge < 10))
+			if(cell.charge == cell.maxcharge || (stomach.crystal_charge < APC_POWER_GAIN))
 				to_chat(H, "<span class='warning'>You can't transfer more charge to the APC.</span>")
 				return
-			if(do_after(user, 75, target = src))
+			if(do_after(user, APC_DRAIN_TIME, target = src))
 				to_chat(H, "<span class='notice'>You transfer some power to the APC.</span>")
-				stomach.adjust_charge(-10)
-				cell.charge += 10
+				stomach.adjust_charge(-APC_POWER_GAIN)
+				cell.charge += APC_POWER_GAIN
 			else
 				to_chat(H, "<span class='warning'>You fail to transfer power to the APC!</span>")
 			return
@@ -1453,6 +1456,9 @@
 #undef APC_NOT_CHARGING
 #undef APC_CHARGING
 #undef APC_FULLY_CHARGED
+
+#undef APC_DRAIN_TIME
+#undef APC_POWER_GAIN
 
 //update_overlay
 #undef APC_UPOVERLAY_CHARGEING0

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -38,6 +38,7 @@
 #define APC_CHARGING 1
 #define APC_FULLY_CHARGED 2
 
+//NSV13 added ethereal power drain defines
 #define APC_DRAIN_TIME 75
 #define APC_POWER_GAIN 200
 
@@ -765,6 +766,7 @@
 			update_icon()
 
 
+//NSV13 changed numbers to defines
 // attack with hand - remove cell (if cover open) or interact with the APC
 
 /obj/machinery/power/apc/attack_hand(mob/user)

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -1,3 +1,4 @@
+//NSV13 added defines for ethereal cell interactions
 #define CELL_DRAIN_TIME 35
 #define CELL_POWER_GAIN 60
 #define CELL_POWER_DRAIN 750
@@ -152,6 +153,7 @@
 				if(prob(25))
 					corrupt()
 
+//NSV13 added ethereal cell interaction defines
 /obj/item/stock_parts/cell/attack_self(mob/user)
 	if(isethereal(user))
 		var/mob/living/carbon/human/H = user

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -1,3 +1,7 @@
+#define CELL_DRAIN_TIME 35
+#define CELL_POWER_GAIN 60
+#define CELL_POWER_DRAIN 750
+
 /obj/item/stock_parts/cell
 	name = "power cell"
 	desc = "A rechargeable electrochemical power cell."
@@ -154,7 +158,7 @@
 		var/datum/species/ethereal/E = H.dna.species
 		if(E.drain_time > world.time)
 			return
-		if(charge < 100)
+		if(charge < CELL_POWER_DRAIN)
 			to_chat(H, "<span class='warning'>The [src] doesn't have enough power!</span>")
 			return
 		var/obj/item/organ/stomach/ethereal/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
@@ -165,13 +169,13 @@
 			to_chat(H, "<span class='warning'>Your charge is full!</span>")
 			return
 		to_chat(H, "<span class='notice'>You clumsily channel power through the [src] and into your body, wasting some in the process.</span>")
-		E.drain_time = world.time + 20
-		if((charge < 100) || (stomach.crystal_charge >= ETHEREAL_CHARGE_FULL))
+		E.drain_time = world.time + CELL_DRAIN_TIME
+		if((charge < CELL_POWER_DRAIN) || (stomach.crystal_charge >= ETHEREAL_CHARGE_FULL))
 			return
-		if(do_after(user, 20, target = src))
-			to_chat(H, "<span class='notice'>You receive some charge from the [src].</span>")
-			stomach.adjust_charge(3)
-			charge -= 100 //you waste way more than you receive, so that ethereals cant just steal one cell and forget about hunger
+		if(do_after(user, CELL_DRAIN_TIME, target = src))
+			to_chat(H, "<span class='notice'>You receive some charge from [src], wasting some in the process.</span>")
+			stomach.adjust_charge(CELL_POWER_GAIN)
+			charge -= CELL_POWER_DRAIN //you waste way more than you receive, so that ethereals cant just steal one cell and forget about hunger
 		else
 			to_chat(H, "<span class='warning'>You fail to receive charge from the [src]!</span>")
 	return
@@ -383,3 +387,7 @@
 	var/area/A = get_area(src)
 	if(!A.lightswitch || !A.light_power)
 		charge = 0 //For naturally depowered areas, we start with no power
+
+#undef CELL_DRAIN_TIME
+#undef CELL_POWER_GAIN
+#undef CELL_POWER_DRAIN

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -12,6 +12,9 @@
 #define BROKEN_SPARKS_MIN (30 SECONDS)
 #define BROKEN_SPARKS_MAX (90 SECONDS)
 
+#define LIGHT_DRAIN_TIME 25
+#define LIGHT_POWER_GAIN 35
+
 /obj/item/wallframe/light_fixture
 	name = "light fixture frame"
 	desc = "Used for building lights."
@@ -660,12 +663,12 @@
 				if(E.drain_time > world.time)
 					return
 				to_chat(H, "<span class='notice'>You start channeling some power through the [fitting] into your body.</span>")
-				E.drain_time = world.time + 30
-				if(do_after(user, 30, target = src))
+				E.drain_time = world.time + LIGHT_DRAIN_TIME
+				if(do_after(user, LIGHT_DRAIN_TIME, target = src))
 					var/obj/item/organ/stomach/ethereal/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
 					if(istype(stomach))
 						to_chat(H, "<span class='notice'>You receive some charge from the [fitting].</span>")
-						stomach.adjust_charge(2)
+						stomach.adjust_charge(LIGHT_POWER_GAIN)
 					else
 						to_chat(H, "<span class='warning'>You fail to receive charge from the [fitting]!</span>")
 				return
@@ -908,3 +911,6 @@
 	layer = 2.5
 	light_type = /obj/item/light/bulb
 	fitting = "bulb"
+
+#undef LIGHT_DRAIN_TIME
+#undef LIGHT_POWER_GAIN

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -12,6 +12,7 @@
 #define BROKEN_SPARKS_MIN (30 SECONDS)
 #define BROKEN_SPARKS_MAX (90 SECONDS)
 
+//NSV13 added ethereal light interaction defines
 #define LIGHT_DRAIN_TIME 25
 #define LIGHT_POWER_GAIN 35
 
@@ -637,6 +638,7 @@
 	update(FALSE)
 	return
 
+//NSV13 added ethereal light interaction defines
 // attack with hand - remove tube/bulb
 // if hands aren't protected and the light is on, burn the player
 

--- a/code/modules/surgery/organs/stomach.dm
+++ b/code/modules/surgery/organs/stomach.dm
@@ -113,7 +113,7 @@
 		if(2)
 			owner.nutrition = 250
 			to_chat(owner, "<span class='warning'>Alert: EMP Detected. Cycling battery.</span>")
-			
+
 /obj/item/organ/stomach/cell/Insert(mob/living/carbon/M, special = 0)
 	..()
 	RegisterSignal(owner, COMSIG_PROCESS_BORGCHARGER_OCCUPANT, .proc/charge)
@@ -149,6 +149,7 @@
 	UnregisterSignal(owner, COMSIG_LIVING_ELECTROCUTE_ACT)
 	..()
 
+//NSV13 changed amount / x from x = 70 to x = 3.5
 /obj/item/organ/stomach/ethereal/proc/charge(datum/source, amount, repairs)
 	adjust_charge(amount / 3.5)
 

--- a/code/modules/surgery/organs/stomach.dm
+++ b/code/modules/surgery/organs/stomach.dm
@@ -150,7 +150,7 @@
 	..()
 
 /obj/item/organ/stomach/ethereal/proc/charge(datum/source, amount, repairs)
-	adjust_charge(amount / 70)
+	adjust_charge(amount / 3.5)
 
 /obj/item/organ/stomach/ethereal/proc/on_electrocute(datum/source, shock_damage, siemens_coeff = 1, flags = NONE)
 	if(flags & SHOCK_ILLUSION)


### PR DESCRIPTION

## About The Pull Request

This PR changes Ethereals to be more like TG ethereals in which they drain and can push large amounts of power but also lose a lot of power per life tick.

## Why It's Good For The Game

Instead of Ethereals being a remain around the APC race, they act like a very bright flame, fast burning, and requiring a lot of fuel to keep going.

## Changelog
:cl:
balance: ethereals now lose a lot more power per life tick and also gain much more from power sources.
/:cl:
