### PR TITLE
fixes fighters leaving ships other than the main overmap

### DIFF
--- a/nsv13/code/modules/overmap/fighters/fighters_launcher.dm
+++ b/nsv13/code/modules/overmap/fighters/fighters_launcher.dm
@@ -264,9 +264,7 @@
 		if(last_overmap)
 			OM = last_overmap
 		else
-			for(var/obj/structure/overmap/O in GLOB.overmap_objects)
-				if(O.role == MAIN_OVERMAP)
-					OM = O
+			OM = get_overmap()
 		if(!OM)
 			return FALSE
 		var/saved_layer = layer


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
makes fighters leave from their current overmap rather than defaulting to the main ship.

## Why It's Good For The Game
fixes #1045 

## Changelog
:cl:TMTIME
fix: Fighters now leave from their actual overmap
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
