### PR TITLE
Mining Ship Tweaks

### DIFF
--- a/_maps/map_files/Mining/nsv13/FOB_Shuttle.dmm
+++ b/_maps/map_files/Mining/nsv13/FOB_Shuttle.dmm
@@ -1172,11 +1172,8 @@
 /turf/open/floor/plating/airless,
 /area/nostromo/maintenance/exterior)
 "ob" = (
-/obj/machinery/computer/ship/ftl_computer{
-	dir = 4;
-	name = "Nostromo FTL computer";
-	req_access = null;
-	req_one_access_txt = "31;48"
+/obj/machinery/computer/ship/ftl_computer/mining{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/nsv/shuttle/fob/central)

--- a/_maps/map_files/Mining/nsv13/Rocinante.dmm
+++ b/_maps/map_files/Mining/nsv13/Rocinante.dmm
@@ -2980,11 +2980,8 @@
 /turf/open/floor/plasteel/techmaint,
 /area/nostromo)
 "hD" = (
-/obj/machinery/computer/ship/ftl_computer{
-	dir = 4;
-	name = "Nostromo FTL computer";
-	req_access = null;
-	req_one_access_txt = "31;48"
+/obj/machinery/computer/ship/ftl_computer/mining{
+	dir = 4
 	},
 /turf/open/floor/monotile,
 /area/nostromo/bridge)

--- a/_maps/map_files/Mining/nsv13/Whisp_FOB.dmm
+++ b/_maps/map_files/Mining/nsv13/Whisp_FOB.dmm
@@ -1495,11 +1495,8 @@
 /turf/open/floor/pod/light,
 /area/nsv/shuttle/fob/bridge)
 "dv" = (
-/obj/machinery/computer/ship/ftl_computer{
-	dir = 4;
-	name = "Nostromo FTL computer";
-	req_access = null;
-	req_one_access_txt = "31;48"
+/obj/machinery/computer/ship/ftl_computer/mining{
+	dir = 4
 	},
 /turf/open/floor/pod/light,
 /area/nsv/shuttle/fob/bridge)

--- a/_maps/map_files/Mining/nsv13/nostromo.dmm
+++ b/_maps/map_files/Mining/nsv13/nostromo.dmm
@@ -2485,11 +2485,8 @@
 /turf/open/floor/plasteel/grid/steel,
 /area/nostromo/bridge)
 "gS" = (
-/obj/machinery/computer/ship/ftl_computer{
-	dir = 4;
-	name = "Nostromo FTL computer";
-	req_access = null;
-	req_one_access_txt = "31;48"
+/obj/machinery/computer/ship/ftl_computer/mining{
+	dir = 4
 	},
 /turf/open/floor/monotile,
 /area/nostromo/bridge)

--- a/_maps/map_files/NSV Storage/Mining/Hephaestus/Hephaestus1.dmm
+++ b/_maps/map_files/NSV Storage/Mining/Hephaestus/Hephaestus1.dmm
@@ -5622,11 +5622,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/computer/ship/ftl_computer{
-	dir = 4;
-	name = "Nostromo FTL computer";
-	req_access = null;
-	req_one_access_txt = "31;48"
+/obj/machinery/computer/ship/ftl_computer/mining{
+	dir = 4
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/nostromo/bridge)

--- a/nsv13/code/modules/mining/asteroid.dm
+++ b/nsv13/code/modules/mining/asteroid.dm
@@ -5,7 +5,7 @@ GLOBAL_LIST_EMPTY(asteroid_spawn_markers)		//handles mining asteroids, kind of s
 /datum/techweb_node/mineral_mining
 	id = "mineral_mining"
 	display_name = "Deep core asteroid mining"
-	description = "Upgrades for the NSV nostromo's asteroid arrestor, allowing it to lock on to more valuable asteroid cores.."
+	description = "Upgrades for the mining ship's asteroid arrestor, allowing it to lock on to more valuable asteroid cores.."
 	prereq_ids = list("base")
 	design_ids = list("deepcore1", "deepcore2")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
@@ -13,7 +13,7 @@ GLOBAL_LIST_EMPTY(asteroid_spawn_markers)		//handles mining asteroids, kind of s
 
 /datum/design/deepcore1
 	name = "Polytrinic non magnetic asteroid arrestor upgrade"
-	desc = "An upgrade module for the Nostromo's asteroid arrestor, allowing it to lock on to asteroids containing valuable non ferrous metals such as gold, silver, copper and plasma"
+	desc = "An upgrade module for the mining ship's asteroid arrestor, allowing it to lock on to asteroids containing valuable non ferrous metals such as gold, silver, copper and plasma"
 	id = "deepcore1"
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 25000,/datum/material/titanium = 25000, /datum/material/silver = 5000)
@@ -23,7 +23,7 @@ GLOBAL_LIST_EMPTY(asteroid_spawn_markers)		//handles mining asteroids, kind of s
 
 /datum/design/deepcore2
 	name = "Phasic asteroid arrestor upgrade"
-	desc = "An upgrade module for the Nostromo's asteroid arrestor, allowing it to lock on to asteroids containing rare and valuable minerals such as diamond, uranium and the exceedingly rare bluespace crystals."
+	desc = "An upgrade module for the mining ship's asteroid arrestor, allowing it to lock on to asteroids containing rare and valuable minerals such as diamond, uranium and the exceedingly rare bluespace crystals."
 	id = "deepcore2"
 	build_type = PROTOLATHE
 	materials = list(/datum/material/copper = 25000,/datum/material/titanium = 25000, /datum/material/gold = 10000, /datum/material/silver = 10000, /datum/material/plasma = 10000, /datum/material/uranium = 5000, /datum/material/diamond = 5000)

--- a/nsv13/code/modules/overmap/ftl.dm
+++ b/nsv13/code/modules/overmap/ftl.dm
@@ -302,6 +302,13 @@ Preset classes of FTL drive with pre-programmed behaviours
 	faction = "syndicate"
 	req_access = list(ACCESS_SYNDICATE)
 
+/obj/machinery/computer/ship/ftl_computer/mining
+	name = "Mining FTL computer"
+	radio_key = /obj/item/encryptionkey/headset_mining
+	engineering_channel = "Supply"
+	req_access = null
+	req_one_access_txt = "31;48"
+
 /obj/machinery/computer/ship/ftl_computer/Initialize()
 	. = ..()
 	start_monitoring(get_overmap()) //I'm a lazy hack that can't actually be assed to deal with an if statement in react right now.

--- a/nsv13/code/modules/overmap/radar.dm
+++ b/nsv13/code/modules/overmap/radar.dm
@@ -52,8 +52,8 @@
 	name = "Air traffic control console"
 
 /obj/machinery/computer/ship/dradis/mining
-	name = "Nostromo DRADIS computer"
-	desc = "A modified dradis console which links to the Nostromo's mineral scanners, able to pick up asteroids that can be mined."
+	name = "Mining DRADIS computer"
+	desc = "A modified dradis console which links to the mining ship's mineral scanners, able to pick up asteroids that can be mined."
 	req_one_access_txt = "31;48"
 	circuit = /obj/item/circuitboard/computer/ship/dradis/mining
 	show_asteroids = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Replaces a bunch of references to the nostromo so they're more generic and makes the mining ship's FTL computer speak on the supply channel rather than engineering.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The nostromo isn't really used anymore and having more generic names allows for different mining ships. Having the FTL computer speak on the engineering channel just confuses people and doesn't let miners know when the ship is ready to jump.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Mining FTL now talks on the supply channel
tweak: Removed a bunch of references to the Nostromo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
