### PR TITLE
Makes the gauss gun reload itself if its out of ammo.

### DIFF
--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/gauss_gun.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/gauss_gun.dm
@@ -182,6 +182,9 @@
 	dir = WEST
 
 /obj/machinery/ship_weapon/gauss_gun/proc/onClick(atom/target)
+	if(ammo.len<1)
+		to_chat(gunner, "<span class='notice'>Attempting to load ammo!</span>")
+		src.raise_rack()
 	if(pdc_mode && world.time >= last_pdc_fire + 2 SECONDS)
 		linked.fire_weapon(target=target, mode=FIRE_MODE_PDC)
 		last_pdc_fire = world.time

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/gauss_gun.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/gauss_gun.dm
@@ -182,7 +182,7 @@
 	dir = WEST
 
 /obj/machinery/ship_weapon/gauss_gun/proc/onClick(atom/target)
-	if(ammo.len<1).
+	if(ammo.len<1)
 		to_chat(gunner, "<span class='notice'>Attempting to load ammo!</span>")
 		src.raise_rack()
 	if(pdc_mode && world.time >= last_pdc_fire + 2 SECONDS)

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/gauss_gun.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/gauss_gun.dm
@@ -26,6 +26,7 @@
 	var/obj/machinery/portable_atmospherics/canister/internal_tank //Internal air tank reference. Used mostly in small ships. If you want to sabotage a fighter, load a plasma tank into its cockpit :)
 	var/pdc_mode = FALSE
 	var/last_pdc_fire = 0 //Pdc cooldown
+	var/BeingLoaded //Used for gunner load
 
 #define VV_HK_REMOVE_GAUSS_GUNNER "getOutOfMyGunIdiot"
 
@@ -181,10 +182,19 @@
 /obj/machinery/ship_weapon/gauss_gun/west
 	dir = WEST
 
+/obj/machinery/ship_weapon/gauss_gun/proc/GunnerLoad()
+	if(BeingLoaded)
+		to_chat(gunner, "<span class='notice'>[src]'s loading systems are on cooldown!</span>")
+		return
+	to_chat(gunner, "<span class='notice'>Loading ammunition</span>")
+	BeingLoaded = 1
+	src.raise_rack()
+	sleep(5 SECONDS)
+	BeingLoaded = 0
+
 /obj/machinery/ship_weapon/gauss_gun/proc/onClick(atom/target)
 	if(ammo.len<1)
-		to_chat(gunner, "<span class='notice'>Attempting to load ammo!</span>")
-		src.raise_rack()
+		src.GunnerLoad()
 	if(pdc_mode && world.time >= last_pdc_fire + 2 SECONDS)
 		linked.fire_weapon(target=target, mode=FIRE_MODE_PDC)
 		last_pdc_fire = world.time

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/gauss_gun.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/gauss_gun.dm
@@ -182,7 +182,7 @@
 	dir = WEST
 
 /obj/machinery/ship_weapon/gauss_gun/proc/onClick(atom/target)
-	if(ammo.len<1)
+	if(ammo.len<1).
 		to_chat(gunner, "<span class='notice'>Attempting to load ammo!</span>")
 		src.raise_rack()
 	if(pdc_mode && world.time >= last_pdc_fire + 2 SECONDS)


### PR DESCRIPTION

## About The Pull Request
Makes the gauss gun try to reload itself when you try to fire without ammo.
## Why It's Good For The Game
More often than not , the gunner has to come down to raise the rack . This makes using the gauss tedious as you have to go down and up everytime,  because the loader did not raise the rack.
## Changelog
:cl:
add:Gauss guns will now raise their rack if you try to fire with no ammo.
/:cl:
