### PR TITLE
Bars Flight Lead from being in a GQ squad.

### DIFF
--- a/nsv13/code/game/general_quarters/squad.dm
+++ b/nsv13/code/game/general_quarters/squad.dm
@@ -85,7 +85,7 @@ GLOBAL_DATUM_INIT(squad_manager, /datum/squad_manager, new)
 	Although your assigned duty is damage control, you must listen to your squad leader, as they may receive orders to redirect your squad to another essential duty <br/>\
 	<i>Squad vendors</i> open up during General Quarters, and allow you to acquire a kit containing tarpaulins for closing breaches, basic tools, metal foam and a distinctive uniform to tell your squad members apart.</span>"
 	var/datum/radio_frequency/radio_connection
-	var/static/list/blacklist = list(/datum/job/captain, /datum/job/hop, /datum/job/chief_engineer, /datum/job/cargo_tech,/datum/job/mining, /datum/job/qm, /datum/job/ai, /datum/job/cyborg, /datum/job/munitions_tech, /datum/job/fighter_pilot, /datum/job/master_at_arms, /datum/job/rd, /datum/job/air_traffic_controller, /datum/job/warden, /datum/job/hos, /datum/job/officer, /datum/job/chief_engineer, /datum/job/bridge)
+	var/static/list/blacklist = list(/datum/job/captain, /datum/job/hop, /datum/job/chief_engineer, /datum/job/cargo_tech,/datum/job/mining, /datum/job/qm, /datum/job/ai, /datum/job/cyborg, /datum/job/munitions_tech, /datum/job/fighter_pilot, /datum/job/master_at_arms, /datum/job/rd, /datum/job/air_traffic_controller, /datum/job/warden, /datum/job/hos, /datum/job/officer, /datum/job/chief_engineer, /datum/job/bridge, /datum/job/flight_leader)
 	var/list/access = list()
 
 /datum/squad/proc/broadcast(msg, mob/living/carbon/human/sender, sound=pick('nsv13/sound/effects/radio1.ogg','nsv13/sound/effects/radio2.ogg'), isOverwatch=FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds FL to the blacklist of roles that are not assigned to squads roundstart as he already has a GQ role. Change can be found in the general_quarters file in squad.dm (ORIGINAL ISSUE THREAD: https://github.com/BeeStation/NSV13/issues/1016)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

FLs won't be overwhelmed with being in squads, it makes em fall in with rest of hangar and it also removes squad bloat so the XO or whoever can count his men in squads with more accurate data.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: tweaked a few things
fix: fixed a few things
code: changed some code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
