### PR TITLE
Fixes RBMK valve control console exploitability

### DIFF
--- a/nsv13/code/modules/power/rbmk.dm
+++ b/nsv13/code/modules/power/rbmk.dm
@@ -689,7 +689,8 @@ The reactor CHEWS through moderator. It does not do this slowly. Be very careful
 	var/newPressure = input(user, "Set new output pressure (kPa)", "Remote pump control", null) as num
 	if(!newPressure)
 		return
-	signal(on, newPressure) //Number sanitization is handled on the actual pumps themselves.
+	newPressure = clamp(newPressure, 0, MAX_OUTPUT_PRESSURE) //Number sanitization is not handled in the pumps themselves, only during their ui_act which this doesn't use.
+	signal(on, newPressure)
 
 /obj/machinery/computer/reactor/attack_robot(mob/user)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Turns out, as opposed to the code comment, valves do NOT sanitize the values provided by the signal, which means you were able to set the pumps to absurd values. This PR fixes that.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Being able to set inacceptably high pressures on pumps via these consoles ain't good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: RBMK valve control consoles can no longer set pumps to higher pressures than allowed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
