### PR TITLE
Eclipse fighter launcher is totally indestructible

### DIFF
--- a/_maps/map_files/Eclipse/Eclipse.dmm
+++ b/_maps/map_files/Eclipse/Eclipse.dmm
@@ -4740,7 +4740,8 @@
 "uL" = (
 /obj/structure/fighter_launcher{
 	dir = 4;
-	invisibility = 100
+	invisibility = 100;
+	resistance_flags = 115
 	},
 /turf/closed/wall/r_wall,
 /area/space/nearstation)


### PR DESCRIPTION
Makes the hidden magcat on eclipse indestructible so that it can't be blown up by torpedoes, and prevent fighters from working