### PR TITLE
Pegasus atmos changes

### DIFF
--- a/_maps/map_files/Pegasus/pegasus1.dmm
+++ b/_maps/map_files/Pegasus/pegasus1.dmm
@@ -1350,10 +1350,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/science/mixing)
-"aLI" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible/layer3,
-/turf/closed/wall/steel,
-/area/engine/atmos)
 "aLK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -2225,22 +2221,16 @@
 /turf/open/floor/engine,
 /area/engine/atmos)
 "bjC" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "N2O to Mix"
+/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 8
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump/layer3{
-	dir = 8;
-	name = "N2O to Stormdrive Flavouriser"
-	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible/layer3,
 /turf/open/floor/monotile,
 /area/engine/atmos)
 "bjO" = (
@@ -4972,11 +4962,8 @@
 /turf/open/floor/engine/n2,
 /area/engine/atmos)
 "cTa" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 6
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
@@ -6457,11 +6444,23 @@
 /turf/closed/wall/steel,
 /area/engine/engine_smes)
 "dNX" = (
-/obj/structure/sign/ship/fire{
+/obj/machinery/atmospherics/pipe/simple/green/visible/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "N2O to Mix"
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/binary/magnetic_constrictor,
-/turf/closed/wall/steel,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/pump/layer3{
+	dir = 8;
+	name = "N2O to Stormdrive Flavouriser"
+	},
+/turf/open/floor/monotile,
 /area/engine/atmos)
 "dOt" = (
 /obj/machinery/door_timer{
@@ -7396,6 +7395,10 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/break_room)
+"eww" = (
+/obj/machinery/atmospherics/pipe/simple/dark/visible/layer3,
+/turf/closed/wall/steel,
+/area/engine/atmos)
 "ewR" = (
 /obj/machinery/light{
 	dir = 1
@@ -7850,13 +7853,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1{
+	dir = 8
 	},
 /turf/open/floor/monotile,
 /area/engine/atmos)
@@ -9233,6 +9238,13 @@
 /obj/machinery/light_switch/west,
 /turf/open/floor/monotile/dark,
 /area/science/robotics)
+"fKS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
+	dir = 9
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/atmos)
 "fKW" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -12032,13 +12044,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/science/mixing)
-"hus" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1,
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
-	dir = 9
-	},
-/turf/open/floor/monotile/dark,
-/area/engine/atmos)
 "huI" = (
 /obj/structure/transit_tube/curved{
 	dir = 4
@@ -12570,8 +12575,11 @@
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/frame1/central)
 "hJJ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/green/visible/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 6
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
@@ -12761,12 +12769,12 @@
 /turf/open/floor/circuit/telecomms/server,
 /area/science/server)
 "hQW" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
+/obj/structure/sign/ship/fire{
 	dir = 1
 	},
-/turf/open/floor/engine,
-/area/space)
+/obj/machinery/atmospherics/components/binary/magnetic_constrictor,
+/turf/closed/wall/steel,
+/area/engine/atmos)
 "hRc" = (
 /obj/structure/cable{
 	icon_state = "1-6"
@@ -13995,9 +14003,11 @@
 /area/security/processing)
 "iIh" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/manifold/purple/visible,
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 1
+	},
 /turf/open/floor/engine,
-/area/engine/atmos)
+/area/space)
 "iIq" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -16082,11 +16092,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/binary/valve/digital/on{
-	dir = 8;
+/obj/machinery/atmospherics/pipe/simple/brown/visible,
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	dir = 4;
 	name = "Bypass All Mixers"
 	},
-/obj/machinery/atmospherics/pipe/simple/brown/visible,
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "jZo" = (
@@ -17530,13 +17540,9 @@
 /turf/open/floor/monotile/dark,
 /area/engine/storage)
 "kNA" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
-	dir = 6
-	},
-/obj/machinery/atmospherics/components/trinary/filter/atmos/plasma/flipped{
-	dir = 8
-	},
-/turf/open/floor/engine/airless,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/manifold/purple/visible,
+/turf/open/floor/engine,
 /area/engine/atmos)
 "kNP" = (
 /obj/effect/turf_decal/stripes/line{
@@ -18665,6 +18671,7 @@
 /obj/machinery/meter{
 	name = "Stormdrive Outlet Readout"
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "lxL" = (
@@ -22422,8 +22429,8 @@
 /turf/open/floor/plasteel/grid/steel,
 /area/nsv/hanger/notkmcstupidhanger)
 "nMA" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/machinery/atmospherics/pipe/manifold/purple/visible,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "nNa" = (
@@ -25110,6 +25117,13 @@
 /obj/machinery/light,
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/frame1/central)
+"pul" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1,
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/atmos)
 "puw" = (
 /obj/structure/munitions_trolley,
 /turf/open/floor/monotile/light,
@@ -26385,7 +26399,6 @@
 /obj/machinery/atmospherics/pipe/simple/dark/visible/layer3{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "qkg" = (
@@ -27962,8 +27975,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/binary/valve/digital{
-	dir = 4;
+/obj/machinery/atmospherics/components/binary/valve/digital/on{
+	dir = 8;
 	name = "Bypass Plasma Stage"
 	},
 /turf/open/floor/monotile/dark,
@@ -33068,19 +33081,19 @@
 /turf/open/floor/monotile,
 /area/security/processing)
 "upy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
-	dir = 4
-	},
 /obj/machinery/meter/atmos/distro_loop{
 	pixel_x = -6;
 	pixel_y = -6;
 	target_layer = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible/layer3,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 4
 	},
 /turf/open/floor/monotile,
@@ -36279,7 +36292,9 @@
 /obj/machinery/atmospherics/pipe/simple/dark/visible/layer3{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
+	dir = 4
+	},
 /turf/open/floor/monotile,
 /area/engine/atmos)
 "wAH" = (
@@ -36718,13 +36733,11 @@
 	dir = 4;
 	pixel_x = -26
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/monotile,
 /area/engine/atmos)
 "wOO" = (
@@ -37018,11 +37031,13 @@
 	},
 /area/maintenance/nsv/bridge)
 "wYr" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/plasma/flipped{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/turf/open/floor/engine/airless,
 /area/engine/atmos)
 "wYT" = (
 /obj/item/fighter_component/armour_plating,
@@ -37234,11 +37249,11 @@
 /turf/open/floor/monotile,
 /area/security/warden)
 "xgg" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1,
+/obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
 	dir = 8
 	},
-/turf/open/floor/monotile/dark,
+/turf/open/floor/engine,
 /area/engine/atmos)
 "xgi" = (
 /obj/structure/cable{
@@ -84710,8 +84725,8 @@ qFu
 eZl
 vME
 nXl
+cTa
 nXl
-hJJ
 lTw
 sIm
 hWO
@@ -85222,13 +85237,13 @@ fkN
 fkN
 fHG
 onq
-cTa
+hJJ
 aFh
 dZk
 nXl
 lTw
 lxK
-hWO
+bjC
 hOu
 aHE
 xlk
@@ -85480,8 +85495,8 @@ bRj
 nBf
 nAn
 mcx
-dNX
-iIh
+hQW
+kNA
 hXK
 vFq
 nMA
@@ -85737,8 +85752,8 @@ iDo
 fkN
 vOR
 aTc
-hQW
-kNA
+iIh
+wYr
 nBf
 jZb
 hKT
@@ -86000,7 +86015,7 @@ nBf
 sqf
 qke
 wAF
-aLI
+eww
 sRg
 pSs
 hXK
@@ -86509,7 +86524,7 @@ qKM
 cOz
 lYB
 cMZ
-wYr
+xgg
 hXK
 neo
 uux
@@ -87280,7 +87295,7 @@ npl
 npl
 ftl
 kYz
-xgg
+pul
 gXv
 hfs
 gMR
@@ -88051,7 +88066,7 @@ sFl
 sFl
 hrR
 sFl
-hus
+fKS
 wea
 etu
 sbf
@@ -88560,7 +88575,7 @@ kju
 rCD
 gSf
 rzv
-bjC
+dNX
 beB
 vTb
 fOT

--- a/_maps/map_files/Pegasus/pegasus1.dmm
+++ b/_maps/map_files/Pegasus/pegasus1.dmm
@@ -312,6 +312,9 @@
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "afz" = (
@@ -949,11 +952,14 @@
 /turf/open/floor/carpet/red,
 /area/security/processing)
 "aAk" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible/layer3{
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
 	dir = 4
 	},
-/turf/open/floor/carpet/orange,
-/area/engine/atmos)
+/turf/open/floor/monotile/dark,
+/area/space)
 "aAy" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -1597,8 +1603,8 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/purple/visible{
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
@@ -2215,19 +2221,22 @@
 /turf/open/floor/engine,
 /area/engine/atmos)
 "bjC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/green/visible/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "N2O to Mix"
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 4
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/dark/visible/layer3,
+/obj/machinery/atmospherics/components/binary/pump/layer3{
+	dir = 8;
+	name = "N2O to Stormdrive Flavouriser"
+	},
 /turf/open/floor/monotile,
 /area/engine/atmos)
 "bjO" = (
@@ -4959,7 +4968,12 @@
 /turf/open/floor/engine/n2,
 /area/engine/atmos)
 "cTa" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/machinery/atmospherics/pipe/simple/green/visible/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 6
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "cTr" = (
@@ -6439,10 +6453,11 @@
 /turf/closed/wall/steel,
 /area/engine/engine_smes)
 "dNX" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 5
+/obj/structure/sign/ship/fire{
+	dir = 1
 	},
-/turf/open/floor/monotile/dark,
+/obj/machinery/atmospherics/components/binary/magnetic_constrictor,
+/turf/closed/wall/steel,
 /area/engine/atmos)
 "dOt" = (
 /obj/machinery/door_timer{
@@ -6759,10 +6774,10 @@
 	},
 /area/maintenance/nsv/deck1/starboard)
 "dZk" = (
-/obj/machinery/atmospherics/pipe/manifold/purple/visible{
-	dir = 4
-	},
 /obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 5
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "dZo" = (
@@ -10888,15 +10903,6 @@
 	},
 /turf/open/floor/monotile,
 /area/science/mixing)
-"gJH" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/purple/visible{
-	dir = 1
-	},
-/turf/open/floor/monotile/dark,
-/area/engine/atmos)
 "gJX" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -11980,6 +11986,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3,
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "hsC" = (
@@ -12550,9 +12557,6 @@
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/frame1/central)
 "hJJ" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 5
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
@@ -12586,10 +12590,10 @@
 /turf/open/floor/plasteel/grid/lino,
 /area/tcommsat/server)
 "hKT" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 8
+/obj/machinery/atmospherics/components/trinary/mixer{
+	dir = 8;
+	name = "N2O Line Additive"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "hLp" = (
@@ -12744,10 +12748,12 @@
 /turf/open/floor/circuit/telecomms/server,
 /area/science/server)
 "hQW" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 1
+	},
 /turf/open/floor/engine,
-/area/engine/atmos)
+/area/space)
 "hRc" = (
 /obj/structure/cable{
 	icon_state = "1-6"
@@ -13975,9 +13981,9 @@
 /turf/open/floor/monotile,
 /area/security/processing)
 "iIh" = (
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/obj/machinery/atmospherics/pipe/simple/dark/visible/layer3,
-/turf/open/floor/monotile/dark,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/manifold/purple/visible,
+/turf/open/floor/engine,
 /area/engine/atmos)
 "iIq" = (
 /obj/machinery/camera/autoname{
@@ -14902,6 +14908,13 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
 /area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
+"jpm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
+	dir = 9
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/atmos)
 "jpz" = (
 /obj/machinery/power/solar,
 /obj/structure/cable/yellow{
@@ -16060,15 +16073,14 @@
 /turf/open/floor/monotile,
 /area/ai_monitored/storage/eva)
 "jZb" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 9
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/dark/visible/layer3{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/valve/digital/on{
+	dir = 8;
+	name = "Bypass All Mixers"
 	},
+/obj/machinery/atmospherics/pipe/simple/brown,
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "jZo" = (
@@ -17512,9 +17524,6 @@
 /turf/open/floor/monotile/dark,
 /area/engine/storage)
 "kNA" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 5
-	},
 /obj/machinery/meter{
 	name = "Constrictor -> Tank Readout"
 	},
@@ -17698,11 +17707,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
 	dir = 4
 	},
 /turf/open/floor/monotile,
@@ -18642,13 +18653,13 @@
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "lxK" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/dark/visible/layer3{
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
 	dir = 6
 	},
-/turf/open/floor/monotile/dark,
+/obj/machinery/atmospherics/components/trinary/filter/atmos/plasma/flipped{
+	dir = 8
+	},
+/turf/open/floor/engine/airless,
 /area/engine/atmos)
 "lxL" = (
 /obj/structure/disposalpipe/trunk/multiz/down,
@@ -19578,12 +19589,12 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
 "mcx" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/trinary/filter/flipped/on/layer3{
 	dir = 8;
 	filter_type = "plasma"
+	},
+/obj/machinery/atmospherics/pipe/manifold/purple/visible{
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
@@ -21312,8 +21323,11 @@
 /obj/machinery/atmospherics/components/binary/pump/layer1{
 	name = "Mix to Distro"
 	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
+	dir = 6
+	},
 /turf/open/floor/monotile/dark,
-/area/engine/atmos)
+/area/space)
 "nae" = (
 /obj/structure/sign/ship/nosmoking{
 	dir = 8;
@@ -22402,13 +22416,8 @@
 /turf/open/floor/plasteel/grid/steel,
 /area/nsv/hanger/notkmcstupidhanger)
 "nMA" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/obj/machinery/atmospherics/pipe/simple/dark/visible/layer3{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/manifold/purple/visible,
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "nNa" = (
@@ -25538,6 +25547,9 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "pHZ" = (
@@ -26367,6 +26379,10 @@
 /obj/machinery/meter{
 	name = "Stormdrive Outlet Readout"
 	},
+/obj/machinery/atmospherics/pipe/simple/dark/visible/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "qkg" = (
@@ -27945,7 +27961,7 @@
 	},
 /obj/machinery/atmospherics/components/binary/valve/digital{
 	dir = 4;
-	name = "Bypass All Mixers"
+	name = "Bypass Plasma Stage"
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
@@ -28431,6 +28447,9 @@
 /area/science/xenobiology)
 "rvY" = (
 /obj/machinery/atmospherics/components/binary/pump,
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
+	dir = 4
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "rws" = (
@@ -29242,6 +29261,10 @@
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/ai_monitored/turret_protected/AIsatextAP)
+"rZP" = (
+/obj/machinery/atmospherics/pipe/simple/dark/visible/layer3,
+/turf/closed/wall/steel,
+/area/engine/atmos)
 "saA" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -29735,6 +29758,9 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1,
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "spX" = (
@@ -29756,14 +29782,12 @@
 /turf/open/floor/monotile,
 /area/security/checkpoint)
 "sqf" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/dark/visible/layer3{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/dark/visible/layer3,
+/obj/machinery/atmospherics/pipe/manifold/purple/visible{
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
@@ -30288,6 +30312,7 @@
 /area/space/nearstation)
 "sFl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3,
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "sFB" = (
@@ -30747,7 +30772,7 @@
 "sRg" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/machinery/atmospherics/pipe/simple/dark/visible/layer3{
-	dir = 4
+	dir = 5
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
@@ -34875,16 +34900,13 @@
 	},
 /area/maintenance/nsv/deck1/starboard)
 "vFq" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 8
-	},
 /obj/machinery/light_switch{
 	pixel_y = 28
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/dark/visible/layer3{
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 6
 	},
 /turf/open/floor/monotile/dark,
@@ -34928,6 +34950,9 @@
 "vGh" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1,
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on,
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
+	dir = 8
+	},
 /turf/open/floor/engine/airless,
 /area/engine/atmos)
 "vGr" = (
@@ -35120,9 +35145,6 @@
 "vME" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible/layer3{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 6
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
@@ -35929,6 +35951,12 @@
 "wpr" = (
 /obj/machinery/portable_atmospherics/canister/constricted_plasma,
 /obj/machinery/atmospherics/pipe/simple/dark/visible/layer1,
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 8
+	},
 /turf/open/floor/engine/airless,
 /area/engine/atmos)
 "wpI" = (
@@ -36239,9 +36267,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Central";
 	dir = 1
@@ -36252,6 +36277,10 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/dark/visible/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
 /turf/open/floor/monotile,
 /area/engine/atmos)
 "wAH" = (
@@ -36442,6 +36471,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/binary/passive_gate/layer3,
 /turf/open/floor/monotile,
 /area/engine/atmos)
 "wHh" = (
@@ -36989,10 +37019,11 @@
 	},
 /area/maintenance/nsv/bridge)
 "wYr" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible/layer3{
-	dir = 5
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
+	dir = 8
 	},
-/turf/open/floor/carpet/orange,
+/turf/open/floor/engine,
 /area/engine/atmos)
 "wYT" = (
 /obj/item/fighter_component/armour_plating,
@@ -37204,7 +37235,10 @@
 /turf/open/floor/monotile,
 /area/security/warden)
 "xgg" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/plasma,
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1,
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "xgi" = (
@@ -84676,8 +84710,8 @@ mAp
 qFu
 eZl
 vME
-cTa
-cTa
+nXl
+nXl
 hJJ
 lTw
 sIm
@@ -84932,10 +84966,10 @@ eWw
 iZB
 fHG
 dif
-gJH
-aFh
-dNX
-sIm
+vME
+nXl
+nXl
+nXl
 lTw
 sIm
 hWO
@@ -85189,15 +85223,15 @@ fkN
 fkN
 fHG
 onq
-gJH
+cTa
 aFh
 dZk
-xgg
+nXl
 kNA
-lxK
-bjC
-iIh
-wYr
+sIm
+hWO
+hOu
+aHE
 xlk
 fth
 xhW
@@ -85447,14 +85481,14 @@ bRj
 nBf
 nAn
 mcx
-cMZ
-fkN
+dNX
+iIh
 hXK
 vFq
 nMA
 upy
 hOu
-aAk
+aHE
 eKG
 vcs
 fth
@@ -85704,14 +85738,14 @@ iDo
 fkN
 vOR
 aTc
-fkN
-gsm
 hQW
+lxK
+gqf
 jZb
 hKT
 kSu
 hXK
-aAk
+aHE
 sts
 pvD
 bnN
@@ -85967,7 +86001,7 @@ nBf
 sqf
 qke
 wAF
-hXK
+rZP
 sRg
 pSs
 hXK
@@ -86476,7 +86510,7 @@ qKM
 cOz
 lYB
 cMZ
-fkN
+wYr
 hXK
 neo
 uux
@@ -87247,7 +87281,7 @@ npl
 npl
 ftl
 kYz
-dSH
+xgg
 gXv
 hfs
 gMR
@@ -88018,7 +88052,7 @@ sFl
 sFl
 hrR
 sFl
-sFl
+jpm
 wea
 etu
 sbf
@@ -88270,7 +88304,7 @@ nXl
 tgU
 qDL
 aAH
-htu
+aAk
 aAH
 aAH
 aAH
@@ -88527,7 +88561,7 @@ kju
 rCD
 gSf
 rzv
-svs
+bjC
 beB
 vTb
 fOT

--- a/_maps/map_files/Pegasus/pegasus1.dmm
+++ b/_maps/map_files/Pegasus/pegasus1.dmm
@@ -13758,6 +13758,15 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/nsv/deck1/starboard)
+"iAH" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold/visible{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/atmos)
 "iBk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -15357,6 +15366,18 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/frame3/central)
+"jBN" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
+	dir = 9
+	},
+/obj/machinery/meter{
+	name = "Constricted Plasma output meter"
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/atmos)
 "jBP" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -16005,15 +16026,6 @@
 "jVM" = (
 /turf/open/openspace,
 /area/maintenance/nsv/deck1/starboard)
-"jVY" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
-	dir = 1
-	},
-/turf/open/floor/monotile/dark,
-/area/engine/atmos)
 "jWl" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -18936,6 +18948,15 @@
 	icon_state = "panelscorched"
 	},
 /area/nsv/weapons/gauss/battery/deck1/port)
+"lDJ" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
+	dir = 1
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/atmos)
 "lEr" = (
 /obj/structure/bed/dogbed/ian{
 	color = "";
@@ -21762,15 +21783,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
-"nmB" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold/visible{
-	dir = 8
-	},
-/turf/open/floor/monotile/dark,
-/area/engine/atmos)
 "nmY" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -28625,18 +28637,6 @@
 	},
 /turf/open/floor/monotile,
 /area/engine/atmos)
-"rzw" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
-	dir = 9
-	},
-/obj/machinery/meter{
-	name = "Constricted Plasma output meter"
-	},
-/turf/open/floor/monotile/dark,
-/area/engine/atmos)
 "rzE" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -35000,6 +35000,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 9
 	},
+/obj/machinery/portable_atmospherics/canister/constricted_plasma,
 /turf/open/floor/engine/airless,
 /area/engine/atmos)
 "vGr" = (
@@ -35999,7 +36000,6 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "wpr" = (
-/obj/machinery/portable_atmospherics/canister/constricted_plasma,
 /obj/machinery/atmospherics/pipe/simple/dark/visible/layer1,
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
@@ -85022,7 +85022,7 @@ hJJ
 hQW
 iIh
 sIm
-nmB
+iAH
 sIm
 hWO
 hXK
@@ -85278,8 +85278,8 @@ onq
 hJJ
 aFh
 dZk
-jVY
-rzw
+lDJ
+jBN
 lxK
 bjC
 hOu

--- a/_maps/map_files/Pegasus/pegasus1.dmm
+++ b/_maps/map_files/Pegasus/pegasus1.dmm
@@ -1350,6 +1350,10 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/science/mixing)
+"aLI" = (
+/obj/machinery/atmospherics/pipe/simple/dark/visible/layer3,
+/turf/closed/wall/steel,
+/area/engine/atmos)
 "aLK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -6774,9 +6778,11 @@
 	},
 /area/maintenance/nsv/deck1/starboard)
 "dZk" = (
-/obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 5
+	},
+/obj/machinery/meter{
+	name = "Constrictor -> Tank Readout"
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
@@ -12026,6 +12032,13 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/science/mixing)
+"hus" = (
+/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
+	dir = 9
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/atmos)
 "huI" = (
 /obj/structure/transit_tube/curved{
 	dir = 4
@@ -14908,13 +14921,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
 /area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
-"jpm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1,
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
-	dir = 9
-	},
-/turf/open/floor/monotile/dark,
-/area/engine/atmos)
 "jpz" = (
 /obj/machinery/power/solar,
 /obj/structure/cable/yellow{
@@ -16080,7 +16086,7 @@
 	dir = 8;
 	name = "Bypass All Mixers"
 	},
-/obj/machinery/atmospherics/pipe/simple/brown,
+/obj/machinery/atmospherics/pipe/simple/brown/visible,
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "jZo" = (
@@ -17524,13 +17530,13 @@
 /turf/open/floor/monotile/dark,
 /area/engine/storage)
 "kNA" = (
-/obj/machinery/meter{
-	name = "Constrictor -> Tank Readout"
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
+	dir = 6
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/components/trinary/filter/atmos/plasma/flipped{
+	dir = 8
 	},
-/turf/open/floor/monotile/dark,
+/turf/open/floor/engine/airless,
 /area/engine/atmos)
 "kNP" = (
 /obj/effect/turf_decal/stripes/line{
@@ -18653,13 +18659,13 @@
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "lxK" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
-	dir = 6
-	},
-/obj/machinery/atmospherics/components/trinary/filter/atmos/plasma/flipped{
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 8
 	},
-/turf/open/floor/engine/airless,
+/obj/machinery/meter{
+	name = "Stormdrive Outlet Readout"
+	},
+/turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "lxL" = (
 /obj/structure/disposalpipe/trunk/multiz/down,
@@ -26376,9 +26382,6 @@
 /area/security/checkpoint)
 "qke" = (
 /obj/machinery/atmospherics/pipe/manifold/purple/visible,
-/obj/machinery/meter{
-	name = "Stormdrive Outlet Readout"
-	},
 /obj/machinery/atmospherics/pipe/simple/dark/visible/layer3{
 	dir = 1
 	},
@@ -29261,10 +29264,6 @@
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/ai_monitored/turret_protected/AIsatextAP)
-"rZP" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible/layer3,
-/turf/closed/wall/steel,
-/area/engine/atmos)
 "saA" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -85227,8 +85226,8 @@ cTa
 aFh
 dZk
 nXl
-kNA
-sIm
+lTw
+lxK
 hWO
 hOu
 aHE
@@ -85739,8 +85738,8 @@ fkN
 vOR
 aTc
 hQW
-lxK
-gqf
+kNA
+nBf
 jZb
 hKT
 kSu
@@ -86001,7 +86000,7 @@ nBf
 sqf
 qke
 wAF
-rZP
+aLI
 sRg
 pSs
 hXK
@@ -88052,7 +88051,7 @@ sFl
 sFl
 hrR
 sFl
-jpm
+hus
 wea
 etu
 sbf

--- a/_maps/map_files/Pegasus/pegasus1.dmm
+++ b/_maps/map_files/Pegasus/pegasus1.dmm
@@ -1096,7 +1096,12 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/security/armory)
 "aFh" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/machinery/atmospherics/pipe/simple/green/visible/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/purple/visible{
+	dir = 1
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "aFJ" = (
@@ -1599,15 +1604,6 @@
 	},
 /turf/open/floor/engine,
 /area/nsv/weapons/gauss/battery/deck1/port)
-"aTc" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 4
-	},
-/turf/open/floor/monotile/dark,
-/area/engine/atmos)
 "aTq" = (
 /turf/open/floor/monotile/dark,
 /area/science/mixing)
@@ -4859,15 +4855,6 @@
 	},
 /turf/open/floor/monotile,
 /area/engine/atmos)
-"cOZ" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
-	dir = 1
-	},
-/turf/open/floor/monotile/dark,
-/area/engine/atmos)
 "cPk" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4880,18 +4867,6 @@
 	},
 /turf/open/floor/monotile,
 /area/engine/engine_room)
-"cPn" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
-	dir = 9
-	},
-/obj/machinery/meter{
-	name = "Constricted Plasma output meter"
-	},
-/turf/open/floor/monotile/dark,
-/area/engine/atmos)
 "cQD" = (
 /obj/structure/sign/ship/securearea{
 	dir = 4;
@@ -4986,8 +4961,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/purple/visible{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 5
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
@@ -6801,9 +6776,8 @@
 	},
 /area/maintenance/nsv/deck1/starboard)
 "dZk" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
@@ -12600,8 +12574,8 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/purple/visible{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
@@ -13130,15 +13104,6 @@
 	},
 /turf/closed/wall/steel,
 /area/shuttle/turbolift/secondary)
-"icm" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold/visible{
-	dir = 8
-	},
-/turf/open/floor/monotile/dark,
-/area/engine/atmos)
 "icn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -14035,9 +14000,7 @@
 /obj/machinery/meter{
 	name = "Constricted Plasma output meter"
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/manifold/purple/visible,
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "iIq" = (
@@ -17572,10 +17535,11 @@
 /turf/open/floor/monotile/dark,
 /area/engine/storage)
 "kNA" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/plasma/flipped{
-	dir = 1
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/layer_manifold/visible{
+	dir = 8
 	},
-/turf/open/floor/monotile/dark,
+/turf/open/floor/engine,
 /area/engine/atmos)
 "kNP" = (
 /obj/effect/turf_decal/stripes/line{
@@ -19427,9 +19391,6 @@
 "lTw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 5
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
@@ -84764,7 +84725,7 @@ eZl
 vME
 hQW
 cTa
-kNA
+nXl
 lTw
 sIm
 hWO
@@ -85018,11 +84979,11 @@ eWw
 iZB
 fHG
 dif
-hJJ
+aFh
 hQW
 iIh
-sIm
-icm
+nXl
+lTw
 sIm
 hWO
 hXK
@@ -85276,10 +85237,10 @@ fkN
 fHG
 onq
 hJJ
-aFh
+nXl
 dZk
-cOZ
-cPn
+nXl
+lTw
 lxK
 bjC
 hOu
@@ -85534,7 +85495,7 @@ nBf
 nAn
 mcx
 cMZ
-xgg
+kNA
 hXK
 vFq
 nMA
@@ -85789,7 +85750,7 @@ qmK
 iDo
 fkN
 vOR
-aTc
+hJJ
 fkN
 wYr
 nBf

--- a/_maps/map_files/Pegasus/pegasus1.dmm
+++ b/_maps/map_files/Pegasus/pegasus1.dmm
@@ -3248,6 +3248,15 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/nsv/hanger/notkmcstupidhanger)
+"bOz" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
+	dir = 1
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/atmos)
 "bOS" = (
 /obj/structure/table/wood,
 /obj/machinery/status_display/ai{
@@ -4965,8 +4974,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/purple/visible{
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
@@ -5949,9 +5958,6 @@
 "dzk" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/dark/visible/layer1,
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 10
-	},
 /turf/open/floor/engine,
 /area/engine/atmos)
 "dzp" = (
@@ -6783,8 +6789,9 @@
 	},
 /area/maintenance/nsv/deck1/starboard)
 "dZk" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/plasma{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
+	dir = 6
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
@@ -12774,13 +12781,8 @@
 /turf/open/floor/circuit/telecomms/server,
 /area/science/server)
 "hQW" = (
-/obj/structure/sign/ship/fire{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 6
-	},
-/turf/closed/wall/steel,
+/obj/machinery/atmospherics/components/binary/magnetic_constrictor,
+/turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "hRc" = (
 /obj/structure/cable{
@@ -14009,11 +14011,13 @@
 /turf/open/floor/monotile,
 /area/security/processing)
 "iIh" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 8
+/obj/machinery/meter{
+	name = "Constricted Plasma output meter"
 	},
-/turf/open/floor/engine,
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 9
+	},
+/turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "iIq" = (
 /obj/machinery/camera/autoname{
@@ -17547,11 +17551,10 @@
 /turf/open/floor/monotile/dark,
 /area/engine/storage)
 "kNA" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 9
+/obj/machinery/atmospherics/components/trinary/filter/atmos/plasma/flipped{
+	dir = 1
 	},
-/turf/open/floor/engine,
+/turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "kNP" = (
 /obj/effect/turf_decal/stripes/line{
@@ -18493,10 +18496,6 @@
 /obj/machinery/light_switch/north,
 /turf/open/floor/monotile,
 /area/engine/gravity_generator)
-"loT" = (
-/obj/machinery/atmospherics/components/binary/magnetic_constrictor,
-/turf/open/floor/monotile/dark,
-/area/engine/atmos)
 "lpb" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -19407,6 +19406,9 @@
 "lTw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
+	dir = 5
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
@@ -22166,13 +22168,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"nDw" = (
-/obj/machinery/atmospherics/pipe/manifold/purple/visible,
-/obj/machinery/meter{
-	name = "Constricted Plasma output meter"
-	},
-/turf/open/floor/monotile/dark,
-/area/engine/atmos)
 "nDN" = (
 /obj/effect/turf_decal/stripes/full,
 /obj/machinery/door/poddoor/ship{
@@ -31646,6 +31641,15 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/nsv/deck1/starboard)
+"ttf" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/atmos)
 "ttU" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -35985,11 +35989,11 @@
 "wpr" = (
 /obj/machinery/portable_atmospherics/canister/constricted_plasma,
 /obj/machinery/atmospherics/pipe/simple/dark/visible/layer1,
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer3{
+	dir = 8
 	},
 /turf/open/floor/engine/airless,
 /area/engine/atmos)
@@ -37056,6 +37060,9 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
+	dir = 8
+	},
 /turf/open/floor/engine/airless,
 /area/engine/atmos)
 "wYT" = (
@@ -37434,6 +37441,18 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
+"xnd" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
+	dir = 9
+	},
+/obj/machinery/meter{
+	name = "Constricted Plasma output meter"
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/atmos)
 "xnf" = (
 /obj/machinery/button/door{
 	id = "fighterpod_airlock";
@@ -84743,9 +84762,9 @@ mAp
 qFu
 eZl
 vME
-loT
+hQW
 cTa
-nXl
+kNA
 lTw
 sIm
 hWO
@@ -85000,10 +85019,10 @@ iZB
 fHG
 dif
 hJJ
-loT
-nDw
-nXl
-lTw
+hQW
+iIh
+sIm
+ttf
 sIm
 hWO
 hXK
@@ -85259,8 +85278,8 @@ onq
 hJJ
 aFh
 dZk
-nXl
-lTw
+bOz
+xnd
 lxK
 bjC
 hOu
@@ -85514,8 +85533,8 @@ bRj
 nBf
 nAn
 mcx
-hQW
-kNA
+cMZ
+xgg
 hXK
 vFq
 nMA
@@ -85771,7 +85790,7 @@ iDo
 fkN
 vOR
 aTc
-iIh
+fkN
 wYr
 nBf
 jZb

--- a/_maps/map_files/Pegasus/pegasus1.dmm
+++ b/_maps/map_files/Pegasus/pegasus1.dmm
@@ -26071,7 +26071,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "pZZ" = (

--- a/_maps/map_files/Pegasus/pegasus1.dmm
+++ b/_maps/map_files/Pegasus/pegasus1.dmm
@@ -3248,15 +3248,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/nsv/hanger/notkmcstupidhanger)
-"bOz" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
-	dir = 1
-	},
-/turf/open/floor/monotile/dark,
-/area/engine/atmos)
 "bOS" = (
 /obj/structure/table/wood,
 /obj/machinery/status_display/ai{
@@ -16014,6 +16005,15 @@
 "jVM" = (
 /turf/open/openspace,
 /area/maintenance/nsv/deck1/starboard)
+"jVY" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
+	dir = 1
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/atmos)
 "jWl" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -19407,7 +19407,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 5
 	},
 /turf/open/floor/monotile/dark,
@@ -21762,6 +21762,15 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
+"nmB" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold/visible{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/atmos)
 "nmY" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -28616,6 +28625,18 @@
 	},
 /turf/open/floor/monotile,
 /area/engine/atmos)
+"rzw" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
+	dir = 9
+	},
+/obj/machinery/meter{
+	name = "Constricted Plasma output meter"
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/atmos)
 "rzE" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -31641,15 +31662,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/nsv/deck1/starboard)
-"ttf" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 8
-	},
-/turf/open/floor/monotile/dark,
-/area/engine/atmos)
 "ttU" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -37441,18 +37453,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
-"xnd" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
-	dir = 9
-	},
-/obj/machinery/meter{
-	name = "Constricted Plasma output meter"
-	},
-/turf/open/floor/monotile/dark,
-/area/engine/atmos)
 "xnf" = (
 /obj/machinery/button/door{
 	id = "fighterpod_airlock";
@@ -85022,7 +85022,7 @@ hJJ
 hQW
 iIh
 sIm
-ttf
+nmB
 sIm
 hWO
 hXK
@@ -85278,8 +85278,8 @@ onq
 hJJ
 aFh
 dZk
-bOz
-xnd
+jVY
+rzw
 lxK
 bjC
 hOu

--- a/_maps/map_files/Pegasus/pegasus1.dmm
+++ b/_maps/map_files/Pegasus/pegasus1.dmm
@@ -4859,6 +4859,15 @@
 	},
 /turf/open/floor/monotile,
 /area/engine/atmos)
+"cOZ" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
+	dir = 1
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/atmos)
 "cPk" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4871,6 +4880,18 @@
 	},
 /turf/open/floor/monotile,
 /area/engine/engine_room)
+"cPn" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
+	dir = 9
+	},
+/obj/machinery/meter{
+	name = "Constricted Plasma output meter"
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/atmos)
 "cQD" = (
 /obj/structure/sign/ship/securearea{
 	dir = 4;
@@ -4963,6 +4984,9 @@
 /area/engine/atmos)
 "cTa" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/purple/visible{
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
@@ -5407,9 +5431,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/purple/visible{
 	dir = 1
 	},
 /turf/open/floor/monotile,
@@ -6780,9 +6801,7 @@
 	},
 /area/maintenance/nsv/deck1/starboard)
 "dZk" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
 	dir = 6
 	},
@@ -8159,9 +8178,6 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 6
 	},
 /turf/open/floor/monotile,
 /area/engine/atmos)
@@ -12585,7 +12601,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/purple/visible{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
@@ -12777,12 +12793,7 @@
 /turf/open/floor/circuit/telecomms/server,
 /area/science/server)
 "hQW" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 5
-	},
-/obj/machinery/meter{
-	name = "Constricted Plasma output meter"
-	},
+/obj/machinery/atmospherics/components/binary/magnetic_constrictor,
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "hRc" = (
@@ -13119,6 +13130,15 @@
 	},
 /turf/closed/wall/steel,
 /area/shuttle/turbolift/secondary)
+"icm" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold/visible{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/atmos)
 "icn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -14012,8 +14032,11 @@
 /turf/open/floor/monotile,
 /area/security/processing)
 "iIh" = (
-/obj/machinery/atmospherics/pipe/manifold/purple/visible{
-	dir = 4
+/obj/machinery/meter{
+	name = "Constricted Plasma output meter"
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 9
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
@@ -17457,15 +17480,6 @@
 	},
 /turf/open/floor/monotile,
 /area/crew_quarters/heads/hos)
-"kKu" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
-	dir = 5
-	},
-/turf/open/floor/monotile/dark,
-/area/engine/atmos)
 "kLo" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -18687,10 +18701,10 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
-	dir = 9
+/obj/machinery/meter{
+	name = "Stormdrive Outlet Readout"
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "lxL" = (
@@ -19413,6 +19427,9 @@
 "lTw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 5
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
@@ -23359,9 +23376,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 10
-	},
 /turf/open/floor/monotile,
 /area/engine/atmos)
 "onL" = (
@@ -26163,12 +26177,6 @@
 	},
 /turf/open/floor/monotile,
 /area/security/checkpoint)
-"qbe" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
-	dir = 1
-	},
-/turf/open/floor/monotile/dark,
-/area/engine/atmos)
 "qbn" = (
 /obj/structure/cable{
 	icon_state = "4-9"
@@ -30445,9 +30453,6 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 8
 	},
-/obj/machinery/meter{
-	name = "Stormdrive Outlet Readout"
-	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "sIy" = (
@@ -33684,18 +33689,6 @@
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/circuit/red,
 /area/ai_monitored/turret_protected/ai)
-"uJc" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
-	dir = 1
-	},
-/obj/machinery/meter{
-	name = "Constricted Plasma output meter"
-	},
-/turf/open/floor/monotile/dark,
-/area/engine/atmos)
 "uJv" = (
 /obj/machinery/advanced_airlock_controller/directional/north,
 /turf/open/floor/plating,
@@ -35201,7 +35194,9 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/magnetic_constrictor,
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 6
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "vMI" = (
@@ -38236,13 +38231,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/frame1/central)
-"xNj" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3,
-/turf/open/floor/monotile/dark,
-/area/engine/atmos)
 "xNm" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -84776,7 +84764,7 @@ eZl
 vME
 hQW
 cTa
-nXl
+kNA
 lTw
 sIm
 hWO
@@ -85030,12 +85018,12 @@ eWw
 iZB
 fHG
 dif
-vME
+hJJ
+hQW
 iIh
-kNA
-gXv
-xNj
-kKu
+sIm
+icm
+sIm
 hWO
 hXK
 aHE
@@ -85290,8 +85278,8 @@ onq
 hJJ
 aFh
 dZk
-qbe
-uJc
+cOZ
+cPn
 lxK
 bjC
 hOu

--- a/_maps/map_files/Pegasus/pegasus1.dmm
+++ b/_maps/map_files/Pegasus/pegasus1.dmm
@@ -959,7 +959,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/space)
+/area/engine/atmos)
 "aAy" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -1096,7 +1096,7 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/security/armory)
 "aFh" = (
-/obj/machinery/atmospherics/components/binary/magnetic_constrictor,
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "aFJ" = (
@@ -1603,8 +1603,8 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/purple/visible{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
@@ -4965,6 +4965,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 5
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "cTr" = (
@@ -5946,6 +5949,9 @@
 "dzk" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/dark/visible/layer1,
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 10
+	},
 /turf/open/floor/engine,
 /area/engine/atmos)
 "dzp" = (
@@ -6777,11 +6783,8 @@
 	},
 /area/maintenance/nsv/deck1/starboard)
 "dZk" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 5
-	},
-/obj/machinery/meter{
-	name = "Constrictor -> Tank Readout"
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/plasma{
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
@@ -9285,6 +9288,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/dark,
 /area/security/prison)
+"fLG" = (
+/obj/machinery/atmospherics/pipe/manifold/purple/visible,
+/turf/open/floor/monotile/dark,
+/area/engine/atmos)
 "fMK" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -12578,8 +12585,8 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/purple/visible{
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
@@ -12611,9 +12618,11 @@
 /turf/open/floor/plasteel/grid/lino,
 /area/tcommsat/server)
 "hKT" = (
-/obj/machinery/atmospherics/components/trinary/mixer{
+/obj/machinery/atmospherics/components/trinary/mixer/on{
 	dir = 8;
-	name = "N2O Line Additive"
+	name = "Constricted Plasma Line Additive";
+	node1_concentration = 0.6;
+	node2_concentration = 0.4
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
@@ -12772,7 +12781,9 @@
 /obj/structure/sign/ship/fire{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/binary/magnetic_constrictor,
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 6
+	},
 /turf/closed/wall/steel,
 /area/engine/atmos)
 "hRc" = (
@@ -14004,10 +14015,10 @@
 "iIh" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/engine,
-/area/space)
+/area/engine/atmos)
 "iIq" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -16092,11 +16103,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/brown/visible,
 /obj/machinery/atmospherics/components/binary/valve/digital{
 	dir = 4;
 	name = "Bypass All Mixers"
 	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "jZo" = (
@@ -17541,7 +17552,12 @@
 /area/engine/storage)
 "kNA" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/manifold/purple/visible,
+/obj/machinery/meter{
+	name = "Constricted Plasma output meter"
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 9
+	},
 /turf/open/floor/engine,
 /area/engine/atmos)
 "kNP" = (
@@ -19606,8 +19622,8 @@
 	dir = 8;
 	filter_type = "plasma"
 	},
-/obj/machinery/atmospherics/pipe/manifold/purple/visible{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
@@ -20133,6 +20149,10 @@
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile/dark,
 /area/security/prison)
+"mqC" = (
+/obj/machinery/atmospherics/components/binary/magnetic_constrictor,
+/turf/open/floor/monotile/dark,
+/area/engine/atmos)
 "mqX" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -21340,7 +21360,7 @@
 	dir = 6
 	},
 /turf/open/floor/monotile/dark,
-/area/space)
+/area/engine/atmos)
 "nae" = (
 /obj/structure/sign/ship/nosmoking{
 	dir = 8;
@@ -24430,11 +24450,9 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/briefingroom)
 "oZe" = (
-/obj/machinery/atmospherics/components/trinary/mixer/on{
+/obj/machinery/atmospherics/components/trinary/mixer{
 	dir = 8;
-	name = "Constricted Plasma Line Additive";
-	node1_concentration = 0.6;
-	node2_concentration = 0.4
+	name = "N2O Line Additive"
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
@@ -26395,10 +26413,10 @@
 /turf/open/floor/monotile/dark,
 /area/security/checkpoint)
 "qke" = (
-/obj/machinery/atmospherics/pipe/manifold/purple/visible,
 /obj/machinery/atmospherics/pipe/simple/dark/visible/layer3{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/manifold/brown,
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "qkg" = (
@@ -27971,14 +27989,14 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/bridge)
 "riX" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/binary/valve/digital/on{
 	dir = 8;
-	name = "Bypass Plasma Stage"
+	name = "Bypass N2O Stage"
 	},
+/obj/machinery/atmospherics/pipe/simple/brown,
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "rjc" = (
@@ -29798,7 +29816,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/dark/visible/layer3,
-/obj/machinery/atmospherics/pipe/manifold/purple/visible{
+/obj/machinery/atmospherics/pipe/manifold/brown{
 	dir = 1
 	},
 /turf/open/floor/monotile/dark,
@@ -34960,10 +34978,11 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "vGh" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1,
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on,
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
-	dir = 8
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 9
 	},
 /turf/open/floor/engine/airless,
 /area/engine/atmos)
@@ -35157,6 +35176,9 @@
 "vME" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible/layer3{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 6
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
@@ -35963,11 +35985,11 @@
 "wpr" = (
 /obj/machinery/portable_atmospherics/canister/constricted_plasma,
 /obj/machinery/atmospherics/pipe/simple/dark/visible/layer1,
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 8
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 4
 	},
 /turf/open/floor/engine/airless,
 /area/engine/atmos)
@@ -36485,7 +36507,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/passive_gate/layer3,
 /turf/open/floor/monotile,
 /area/engine/atmos)
 "wHh" = (
@@ -37031,11 +37052,9 @@
 	},
 /area/maintenance/nsv/bridge)
 "wYr" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on/layer1,
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 6
-	},
-/obj/machinery/atmospherics/components/trinary/filter/atmos/plasma/flipped{
-	dir = 8
 	},
 /turf/open/floor/engine/airless,
 /area/engine/atmos)
@@ -84724,7 +84743,7 @@ mAp
 qFu
 eZl
 vME
-nXl
+mqC
 cTa
 nXl
 lTw
@@ -84980,9 +84999,9 @@ eWw
 iZB
 fHG
 dif
-vME
-nXl
-nXl
+hJJ
+mqC
+fLG
 nXl
 lTw
 sIm

--- a/_maps/map_files/Pegasus/pegasus1.dmm
+++ b/_maps/map_files/Pegasus/pegasus1.dmm
@@ -9288,10 +9288,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/dark,
 /area/security/prison)
-"fLG" = (
-/obj/machinery/atmospherics/pipe/manifold/purple/visible,
-/turf/open/floor/monotile/dark,
-/area/engine/atmos)
 "fMK" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -17552,9 +17548,6 @@
 /area/engine/storage)
 "kNA" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/meter{
-	name = "Constricted Plasma output meter"
-	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 9
 	},
@@ -18500,6 +18493,10 @@
 /obj/machinery/light_switch/north,
 /turf/open/floor/monotile,
 /area/engine/gravity_generator)
+"loT" = (
+/obj/machinery/atmospherics/components/binary/magnetic_constrictor,
+/turf/open/floor/monotile/dark,
+/area/engine/atmos)
 "lpb" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -20149,10 +20146,6 @@
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile/dark,
 /area/security/prison)
-"mqC" = (
-/obj/machinery/atmospherics/components/binary/magnetic_constrictor,
-/turf/open/floor/monotile/dark,
-/area/engine/atmos)
 "mqX" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -22173,6 +22166,13 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"nDw" = (
+/obj/machinery/atmospherics/pipe/manifold/purple/visible,
+/obj/machinery/meter{
+	name = "Constricted Plasma output meter"
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/atmos)
 "nDN" = (
 /obj/effect/turf_decal/stripes/full,
 /obj/machinery/door/poddoor/ship{
@@ -26416,7 +26416,7 @@
 /obj/machinery/atmospherics/pipe/simple/dark/visible/layer3{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/brown,
+/obj/machinery/atmospherics/pipe/manifold/brown/visible,
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "qkg" = (
@@ -27996,7 +27996,7 @@
 	dir = 8;
 	name = "Bypass N2O Stage"
 	},
-/obj/machinery/atmospherics/pipe/simple/brown,
+/obj/machinery/atmospherics/pipe/simple/brown/visible,
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "rjc" = (
@@ -29816,7 +29816,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/dark/visible/layer3,
-/obj/machinery/atmospherics/pipe/manifold/brown{
+/obj/machinery/atmospherics/pipe/manifold/brown/visible{
 	dir = 1
 	},
 /turf/open/floor/monotile/dark,
@@ -84743,7 +84743,7 @@ mAp
 qFu
 eZl
 vME
-mqC
+loT
 cTa
 nXl
 lTw
@@ -85000,8 +85000,8 @@ iZB
 fHG
 dif
 hJJ
-mqC
-fLG
+loT
+nDw
 nXl
 lTw
 sIm

--- a/_maps/map_files/Pegasus/pegasus1.dmm
+++ b/_maps/map_files/Pegasus/pegasus1.dmm
@@ -4965,9 +4965,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/purple/visible{
-	dir = 8
-	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "cTr" = (
@@ -5410,6 +5407,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/purple/visible{
 	dir = 1
 	},
 /turf/open/floor/monotile,
@@ -6780,7 +6780,9 @@
 	},
 /area/maintenance/nsv/deck1/starboard)
 "dZk" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 9
+	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
 	dir = 6
 	},
@@ -8157,6 +8159,9 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 6
 	},
 /turf/open/floor/monotile,
 /area/engine/atmos)
@@ -12580,7 +12585,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/purple/visible{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
@@ -12772,7 +12777,12 @@
 /turf/open/floor/circuit/telecomms/server,
 /area/science/server)
 "hQW" = (
-/obj/machinery/atmospherics/components/binary/magnetic_constrictor,
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 5
+	},
+/obj/machinery/meter{
+	name = "Constricted Plasma output meter"
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "hRc" = (
@@ -13758,15 +13768,6 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/nsv/deck1/starboard)
-"iAH" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold/visible{
-	dir = 8
-	},
-/turf/open/floor/monotile/dark,
-/area/engine/atmos)
 "iBk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -14011,11 +14012,8 @@
 /turf/open/floor/monotile,
 /area/security/processing)
 "iIh" = (
-/obj/machinery/meter{
-	name = "Constricted Plasma output meter"
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 9
+/obj/machinery/atmospherics/pipe/manifold/purple/visible{
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
@@ -15366,18 +15364,6 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/frame3/central)
-"jBN" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
-	dir = 9
-	},
-/obj/machinery/meter{
-	name = "Constricted Plasma output meter"
-	},
-/turf/open/floor/monotile/dark,
-/area/engine/atmos)
 "jBP" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -17471,6 +17457,15 @@
 	},
 /turf/open/floor/monotile,
 /area/crew_quarters/heads/hos)
+"kKu" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
+	dir = 5
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/atmos)
 "kLo" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -18692,10 +18687,10 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 8
 	},
-/obj/machinery/meter{
-	name = "Stormdrive Outlet Readout"
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
+	dir = 9
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "lxL" = (
@@ -18948,15 +18943,6 @@
 	icon_state = "panelscorched"
 	},
 /area/nsv/weapons/gauss/battery/deck1/port)
-"lDJ" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
-	dir = 1
-	},
-/turf/open/floor/monotile/dark,
-/area/engine/atmos)
 "lEr" = (
 /obj/structure/bed/dogbed/ian{
 	color = "";
@@ -19427,9 +19413,6 @@
 "lTw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 5
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
@@ -23376,6 +23359,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 10
+	},
 /turf/open/floor/monotile,
 /area/engine/atmos)
 "onL" = (
@@ -26177,6 +26163,12 @@
 	},
 /turf/open/floor/monotile,
 /area/security/checkpoint)
+"qbe" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
+	dir = 1
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/atmos)
 "qbn" = (
 /obj/structure/cable{
 	icon_state = "4-9"
@@ -30453,6 +30445,9 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 8
 	},
+/obj/machinery/meter{
+	name = "Stormdrive Outlet Readout"
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "sIy" = (
@@ -33689,6 +33684,18 @@
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/circuit/red,
 /area/ai_monitored/turret_protected/ai)
+"uJc" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
+	dir = 1
+	},
+/obj/machinery/meter{
+	name = "Constricted Plasma output meter"
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/atmos)
 "uJv" = (
 /obj/machinery/advanced_airlock_controller/directional/north,
 /turf/open/floor/plating,
@@ -35194,9 +35201,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 6
-	},
+/obj/machinery/atmospherics/components/binary/magnetic_constrictor,
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "vMI" = (
@@ -38231,6 +38236,13 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/frame1/central)
+"xNj" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3,
+/turf/open/floor/monotile/dark,
+/area/engine/atmos)
 "xNm" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -84764,7 +84776,7 @@ eZl
 vME
 hQW
 cTa
-kNA
+nXl
 lTw
 sIm
 hWO
@@ -85018,12 +85030,12 @@ eWw
 iZB
 fHG
 dif
-hJJ
-hQW
+vME
 iIh
-sIm
-iAH
-sIm
+kNA
+gXv
+xNj
+kKu
 hWO
 hXK
 aHE
@@ -85278,8 +85290,8 @@ onq
 hJJ
 aFh
 dZk
-lDJ
-jBN
+qbe
+uJc
 lxK
 bjC
 hOu


### PR DESCRIPTION
## About The Pull Request

Reworks the Pegasus atmos to be a bit more compact while also allowing for an n2o input line to the stormdrive
![image](https://user-images.githubusercontent.com/33578623/97120488-4a038a80-16e5-11eb-8fdf-5bc8f9bd766b.png)


## Why It's Good For The Game

This has been requested by a veteran engineer IPC, A.I.M. and I believe it would allow for easier input of n2o into the engine, theres also some extra room for building.

## Changelog
:cl:

tweak: changed the Pegasus atmos to be a bit more compact and adds an n2o line
tweak: removed the useless plasma filter line for the magnetic constrictors 
/:cl: