### PR TITLE
adds a protective nanocarbon glass wall to the tycoons cooling loop

### DIFF
--- a/_maps/map_files/Tycoon/Tycoon2.dmm
+++ b/_maps/map_files/Tycoon/Tycoon2.dmm
@@ -44137,6 +44137,13 @@
 /obj/item/stack/cable_coil,
 /turf/open/floor/monotile,
 /area/medical/chemistry)
+"eTX" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer1,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer3,
+/turf/open/space/basic,
+/area/space/nearstation)
 "eVQ" = (
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
@@ -44868,6 +44875,19 @@
 	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
+"hKS" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer3{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "hLd" = (
 /turf/closed/wall/ship,
 /area/hallway/secondary/service)
@@ -46722,6 +46742,13 @@
 	},
 /turf/open/floor/monotile,
 /area/crew_quarters/fitness/recreation)
+"nUo" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "nUJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -46951,6 +46978,19 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/science/mixing/chamber)
+"oHb" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer3{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "oHz" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -48396,6 +48436,19 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/fitness/recreation)
+"tNT" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer3{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "tPU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
@@ -48500,6 +48553,11 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
+"ulr" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/space/basic,
+/area/space/nearstation)
 "uqx" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -48843,6 +48901,19 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
+"vzu" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer3{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "vBD" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
@@ -101937,18 +102008,18 @@ pZC
 azk
 fUk
 atK
+hKS
+vzu
+mbI
+vzu
+hKS
+vzu
 mbI
 mbI
+vzu
 mbI
-mbI
-mbI
-mbI
-mbI
-mbI
-mbI
-mbI
-mbI
-mbI
+vzu
+hKS
 rLi
 aaa
 aaa
@@ -102194,18 +102265,18 @@ ano
 ano
 fUk
 cSU
+hKS
+nUo
 mbI
+nUo
+hKS
+nUo
 mbI
+vzu
+nUo
 mbI
-mbI
-mbI
-mbI
-mbI
-mbI
-mbI
-mbI
-mbI
-mbI
+nUo
+hKS
 rLi
 aaa
 aaa
@@ -102451,18 +102522,18 @@ apq
 atK
 fUk
 cSU
+hKS
+oHb
 mbI
+oHb
+hKS
+oHb
 mbI
+nUo
+oHb
 mbI
-mbI
-mbI
-mbI
-mbI
-mbI
-mbI
-mbI
-mbI
-mbI
+oHb
+hKS
 rLi
 aaa
 aaa
@@ -102708,18 +102779,18 @@ atK
 atK
 fUk
 atK
+vzu
+hKS
+vzu
 mbI
+vzu
 mbI
+vzu
+oHb
 mbI
-mbI
-mbI
-mbI
-mbI
-mbI
-mbI
-mbI
-mbI
-mbI
+vzu
+hKS
+vzu
 rLi
 aaa
 aaa
@@ -102965,18 +103036,18 @@ aDR
 aDR
 iJw
 atK
+nUo
+hKS
+nUo
+mbI
+nUo
+mbI
+nUo
 mbI
 mbI
-mbI
-mbI
-mbI
-mbI
-mbI
-mbI
-mbI
-mbI
-mbI
-mbI
+nUo
+hKS
+nUo
 rLi
 aaa
 aaa
@@ -103222,18 +103293,18 @@ atK
 atK
 atK
 atK
+oHb
+mbI
+oHb
+mbI
+oHb
+mbI
+oHb
 mbI
 mbI
-mbI
-mbI
-mbI
-mbI
-mbI
-mbI
-mbI
-mbI
-mbI
-mbI
+oHb
+hKS
+oHb
 rLi
 aaa
 aaa
@@ -103475,10 +103546,10 @@ azk
 fUk
 atK
 kRi
+jTD
+jTD
+jTD
 jUR
-jUR
-jUR
-jUR
 pZr
 sdw
 pZr
@@ -103490,7 +103561,7 @@ sdw
 pZr
 sdw
 pZr
-mbI
+hKS
 rLi
 aaa
 aaa
@@ -103731,21 +103802,21 @@ eVQ
 azk
 fUk
 atK
-tzE
+vzu
 iLm
-jUR
-jUR
-jUR
-jUR
-jUR
-jUR
-jUR
-jUR
-jUR
-jUR
-jUR
-jUR
-jUR
+tNT
+ulr
+eTX
+jTD
+jTD
+tNT
+ulr
+eTX
+jTD
+jTD
+tNT
+ulr
+eTX
 jUR
 pZr
 rLi
@@ -103988,7 +104059,7 @@ hPq
 azk
 fUk
 atK
-tzE
+nUo
 npS
 rLi
 rLi
@@ -104245,8 +104316,8 @@ hwT
 azk
 fUk
 atK
-tzE
-npS
+oHb
+vzu
 rLi
 aaa
 aaa
@@ -104503,7 +104574,7 @@ cBD
 fUk
 cSU
 tzE
-npS
+nUo
 rLi
 aaa
 aaa
@@ -104760,7 +104831,7 @@ azk
 fUk
 cSU
 tzE
-npS
+oHb
 rLi
 aaa
 aaa
@@ -105016,8 +105087,8 @@ hwT
 azk
 fUk
 atK
+vzu
 tzE
-npS
 rLi
 aaa
 aaa
@@ -105273,8 +105344,8 @@ eVQ
 azk
 fUk
 atK
+nUo
 tzE
-npS
 rLi
 aaa
 aaa
@@ -105530,8 +105601,8 @@ vbz
 azk
 dTo
 atK
+oHb
 tzE
-npS
 rLi
 aaa
 aaa
@@ -105788,7 +105859,7 @@ aDR
 iJw
 atK
 tzE
-npS
+vzu
 rLi
 aaa
 aaa
@@ -106045,7 +106116,7 @@ apq
 apq
 apq
 tzE
-npS
+nUo
 rLi
 aaa
 aaa
@@ -106302,7 +106373,7 @@ apq
 apq
 apq
 tzE
-npS
+oHb
 rLi
 aaa
 aaa
@@ -106554,9 +106625,9 @@ iRR
 jTD
 jTD
 jTD
-jTD
-jTD
-jTD
+tNT
+ulr
+eTX
 jTD
 rAf
 npS
@@ -106807,15 +106878,15 @@ aaa
 aaa
 rLi
 sdw
+tNT
+ulr
+eTX
+jTD
 jUR
-jUR
-jUR
-jUR
-jUR
-jUR
-jUR
-jUR
-jUR
+jTD
+tNT
+ulr
+eTX
 pZr
 rLi
 aaa

--- a/_maps/map_files/Tycoon/Tycoon2.dmm
+++ b/_maps/map_files/Tycoon/Tycoon2.dmm
@@ -43455,6 +43455,9 @@
 	},
 /turf/open/space/basic,
 /area/engine/atmos)
+"cSU" = (
+/turf/open/floor/plating,
+/area/space/nearstation)
 "cTn" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
@@ -44355,6 +44358,11 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/service)
+"fYc" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/ship,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "gbD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -47879,6 +47887,11 @@
 	},
 /turf/open/floor/monotile,
 /area/engine/engineering/reactor_core)
+"rLi" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/ship,
+/turf/open/space/basic,
+/area/space/nearstation)
 "rLI" = (
 /obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
 /turf/open/floor/engine,
@@ -100651,9 +100664,9 @@ aaJ
 fUk
 apq
 arT
-aBX
-aBX
-aBX
+fYc
+fYc
+fYc
 aaa
 aaa
 aaa
@@ -100908,7 +100921,7 @@ arT
 fUk
 apq
 arT
-aBX
+fYc
 aaa
 aaa
 aaa
@@ -101165,7 +101178,7 @@ aDR
 iJw
 arT
 arT
-aBX
+fYc
 aaa
 aaa
 aaa
@@ -101416,13 +101429,13 @@ aBX
 aBX
 aBX
 aBX
+cSU
+cSU
 aBX
 aBX
 aBX
 aBX
-aBX
-aBX
-aBX
+fYc
 aaa
 aaa
 aaa
@@ -101679,7 +101692,7 @@ kRi
 cTn
 iLm
 cTn
-atK
+rLi
 aaa
 aaa
 aaa
@@ -101936,7 +101949,7 @@ mbI
 mbI
 mbI
 mbI
-atK
+rLi
 aaa
 aaa
 aaa
@@ -102180,7 +102193,7 @@ ano
 ano
 ano
 fUk
-atK
+cSU
 mbI
 mbI
 mbI
@@ -102193,7 +102206,7 @@ mbI
 mbI
 mbI
 mbI
-atK
+rLi
 aaa
 aaa
 aaa
@@ -102437,7 +102450,7 @@ arT
 apq
 atK
 fUk
-atK
+cSU
 mbI
 mbI
 mbI
@@ -102450,7 +102463,7 @@ mbI
 mbI
 mbI
 mbI
-atK
+rLi
 aaa
 aaa
 aaa
@@ -102707,7 +102720,7 @@ mbI
 mbI
 mbI
 mbI
-atK
+rLi
 aaa
 aaa
 aaa
@@ -102964,7 +102977,7 @@ mbI
 mbI
 mbI
 mbI
-atK
+rLi
 aaa
 aaa
 aaa
@@ -103221,7 +103234,7 @@ mbI
 mbI
 mbI
 mbI
-atK
+rLi
 aaa
 aaa
 aaa
@@ -103478,7 +103491,7 @@ pZr
 sdw
 pZr
 mbI
-atK
+rLi
 aaa
 aaa
 aaa
@@ -103735,7 +103748,7 @@ jUR
 jUR
 jUR
 pZr
-atK
+rLi
 aaa
 aaa
 aaa
@@ -103977,22 +103990,22 @@ fUk
 atK
 tzE
 npS
-atK
-atK
-atK
-atK
-atK
-atK
-atK
-atK
-atK
-atK
-atK
-atK
-atK
-atK
-atK
-atK
+rLi
+rLi
+rLi
+rLi
+rLi
+rLi
+rLi
+rLi
+rLi
+rLi
+rLi
+rLi
+rLi
+rLi
+rLi
+rLi
 aaa
 aaa
 aaa
@@ -104234,7 +104247,7 @@ fUk
 atK
 tzE
 npS
-atK
+rLi
 aaa
 aaa
 aaa
@@ -104488,10 +104501,10 @@ jtu
 eVQ
 cBD
 fUk
-atK
+cSU
 tzE
 npS
-atK
+rLi
 aaa
 aaa
 aaa
@@ -104745,10 +104758,10 @@ wwd
 urB
 azk
 fUk
-atK
+cSU
 tzE
 npS
-atK
+rLi
 aaa
 aaa
 aaa
@@ -105005,7 +105018,7 @@ fUk
 atK
 tzE
 npS
-atK
+rLi
 aaa
 aaa
 aaa
@@ -105262,7 +105275,7 @@ fUk
 atK
 tzE
 npS
-atK
+rLi
 aaa
 aaa
 aaa
@@ -105519,7 +105532,7 @@ dTo
 atK
 tzE
 npS
-atK
+rLi
 aaa
 aaa
 aaa
@@ -105764,7 +105777,7 @@ atK
 atK
 aaJ
 aaJ
-atK
+rLi
 ygv
 qKe
 sul
@@ -105776,7 +105789,7 @@ iJw
 atK
 tzE
 npS
-atK
+rLi
 aaa
 aaa
 aaa
@@ -106021,19 +106034,19 @@ aaJ
 aaJ
 aaJ
 aaJ
-atK
+rLi
 npS
 fCZ
-aaJ
-aaJ
-aaJ
-aaJ
-aaJ
-aaJ
-aaJ
+apq
+apq
+apq
+apq
+apq
+apq
+apq
 tzE
 npS
-atK
+rLi
 aaa
 aaa
 aaa
@@ -106278,19 +106291,19 @@ aaa
 aaa
 aaa
 aaa
-atK
+rLi
 npS
 xyX
-aaJ
-aaJ
-aaJ
-aaJ
-aaJ
-aaJ
-aaJ
+apq
+apq
+apq
+apq
+apq
+apq
+apq
 tzE
 npS
-atK
+rLi
 aaa
 aaa
 aaa
@@ -106535,7 +106548,7 @@ aaa
 aaa
 aaa
 aaa
-atK
+rLi
 npS
 iRR
 jTD
@@ -106547,7 +106560,7 @@ jTD
 jTD
 rAf
 npS
-atK
+rLi
 aaa
 aaa
 aaa
@@ -106792,7 +106805,7 @@ aaa
 aaa
 aaa
 aaa
-atK
+rLi
 sdw
 jUR
 jUR
@@ -106804,7 +106817,7 @@ jUR
 jUR
 jUR
 pZr
-atK
+rLi
 aaa
 aaa
 aaa
@@ -107049,19 +107062,19 @@ aaa
 aaa
 aaa
 aaa
-atK
-atK
-atK
-atK
-atK
-atK
-atK
-atK
-atK
-atK
-atK
-atK
-atK
+rLi
+rLi
+rLi
+rLi
+rLi
+rLi
+rLi
+rLi
+rLi
+rLi
+rLi
+rLi
+rLi
 aaa
 aaa
 aaa


### PR DESCRIPTION
## About The Pull Request

This PR adds a protective nanocarbon window layer around the Tycoon's RBMK cooling loop and adds layer manifold redundancy to help keep cooling flowing and allows more readily access to it

![image](https://user-images.githubusercontent.com/33578623/97066661-b44ceb80-157c-11eb-8162-9b48100744ee.png)


## Why It's Good For The Game

Its incredibly hard to prevent a nuclear meltdown during intense combat due to the low protection that the grilles provide, to say nothing about the sensitivity of the heat exchange pipes, this will help to alleviate the issue.

## Changelog
:cl:

tweak:  added a protective nanocarbon window layer around the tycoon and made cooling loop access easier by cutting a few grilles, and also added redundancy layer manifolds to keep gas flowing longer

/:cl: