### PR TITLE
Add cameras to the DMC Rocinante

### DIFF
--- a/_maps/map_files/Mining/nsv13/Rocinante.dmm
+++ b/_maps/map_files/Mining/nsv13/Rocinante.dmm
@@ -5035,7 +5035,7 @@
 /area/nostromo/hangar/starboard)
 "yS" = (
 /obj/machinery/camera{
-	c_tag = "Central Frame - Starboard";
+	c_tag = "Central Frame - Fore Starboard";
 	dir = 1;
 	network = list("mine")
 	},

--- a/_maps/map_files/Mining/nsv13/Rocinante.dmm
+++ b/_maps/map_files/Mining/nsv13/Rocinante.dmm
@@ -54,12 +54,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/nostromo/maintenance/exterior)
-"ak" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/ship/interior,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/techmaint,
-/area/nostromo/mining)
 "al" = (
 /obj/structure/hull_plate/end{
 	dir = 9
@@ -113,6 +107,11 @@
 	pixel_y = 26
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/machinery/camera{
+	c_tag = "Dormitories";
+	dir = 4;
+	network = list("mine")
+	},
 /turf/open/floor/carpet/ship,
 /area/nostromo/crew_quarters)
 "av" = (
@@ -268,7 +267,12 @@
 /turf/open/floor/plasteel/ridged/steel,
 /area/nostromo/mining)
 "aT" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/plasteel/stairs/old{
 	dir = 4;
 	icon_state = "stairs-old"
@@ -299,9 +303,14 @@
 /turf/open/floor/plasteel/ridged/steel,
 /area/nostromo/bridge)
 "aY" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
 /turf/open/floor/plasteel/stairs/old{
 	dir = 4;
@@ -310,9 +319,14 @@
 /area/nostromo/mining)
 "aZ" = (
 /obj/machinery/door/airlock/ship{
-	name = "Primary storage junction"
+	name = "Primary Storage Junction"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/floor/plasteel/stairs/old{
 	dir = 8;
 	icon_state = "stairs-old"
@@ -367,15 +381,18 @@
 /obj/machinery/door/airlock/ship/hatch{
 	name = "maintenance hatch"
 	},
-/obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/mining_ship/central)
 "bi" = (
 /obj/machinery/door/airlock/ship/public{
-	name = "Dorms"
+	name = "Staff Quarters"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -400,9 +417,12 @@
 /obj/machinery/door/airlock/ship/hatch{
 	name = "maintenance hatch"
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/mining_ship/forward)
 "bn" = (
@@ -632,17 +652,18 @@
 /turf/closed/wall/ship,
 /area/nostromo/bridge)
 "bY" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/ship/interior,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/techmaint,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/nostromo/bridge)
 "bZ" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /obj/machinery/door/airlock/glass_large/ship{
-	name = "DMC Rocinante CIC"
+	name = "DMC Rocinante Bridge"
 	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/nostromo/bridge)
@@ -653,12 +674,15 @@
 /turf/closed/wall/ship,
 /area/maintenance/nsv/mining_ship/aft)
 "cb" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/nostromo/bridge)
 "cc" = (
@@ -670,9 +694,8 @@
 /turf/open/floor/plasteel/grid/steel,
 /area/nostromo/bridge)
 "ce" = (
-/obj/structure/window/reinforced/fulltile/ship/interior,
-/obj/structure/grille,
-/turf/open/floor/plasteel/dark,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/nostromo/mining)
 "cf" = (
 /obj/item/tank/internals/oxygen,
@@ -684,9 +707,12 @@
 /obj/machinery/door/airlock/ship/hatch{
 	name = "maintenance hatch"
 	},
-/obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/nostromo)
@@ -814,6 +840,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/camera{
+	c_tag = "Hangar - Port Starboard";
+	dir = 4;
+	network = list("mine")
+	},
 /turf/open/floor/monotile/dark/airless,
 /area/nostromo/hangar/starboard)
 "cx" = (
@@ -904,12 +935,15 @@
 /turf/open/floor/plasteel/ridged/steel,
 /area/nostromo/bridge)
 "cN" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/ship{
-	name = "Central frame"
+	name = "Central Frame"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/plasteel/ship/padded,
 /area/nostromo)
 "cO" = (
@@ -932,12 +966,6 @@
 /obj/machinery/advanced_airlock_controller/directional/east,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/nsv/mining_ship/aft)
-"cQ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/ship/interior,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/ship/padded,
-/area/nostromo)
 "cR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
@@ -959,6 +987,12 @@
 	name = "maintenance hatch"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/nostromo/crew_quarters)
 "cV" = (
@@ -1068,10 +1102,6 @@
 /turf/open/floor/monotile,
 /area/nostromo/bridge)
 "dk" = (
-/obj/machinery/door/airlock/ship/external/glass{
-	name = "Pressurization chamber";
-	req_one_access_txt = "31;48"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4;
 	icon_state = "airlock_cyclelink_helper"
@@ -1082,6 +1112,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/machinery/door/airlock/ship/external/glass{
+	name = "Pressurization Chamber";
+	req_one_access_txt = "31;48"
+	},
 /turf/open/floor/plasteel/techmaint,
 /area/nostromo/mining)
 "dl" = (
@@ -1090,6 +1124,12 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
 /turf/open/floor/plasteel/ship/padded,
 /area/maintenance/nsv/mining_ship/forward)
@@ -1122,13 +1162,15 @@
 /area/maintenance/nsv/mining_ship/aft)
 "dp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/machinery/camera{
+	c_tag = "Central Frame - Fore Port";
+	network = list("mine")
+	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/nostromo)
 "dq" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/ship/interior,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/ship/padded,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/maintenance/nsv/mining_ship/aft)
 "dr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -1144,11 +1186,23 @@
 /obj/machinery/door/airlock/ship/hatch{
 	name = "ICU hatch"
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/maintenance/nsv/mining_ship/central)
 "du" = (
 /obj/machinery/door/airlock/ship/hatch{
 	name = "maintenance hatch"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/mining_ship/central)
@@ -1157,6 +1211,10 @@
 	name = "maintenance hatch"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/plasteel/techmaint,
 /area/nostromo/engineering/atmospherics)
 "dw" = (
@@ -1214,10 +1272,8 @@
 /turf/open/floor/carpet/ship,
 /area/nostromo/crew_quarters)
 "dF" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/ship/interior,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/ship/padded,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/nostromo/crew_quarters)
 "dG" = (
 /obj/structure/chair/sofa{
@@ -1276,6 +1332,12 @@
 "dO" = (
 /obj/machinery/door/airlock/ship/hatch{
 	name = "maintenance hatch"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/maintenance/nsv/mining_ship/central)
@@ -1416,6 +1478,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel/techmaint,
 /area/nostromo)
 "eg" = (
@@ -1440,7 +1505,12 @@
 /obj/machinery/door/airlock/ship/hatch{
 	name = "maintenance hatch"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/nsv/mining_ship/forward)
 "ej" = (
@@ -1455,12 +1525,12 @@
 /turf/open/floor/monotile,
 /area/nostromo/mining)
 "ek" = (
-/obj/machinery/door/airlock/ship/external/glass{
-	name = "Pressurization chamber";
-	req_one_access_txt = "31;48"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
+	},
+/obj/machinery/door/airlock/ship/external/glass{
+	name = "Pressurization Chamber";
+	req_one_access_txt = "31;48"
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/nostromo/mining)
@@ -1503,8 +1573,10 @@
 	},
 /area/nostromo/maintenance/exterior)
 "ep" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/camera{
+	c_tag = "Asteroid Cage";
+	dir = 4;
+	network = list("mine")
 	},
 /turf/open/floor/plasteel/techmaint{
 	initial_gas_mix = "TEMP=2.7"
@@ -1739,15 +1811,14 @@
 	},
 /area/nostromo/hangar/starboard)
 "eU" = (
-/obj/structure/window/reinforced/fulltile/ship/interior,
-/obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/nostromo/mining)
 "eV" = (
 /obj/structure/cable/yellow{
@@ -1811,9 +1882,6 @@
 /obj/machinery/door/airlock/ship/hatch{
 	name = "maintenance hatch"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -1833,7 +1901,6 @@
 /obj/machinery/door/airlock/ship/public{
 	name = "Observation lounge"
 	},
-/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -1843,7 +1910,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
-/turf/open/floor/plasteel/ship/padded,
+/turf/open/floor/carpet/ship,
 /area/nostromo/crew_quarters)
 "ff" = (
 /obj/structure/cable{
@@ -1875,10 +1942,8 @@
 /turf/open/floor/monotile,
 /area/nostromo/crew_quarters)
 "fi" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/ship/interior,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/ship/padded,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/nostromo/medbay)
 "fj" = (
 /obj/structure/cable{
@@ -2029,10 +2094,8 @@
 /turf/open/floor/plasteel/ridged/steel,
 /area/nostromo/engineering)
 "fy" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/ship/interior,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/ship/padded,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/nostromo/engineering)
 "fz" = (
 /obj/structure/cable{
@@ -2092,14 +2155,19 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/ship/engineering/glass{
-	name = "DMC Rocinante central power core";
+	name = "DMC Rocinante Central Power Core";
 	req_one_access_txt = "48"
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
 /turf/open/floor/plasteel/ship/padded,
@@ -2368,6 +2436,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/plasteel/ship/padded,
 /area/maintenance/nsv/mining_ship/central)
 "gl" = (
@@ -2376,6 +2450,12 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
 	},
 /turf/open/floor/plasteel/ship/padded,
 /area/nostromo/medbay)
@@ -2493,7 +2573,13 @@
 /area/nostromo/crew_quarters)
 "gA" = (
 /obj/machinery/door/airlock/ship{
-	name = "CIC maintenance"
+	name = "Bridge Maintenance"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/nostromo/bridge)
@@ -2530,6 +2616,12 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
 /turf/open/floor/plasteel/ship/padded,
 /area/maintenance/nsv/mining_ship/aft)
@@ -2633,7 +2725,7 @@
 /area/nostromo/bridge)
 "gS" = (
 /obj/machinery/door/airlock/ship/external/glass{
-	name = "Asteroid cage";
+	name = "Asteroid Cage";
 	req_one_access_txt = "31;48"
 	},
 /obj/structure/cable/yellow{
@@ -2760,6 +2852,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/plasteel/ship/padded,
 /area/maintenance/nsv/mining_ship/central)
 "hf" = (
@@ -2775,7 +2873,7 @@
 /area/nostromo/maintenance/exterior)
 "hh" = (
 /obj/machinery/door/airlock/ship/engineering/glass{
-	name = "DMC Rocinante atmospherics section";
+	name = "DMC Rocinante Atmospherics Section";
 	req_one_access_txt = "48"
 	},
 /obj/structure/cable/yellow{
@@ -2783,6 +2881,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
 /turf/open/floor/plasteel/ship/padded,
 /area/maintenance/nsv/mining_ship/central)
@@ -2841,13 +2945,18 @@
 /turf/open/floor/carpet/ship,
 /area/nostromo/crew_quarters)
 "hn" = (
-/obj/machinery/door/airlock/ship/engineering/glass{
-	name = "DMC Rocinante atmospherics section";
-	req_one_access_txt = "48"
-	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
+	},
+/obj/machinery/door/airlock/ship/engineering/glass{
+	name = "DMC Rocinante Atmospherics Extension";
+	req_one_access_txt = "48"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
 /turf/open/floor/plasteel/ship/padded,
 /area/maintenance/nsv/mining_ship/central)
@@ -2914,31 +3023,38 @@
 /obj/machinery/door/airlock/ship/hatch{
 	name = "maintenance hatch"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/nsv/mining_ship/aft)
 "hx" = (
 /obj/machinery/door/airlock/ship/hatch{
 	name = "maintenance hatch"
 	},
-/obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/nsv/mining_ship/aft)
 "hy" = (
 /obj/machinery/door/airlock/ship{
-	name = "Central frame"
+	name = "Central Frame"
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/plasteel/techmaint,
 /area/maintenance/nsv/mining_ship/aft)
 "hz" = (
@@ -2957,10 +3073,13 @@
 /obj/machinery/door/airlock/ship/hatch{
 	name = "maintenance hatch"
 	},
-/obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/mining_ship/central)
@@ -3023,10 +3142,15 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/ship/engineering/glass{
-	name = "DMC Rocinante atmospherics extension";
+	name = "DMC Rocinante Atmospherics Extension";
 	req_one_access_txt = "48"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/plasteel/ship/padded,
 /area/nostromo/engineering/atmospherics)
 "hI" = (
@@ -3077,10 +3201,6 @@
 /turf/open/floor/monotile/airless,
 /area/nostromo/hangar/starboard)
 "hO" = (
-/obj/machinery/door/airlock/ship/external/glass{
-	name = "Hangar bay";
-	req_one_access_txt = "31;48"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4;
 	icon_state = "airlock_cyclelink_helper"
@@ -3093,6 +3213,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
+	},
+/obj/machinery/door/airlock/ship/external/glass{
+	name = "Hangar Bay";
+	req_one_access_txt = "31;48"
 	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/maintenance/nsv/mining_ship/forward)
@@ -3127,6 +3251,12 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
 /turf/open/floor/plasteel/ridged/steel,
@@ -3165,8 +3295,13 @@
 /obj/machinery/door/airlock/ship/hatch{
 	name = "maintenance hatch"
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/nostromo/tcomms)
 "hW" = (
 /obj/structure/chair/comfy/shuttle{
@@ -3186,9 +3321,8 @@
 /area/nostromo/mining)
 "hY" = (
 /obj/machinery/door/airlock/ship{
-	name = "Space suit storage"
+	name = "E.V.A. Storage"
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -3197,6 +3331,12 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/nostromo/mining)
@@ -3318,6 +3458,11 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
+/obj/machinery/camera{
+	c_tag = "Transfer Shuttle Dock";
+	dir = 8;
+	network = list("mine")
+	},
 /turf/open/floor/plasteel/techmaint,
 /area/maintenance/nsv/mining_ship/aft)
 "in" = (
@@ -3348,15 +3493,16 @@
 /turf/open/floor/plasteel/ridged/steel,
 /area/nostromo/mining)
 "ir" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/camera{
+	c_tag = "E.V.A. Storage";
+	dir = 8;
+	network = list("mine")
+	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/nostromo/mining)
 "is" = (
@@ -3398,6 +3544,11 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
+/obj/machinery/camera{
+	c_tag = "Observation Lounge";
+	dir = 8;
+	network = list("mine")
+	},
 /turf/open/floor/carpet/ship,
 /area/nostromo/crew_quarters)
 "ix" = (
@@ -3411,10 +3562,15 @@
 /turf/open/floor/plasteel/grid/steel,
 /area/nostromo)
 "iy" = (
-/obj/machinery/door/airlock/ship{
-	name = "Space suit storage"
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship{
+	name = "E.V.A. Storage"
+	},
 /turf/open/floor/plasteel/techmaint,
 /area/nostromo/mining)
 "iz" = (
@@ -3445,14 +3601,21 @@
 /obj/machinery/door/airlock/ship/public{
 	name = "Galley"
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/ship/padded,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/carpet/ship,
 /area/nostromo/crew_quarters)
 "iD" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
 /obj/item/kitchen/fork,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/window/reinforced/spawner/west,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/plasteel/techmaint,
 /area/nostromo/crew_quarters)
 "iE" = (
@@ -3462,9 +3625,12 @@
 /area/nostromo)
 "iF" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
 /obj/item/kitchen/fork,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /turf/open/floor/plasteel/techmaint,
@@ -3548,6 +3714,11 @@
 "iS" = (
 /obj/structure/extinguisher_cabinet/north,
 /obj/machinery/cryopod,
+/obj/machinery/camera{
+	c_tag = "Cryostasis";
+	dir = 8;
+	network = list("mine")
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/nostromo)
 "iT" = (
@@ -3701,12 +3872,15 @@
 /turf/open/floor/plasteel/techmaint,
 /area/nostromo/mining)
 "jk" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/door/airlock/glass_large/ship{
-	name = "DMC Rocinante CIC"
+	name = "DMC Rocinante Bridge"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/nostromo/bridge)
 "jl" = (
@@ -3751,7 +3925,7 @@
 /area/nostromo/hangar/starboard)
 "jp" = (
 /obj/machinery/door/airlock/ship/public{
-	name = "Abandoned crew quarters"
+	name = "Abandoned Crew Quarters"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -3817,12 +3991,17 @@
 /turf/open/floor/plasteel/techmaint,
 /area/nostromo)
 "jx" = (
-/obj/machinery/door/airlock/ship{
-	name = "Primary storage junction"
-	},
-/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship{
+	name = "Primary Storage Junction"
 	},
 /turf/open/floor/plasteel/stairs/old{
 	dir = 8;
@@ -3922,9 +4101,15 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/ship/public/glass{
-	name = "DMC Rocinante cryostasis"
+	name = "DMC Rocinante Cryostasis"
 	},
-/turf/open/floor/plasteel/ridged/steel,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/techmaint,
 /area/nostromo)
 "jI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -3986,10 +4171,8 @@
 /turf/open/floor/plasteel/ridged/steel,
 /area/nostromo)
 "jQ" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/ship/interior,
-/turf/open/floor/plasteel/techmaint,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/nostromo)
 "jR" = (
 /obj/structure/cable/yellow{
@@ -4002,28 +4185,24 @@
 /area/maintenance/nsv/mining_ship/aft)
 "jS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Central Frame - Aft Port";
+	network = list("mine")
 	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/nostromo)
 "jT" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/camera{
+	c_tag = "Ferry Dock";
+	dir = 8;
+	network = list("mine")
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/techmaint,
-/area/nostromo)
+/turf/open/floor/plasteel/dark,
+/area/maintenance/nsv/mining_ship/aft)
 "jU" = (
 /turf/open/floor/plasteel/ridged/steel,
 /area/nostromo/engineering)
@@ -4088,6 +4267,12 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
 /turf/open/floor/plasteel/ship/padded,
@@ -4194,7 +4379,7 @@
 /area/maintenance/nsv/mining_ship/forward)
 "kp" = (
 /obj/machinery/door/airlock/ship/external/glass{
-	name = "Hangar bay";
+	name = "Hangar Bay";
 	req_one_access_txt = "31;48"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -4336,11 +4521,9 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/mining_ship/central)
 "kJ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/ship/interior,
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/plasteel/ship/padded,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/maintenance/nsv/mining_ship/central)
 "kK" = (
 /obj/structure/fluff/support_beam,
@@ -4375,6 +4558,11 @@
 "kO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
+	},
+/obj/machinery/camera{
+	c_tag = "TE/LE/COM Core";
+	dir = 8;
+	network = list("mine")
 	},
 /turf/open/floor/monotile/dark,
 /area/nostromo/tcomms)
@@ -4598,7 +4786,7 @@
 /area/nostromo/mining)
 "lo" = (
 /obj/machinery/door/airlock/ship/external/glass{
-	name = "Pressurization chamber";
+	name = "Pressurization Chamber";
 	req_one_access_txt = "31;48"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -4647,15 +4835,15 @@
 /turf/open/floor/plasteel/techmaint,
 /area/nostromo/mining)
 "lr" = (
-/obj/machinery/door/airlock/ship/external/glass{
-	name = "Pressurization chamber";
-	req_one_access_txt = "31;48"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/ship/external/glass{
+	name = "Pressurization Chamber";
+	req_one_access_txt = "31;48"
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/nostromo/mining)
@@ -4712,6 +4900,34 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/tech/grid,
 /area/nostromo)
+"ms" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/ship/external/glass{
+	name = "Hangar Bay";
+	req_one_access_txt = "31;48"
+	},
+/turf/open/floor/plasteel/ridged/steel,
+/area/maintenance/nsv/mining_ship/forward)
+"nk" = (
+/obj/machinery/door/airlock/ship/hatch{
+	name = "maintenance hatch"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel/ship/padded,
+/area/maintenance/nsv/mining_ship/forward)
 "nX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
@@ -4721,9 +4937,34 @@
 	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/nostromo)
+"ov" = (
+/obj/machinery/camera{
+	c_tag = "Galley";
+	dir = 8;
+	network = list("mine")
+	},
+/turf/open/floor/plasteel/ridged/steel,
+/area/nostromo/crew_quarters)
+"pv" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Central Frame - Starboard";
+	dir = 1;
+	network = list("mine")
+	},
+/turf/open/floor/plasteel/ridged/steel,
+/area/nostromo)
 "pF" = (
 /obj/machinery/door/airlock/ship/hatch{
 	name = "maintenance hatch"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/mining_ship/aft)
@@ -4747,6 +4988,14 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plasteel/techmaint,
 /area/nostromo)
+"sV" = (
+/obj/machinery/camera{
+	c_tag = "Hangar - Fore Starboard";
+	dir = 8;
+	network = list("mine")
+	},
+/turf/open/floor/monotile/dark/airless,
+/area/nostromo/hangar/starboard)
 "tK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/closed/wall/ship,
@@ -4757,9 +5006,40 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/mining_ship/aft)
+"vX" = (
+/obj/machinery/door/airlock/ship/hatch{
+	name = "maintenance hatch"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/mining_ship/aft)
 "yl" = (
 /obj/machinery/cryopod,
 /turf/open/floor/plasteel/tech/grid,
+/area/nostromo)
+"yF" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Hangar - Aft Starboard";
+	dir = 4;
+	network = list("mine")
+	},
+/turf/open/floor/monotile/dark/airless,
+/area/nostromo/hangar/starboard)
+"yS" = (
+/obj/machinery/camera{
+	c_tag = "Central Frame - Starboard";
+	dir = 1;
+	network = list("mine")
+	},
+/turf/open/floor/plasteel/ridged/steel,
 /area/nostromo)
 "Ab" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -4767,6 +5047,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Central Frame - Aft Starboard";
+	dir = 1;
+	network = list("mine")
 	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/nostromo)
@@ -4777,6 +5062,29 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/ridged/steel,
 /area/nostromo)
+"Cc" = (
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/ridged/steel,
+/area/nostromo)
+"CR" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/machinery/camera{
+	c_tag = "Central Frame - Port";
+	network = list("mine")
+	},
+/turf/open/floor/plasteel/ridged/steel,
+/area/nostromo)
+"Eh" = (
+/obj/machinery/camera{
+	c_tag = "Primary Storage Junction";
+	dir = 1;
+	network = list("mine")
+	},
+/turf/open/floor/monotile,
+/area/nostromo/mining)
 "Em" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -4838,6 +5146,14 @@
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/maintenance/nsv/mining_ship/aft)
+"IU" = (
+/obj/machinery/camera{
+	c_tag = "Hangar - Fore Port";
+	dir = 8;
+	network = list("mine")
+	},
+/turf/open/floor/monotile/dark/airless,
+/area/nostromo/hangar/starboard)
 "Jo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -4867,6 +5183,7 @@
 	dir = 5;
 	icon_state = "pipe11-2"
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/plasteel/techmaint,
 /area/nostromo/mining)
 "La" = (
@@ -4915,6 +5232,16 @@
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/plasteel/techmaint,
 /area/nostromo)
+"Qf" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/ship/external/glass{
+	name = "Asteroid Cage";
+	req_one_access_txt = "31;48"
+	},
+/turf/open/floor/monotile/dark/airless,
+/area/nostromo/hangar/starboard)
 "Qv" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -4934,6 +5261,15 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space)
+"QC" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/techmaint{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/nostromo/hangar/starboard)
 "Sm" = (
 /turf/open/floor/plasteel/ridged/steel,
 /area/maintenance/nsv/mining_ship/forward)
@@ -4955,6 +5291,38 @@
 	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/nostromo)
+"Uf" = (
+/obj/machinery/camera{
+	c_tag = "Central Power Core";
+	dir = 8;
+	network = list("mine")
+	},
+/turf/open/floor/plasteel/ridged/steel,
+/area/nostromo/engineering)
+"UY" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8;
+	icon_state = "tile_corner"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1;
+	icon_state = "tile_corner"
+	},
+/obj/machinery/camera{
+	c_tag = "Intensive Care Unit";
+	dir = 8;
+	network = list("mine")
+	},
+/turf/open/floor/plasteel/techmaint,
+/area/nostromo/medbay)
+"VB" = (
+/obj/machinery/camera{
+	c_tag = "Bridge";
+	dir = 4;
+	network = list("mine")
+	},
+/turf/open/floor/monotile,
+/area/nostromo/bridge)
 "VD" = (
 /obj/machinery/cryopod{
 	dir = 1;
@@ -20816,7 +21184,7 @@ iw
 iH
 iI
 kx
-iI
+ov
 kB
 ac
 hv
@@ -21831,7 +22199,7 @@ ca
 pF
 bW
 jS
-jT
+dP
 dK
 dK
 fi
@@ -21848,7 +22216,7 @@ dS
 ja
 Ab
 ac
-pF
+vX
 ip
 ac
 ac
@@ -22601,7 +22969,7 @@ ac
 cG
 cG
 bW
-db
+Cc
 ef
 fi
 gb
@@ -23121,13 +23489,13 @@ dK
 gd
 gj
 gj
-gj
+UY
 kb
 dK
 fx
 fD
 ib
-jU
+Uf
 jU
 dS
 eg
@@ -24657,7 +25025,7 @@ ac
 fQ
 cG
 bW
-ds
+CR
 ff
 bg
 dn
@@ -24673,7 +25041,7 @@ hG
 jf
 cT
 jv
-jO
+pv
 ac
 cG
 jR
@@ -25165,7 +25533,7 @@ aa
 aa
 az
 bQ
-cE
+jT
 cP
 do
 gH
@@ -25427,7 +25795,7 @@ cR
 tK
 gK
 ht
-cQ
+jQ
 db
 fn
 cT
@@ -25704,7 +26072,7 @@ jy
 db
 aH
 aH
-dl
+nk
 aH
 ac
 ac
@@ -25951,7 +26319,7 @@ cI
 dj
 gr
 gO
-gr
+VB
 ia
 cI
 cj
@@ -27488,7 +27856,7 @@ dp
 lv
 ab
 ab
-ak
+ce
 aY
 ab
 ce
@@ -27496,7 +27864,7 @@ eU
 ce
 ab
 aT
-ak
+ce
 ab
 ab
 jC
@@ -27757,7 +28125,7 @@ jm
 jt
 ab
 jA
-db
+yS
 aH
 eb
 dV
@@ -28264,7 +28632,7 @@ jx
 ab
 ci
 gx
-bp
+Eh
 ab
 aZ
 ab
@@ -30837,7 +31205,7 @@ ab
 dk
 bA
 ab
-kp
+ms
 aH
 aH
 eY
@@ -31864,7 +32232,7 @@ ls
 hJ
 eK
 eC
-kQ
+yF
 bS
 br
 bx
@@ -34684,7 +35052,7 @@ aF
 bv
 br
 br
-br
+IU
 dh
 eE
 eW
@@ -34692,7 +35060,7 @@ bs
 eW
 eE
 kQ
-br
+sV
 br
 br
 kV
@@ -34946,7 +35314,7 @@ ez
 eF
 gS
 eF
-gS
+Qf
 eF
 ez
 aF
@@ -35458,7 +35826,7 @@ aL
 aL
 eB
 aM
-hd
+QC
 aF
 it
 aM


### PR DESCRIPTION
Cameras and border firedoors have been added to the DMC Rocinante, and I fixed the odd issues I found while doing it.

![image](https://user-images.githubusercontent.com/31044876/99830183-408b0800-2b55-11eb-926b-d511981678df.png)

This also means that the outpost camera console isn't useless anymore.

:cl:
add: Cameras added to DMC Rocinante
/:cl:
