### PR TITLE
Fixes all active turfs found on mining ruins

### DIFF
--- a/_maps/map_files/Mining/nsv13/ruins/mining11.dmm
+++ b/_maps/map_files/Mining/nsv13/ruins/mining11.dmm
@@ -27,36 +27,36 @@
 /turf/open/space/basic,
 /area/space)
 "g" = (
-/turf/open/floor/monotile,
+/turf/open/floor/monotile/airless,
 /area/ruin/powered)
 "h" = (
 /obj/effect/decal/nuclear_waste,
-/turf/open/floor/monotile,
+/turf/open/floor/monotile/airless,
 /area/ruin/powered)
 "i" = (
 /obj/structure/closet/radiation,
-/turf/open/floor/monotile,
+/turf/open/floor/monotile/airless,
 /area/ruin/powered)
 "j" = (
 /obj/machinery/vending/tool,
-/turf/open/floor/monotile,
+/turf/open/floor/monotile/airless,
 /area/ruin/powered)
 "k" = (
 /obj/machinery/vending/engivend,
-/turf/open/floor/monotile,
+/turf/open/floor/monotile/airless,
 /area/ruin/powered)
 "l" = (
 /obj/machinery/door/airlock/ship/engineering,
-/turf/open/floor/monotile,
+/turf/open/floor/monotile/airless,
 /area/ruin/powered)
 "m" = (
 /obj/machinery/light/broken,
 /obj/structure/closet/crate,
-/turf/open/floor/monotile,
+/turf/open/floor/monotile/airless,
 /area/ruin/powered)
 "n" = (
 /obj/structure/closet/crate,
-/turf/open/floor/monotile,
+/turf/open/floor/monotile/airless,
 /area/ruin/powered)
 "o" = (
 /turf/open/floor/plating/asteroid/airless,
@@ -67,17 +67,16 @@
 /area/ruin/powered)
 "q" = (
 /obj/machinery/light/broken{
-	icon_state = "tube-broken";
 	dir = 4
 	},
-/turf/open/floor/monotile,
+/turf/open/floor/monotile/airless,
 /area/ruin/powered)
 "r" = (
-/turf/open/floor/engine,
+/turf/open/floor/engine/airless,
 /area/ruin/powered)
 "s" = (
 /obj/effect/decal/nuclear_waste,
-/turf/open/floor/engine,
+/turf/open/floor/engine/airless,
 /area/ruin/powered)
 "t" = (
 /obj/machinery/smartfridge/drinks{
@@ -87,24 +86,22 @@
 	name = "Ruined stormdrive";
 	pixel_x = -16
 	},
-/turf/open/floor/engine,
+/turf/open/floor/engine/airless,
 /area/ruin/powered)
 "u" = (
 /obj/machinery/light/broken{
-	icon_state = "tube-broken";
 	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/floor/engine/airless,
 /area/ruin/powered)
 "v" = (
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/powered)
 "w" = (
 /obj/machinery/light/broken{
-	icon_state = "tube-broken";
 	dir = 8
 	},
-/turf/open/floor/monotile,
+/turf/open/floor/monotile/airless,
 /area/ruin/powered)
 "x" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -112,45 +109,41 @@
 /area/ruin/powered)
 "y" = (
 /obj/machinery/light/broken{
-	icon_state = "tube-broken";
 	dir = 1
 	},
-/turf/open/floor/monotile,
+/turf/open/floor/monotile/airless,
 /area/ruin/powered)
 "z" = (
 /obj/structure/frame,
-/turf/open/floor/monotile,
+/turf/open/floor/monotile/airless,
 /area/ruin/powered)
 "A" = (
 /obj/machinery/door/airlock/ship/external{
 	name = "Nuclear lab"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	icon_state = "airlock_cyclelink_helper";
 	dir = 4
 	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/powered)
 "B" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/powered)
 "C" = (
 /obj/machinery/door/airlock/ship/external{
 	name = "Nuclear lab"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	icon_state = "airlock_cyclelink_helper";
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/powered)
 "D" = (
 /obj/machinery/light/broken,
-/turf/open/floor/monotile,
+/turf/open/floor/monotile/airless,
 /area/ruin/powered)
 "E" = (
 /obj/structure/sign/warning/radiation/rad_area{

--- a/_maps/map_files/Mining/nsv13/ruins/mining12.dmm
+++ b/_maps/map_files/Mining/nsv13/ruins/mining12.dmm
@@ -40,7 +40,6 @@
 /area/ruin/powered)
 "j" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
 	dir = 4
 	},
 /obj/structure/window/reinforced{
@@ -50,7 +49,6 @@
 /area/ruin/powered)
 "k" = (
 /obj/structure/shuttle/engine/propulsion/burst{
-	icon_state = "propulsion";
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
@@ -63,7 +61,7 @@
 /area/ruin/powered)
 "m" = (
 /obj/structure/grille/broken,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/powered)
 "n" = (
 /obj/structure/table_frame,
@@ -71,7 +69,6 @@
 /area/ruin/powered)
 "o" = (
 /obj/structure/chair/comfy/shuttle{
-	icon_state = "shuttle_chair";
 	dir = 8
 	},
 /turf/open/floor/plating/airless,

--- a/_maps/map_files/Mining/nsv13/ruins/mining16.dmm
+++ b/_maps/map_files/Mining/nsv13/ruins/mining16.dmm
@@ -49,17 +49,12 @@
 /area/ruin/powered)
 "l" = (
 /obj/structure/chair{
-	dir = 4;
-	icon_state = "chair"
+	dir = 4
 	},
 /turf/open/floor/plating/asteroid,
 /area/ruin/powered)
 "m" = (
-/obj/structure/chair{
-	dir = 1;
-	icon_state = "chair"
-	},
-/turf/open/floor/plating/asteroid,
+/turf/open/floor/plating/asteroid/airless,
 /area/ruin/powered)
 "n" = (
 /obj/structure/rack,
@@ -103,8 +98,7 @@
 /area/ruin/powered)
 "v" = (
 /obj/structure/chair{
-	dir = 8;
-	icon_state = "chair"
+	dir = 8
 	},
 /turf/open/floor/plating/asteroid,
 /area/ruin/powered)
@@ -115,13 +109,11 @@
 /area/ruin/powered)
 "x" = (
 /obj/structure/chair{
-	dir = 4;
-	icon_state = "chair"
+	dir = 4
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /turf/open/floor/plating/asteroid,
 /area/ruin/powered)
@@ -143,8 +135,7 @@
 /area/ruin/powered)
 "B" = (
 /obj/structure/chair{
-	dir = 4;
-	icon_state = "chair"
+	dir = 4
 	},
 /obj/structure/windoor_assembly{
 	dir = 4
@@ -614,7 +605,7 @@ i
 s
 b
 b
-m
+N
 i
 i
 i
@@ -656,7 +647,7 @@ j
 b
 b
 b
-m
+N
 i
 i
 b
@@ -698,7 +689,7 @@ i
 k
 b
 b
-m
+N
 i
 n
 b
@@ -740,7 +731,7 @@ i
 k
 b
 b
-m
+N
 i
 i
 b
@@ -782,7 +773,7 @@ i
 k
 b
 b
-m
+N
 i
 i
 b
@@ -841,7 +832,7 @@ a
 a
 a
 a
-b
+m
 c
 d
 N
@@ -883,7 +874,7 @@ a
 a
 a
 a
-b
+m
 c
 d
 N

--- a/_maps/map_files/Mining/nsv13/ruins/mining22.dmm
+++ b/_maps/map_files/Mining/nsv13/ruins/mining22.dmm
@@ -20,28 +20,28 @@
 /obj/machinery/door/airlock/ship/engineering{
 	req_one_access_txt = "200"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/powered)
 "e" = (
 /obj/machinery/door/airlock/ship/command{
 	name = "Bridge";
 	req_one_access_txt = "200"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/powered)
 "f" = (
 /obj/machinery/door/airlock/ship/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/powered)
 "g" = (
 /obj/item/shard{
 	icon_state = "small"
 	},
 /obj/structure/grille/broken,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/powered)
 "h" = (
 /obj/structure/shuttle/engine/heater{
@@ -56,10 +56,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/powered)
 "k" = (
-/turf/open/floor/plating/asteroid,
+/turf/open/floor/plating/asteroid/airless,
 /area/ruin/powered)
 "l" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -69,11 +69,11 @@
 /area/ruin/powered)
 "m" = (
 /obj/item/shard,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/powered)
 "n" = (
 /obj/item/reagent_containers/food/drinks/beer,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/powered)
 "o" = (
 /obj/structure/frame/computer{
@@ -89,13 +89,13 @@
 /obj/item/reagent_containers/food/snacks/meat/slab,
 /obj/item/reagent_containers/food/snacks/meat/slab,
 /obj/item/organ/appendix,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/powered)
 "q" = (
 /obj/structure/closet/secure_closet/freezer/meat/open{
 	opened = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/powered)
 "r" = (
 /turf/closed/wall/mineral/titanium/interior,
@@ -108,11 +108,11 @@
 /obj/item/stack/sheet/mineral/uranium{
 	amount = 50
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/powered)
 "t" = (
 /obj/item/clothing/glasses/regular/hipster,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/powered)
 "u" = (
 /obj/machinery/light/small{
@@ -132,22 +132,22 @@
 	icon_state = "small"
 	},
 /obj/structure/grille,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/powered)
 "x" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/organ/brain,
 /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/slime,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/powered)
 "y" = (
 /obj/machinery/recharger,
 /obj/structure/table,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/powered)
 "z" = (
 /obj/structure/table,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/powered)
 "A" = (
 /turf/closed/wall/mineral/titanium/overspace,
@@ -157,34 +157,28 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/powered)
 "D" = (
 /turf/closed/mineral,
 /area/ruin/powered)
 "E" = (
 /obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/powered)
 "F" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ruin/powered)
 "H" = (
 /obj/structure/table_frame,
-/turf/open/floor/plating,
-/area/ruin/powered)
-"I" = (
-/obj/structure/ore_box,
-/turf/open/floor/plating/airless{
-	icon_state = "platingdmg1"
-	},
+/turf/open/floor/plating/airless,
 /area/ruin/powered)
 "J" = (
 /obj/machinery/teleport/hub,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/powered)
 "K" = (
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/powered)
 "L" = (
 /obj/machinery/light{
@@ -196,17 +190,17 @@
 /area/ruin/powered)
 "M" = (
 /obj/structure/reagent_dispensers,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/powered)
 "O" = (
 /obj/structure/closet/crate,
 /obj/item/clothing/under/misc/overalls,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/powered)
 "P" = (
 /obj/structure/table,
 /obj/machinery/microwave,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/powered)
 "Q" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -215,29 +209,29 @@
 "R" = (
 /obj/structure/rack,
 /obj/item/storage/belt/utility/full,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/powered)
 "T" = (
 /obj/machinery/computer/teleporter,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/powered)
 "U" = (
 /obj/machinery/door/airlock/ship/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/powered)
 "W" = (
 /turf/open/space/basic,
 /area/space)
 "Y" = (
 /obj/structure/ore_box,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/powered)
 "Z" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/powered)
 
 (1,1,1) = {"
@@ -1445,7 +1439,7 @@ K
 K
 v
 m
-I
+Y
 r
 D
 D

--- a/_maps/map_files/Mining/nsv13/ruins/mining24.dmm
+++ b/_maps/map_files/Mining/nsv13/ruins/mining24.dmm
@@ -3,7 +3,6 @@
 /obj/structure/mineral_door/wood,
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
 	name = "nanoweave carpet (puce)"
 	},
 /area/ruin/powered)
@@ -22,7 +21,6 @@
 "L" = (
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
 	name = "nanoweave carpet (puce)"
 	},
 /area/ruin/powered)
@@ -30,7 +28,6 @@
 /obj/structure/table/wood/fancy/royalblack,
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
 	name = "nanoweave carpet (puce)"
 	},
 /area/ruin/powered)
@@ -39,7 +36,6 @@
 /obj/structure/table/wood/fancy/royalblack,
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
 	name = "nanoweave carpet (puce)"
 	},
 /area/ruin/powered)
@@ -47,7 +43,6 @@
 /obj/structure/statue/uranium/nuke,
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
 	name = "nanoweave carpet (puce)"
 	},
 /area/ruin/powered)
@@ -55,7 +50,6 @@
 /obj/structure/statue/diamond/captain,
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
 	name = "nanoweave carpet (puce)"
 	},
 /area/ruin/powered)

--- a/_maps/map_files/Mining/nsv13/ruins/mining29.dmm
+++ b/_maps/map_files/Mining/nsv13/ruins/mining29.dmm
@@ -2,13 +2,13 @@
 "d" = (
 /obj/item/hemostat/alien,
 /turf/open/floor/plating/abductor{
-	initial_gas_mix = "LAVALAND_ATMOS"
+	initial_gas_mix = "TEMP=2.7"
 	},
 /area/ruin/powered)
 "g" = (
 /obj/structure/closet/abductor,
 /turf/open/floor/plating/abductor{
-	initial_gas_mix = "LAVALAND_ATMOS"
+	initial_gas_mix = "TEMP=2.7"
 	},
 /area/ruin/powered)
 "q" = (
@@ -21,29 +21,29 @@
 /obj/structure/table/abductor,
 /obj/item/storage/box/alienhandcuffs,
 /turf/open/floor/plating/abductor{
-	initial_gas_mix = "LAVALAND_ATMOS"
+	initial_gas_mix = "TEMP=2.7"
 	},
 /area/ruin/powered)
 "w" = (
-/turf/open/floor/plating/asteroid,
+/turf/open/floor/plating/asteroid/airless,
 /area/ruin/powered)
 "B" = (
 /obj/item/scalpel/alien,
 /obj/item/surgical_drapes,
 /turf/open/floor/plating/abductor{
-	initial_gas_mix = "LAVALAND_ATMOS"
+	initial_gas_mix = "TEMP=2.7"
 	},
 /area/ruin/powered)
 "F" = (
 /obj/structure/bed/abductor,
 /turf/open/floor/plating/abductor{
-	initial_gas_mix = "LAVALAND_ATMOS"
+	initial_gas_mix = "TEMP=2.7"
 	},
 /area/ruin/powered)
 "G" = (
 /obj/machinery/abductor/gland_dispenser,
 /turf/open/floor/plating/abductor{
-	initial_gas_mix = "LAVALAND_ATMOS"
+	initial_gas_mix = "TEMP=2.7"
 	},
 /area/ruin/powered)
 "I" = (
@@ -51,7 +51,7 @@
 	team_number = 100
 	},
 /turf/open/floor/plating/abductor{
-	initial_gas_mix = "LAVALAND_ATMOS"
+	initial_gas_mix = "TEMP=2.7"
 	},
 /area/ruin/powered)
 "K" = (
@@ -59,20 +59,20 @@
 	team_number = 100
 	},
 /turf/open/floor/plating/abductor{
-	initial_gas_mix = "LAVALAND_ATMOS"
+	initial_gas_mix = "TEMP=2.7"
 	},
 /area/ruin/powered)
 "L" = (
 /obj/effect/mob_spawn/human/abductor,
 /turf/open/floor/plating/abductor{
-	initial_gas_mix = "LAVALAND_ATMOS"
+	initial_gas_mix = "TEMP=2.7"
 	},
 /area/ruin/powered)
 "N" = (
 /obj/structure/table/optable/abductor,
 /obj/item/cautery/alien,
 /turf/open/floor/plating/abductor{
-	initial_gas_mix = "LAVALAND_ATMOS"
+	initial_gas_mix = "TEMP=2.7"
 	},
 /area/ruin/powered)
 "O" = (
@@ -80,7 +80,7 @@
 /area/space)
 "V" = (
 /turf/open/floor/plating/abductor{
-	initial_gas_mix = "LAVALAND_ATMOS"
+	initial_gas_mix = "TEMP=2.7"
 	},
 /area/ruin/powered)
 "Y" = (
@@ -88,14 +88,14 @@
 /obj/item/surgicaldrill/alien,
 /obj/item/circular_saw/alien,
 /turf/open/floor/plating/abductor{
-	initial_gas_mix = "LAVALAND_ATMOS"
+	initial_gas_mix = "TEMP=2.7"
 	},
 /area/ruin/powered)
 "Z" = (
 /obj/item/retractor/alien,
 /obj/item/paper/guides/antag/abductor,
 /turf/open/floor/plating/abductor{
-	initial_gas_mix = "LAVALAND_ATMOS"
+	initial_gas_mix = "TEMP=2.7"
 	},
 /area/ruin/powered)
 

--- a/_maps/map_files/Mining/nsv13/ruins/mining3.dmm
+++ b/_maps/map_files/Mining/nsv13/ruins/mining3.dmm
@@ -71,7 +71,6 @@
 /area/ruin/powered)
 "aq" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold-2";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -79,7 +78,6 @@
 "ar" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "pipe11-2";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -87,7 +85,6 @@
 /area/ruin/powered)
 "as" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "pipe11-2";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -95,7 +92,6 @@
 "at" = (
 /obj/machinery/smartfridge/chemistry/preloaded,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "pipe11-2";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -103,7 +99,6 @@
 "au" = (
 /obj/machinery/chem_heater,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "pipe11-2";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -113,7 +108,6 @@
 /obj/item/storage/bag/chemistry,
 /obj/item/storage/box/beakers,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "pipe11-2";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -142,14 +136,12 @@
 "aB" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
 "aC" = (
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -188,7 +180,6 @@
 "aI" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	icon_state = "scrub_map_on-2";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -197,11 +188,9 @@
 "aJ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window{
-	icon_state = "left";
 	dir = 8
 	},
 /obj/machinery/door/window{
-	icon_state = "left";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -214,7 +203,6 @@
 /area/ruin/powered)
 "aL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	icon_state = "scrub_map_on-2";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -259,7 +247,6 @@
 "aT" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold-2";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -270,14 +257,12 @@
 /area/ruin/powered)
 "aV" = (
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
 "aW" = (
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe";
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -288,7 +273,6 @@
 "aX" = (
 /obj/machinery/chem_heater,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "pipe11-2";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -296,7 +280,6 @@
 "aY" = (
 /obj/structure/table/glass,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "pipe11-2";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -305,7 +288,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "pipe11-2";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -313,7 +295,6 @@
 "ba" = (
 /obj/machinery/dna_scannernew,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "pipe11-2";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -321,14 +302,12 @@
 "bb" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "pipe11-2";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
 "bc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "pipe11-2";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -340,14 +319,12 @@
 "be" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "pipe11-2";
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/ruin/powered)
 "bf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "pipe11-2";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -383,7 +360,6 @@
 /area/ruin/powered)
 "bm" = (
 /obj/machinery/computer/cloning{
-	icon_state = "computer";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -434,7 +410,6 @@
 /area/ruin/powered)
 "bw" = (
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j1";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -443,7 +418,6 @@
 "bx" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -455,7 +429,6 @@
 /area/ruin/powered)
 "bz" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	icon_state = "pipe11-2";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -466,7 +439,6 @@
 /area/ruin/powered)
 "bB" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	icon_state = "pipe11-2";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -477,7 +449,6 @@
 /area/ruin/powered)
 "bD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "pipe11-2";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -493,7 +464,6 @@
 /area/ruin/powered)
 "bG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "pipe11-2";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -526,7 +496,6 @@
 /area/ruin/powered)
 "bL" = (
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -536,18 +505,15 @@
 /area/ruin/powered)
 "bM" = (
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold-2";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
 "bN" = (
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -559,7 +525,6 @@
 "bO" = (
 /obj/machinery/door/airlock/medical/glass,
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -569,7 +534,6 @@
 /area/ruin/powered)
 "bP" = (
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j1";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -577,22 +541,18 @@
 /area/ruin/powered)
 "bQ" = (
 /obj/structure/disposalpipe/junction/flip{
-	icon_state = "pipe-j2";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold-2";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
 "bR" = (
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "pipe11-2";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -602,33 +562,27 @@
 /area/ruin/powered)
 "bS" = (
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "pipe11-2";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
 "bT" = (
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe";
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold-2";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
 "bU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "pipe11-2";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "pipe11-2";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -668,21 +622,18 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	icon_state = "scrub_map_on-2";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
 "ca" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold-2";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
 "cb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "pipe11-2";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -690,7 +641,6 @@
 /area/ruin/powered)
 "cc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "pipe11-2";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -703,7 +653,6 @@
 "ce" = (
 /obj/machinery/door/airlock/medical/glass,
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -713,7 +662,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "pipe11-2";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -729,7 +677,6 @@
 /area/ruin/powered)
 "ci" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	icon_state = "scrub_map_on-2";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -778,7 +725,6 @@
 /obj/item/storage/firstaid/ancient,
 /obj/item/storage/firstaid/brute,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "pipe11-2";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -794,7 +740,6 @@
 "cq" = (
 /obj/structure/table/glass,
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe";
 	dir = 10
 	},
 /obj/item/storage/firstaid/ancient,
@@ -810,14 +755,12 @@
 "cs" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "pipe11-2";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
 "ct" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "pipe11-2";
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
@@ -873,7 +816,6 @@
 /area/ruin/powered)
 "cD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	icon_state = "scrub_map_on-2";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -881,7 +823,6 @@
 "cE" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -912,7 +853,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "pipe11-2";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -923,14 +863,12 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "pipe11-2";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
 "cL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "pipe11-2";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -996,14 +934,12 @@
 /area/ruin/powered)
 "cX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "pipe11-2";
 	dir = 5
 	},
 /turf/open/floor/plating,
 /area/ruin/powered)
 "cY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "pipe11-2";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -1015,7 +951,6 @@
 "da" = (
 /obj/machinery/door/airlock/grunge,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "pipe11-2";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -1065,6 +1000,9 @@
 /area/ruin/powered)
 "xJ" = (
 /turf/template_noop,
+/area/ruin/powered)
+"Bq" = (
+/turf/open/floor/plating/asteroid,
 /area/ruin/powered)
 
 (1,1,1) = {"
@@ -2264,7 +2202,7 @@ ai
 bI
 bd
 ai
-ac
+Bq
 ab
 ab
 ab
@@ -2306,7 +2244,7 @@ ai
 ai
 bV
 ai
-ac
+Bq
 ab
 ab
 ab
@@ -2344,11 +2282,11 @@ ai
 ai
 be
 ai
-ac
+Bq
 ai
 bX
 bD
-ac
+Bq
 ab
 ab
 ab
@@ -2386,7 +2324,7 @@ ab
 ao
 bf
 ai
-ac
+Bq
 ai
 bY
 ci
@@ -2428,9 +2366,9 @@ ab
 ab
 ab
 ab
-ac
-ac
-ac
+Bq
+Bq
+Bq
 ab
 ab
 ab
@@ -2472,7 +2410,7 @@ ab
 ab
 ab
 ab
-ac
+Bq
 ab
 ab
 ab


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

At first I just looked at mining11.dmm, ruined stormdrive. Previously, the asteroid ruin was mixed airless sand turfs and pressurized reinforced plating, monotiles and tileless plating. Now it's all airless. Also removes a tiny fan

Then I went ahead and just checked them all 

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Lag bad


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
