### PR TITLE
Adds engineering optional objectives

### DIFF
--- a/nsv13.dme
+++ b/nsv13.dme
@@ -3219,6 +3219,7 @@
 #include "nsv13\code\modules\collision\collision_response.dm"
 #include "nsv13\code\modules\collision\shape.dm"
 #include "nsv13\code\modules\collision\vector2d.dm"
+#include "nsv13\code\modules\crew_objectives\engineering_objectives.dm"
 #include "nsv13\code\modules\events\overmap\_overmap_event_handler.dm"
 #include "nsv13\code\modules\events\overmap\belt_rats.dm"
 #include "nsv13\code\modules\events\overmap\lone_hunter.dm"

--- a/nsv13/code/modules/crew_objectives/engineering_objectives.dm
+++ b/nsv13/code/modules/crew_objectives/engineering_objectives.dm
@@ -56,4 +56,13 @@
 
 /datum/objective/crew/power_generation/update_explanation_text()
 	. = ..()
-	explanation_text = "Maintain production of [target_amount] Watts in the engine until the end of the shift."
+	explanation_text = "Maintain production of [target_amount] Watts in an engine until the end of the shift."
+
+/datum/objective/crew/power_generation/check_completion()
+	for(var/obj/machinery/atmospherics/components/binary/stormdrive_reactor/C in GLOB.machines)
+		if(C.last_power_produced >= target_amount)
+			return TRUE
+	for(var/obj/machinery/atmospherics/components/trinary/nuclear_reactor/C in GLOB.machines)
+		if(C.last_power_produced >= target_amount)
+			return TRUE
+	return FALSE

--- a/nsv13/code/modules/crew_objectives/engineering_objectives.dm
+++ b/nsv13/code/modules/crew_objectives/engineering_objectives.dm
@@ -50,7 +50,7 @@
 /datum/objective/crew/power_generation/New()
 	. = ..()
 	var/base_target_power = 13000000
-	target_percent = rand(60,90)
+	var/target_percent = rand(60,90)
 	target_amount = base_target_power * target_percent
 	update_explanation_text()
 

--- a/nsv13/code/modules/crew_objectives/engineering_objectives.dm
+++ b/nsv13/code/modules/crew_objectives/engineering_objectives.dm
@@ -46,10 +46,20 @@
 /datum/objective/crew/power_generation
 	explanation_text = "Maintain production of x MW in the engine until the end of the shift."
 	jobs = "chiefengineer,stationengineer,atmospherictechnician"
+	var/obj/machinery/atmospherics/components/binary/stormdrive_reactor/SD
+	var/obj/machinery/atmospherics/components/trinary/nuclear_reactor/RBMK
 
 /datum/objective/crew/power_generation/New()
 	. = ..()
-	var/base_target_power = 13000000
+	SD = locate() in GLOB.machines
+	RBMK = locate() in GLOB.machines
+	var/base_target_power
+	if(SD)
+		base_target_power = 13000000
+	else if(RBMK)
+		base_target_power = 10000000
+	else
+		base_target_power = 5000000
 	var/target_percent = rand(60,90)
 	target_amount = base_target_power * target_percent
 	update_explanation_text()
@@ -59,10 +69,8 @@
 	explanation_text = "Maintain production of [target_amount] Watts in an engine until the end of the shift."
 
 /datum/objective/crew/power_generation/check_completion()
-	for(var/obj/machinery/atmospherics/components/binary/stormdrive_reactor/C in GLOB.machines)
-		if(C.last_power_produced >= target_amount)
-			return TRUE
-	for(var/obj/machinery/atmospherics/components/trinary/nuclear_reactor/C in GLOB.machines)
-		if(C.last_power_produced >= target_amount)
-			return TRUE
+	if(SD.last_power_produced >= target_amount)
+		return TRUE
+	if(RBMK.last_power_produced >= target_amount)
+		return TRUE
 	return FALSE

--- a/nsv13/code/modules/crew_objectives/engineering_objectives.dm
+++ b/nsv13/code/modules/crew_objectives/engineering_objectives.dm
@@ -1,0 +1,59 @@
+/*				ENGINEERING OBJECTIVES				*/
+
+/datum/objective/crew/integrity //ported from old Hippie
+	explanation_text = "Ensure the station's integrity rating is at least (Something broke, yell on GitHub)% when the shift ends."
+	jobs = "chiefengineer,stationengineer"
+
+/datum/objective/crew/integrity/New()
+	. = ..()
+	target_amount = rand(60,95)
+	update_explanation_text()
+
+/datum/objective/crew/integrity/update_explanation_text()
+	. = ..()
+	explanation_text = "Ensure the station's integrity rating is at least [target_amount]% when the shift ends."
+
+/datum/objective/crew/integrity/check_completion()
+	var/datum/station_state/end_state = new /datum/station_state()
+	end_state.count()
+	var/station_integrity = min(PERCENT(GLOB.start_state.score(end_state)), 100)
+	if(!SSticker.mode.station_was_nuked && station_integrity >= target_amount)
+		return TRUE
+	else
+		return FALSE
+
+/datum/objective/crew/poly
+	explanation_text = "Make sure Poly keeps his headset, and stays alive until the end of the shift."
+	jobs = "chiefengineer"
+
+/datum/objective/crew/poly/check_completion()
+	for(var/mob/living/simple_animal/parrot/Poly/dumbbird in GLOB.mob_list)
+		if(!(dumbbird.stat == DEAD) && dumbbird.ears)
+			if(istype(dumbbird.ears, /obj/item/radio/headset))
+				return TRUE
+	return FALSE
+
+/datum/objective/crew/meltdown
+	explanation_text = "Make sure that the engine does not meltdown while you are on the job."
+	jobs = "chiefengineer,stationengineer,atmospherictechnician"
+	var/meltdown = FALSE
+
+/datum/objective/crew/meltdown/check_completion()
+	if(meltdown)
+		return FALSE
+	return TRUE
+
+/datum/objective/crew/power_generation
+	explanation_text = "Maintain production of x MW in the engine until the end of the shift."
+	jobs = "chiefengineer,stationengineer,atmospherictechnician"
+
+/datum/objective/crew/power_generation/New()
+	. = ..()
+	var/base_target_power = 13000000
+	target_percent = rand(60,90)
+	target_amount = base_target_power * target_percent
+	update_explanation_text()
+
+/datum/objective/crew/power_generation/update_explanation_text()
+	. = ..()
+	explanation_text = "Maintain production of [target_amount] Watts in the engine until the end of the shift."

--- a/nsv13/code/modules/power/rbmk.dm
+++ b/nsv13/code/modules/power/rbmk.dm
@@ -452,6 +452,7 @@ The reactor CHEWS through moderator. It does not do this slowly. Be very careful
 	T.assume_air(coolant_output)
 	explosion(get_turf(src), 0, 5, 10, 20, TRUE, TRUE)
 	empulse(get_turf(src), 25, 15)
+	fail_meltdown_objective()
 
 //Failure condition 2: Blowout. Achieved by reactor going over-pressured. This is a round-ender because it requires more fuckery to achieve.
 /obj/machinery/atmospherics/components/trinary/nuclear_reactor/proc/blowout()
@@ -466,6 +467,15 @@ The reactor CHEWS through moderator. It does not do this slowly. Be very careful
 			var/obj/effect/landmark/nuclear_waste_spawner/WS = X
 			if(shares_overmap(src, WS)) //Begin the SLUDGING
 				WS.fire()
+
+/obj/machinery/atmospherics/components/trinary/nuclear_reactor/proc/fail_meltdown_objective()
+	for(var/client/C in GLOB.clients)
+		if(C)
+			if(CONFIG_GET(flag/allow_crew_objectives))
+				var/mob/M = C.mob
+				if(M?.mind?.current && LAZYLEN(M.mind.crew_objectives) && M.job == "Station Engineer")
+					for(var/datum/objective/crew/meltdown/MO in M.mind.crew_objectives)
+						MO.meltdown = TRUE
 
 /obj/machinery/atmospherics/components/trinary/nuclear_reactor/update_icon()
 	icon_state = "reactor_off"

--- a/nsv13/code/modules/power/rbmk.dm
+++ b/nsv13/code/modules/power/rbmk.dm
@@ -473,7 +473,7 @@ The reactor CHEWS through moderator. It does not do this slowly. Be very careful
 		if(C)
 			if(CONFIG_GET(flag/allow_crew_objectives))
 				var/mob/M = C.mob
-				if(M?.mind?.current && LAZYLEN(M.mind.crew_objectives) && M.job == "Station Engineer")
+				if(M?.mind?.current && LAZYLEN(M.mind.crew_objectives) && (M.job == "Station Engineer" || M.job == "Chief Engineer" || M.job == "Atmospheric Technician"))
 					for(var/datum/objective/crew/meltdown/MO in M.mind.crew_objectives)
 						MO.meltdown = TRUE
 

--- a/nsv13/code/modules/power/stormdrive.dm
+++ b/nsv13/code/modules/power/stormdrive.dm
@@ -1033,12 +1033,22 @@ Control Rods
 		cut_overlays()
 		flick("meltdown", src)
 		do_meltdown_effects()
+		fail_meltdown_objective()
 		sleep(10)
 		icon_state = "broken"
 		reactor_end_times = FALSE //We don't need this anymore
 	else
 		warning_state = WARNING_STATE_NONE
 		reactor_end_times = FALSE
+
+/obj/machinery/atmospherics/components/binary/stormdrive_reactor/proc/fail_meltdown_objective()
+	for(var/client/C in GLOB.clients)
+		if(C)
+			if(CONFIG_GET(flag/allow_crew_objectives))
+				var/mob/M = C.mob
+				if(M?.mind?.current && LAZYLEN(M.mind.crew_objectives))
+					for(var/datum/objective/crew/meltdown/MO in M.mind.crew_objectives)
+						MO.meltdown = TRUE
 
 /obj/machinery/atmospherics/components/binary/stormdrive_reactor/proc/do_meltdown_effects()
 	explosion(get_turf(src), 0, 0, 10, 20, TRUE, TRUE)

--- a/nsv13/code/modules/power/stormdrive.dm
+++ b/nsv13/code/modules/power/stormdrive.dm
@@ -1046,7 +1046,7 @@ Control Rods
 		if(C)
 			if(CONFIG_GET(flag/allow_crew_objectives))
 				var/mob/M = C.mob
-				if(M?.mind?.current && LAZYLEN(M.mind.crew_objectives))
+				if(M?.mind?.current && LAZYLEN(M.mind.crew_objectives) && (M.job == "Station Engineer" || M.job == "Chief Engineer" || M.job == "Atmospheric Technician"))
 					for(var/datum/objective/crew/meltdown/MO in M.mind.crew_objectives)
 						MO.meltdown = TRUE
 


### PR DESCRIPTION
## About The Pull Request

This PR adds an objective to never have an engine meltdown, either SD or RBMK, and also adds an objective to produce randomly between 60-90% of 13 MW for the SD and 10 MW for the RBMK

## Why It's Good For The Game

Engineers really need more objectives

## Changelog
:cl:
add: Added new objectives for engineer, one to have a certain power output by roundend, and the other to never have an engine meltdown (SD or RBMK)
/:cl: