### PR TITLE
starsystem change - Dolos-B-Gone

### DIFF
--- a/nsv13/code/controllers/subsystem/starsystem.dm
+++ b/nsv13/code/controllers/subsystem/starsystem.dm
@@ -899,6 +899,7 @@ Welcome to the endgame. This sector is the hardest you'll encounter in game and 
 	system_type = "radioactive"
 	adjacency_list = list("Abassi", "Deimos", "Phobos") //No going back from here...
 	threat_level = THREAT_LEVEL_DANGEROUS
+	hidden = TRUE
 	fleet_type = /datum/fleet/dolos //You're insane to attempt this.
 
 /datum/star_system/sector4/abassi


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Sets Dolos as "hidden" innately in the starsystem subsystem, preventing access without admin intervention.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Dolos was designed to be an incredibly difficult sector, which with our recent release has severely lost its edge due to shield technology, new strategies regarding MAC cannons, and excessive attempts by players leading it to be far less special and instead incredibly common in the gameplay loop. This PR disables Dolos to prevent crews from doing "Dolos runs" and allowing admins to once again use it for events or other theatrics at their leisure. It also helps to prevent 3+ hour rounds which have unfortunately continued after our initial attempts to stop them with the Armada.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Set Dolo's hidden value to "TRUE"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
