### PR TITLE
Makes pilots not get deleted (Should fix uncloneability)

### DIFF
--- a/nsv13/code/modules/overmap/fighters/fighters2.dm
+++ b/nsv13/code/modules/overmap/fighters/fighters2.dm
@@ -40,6 +40,10 @@ Repair
 	toggle_canopy()
 	forceMove(get_turf(locate(255, y, z)))
 
+/obj/structure/overmap/fighter/Destroy()
+	throw_pilot()
+	.=..()
+
 /obj/structure/overmap/fighter
 	name = "Space Fighter"
 	icon = 'nsv13/icons/overmap/nanotrasen/fighter.dmi'
@@ -539,6 +543,54 @@ Repair
 	for(var/mob/M in operators)
 		stop_piloting(M)
 		to_chat(M, "<span class='warning'>You have been remotely ejected from [src]!.</span>")
+
+/obj/structure/overmap/proc/throw_pilot() //Used when yeeting a pilot out of an exploding ship
+	if(!SSmapping.level_trait(loc.z, ZTRAIT_BOARDABLE)) //Check if we're on the overmap
+		var/max = world.maxx-TRANSITIONEDGE
+		var/min = 1+TRANSITIONEDGE
+
+		var/list/possible_transitions = list()
+		for(var/A in SSmapping.z_list)
+			var/datum/space_level/D = A
+			if (D.linkage == CROSSLINKED)
+				possible_transitions += D.z_value
+			if(!possible_transitions.len) //Just in case there is no space z level
+				for(var/z in SSmapping.levels_by_trait(ZTRAIT_STATION))
+				possible_transitions += z
+
+		var/_z = pick(possible_transitions)
+		var/_x
+		var/_y
+
+		switch(dir)
+			if(SOUTH)
+				_x = rand(min,max)
+				_y = max
+			if(WEST)
+				_x = max
+				_y = rand(min,max)
+			if(EAST)
+				_x = min
+				_y = rand(min,max)
+			else
+				_x = rand(min,max)
+				_y = min
+
+		var/turf/T = locate(_x, _y, _z) //Where are we putting you
+		for(var/mob/living/M in contents)
+			mobs_in_ship -= M
+			M.stop_sound_channel(CHANNEL_SHIP_ALERT) //In space no one can hear your ship explode
+			M.apply_damage(400) //No way you're surviving that
+			M.unfuck_overmap() //Remove camera because you're not looking at the deleted ship
+			M.forceMove(T) //Yeets the spessman
+
+	else //If we're anywhere that isn't the overmap
+		for(var/mob/living/M in contents)
+			mobs_in_ship -= M
+			M.stop_sound_channel(CHANNEL_SHIP_ALERT)
+			M.apply_damage(200) //Turns out exploding will kill you
+			M.unfuck_overmap() //Remove camera because you're not looking at the deleted ship
+			M.forceMove(get_turf(src)) //Just gonna plop you on the ground
 
 /obj/structure/overmap/fighter/attackby(obj/item/W, mob/user, params)   //fueling and changing equipment
 	add_fingerprint(user)

--- a/nsv13/code/modules/overmap/overmap.dm
+++ b/nsv13/code/modules/overmap/overmap.dm
@@ -344,6 +344,8 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 
 	var/turf/T = locate(_x, _y, _z) //Where are we putting you
 	for(var/mob/living/M in contents)
+		M.stop_sound_channel(CHANNEL_SHIP_ALERT) //In space no one can hear your ship explode
+		mobs_in_ship -= M //How can you be in something that just got deleted?
 		M.forceMove(T) //Yeets the spessman
 		M.apply_damage(400) //No way you're surviving that
 

--- a/nsv13/code/modules/overmap/overmap.dm
+++ b/nsv13/code/modules/overmap/overmap.dm
@@ -311,6 +311,37 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 	if(ai_controlled)
 		weapon_types[FIRE_MODE_MISSILE] = new/datum/ship_weapon/missile_launcher(src)
 
+/obj/structure/overmap/proc/throw_pilot(var/mob/living/M in contents)
+	var/max = world.maxx-TRANSITIONEDGE
+	var/min = 1+TRANSITIONEDGE
+	var/list/possible_transitions = list()
+	for(var/A in SSmapping.z_list)
+		var/datum/space_level/D = A
+		if (D.linkage == CROSSLINKED)
+			possible_transitions += D.z_value
+		if(!possible_transitions.len)
+			for(var/z in SSmapping.levels_by_trait(ZTRAIT_STATION))
+			possible_transitions += z
+	var/_z = pick(possible_transitions)
+	var/_x
+	var/_y
+	switch(dir)
+		if(SOUTH)
+			_x = rand(min,max)
+			_y = max
+		if(WEST)
+			_x = max
+			_y = rand(min,max)
+		if(EAST)
+			_x = min
+			_y = rand(min,max)
+		else
+			_x = rand(min,max)
+			_y = min
+	var/turf/T = locate(_x, _y, _z) //Where are we putting you
+	M.apply_damage(400) //Yeah you're not gonna survive that
+	M.forceMove(T) //Yeets the spessman
+
 /obj/item/projectile/Destroy()
 	if(physics2d)
 		qdel(physics2d)
@@ -319,6 +350,8 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 
 /obj/structure/overmap/Destroy()
 	SEND_SIGNAL(src,COMSIG_SHIP_KILLED)
+	if(/obj/structure/overmap/fighter/light || /obj/structure/overmap/fighter/heavy || /obj/structure/overmap/fighter/light/flight_leader || /obj/structure/overmap/fighter/utility || /obj/structure/overmap/fighter/escapepod || /obj/structure/overmap/fighter/light/syndicate || /obj/structure/overmap/fighter/utility/syndicate)
+		throw_pilot()
 	QDEL_LIST(current_tracers)
 	if(cabin_air)
 		QDEL_NULL(cabin_air)

--- a/nsv13/code/modules/overmap/overmap.dm
+++ b/nsv13/code/modules/overmap/overmap.dm
@@ -311,74 +311,6 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 	if(ai_controlled)
 		weapon_types[FIRE_MODE_MISSILE] = new/datum/ship_weapon/missile_launcher(src)
 
-/obj/structure/overmap/proc/throw_pilot()
-	if(!SSmapping.level_trait(loc.z, ZTRAIT_BOARDABLE)) //Check if we're on the overmap
-		var/max = world.maxx-TRANSITIONEDGE
-		var/min = 1+TRANSITIONEDGE
-
-		var/list/possible_transitions = list()
-		for(var/A in SSmapping.z_list)
-			var/datum/space_level/D = A
-			if (D.linkage == CROSSLINKED)
-				possible_transitions += D.z_value
-			if(!possible_transitions.len) //Just in case there is no space z level
-				for(var/z in SSmapping.levels_by_trait(ZTRAIT_STATION))
-				possible_transitions += z
-
-		var/_z = pick(possible_transitions)
-		var/_x
-		var/_y
-
-		switch(dir)
-			if(SOUTH)
-				_x = rand(min,max)
-				_y = max
-			if(WEST)
-				_x = max
-				_y = rand(min,max)
-			if(EAST)
-				_x = min
-				_y = rand(min,max)
-			else
-				_x = rand(min,max)
-				_y = min
-
-		var/turf/T = locate(_x, _y, _z) //Where are we putting you
-		for(var/mob/living/M in contents)
-			mobs_in_ship -= M
-			M.stop_sound_channel(CHANNEL_SHIP_ALERT) //In space no one can hear your ship explode
-			M.forceMove(T) //Yeets the spessman
-			M.apply_damage(400) //No way you're surviving that
-			M.client.view_size.resetToDefault() //No camera jank anymore please
-			M.client.overmap_zoomout = 0 //Report on ^: there is still camera jank
-			M.client.pixel_x = 0
-			M.client.pixel_y = 0
-			var/mob/camera/aiEye/remote/overmap_observer/eyeobj = M.remote_control
-			M.cancel_camera()
-			QDEL_NULL(eyeobj)
-			QDEL_NULL(eyeobj?.off_action)
-			QDEL_NULL(M.remote_control)
-			call(/datum/action/innate/camera_off/overmap/Activate)()
-			M.set_focus(M)
-
-	else //If we're anywhere that isn't the overmap
-		for(var/mob/living/M in contents)
-			mobs_in_ship -= M
-			M.stop_sound_channel(CHANNEL_SHIP_ALERT)
-			M.forceMove(get_turf(src)) //Just gonna plop you on the ground
-			M.apply_damage(200) //Turns out exploding will kill you
-			M.client.view_size.resetToDefault()
-			M.client.overmap_zoomout = 0
-			M.client.pixel_x = 0
-			M.client.pixel_y = 0
-			var/mob/camera/aiEye/remote/overmap_observer/eyeobj = M.remote_control
-			M.cancel_camera()
-			QDEL_NULL(eyeobj)
-			QDEL_NULL(eyeobj?.off_action)
-			QDEL_NULL(M.remote_control)
-			call(/datum/action/innate/camera_off/overmap/Activate)()
-			M.set_focus(M)
-
 /obj/item/projectile/Destroy()
 	if(physics2d)
 		qdel(physics2d)
@@ -387,8 +319,6 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 
 /obj/structure/overmap/Destroy()
 	SEND_SIGNAL(src,COMSIG_SHIP_KILLED)
-	if(mobs_in_ship)
-		throw_pilot()
 	QDEL_LIST(current_tracers)
 	if(cabin_air)
 		QDEL_NULL(cabin_air)

--- a/nsv13/code/modules/overmap/overmap.dm
+++ b/nsv13/code/modules/overmap/overmap.dm
@@ -314,17 +314,20 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 /obj/structure/overmap/proc/throw_pilot(var/mob/living/M in contents)
 	var/max = world.maxx-TRANSITIONEDGE
 	var/min = 1+TRANSITIONEDGE
+
 	var/list/possible_transitions = list()
 	for(var/A in SSmapping.z_list)
 		var/datum/space_level/D = A
 		if (D.linkage == CROSSLINKED)
 			possible_transitions += D.z_value
-		if(!possible_transitions.len)
+		if(!possible_transitions.len) //Just in case there is no space z level
 			for(var/z in SSmapping.levels_by_trait(ZTRAIT_STATION))
 			possible_transitions += z
+
 	var/_z = pick(possible_transitions)
 	var/_x
 	var/_y
+
 	switch(dir)
 		if(SOUTH)
 			_x = rand(min,max)
@@ -338,9 +341,11 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 		else
 			_x = rand(min,max)
 			_y = min
+
 	var/turf/T = locate(_x, _y, _z) //Where are we putting you
-	M.apply_damage(400) //Yeah you're not gonna survive that
 	M.forceMove(T) //Yeets the spessman
+	mobs_in_ship -= M //You are not in the fighter anymore
+	M.apply_damage(400) //No way you're surviving that
 
 /obj/item/projectile/Destroy()
 	if(physics2d)
@@ -350,7 +355,7 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 
 /obj/structure/overmap/Destroy()
 	SEND_SIGNAL(src,COMSIG_SHIP_KILLED)
-	if(/obj/structure/overmap/fighter/light || /obj/structure/overmap/fighter/heavy || /obj/structure/overmap/fighter/light/flight_leader || /obj/structure/overmap/fighter/utility || /obj/structure/overmap/fighter/escapepod || /obj/structure/overmap/fighter/light/syndicate || /obj/structure/overmap/fighter/utility/syndicate)
+	if(mobs_in_ship)
 		throw_pilot()
 	QDEL_LIST(current_tracers)
 	if(cabin_air)

--- a/nsv13/code/modules/overmap/overmap.dm
+++ b/nsv13/code/modules/overmap/overmap.dm
@@ -358,6 +358,7 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 			QDEL_NULL(eyeobj)
 			QDEL_NULL(eyeobj?.off_action)
 			QDEL_NULL(M.remote_control)
+			call(/datum/action/innate/camera_off/overmap/Activate)()
 			M.set_focus(M)
 
 	else //If we're anywhere that isn't the overmap
@@ -375,6 +376,7 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 			QDEL_NULL(eyeobj)
 			QDEL_NULL(eyeobj?.off_action)
 			QDEL_NULL(M.remote_control)
+			call(/datum/action/innate/camera_off/overmap/Activate)()
 			M.set_focus(M)
 
 /obj/item/projectile/Destroy()

--- a/nsv13/code/modules/overmap/overmap.dm
+++ b/nsv13/code/modules/overmap/overmap.dm
@@ -311,7 +311,7 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 	if(ai_controlled)
 		weapon_types[FIRE_MODE_MISSILE] = new/datum/ship_weapon/missile_launcher(src)
 
-/obj/structure/overmap/proc/throw_pilot(var/mob/living/M in contents)
+/obj/structure/overmap/proc/throw_pilot()
 	var/max = world.maxx-TRANSITIONEDGE
 	var/min = 1+TRANSITIONEDGE
 
@@ -343,9 +343,9 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 			_y = min
 
 	var/turf/T = locate(_x, _y, _z) //Where are we putting you
-	M.forceMove(T) //Yeets the spessman
-	mobs_in_ship -= M //You are not in the fighter anymore
-	M.apply_damage(400) //No way you're surviving that
+	for(var/mob/living/M in contents)
+		M.forceMove(T) //Yeets the spessman
+		M.apply_damage(400) //No way you're surviving that
 
 /obj/item/projectile/Destroy()
 	if(physics2d)


### PR DESCRIPTION
## About The Pull Request
Stops pilots from getting deleted along with their fighters when they blow up, they are instead sent to (and murdered on) the empty space z level.
should fix: #666 and fix #407 

## Changelog
:cl:
fix: Stops fighter pilots' corpses from getting deleted upon ship death.
/:cl: