### PR TITLE
Reduce power usage of viewscreens and lore terminals

### DIFF
--- a/nsv13/code/modules/overmap/components.dm
+++ b/nsv13/code/modules/overmap/components.dm
@@ -262,6 +262,7 @@ GLOBAL_LIST_INIT(computer_beeps, list('nsv13/sound/effects/computer/beep.ogg','n
 	desc = "A large CRT monitor which shows an exterior view of the ship."
 	icon = 'nsv13/icons/obj/computers.dmi'
 	icon_state = "viewscreen"
+	idle_power_usage = 15
 	mouse_over_pointer = MOUSE_HAND_POINTER
 	pixel_y = 26
 	density = FALSE

--- a/nsv13/game/lore_terminal.dm
+++ b/nsv13/game/lore_terminal.dm
@@ -8,6 +8,7 @@ GLOBAL_DATUM_INIT(lore_terminal_controller, /datum/lore_controller, new)
 	pixel_y = 26 //So they snap to walls correctly
 	density = FALSE
 	anchored = TRUE
+	idle_power_usage = 15
 	var/access_tag = "ntcommon"  //Every subtype of this type will be readable by this console. Use this for away terms as seen here \/
 	var/list/entries = list() //Every entry that we've got.
 	var/in_use = FALSE //Stops sound spam


### PR DESCRIPTION
Seegson viewscreens and Lore terminals use 15w of power instead of 300.

This power is better used elsewhere, damnit. Especially since we have so many of these on our maps.

:cl:
tweak: Reduced idle power consumption of viewscreens and lore terminals
/:cl: