### PR TITLE
Allows teleportation on the mining ship

### DIFF
--- a/nsv13/game/areas.dm
+++ b/nsv13/game/areas.dm
@@ -199,7 +199,6 @@
 /area/maintenance/nsv/mining_ship
 	has_gravity = TRUE
 	looping_ambience = 'nsv13/sound/ambience/maintenance.ogg'
-	noteleport = TRUE
 
 /area/maintenance/nsv/mining_ship/central
 	name = "Rocinante maintenance"
@@ -505,7 +504,6 @@
 /area/nostromo
 	name = "DMC Rocinante"
 	ambientsounds = list('nsv13/sound/ambience/leit_motif.ogg','nsv13/sound/ambience/wind.ogg','nsv13/sound/ambience/wind2.ogg','nsv13/sound/ambience/wind3.ogg','nsv13/sound/ambience/wind4.ogg','nsv13/sound/ambience/wind5.ogg','nsv13/sound/ambience/wind6.ogg')
-	noteleport = TRUE
 	icon_state = "mining"
 	has_gravity = TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the noteleport variable from mining ship areas so that teleportation can be used.
Fixes #457
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I don't see any reason why teleportation shouldn't be allowed
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Teleportation can be used on the mining ship
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
