### PR TITLE
lets travis greentext

### DIFF
--- a/_maps/map_files/Hammerhead/Hammerhead.dmm
+++ b/_maps/map_files/Hammerhead/Hammerhead.dmm
@@ -22685,7 +22685,7 @@
 /area/crew_quarters/dorms)
 "bDE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bEf" = (
 /turf/open/floor/plating,
@@ -23812,7 +23812,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 10
 	},
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "crw" = (
 /obj/effect/turf_decal/tile/yellow,
@@ -25136,7 +25136,7 @@
 /area/quartermaster/warehouse)
 "dqr" = (
 /obj/effect/spawner/room/threexfive,
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "dqt" = (
 /obj/machinery/door/firedoor/border_only/directional/north,
@@ -25587,7 +25587,7 @@
 	dir = 5
 	},
 /obj/effect/spawner/room/threexthree,
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "dDB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
@@ -26762,9 +26762,6 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"eyd" = (
-/turf/template_noop,
-/area/maintenance/department/cargo)
 "eyQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -26931,9 +26928,6 @@
 /obj/item/toy/plush/lizardplushie,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"eEG" = (
-/turf/template_noop,
-/area/maintenance/department/bridge)
 "eFd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -27196,7 +27190,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/port/aft)
 "ePb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -28521,12 +28515,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
-"fFS" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/template_noop,
-/area/maintenance/department/electrical)
 "fGl" = (
 /obj/structure/window/reinforced,
 /obj/machinery/conveyor{
@@ -29519,7 +29507,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "gri" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
@@ -29576,9 +29564,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/hallway/primary/aft)
-"gtQ" = (
-/turf/template_noop,
-/area/maintenance/department/medical/morgue)
 "guf" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "12"
@@ -30028,18 +30013,6 @@
 "gMn" = (
 /turf/open/floor/wood,
 /area/maintenance/starboard/central)
-"gMp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/turf/template_noop,
-/area/maintenance/department/electrical)
 "gMA" = (
 /obj/machinery/light/broken{
 	dir = 4
@@ -30294,7 +30267,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 6
 	},
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "gVT" = (
 /obj/machinery/camera/autoname{
@@ -31477,7 +31450,7 @@
 /area/security/brig)
 "hBo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "hBM" = (
 /obj/effect/turf_decal/tile/brown{
@@ -31590,7 +31563,7 @@
 /area/crew_quarters/bar)
 "hFA" = (
 /obj/effect/spawner/room/fivexfour,
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/port/aft)
 "hFC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
@@ -31603,7 +31576,7 @@
 /area/nsv/hanger/storage)
 "hFE" = (
 /obj/effect/spawner/room/threexthree,
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/port/aft)
 "hFG" = (
 /obj/effect/landmark/blobstart,
@@ -32110,7 +32083,7 @@
 /area/maintenance/department/science/central)
 "hXU" = (
 /obj/effect/spawner/room/tenxfive,
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "hXV" = (
 /obj/effect/turf_decal/stripes/white/line{
@@ -32792,7 +32765,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "itZ" = (
 /obj/structure/window{
@@ -33310,12 +33283,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
-"iLn" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/template_noop,
-/area/maintenance/department/electrical)
 "iLR" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -33487,12 +33454,6 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/ship,
 /area/construction)
-"iRr" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/template_noop,
-/area/maintenance/department/electrical)
 "iSh" = (
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
@@ -33506,7 +33467,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 5
 	},
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "iSw" = (
 /obj/effect/turf_decal/tile/brown{
@@ -33750,11 +33711,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "jbD" = (
 /obj/effect/spawner/room/fivexfour,
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/port/central)
 "jbH" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -34014,7 +33975,7 @@
 /area/hallway/secondary/exit)
 "jkQ" = (
 /obj/effect/spawner/room/tenxfive,
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "jkW" = (
 /obj/machinery/firealarm{
@@ -34037,7 +33998,7 @@
 /area/maintenance/port/central)
 "jle" = (
 /obj/effect/spawner/room/fivexfour,
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "jlH" = (
 /obj/effect/landmark/event_spawn,
@@ -34079,7 +34040,7 @@
 /area/hallway/primary/fore)
 "jnm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "jnt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -34717,9 +34678,6 @@
 /obj/item/multitool,
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"jHX" = (
-/turf/template_noop,
-/area/maintenance/starboard/central)
 "jIa" = (
 /obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/plasteel,
@@ -35037,7 +34995,7 @@
 /area/medical/virology)
 "jSC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/port/aft)
 "jSD" = (
 /obj/machinery/airalarm/directional/north,
@@ -38626,7 +38584,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 1
 	},
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "mhv" = (
 /turf/open/floor/plasteel,
@@ -40354,7 +40312,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 10
 	},
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "nmN" = (
 /obj/effect/landmark/start/cook,
@@ -40390,9 +40348,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"noG" = (
-/turf/template_noop,
-/area/maintenance/port/aft)
 "noN" = (
 /obj/machinery/computer/lore_terminal,
 /turf/open/floor/plasteel/dark,
@@ -40878,7 +40833,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "nFC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -41162,7 +41117,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 1
 	},
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "nQl" = (
 /obj/effect/turf_decal/tile/blue{
@@ -41755,7 +41710,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "ogm" = (
 /obj/machinery/door/airlock/ship/maintenance{
@@ -42016,7 +41971,7 @@
 /area/nsv/hanger)
 "onQ" = (
 /obj/effect/spawner/room/fivexthree,
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/fore)
 "oob" = (
 /obj/effect/turf_decal/tile/purple,
@@ -42051,7 +42006,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 5
 	},
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "oqC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -42136,7 +42091,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 4
 	},
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "osO" = (
 /obj/machinery/camera/autoname{
@@ -45343,7 +45298,7 @@
 /area/chapel/main)
 "qCO" = (
 /obj/effect/spawner/room/fivexfour,
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "qDa" = (
 /obj/effect/turf_decal/box/red/corners{
@@ -45715,7 +45670,7 @@
 /area/engine/engineering)
 "qRU" = (
 /obj/effect/spawner/room/threexthree,
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "qSe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -46543,7 +46498,7 @@
 /area/ai_monitored/turret_protected/aisat/hallway/support_ship)
 "rrk" = (
 /obj/effect/spawner/room/threexthree,
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "rrv" = (
 /obj/effect/turf_decal/stripes/red/line{
@@ -47076,12 +47031,6 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
-"rGw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/template_noop,
-/area/maintenance/department/bridge)
 "rGF" = (
 /obj/structure/window{
 	dir = 1
@@ -47185,9 +47134,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/lockup)
-"rKa" = (
-/turf/template_noop,
-/area/maintenance/fore)
 "rKc" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /obj/machinery/firealarm{
@@ -48319,7 +48265,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "sxk" = (
 /obj/structure/cable{
@@ -48753,7 +48699,7 @@
 /area/engine/engineering/hangar)
 "sJS" = (
 /obj/effect/landmark/nuclear_waste_spawner,
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "sJZ" = (
 /obj/effect/landmark/start/assistant,
@@ -48810,12 +48756,6 @@
 /obj/item/ship_weapon/ammunition/torpedo,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory/lockup)
-"sLQ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/template_noop,
-/area/maintenance/port/aft)
 "sMJ" = (
 /obj/structure/grille,
 /obj/structure/cable{
@@ -48927,7 +48867,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "sQf" = (
 /obj/effect/turf_decal/tile/red,
@@ -49013,7 +48953,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/port/aft)
 "sTv" = (
 /obj/machinery/airalarm/directional/south,
@@ -49297,12 +49237,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"tcF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/template_noop,
-/area/maintenance/department/cargo)
 "tcI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
@@ -50932,7 +50866,7 @@
 /area/nsv/crew_quarters/heads/maa)
 "uaT" = (
 /obj/effect/landmark/blobstart,
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "ubv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
@@ -51232,10 +51166,6 @@
 /obj/effect/spawner/lootdrop/maintenance/seven,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"ung" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/template_noop,
-/area/maintenance/department/bridge)
 "unu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -51943,7 +51873,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 5
 	},
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "uJO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
@@ -52260,12 +52190,12 @@
 "uYp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/port/aft)
 "uYO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/port/aft)
 "uYX" = (
 /turf/open/floor/plasteel/white,
@@ -52804,7 +52734,7 @@
 /area/maintenance/department/medical/morgue)
 "vpp" = (
 /obj/effect/spawner/room/threexthree,
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "vpv" = (
 /obj/effect/turf_decal/stripes/red/line,
@@ -53687,7 +53617,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 1
 	},
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "vSq" = (
 /obj/machinery/atmospherics/pipe/simple/brown/hidden{
@@ -54818,9 +54748,6 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
-"wHE" = (
-/turf/template_noop,
-/area/maintenance/port/central)
 "wHH" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/yellow,
@@ -55689,9 +55616,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"xmP" = (
-/turf/template_noop,
-/area/maintenance/department/electrical)
 "xnj" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/computer/ship/munitions_computer{
@@ -56138,7 +56062,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "xDx" = (
 /obj/structure/rack,
@@ -56925,7 +56849,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "yaR" = (
 /obj/machinery/airalarm/directional/south,
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/port/aft)
 "yaX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -56974,9 +56898,6 @@
 /obj/item/clothing/head/helmet/decktech,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/hanger)
-"ycz" = (
-/turf/template_noop,
-/area/maintenance/department/crew_quarters/bar)
 "ycB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -72822,8 +72743,8 @@ aux
 aux
 aux
 jxt
-noG
-noG
+aUL
+aUL
 hFE
 aJB
 wTz
@@ -73079,7 +73000,7 @@ aux
 jxt
 aJX
 jxt
-noG
+aUL
 sTo
 ePa
 yie
@@ -73336,9 +73257,9 @@ aux
 jxt
 big
 jxt
-noG
-sLQ
-noG
+aUL
+bRg
+aUL
 aJB
 bRg
 amR
@@ -76160,8 +76081,8 @@ aux
 fkN
 aEn
 feG
-noG
-noG
+aUL
+aUL
 hFE
 jxt
 aaa
@@ -76417,9 +76338,9 @@ aux
 fkN
 fkN
 feG
-noG
-noG
-noG
+aUL
+aUL
+aUL
 jxt
 aaa
 dMd
@@ -76674,9 +76595,9 @@ aux
 aar
 aar
 jxt
-noG
-noG
-noG
+aUL
+aUL
+aUL
 atd
 aaa
 apW
@@ -77501,8 +77422,8 @@ vHw
 aho
 gbJ
 aho
-xmP
-xmP
+ata
+ata
 osI
 qCO
 akX
@@ -77758,10 +77679,10 @@ iQX
 aho
 dSe
 lzg
-iRr
-iRr
+bVr
+bVr
 gre
-xmP
+ata
 aho
 aho
 akX
@@ -78015,15 +77936,15 @@ vHw
 aho
 vHw
 aho
-xmP
+ata
 hBo
 uJI
-xmP
+ata
 aho
-xmP
-xmP
-xmP
-xmP
+ata
+ata
+ata
+ata
 hXU
 imv
 bku
@@ -78272,16 +78193,16 @@ vHw
 aho
 vHw
 aho
-xmP
-xmP
+ata
+ata
 nmG
 jbw
 lDl
 jbw
 jbw
 iSr
-xmP
-xmP
+ata
+ata
 tyn
 aHd
 bkw
@@ -78529,16 +78450,16 @@ vHw
 aho
 iQX
 aho
-xmP
-xmP
-xmP
-xmP
+ata
+ata
+ata
+ata
 aho
-xmP
-xmP
+ata
+ata
 xCZ
-xmP
-xmP
+ata
+ata
 tyn
 aHd
 aHd
@@ -78791,11 +78712,11 @@ iWB
 iWB
 imv
 imv
-xmP
-xmP
+ata
+ata
 xCZ
-xmP
-xmP
+ata
+ata
 imv
 aux
 aux
@@ -79048,11 +78969,11 @@ ajz
 aaa
 aaa
 iWB
-xmP
-xmP
-gMp
-xmP
-xmP
+ata
+ata
+cWT
+ata
+ata
 tyn
 aHd
 bkw
@@ -79305,11 +79226,11 @@ vHO
 fDd
 ajz
 iWB
-xmP
-xmP
-gMp
-xmP
-xmP
+ata
+ata
+cWT
+ata
+ata
 tyn
 aHd
 aHd
@@ -79562,11 +79483,11 @@ ajz
 bGF
 bEf
 imv
-xmP
+ata
 hBo
 ofY
-xmP
-xmP
+ata
+ata
 imv
 aux
 aux
@@ -79819,11 +79740,11 @@ ajz
 ajz
 aaa
 imv
-xmP
-xmP
+ata
+ata
 vRU
 mhr
-xmP
+ata
 tyn
 aHd
 bkw
@@ -80077,10 +79998,10 @@ imv
 imv
 imv
 sJS
-xmP
-gMp
-xmP
-xmP
+ata
+cWT
+ata
+ata
 tyn
 aHd
 aHd
@@ -80333,11 +80254,11 @@ tLz
 rVd
 xpC
 aho
-xmP
-xmP
-gMp
-xmP
-xmP
+ata
+ata
+cWT
+ata
+ata
 imv
 aux
 aux
@@ -80532,9 +80453,9 @@ aJB
 exG
 aJB
 aJB
-noG
-noG
-noG
+aUL
+aUL
+aUL
 hFA
 cag
 cag
@@ -80789,10 +80710,10 @@ fVO
 aUL
 rpf
 aJB
-noG
-noG
-noG
-noG
+aUL
+aUL
+aUL
+aUL
 jxt
 cag
 cag
@@ -81046,10 +80967,10 @@ bNw
 hGy
 aUL
 aJB
-noG
-noG
-noG
-noG
+aUL
+aUL
+aUL
+aUL
 jxt
 aaa
 aaa
@@ -81303,9 +81224,9 @@ atd
 oQc
 jNt
 aJB
-noG
-noG
-noG
+aUL
+aUL
+aUL
 yaR
 jxt
 wza
@@ -82637,8 +82558,8 @@ ayq
 aNQ
 aaj
 aaf
-xmP
-iLn
+ata
+vHw
 vpp
 imv
 imv
@@ -82894,9 +82815,9 @@ aID
 aRs
 aaj
 aaf
-xmP
-iLn
-xmP
+ata
+vHw
+ata
 aho
 nkB
 wBG
@@ -83151,9 +83072,9 @@ aaj
 mtG
 bag
 aaf
-xmP
-fFS
-iRr
+ata
+vtn
+bVr
 syA
 uEX
 bVr
@@ -89282,9 +89203,9 @@ wza
 wza
 bFX
 pwe
-wHE
-wHE
-wHE
+aub
+aub
+aub
 jbD
 aIx
 dSy
@@ -89539,10 +89460,10 @@ aux
 wza
 cZS
 aIx
-wHE
-wHE
-wHE
-wHE
+aub
+aub
+aub
+aub
 aIx
 ahx
 auu
@@ -89796,10 +89717,10 @@ aux
 wza
 sZX
 aIx
-wHE
-wHE
-wHE
-wHE
+aub
+aub
+aub
+aub
 aIx
 pim
 auu
@@ -90053,10 +89974,10 @@ aIJ
 wza
 cHE
 aIx
-wHE
-wHE
-wHE
-wHE
+aub
+aub
+aub
+aub
 aIx
 abP
 auu
@@ -90310,10 +90231,10 @@ ohS
 wza
 cZS
 aIx
-wHE
-wHE
-wHE
-wHE
+aub
+aub
+aub
+aub
 aIx
 abP
 auu
@@ -93943,10 +93864,10 @@ aVL
 aVL
 aVL
 aVL
-gtQ
-gtQ
-gtQ
-gtQ
+arM
+arM
+arM
+arM
 dqr
 dLA
 vpo
@@ -94200,16 +94121,16 @@ lzy
 lzy
 lzy
 aVL
-gtQ
-gtQ
-gtQ
-gtQ
-gtQ
+arM
+arM
+arM
+arM
+arM
 dLA
 iSh
 suQ
-jHX
-jHX
+iSh
+iSh
 rrk
 dLA
 boH
@@ -94457,22 +94378,22 @@ aVL
 aVL
 lzy
 aVL
-gtQ
-gtQ
-gtQ
-gtQ
-gtQ
+arM
+arM
+arM
+arM
+arM
 dLA
 iSh
 oEb
-jHX
-jHX
-jHX
+iSh
+iSh
+iSh
 dLA
 boH
 dLA
-gtQ
-gtQ
+arM
+arM
 qRU
 nub
 dEY
@@ -94722,15 +94643,15 @@ dLA
 dLA
 iSh
 suQ
-jHX
-jHX
-jHX
+iSh
+iSh
+iSh
 dLA
 boH
 hNh
-gtQ
-gtQ
-gtQ
+arM
+arM
+arM
 nub
 dEY
 aaa
@@ -94985,9 +94906,9 @@ aeR
 dLA
 boH
 dLA
-gtQ
-gtQ
-gtQ
+arM
+arM
+arM
 nub
 dEY
 aaa
@@ -97030,9 +96951,9 @@ gwJ
 ieh
 gCY
 xcC
-jHX
+iSh
 nFy
-jHX
+iSh
 wnd
 wnd
 wnd
@@ -97287,9 +97208,9 @@ ksI
 epl
 uIM
 xcC
-jHX
+iSh
 nFy
-jHX
+iSh
 wnd
 aaa
 aaa
@@ -103417,10 +103338,10 @@ xKk
 vJT
 wfr
 aYK
-ycz
-ycz
-ycz
-ycz
+aTo
+aTo
+aTo
+aTo
 jkQ
 aYK
 aTo
@@ -103674,11 +103595,11 @@ xKk
 omQ
 tOb
 vtK
-ycz
-ycz
-ycz
-ycz
-ycz
+aTo
+aTo
+aTo
+aTo
+aTo
 lhw
 aTo
 dZq
@@ -103931,11 +103852,11 @@ nth
 nth
 nth
 nth
-ycz
-ycz
-ycz
-ycz
-ycz
+aTo
+aTo
+aTo
+aTo
+aTo
 nth
 nth
 nth
@@ -104188,11 +104109,11 @@ aaa
 abx
 apQ
 xKk
-ycz
-ycz
-ycz
-ycz
-ycz
+aTo
+aTo
+aTo
+aTo
+aTo
 nth
 ajz
 ajz
@@ -104445,11 +104366,11 @@ aaa
 abx
 apQ
 xKk
-ycz
-ycz
-ycz
-ycz
-ycz
+aTo
+aTo
+aTo
+aTo
+aTo
 nth
 ajz
 aaa
@@ -104702,11 +104623,11 @@ aaa
 abx
 apQ
 xKk
-ycz
-ycz
-ycz
-ycz
-ycz
+aTo
+aTo
+aTo
+aTo
+aTo
 nth
 ajz
 ajz
@@ -104959,11 +104880,11 @@ aaa
 abx
 apQ
 xKk
-ycz
-ycz
+aTo
+aTo
 gVS
 nQg
-ycz
+aTo
 nth
 aaa
 ajz
@@ -105216,11 +105137,11 @@ aaa
 abx
 apQ
 xKk
-ycz
+aTo
 jnm
 swX
-ycz
-ycz
+aTo
+aTo
 nth
 aaa
 ajz
@@ -105473,11 +105394,11 @@ aaa
 abx
 apQ
 xKk
-ycz
-ycz
+aTo
+aTo
 sPZ
-ycz
-ycz
+aTo
+aTo
 nth
 ajz
 ajz
@@ -105730,11 +105651,11 @@ aaa
 abx
 apQ
 xKk
-ycz
-ycz
+aTo
+aTo
 sPZ
-ycz
-ycz
+aTo
+aTo
 nth
 aaa
 ajz
@@ -110917,8 +110838,8 @@ aaa
 ajz
 ajz
 lVr
-rKa
-rKa
+avU
+avU
 onQ
 aQg
 wsG
@@ -111174,9 +111095,9 @@ aaa
 aaa
 ajz
 lVr
-rKa
-rKa
-rKa
+avU
+avU
+avU
 aQg
 aEV
 cXR
@@ -111431,9 +111352,9 @@ lqs
 lqs
 lqs
 lqs
-rKa
-rKa
-rKa
+avU
+avU
+avU
 aQg
 bas
 aGh
@@ -111688,9 +111609,9 @@ bQp
 avU
 avU
 dts
-rKa
-rKa
-rKa
+avU
+avU
+avU
 aQg
 jGO
 aGh
@@ -111945,9 +111866,9 @@ lOv
 vQl
 oRz
 aQg
-rKa
-rKa
-rKa
+avU
+avU
+avU
 rhf
 arc
 aGh
@@ -112136,9 +112057,9 @@ aaa
 abx
 aeX
 tVt
-eyd
-eyd
-tcF
+aoW
+aoW
+gsZ
 jle
 aba
 aXE
@@ -112393,10 +112314,10 @@ aaa
 abx
 aeX
 tVt
-eyd
-eyd
-tcF
-eyd
+aoW
+aoW
+gsZ
+aoW
 aba
 aXE
 aHg
@@ -112650,10 +112571,10 @@ aaa
 abx
 aeX
 tVt
-eyd
-eyd
-tcF
-eyd
+aoW
+aoW
+gsZ
+aoW
 aba
 aYH
 aHg
@@ -112907,10 +112828,10 @@ aaa
 abx
 aeX
 tVt
-eyd
-eyd
-tcF
-eyd
+aoW
+aoW
+gsZ
+aoW
 aba
 eHs
 aHg
@@ -113164,10 +113085,10 @@ aaa
 abx
 aeX
 tVt
-eyd
-eyd
-tcF
-eyd
+aoW
+aoW
+gsZ
+aoW
 aba
 acf
 aHg
@@ -114516,8 +114437,8 @@ aZT
 aZT
 bgI
 sUL
-ung
-ung
+bgJ
+bgJ
 dDc
 alw
 bgL
@@ -114773,9 +114694,9 @@ aeX
 aZT
 aZT
 aZT
-eEG
+aqS
 uaT
-rGw
+bgI
 pME
 gXv
 pPU
@@ -115030,9 +114951,9 @@ aeX
 aeX
 bfT
 aZT
-eEG
-eEG
-eEG
+aqS
+aqS
+aqS
 alw
 rMv
 pPU


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

travis keeps rejecting my prs due to an unrelated runtime. looking into it, this vent was the issue
![StrongDMM_2020-11-17_13-29-58](https://user-images.githubusercontent.com/29457447/99434859-34aa0680-2907-11eb-9853-8082106a86c0.jpg)
its placed on turf/template_noop , which doesnt have air as a variable, as such when the vent tries to scrub, it gets a null air mix and runtimes.
I think the vent tries to scrub before the random room is loaded in

Went with upstreams method of just using plating, which seemed to work

![dreamseeker_2020-11-17_18-53-37](https://user-images.githubusercontent.com/29457447/99435042-7cc92900-2907-11eb-9d9a-271db88e6ffa.jpg)

Only doing HH as thats the one we default to and don't want to mess with other maps giving maptainers a headache

## Why It's Good For The Game

lets travis do its thing
no cl as it doesnt change the game

~no i'm not giving my prs a sensible title shut up~