### PR TITLE
Overmap Shield Tech -> Data Disk

### DIFF
--- a/nsv13/code/modules/overmap/shieldgen.dm
+++ b/nsv13/code/modules/overmap/shieldgen.dm
@@ -30,10 +30,11 @@
 	id = "ship_shield_tech";
 	display_name = "Experimental Shield Technology";
 	description = "Highly experimental shield technology to vastly increase survivability in ships. Although Nanotrasen researchers have had access to this technology for quite some time, the incredible amount of power required to maintain shields has proven to be the greatest challenge in implementing them.";
-	prereq_ids = list("adv_engi");
+	prereq_ids = list("");
 	design_ids = list("shield_fan", "shield_capacitor", "shield_modulator", "shield_interface", "shield_frame");
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1000);
 	export_price = 5000;
+	hidden = TRUE
 }
 
 /datum/design/shield_fan
@@ -96,6 +97,25 @@
 	category = list("Experimental Technology");
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE;
 }
+
+/obj/item/disk/design_disk/overmap_shields
+	name = "SolGov Experimental Shielding Technology Disk"
+	desc = "This disk is the property of SolGov, unlawful use of the data contained on this disk is prohibited."
+	icon_state = "datadisk2"
+	max_blueprints = 5
+
+/obj/item/disk/design_disk/overmap_shields/Initialize()
+	. = ..()
+	var/datum/design/shield_fan/A = new
+	var/datum/design/shield_capacitor/B = new
+	var/datum/design/shield_modulator/C = new
+	var/datum/design/shield_interface/D = new
+	var/datum/design/shield_frame/E = new
+	blueprints[1] = A
+	blueprints[2] = B
+	blueprints[3] = C
+	blueprints[4] = D
+	blueprints[5] = E
 
 /obj/structure/shieldgen_frame/attackby(obj/item/I, mob/living/user, params)
 	if(state != 11){

--- a/nsv13/code/modules/overmap/traders.dm
+++ b/nsv13/code/modules/overmap/traders.dm
@@ -90,7 +90,7 @@
 	faction_type = FACTION_ID_SYNDICATE
 	system_type = "syndicate"
 	//Top tier trader with the best items available.
-	sold_items = list(/datum/trader_item/nuke,/datum/trader_item/torpedo, /datum/trader_item/missile, /datum/trader_item/mac, /datum/trader_item/railgun, /datum/trader_item/c20r, /datum/trader_item/c45, /datum/trader_item/stechkin, /datum/trader_item/pdc, /datum/trader_item/flak, /datum/trader_item/fighter/syndicate)
+	sold_items = list(/datum/trader_item/nuke,/datum/trader_item/torpedo, /datum/trader_item/missile, /datum/trader_item/mac, /datum/trader_item/railgun, /datum/trader_item/c20r, /datum/trader_item/c45, /datum/trader_item/stechkin, /datum/trader_item/pdc, /datum/trader_item/flak, /datum/trader_item/fighter/syndicate, /datum/trader_item/overmap_shields)
 	station_type = /obj/structure/overmap/trader/syndicate
 	image = "https://cdn.discordapp.com/attachments/728055734159540244/764570187357093928/unknown.png"
 	greetings = list("You've made it pretty far in, huh? We won't tell if you're buying...", "Freedom isn't free, buy a gun to secure yours.", "Excercise your right to bear arms now!")

--- a/nsv13/code/modules/overmap/traders_items.dm
+++ b/nsv13/code/modules/overmap/traders_items.dm
@@ -256,3 +256,10 @@
 	price = 100
 	stock = 5
 	unlock_path = /obj/item/ammo_box/magazine/tazer_cartridge
+
+/datum/trader_item/overmap_shields
+	name = "SolGov Experimental Shielding Technology Disk"
+	desc = "Stolen straight out from under their noses! Pity we don't know how to read it."
+	price = 100000
+	stock = 1
+	unlock_path = /obj/item/disk/design_disk/overmap_shields


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR moves the Solgov Experimental Shield Technology from a techweb into a data disk in order for it to be a starmap acquired item rather than just sitting and researching it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Discourages turtling at round start for shields.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added Shield Tech data disk
del: Removed the ability to research shields at round start
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
