### PR TITLE
Various Eclipse fixes

### DIFF
--- a/_maps/map_files/Eclipse/Eclipse.dmm
+++ b/_maps/map_files/Eclipse/Eclipse.dmm
@@ -54,7 +54,7 @@
 /obj/machinery/grill/unwrenched,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/item/reagent_containers/food/drinks/soda_cans/monkey_energy,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/fore)
 "aq" = (
 /obj/structure/cable/yellow{
@@ -76,7 +76,7 @@
 /area/engine/engine_room)
 "ar" = (
 /obj/machinery/chem_master,
-/turf/open/floor/plasteel/airless/white/side{
+/turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
 /area/science/xenobiology)
@@ -126,7 +126,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/department/medical)
 "aA" = (
 /obj/structure/table/reinforced,
@@ -167,7 +167,7 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/science/xenobiology)
 "aQ" = (
 /obj/structure/table_frame,
@@ -186,7 +186,7 @@
 /area/crew_quarters/dorms/nsv/dorms_2)
 "bb" = (
 /turf/open/floor/monotile/dark,
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "bc" = (
 /turf/open/floor/plasteel/dark/side{
 	dir = 6
@@ -209,7 +209,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "bh" = (
 /obj/item/stack/sheet/mineral/plasma{
@@ -291,7 +291,7 @@
 /obj/item/ship_weapon/ammunition/railgun_ammo,
 /obj/item/ship_weapon/ammunition/railgun_ammo,
 /obj/item/ship_weapon/ammunition/railgun_ammo,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
 "bv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -299,7 +299,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/monotile/dark,
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "bw" = (
 /obj/machinery/light{
 	dir = 1
@@ -334,7 +334,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "bH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -474,7 +474,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/disposal)
 "ct" = (
 /obj/structure/window/plasma/reinforced,
@@ -495,13 +495,13 @@
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/monotile/dark,
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "cA" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "cB" = (
 /obj/structure/bookcase/random/nonfiction,
@@ -522,18 +522,18 @@
 	icon_state = "0-2"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cJ" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cM" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "cN" = (
 /obj/machinery/armour_plating_nanorepair_pump/aft_port{
@@ -552,14 +552,14 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "cW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "cZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
@@ -619,7 +619,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/aft)
 "dw" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -647,7 +647,7 @@
 /turf/open/floor/plasteel/dark/side{
 	dir = 4
 	},
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "dA" = (
 /obj/machinery/mineral/equipment_vendor,
 /obj/machinery/light{
@@ -671,7 +671,7 @@
 /turf/open/floor/plasteel/dark/side{
 	dir = 4
 	},
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "dG" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/captain/private)
@@ -717,7 +717,7 @@
 /area/medical/sleeper)
 "dL" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/disposal)
 "dM" = (
 /obj/machinery/light,
@@ -738,7 +738,7 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "dS" = (
 /obj/structure/cable{
@@ -922,14 +922,6 @@
 "eM" = (
 /turf/open/floor/plasteel/checker,
 /area/crew_quarters/kitchen)
-"eO" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/techmaint{
-	initial_gas_mix = "TEMP=2.7"
-	},
-/area/space/nearstation)
 "eP" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel/dark/side{
@@ -1005,7 +997,7 @@
 /turf/open/floor/plasteel/dark/side{
 	dir = 8
 	},
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "fd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -1087,7 +1079,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/disposal)
 "fn" = (
 /obj/structure/closet/crate{
@@ -1111,7 +1103,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile,
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "fq" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -1330,7 +1322,7 @@
 /obj/item/ammo_box/magazine/pdc/flak,
 /obj/item/ammo_box/magazine/pdc/flak,
 /obj/item/radio/intercom/directional/north,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
 "gf" = (
 /obj/structure/shuttle/engine/heater{
@@ -1612,7 +1604,7 @@
 	pixel_y = 6
 	},
 /obj/item/wrench,
-/turf/open/floor/plasteel/airless/white/side{
+/turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
 /area/science/xenobiology)
@@ -1682,7 +1674,7 @@
 /turf/open/floor/plasteel/dark/side{
 	dir = 8
 	},
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "hK" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable{
@@ -1796,20 +1788,6 @@
 	},
 /turf/open/floor/plasteel/dark/side,
 /area/crew_quarters/lounge)
-"ie" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/techmaint{
-	initial_gas_mix = "TEMP=2.7"
-	},
-/area/space/nearstation)
 "if" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel/dark/side,
@@ -1850,7 +1828,7 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/disposal)
 "ir" = (
 /obj/machinery/vending/cola/random,
@@ -1918,7 +1896,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/aft)
 "iA" = (
 /turf/closed/wall/r_wall,
@@ -1932,7 +1910,7 @@
 "iD" = (
 /obj/effect/turf_decal/ship/outline,
 /turf/open/floor/monotile/dark,
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "iE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
@@ -1940,7 +1918,7 @@
 /area/science/server)
 "iG" = (
 /obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/disposal)
 "iH" = (
 /obj/machinery/rnd/destructive_analyzer,
@@ -1984,7 +1962,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/aft)
 "iN" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -2081,7 +2059,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/aft)
 "jh" = (
 /obj/machinery/firealarm/directional/west,
@@ -2151,7 +2129,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/disposal)
 "jx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -2285,7 +2263,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "jQ" = (
 /obj/structure/rack,
 /obj/item/shovel,
@@ -2293,7 +2271,7 @@
 /turf/open/floor/plasteel/dark/side{
 	dir = 4
 	},
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "jR" = (
 /obj/structure/sign/departments/minsky/research/xenobiology,
 /turf/closed/wall/r_wall,
@@ -2323,10 +2301,11 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "jW" = (
-/turf/open/floor/plating/airless,
+/obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
+/turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "kb" = (
-/turf/open/floor/plasteel/airless/white/side{
+/turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
 /area/science/xenobiology)
@@ -2346,7 +2325,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/aft)
 "kh" = (
 /obj/machinery/squad_vendor,
@@ -2433,7 +2412,7 @@
 /turf/open/floor/plasteel/dark/side{
 	dir = 4
 	},
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "kB" = (
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 40
@@ -2488,7 +2467,7 @@
 /turf/open/floor/plasteel/dark/side{
 	dir = 4
 	},
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "kG" = (
 /obj/effect/turf_decal/box/white,
 /obj/machinery/light{
@@ -2563,7 +2542,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/aft)
 "lb" = (
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -2586,7 +2565,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/fore)
 "ld" = (
 /obj/machinery/gravity_generator/main/station,
@@ -2654,6 +2633,11 @@
 /obj/item/reagent_containers/glass/bottle/water,
 /obj/item/pinpointer/nuke,
 /obj/item/disk/nuclear,
+/obj/item/gun/energy/laser/captain{
+	can_charge = 0;
+	desc = "This is an antique laser gun. You can tell it's incredibly old by the faded leather and and scratched metal. Its battery is a bulky internal one from ages long past, you don't think anything on the ship could recharge it.";
+	selfcharge = 0
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain/private)
 "lt" = (
@@ -2905,7 +2889,7 @@
 /turf/open/floor/plasteel/dark/side{
 	dir = 8
 	},
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "ml" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -2937,7 +2921,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/disposal)
 "mw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -3033,6 +3017,10 @@
 	dir = 5
 	},
 /area/nsv/weapons/fore)
+"mL" = (
+/obj/machinery/computer/ship/viewscreen,
+/turf/open/floor/plasteel/dark/side,
+/area/hallway/secondary/entry)
 "mN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -3067,7 +3055,7 @@
 /area/engine/gravity_generator)
 "mX" = (
 /obj/item/toy/plush/lizardplushie,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "mY" = (
 /obj/effect/turf_decal/tile/blue,
@@ -3118,8 +3106,12 @@
 "nh" = (
 /obj/item/trash/can/food/peaches,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
+"nk" = (
+/obj/machinery/computer/ship/viewscreen,
+/turf/open/floor/plasteel/dark/side,
+/area/hallway/primary/central)
 "nl" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -3360,7 +3352,7 @@
 /obj/machinery/computer/rdconsole/core{
 	dir = 8
 	},
-/turf/open/floor/plasteel/airless/white/side{
+/turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
 /area/science/xenobiology)
@@ -3369,14 +3361,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/department/medical)
 "op" = (
 /obj/structure/extinguisher_cabinet/west,
 /turf/open/floor/plasteel/dark/side{
 	dir = 4
 	},
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "or" = (
 /turf/open/floor/plasteel/dark/side{
 	dir = 1
@@ -3403,12 +3395,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "oz" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "oB" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -3511,7 +3503,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "ph" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -3520,13 +3512,13 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/aft)
 "pj" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/disposal)
 "pl" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -3542,7 +3534,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "pn" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -3973,7 +3965,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/aft)
 "rk" = (
 /obj/machinery/disposal/bin,
@@ -4003,7 +3995,7 @@
 /obj/effect/turf_decal/caution/stand_clear{
 	dir = 1
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/disposal)
 "rs" = (
 /obj/effect/turf_decal/ship/techfloor{
@@ -4038,7 +4030,7 @@
 /turf/open/floor/monotile/dark,
 /area/bridge)
 "rx" = (
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/fore)
 "ry" = (
 /obj/structure/bedsheetbin,
@@ -4105,11 +4097,12 @@
 	},
 /obj/structure/fluff/paper/stack,
 /obj/item/storage/lockbox/medal,
+/obj/item/tank/jetpack/oxygen/captain,
 /turf/open/floor/carpet/ship/beige_carpet,
 /area/crew_quarters/heads/captain/private)
 "rP" = (
 /obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/aft)
 "rT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -4154,7 +4147,7 @@
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "sm" = (
 /obj/structure/table/wood,
@@ -4211,7 +4204,7 @@
 "sA" = (
 /obj/effect/turf_decal/arrows,
 /turf/open/floor/monotile,
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "sE" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -4365,7 +4358,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "tk" = (
 /turf/open/floor/plasteel/dark/side,
@@ -4385,7 +4378,7 @@
 	dir = 1
 	},
 /turf/open/floor/monotile/dark,
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "to" = (
 /turf/open/floor/carpet/ship/beige_carpet,
 /area/crew_quarters/dorms)
@@ -4579,7 +4572,7 @@
 /obj/effect/turf_decal/ship/outline,
 /obj/structure/closet/crate,
 /turf/open/floor/monotile/dark,
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "ue" = (
 /obj/item/book/manual/wiki/tcomms,
 /obj/machinery/computer/rdservercontrol{
@@ -4618,7 +4611,7 @@
 /area/crew_quarters/kitchen)
 "uo" = (
 /turf/closed/wall/r_wall,
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "uq" = (
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
@@ -4686,7 +4679,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/disposal)
 "uA" = (
 /obj/item/radio/intercom/directional/north,
@@ -4697,7 +4690,7 @@
 /turf/open/floor/plasteel/dark/side{
 	dir = 4
 	},
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "uF" = (
 /obj/structure/window/plasma/reinforced{
 	dir = 4
@@ -4740,8 +4733,7 @@
 "uL" = (
 /obj/structure/fighter_launcher{
 	dir = 4;
-	invisibility = 100;
-	resistance_flags = 115
+	invisibility = 100
 	},
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
@@ -4838,7 +4830,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/disposal)
 "vf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -4878,7 +4870,7 @@
 	icon_state = "1-4"
 	},
 /obj/effect/landmark/blobstart,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "vr" = (
 /obj/machinery/advanced_airlock_controller{
@@ -4910,7 +4902,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/ship/maintenance,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "vx" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -5032,10 +5024,16 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/auto_name/east,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/fore)
 "vZ" = (
-/obj/item/reagent_containers/food/snacks/salad/fruit,
+/obj/item/reagent_containers/food/snacks/salad/fruit{
+	bonus_reagents = null;
+	desc = "A bowl of plastic fruit. Each fruit in the bowl shines with an ominous glare that portrays an aura of foreboding in the room. You feel like it'd be a bad idea to try and eat it.";
+	list_reagents = list(/datum/reagent/toxin/lipolicide= 50);
+	name = "plastic fruit bowl";
+	prevent_grinding = 1
+	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/structure/cable{
@@ -5221,7 +5219,7 @@
 /turf/open/floor/plasteel/dark/side{
 	dir = 4
 	},
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "wT" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -5288,7 +5286,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/dark,
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "xk" = (
 /obj/structure/sign/poster/official/safety_internals,
 /turf/closed/wall/r_wall,
@@ -5365,7 +5363,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "xC" = (
 /obj/item/stack/sheet/mineral/uranium,
@@ -5409,7 +5407,7 @@
 /turf/open/floor/monotile,
 /area/nsv/weapons/fore)
 "xI" = (
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "xL" = (
 /obj/structure/sign/poster/contraband/space_up,
@@ -5496,7 +5494,7 @@
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/aft)
 "yl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -5548,7 +5546,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/aft)
 "yH" = (
 /obj/machinery/door/firedoor/border_only/directional/north,
@@ -5666,7 +5664,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/monotile/dark,
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "yZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5724,7 +5722,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "zo" = (
 /obj/machinery/light{
@@ -5805,7 +5803,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "zA" = (
 /turf/closed/wall/r_wall,
@@ -5836,7 +5834,7 @@
 	dir = 1
 	},
 /turf/open/floor/monotile/dark,
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "zG" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -5891,7 +5889,7 @@
 /turf/open/floor/plasteel/dark/side{
 	dir = 4
 	},
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "zL" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -5907,7 +5905,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plasteel/airless/white/side{
+/turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
 /area/science/xenobiology)
@@ -5946,7 +5944,7 @@
 	dir = 1
 	},
 /turf/open/floor/monotile,
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "zV" = (
 /obj/item/trash/can,
 /turf/open/floor/plasteel/dark/side,
@@ -6008,9 +6006,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/techmaint{
-	initial_gas_mix = "TEMP=2.7"
-	},
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "Ao" = (
 /obj/machinery/power/apc/auto_name/west,
@@ -6038,7 +6034,7 @@
 	pixel_y = 16
 	},
 /obj/item/storage/box/beakers,
-/turf/open/floor/plasteel/airless/white/side{
+/turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
 /area/science/xenobiology)
@@ -6072,7 +6068,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "AJ" = (
 /obj/structure/hull_plate/end,
 /turf/open/floor/plating/airless,
@@ -6116,7 +6112,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/aft)
 "AQ" = (
 /obj/structure/cable/yellow{
@@ -6129,7 +6125,7 @@
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
 "AS" = (
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/disposal)
 "AT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -6139,7 +6135,7 @@
 	dir = 6
 	},
 /turf/open/floor/monotile/dark,
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "AV" = (
 /obj/effect/turf_decal/ship/techfloor,
 /obj/machinery/computer/cryopod{
@@ -6461,6 +6457,7 @@
 /area/hallway/primary/fore)
 "Cz" = (
 /obj/item/trash/boritos,
+/obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/plasteel/dark/side,
 /area/hallway/primary/fore)
 "CA" = (
@@ -6468,7 +6465,7 @@
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/three,
 /turf/open/floor/monotile/dark,
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "CC" = (
 /obj/machinery/door/window/brigdoor/westleft{
 	name = "Xenobiology Containment";
@@ -6573,7 +6570,7 @@
 	id = "crematoriumChapel";
 	pixel_y = 30
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/disposal)
 "Dd" = (
 /obj/structure/lattice/catwalk,
@@ -6627,6 +6624,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/plasteel/dark/side,
 /area/hallway/primary/aft)
 "Dm" = (
@@ -6694,7 +6692,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/disposal)
 "DD" = (
 /obj/machinery/ship_weapon/pdc_mount/flak,
@@ -6707,9 +6705,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel/techmaint{
-	initial_gas_mix = "TEMP=2.7"
-	},
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "DH" = (
 /obj/structure/cable{
@@ -6724,7 +6720,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "DJ" = (
 /obj/machinery/smartfridge/extract/preloaded,
@@ -6761,7 +6757,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/ship/maintenance,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "DT" = (
 /turf/closed/wall/r_wall,
@@ -6802,7 +6798,7 @@
 	dir = 1
 	},
 /turf/open/floor/monotile/dark,
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "DY" = (
 /obj/machinery/atmospherics/pipe/simple,
 /obj/structure/cable/yellow{
@@ -6845,7 +6841,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "Eo" = (
 /obj/structure/shuttle/engine/heater{
@@ -6857,7 +6853,7 @@
 /turf/open/floor/plasteel/dark/side{
 	dir = 8
 	},
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "Er" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -6905,7 +6901,7 @@
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "EB" = (
 /obj/structure/closet/secure_closet/freezer/fridge/open,
@@ -6930,7 +6926,7 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/fore)
 "EJ" = (
 /obj/machinery/door/airlock/ship/external/glass{
@@ -6978,7 +6974,7 @@
 /turf/open/floor/plasteel/dark/side{
 	dir = 4
 	},
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "ER" = (
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
@@ -6999,7 +6995,7 @@
 /area/bridge)
 "ES" = (
 /obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/fore)
 "EV" = (
 /obj/structure/shuttle/engine/heater{
@@ -7055,7 +7051,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/ship/maintenance,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/aft)
 "Fg" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
@@ -7130,7 +7126,7 @@
 /area/tcommsat/server)
 "Fs" = (
 /obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "Ft" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -7215,7 +7211,7 @@
 /turf/open/floor/plasteel/dark/side{
 	dir = 8
 	},
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "FO" = (
 /obj/machinery/armour_plating_nanorepair_pump/aft_starboard{
 	apnw_id = "pleaseSendHelp";
@@ -7262,7 +7258,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "Ga" = (
 /obj/machinery/cryopod,
 /turf/open/floor/plasteel/dark/side{
@@ -7297,7 +7293,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/disposal)
 "Gi" = (
 /obj/structure/fluff/support_beam{
@@ -7333,9 +7329,7 @@
 	pixel_y = 26;
 	req_access = null
 	},
-/turf/open/floor/plasteel/techmaint{
-	initial_gas_mix = "TEMP=2.7"
-	},
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "Gs" = (
 /obj/machinery/camera/autoname{
@@ -7487,7 +7481,7 @@
 /turf/open/floor/plasteel/dark/side{
 	dir = 8
 	},
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "GN" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
@@ -7555,12 +7549,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/aft)
 "Ha" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/monotile/dark,
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "Hb" = (
 /obj/machinery/mineral/equipment_vendor,
 /obj/machinery/light,
@@ -7607,7 +7601,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "Hk" = (
 /obj/effect/turf_decal/tile/blue,
@@ -7629,14 +7623,14 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/disposal)
 "Hs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /obj/machinery/airalarm/directional/north,
-/obj/machinery/portable_atmospherics/scrubber/huge,
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plasteel/dark/side,
 /area/engine/engine_smes)
 "Ht" = (
@@ -7644,7 +7638,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/disposal)
 "Hu" = (
 /obj/structure/chair/comfy/black{
@@ -7744,7 +7738,7 @@
 /obj/effect/spawner/lootdrop/maintenance/four,
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile/dark,
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "HQ" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/o2{
 	dir = 1;
@@ -7753,21 +7747,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/aft)
 "HS" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/techmaint{
-	initial_gas_mix = "TEMP=2.7"
-	},
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "HT" = (
 /obj/structure/cable{
@@ -7781,7 +7767,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/dark,
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "HV" = (
 /obj/structure/closet/crate{
 	name = "railgun projectile crate"
@@ -7816,7 +7802,7 @@
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/seven,
 /turf/open/floor/monotile/dark,
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "Ie" = (
 /turf/open/floor/plasteel/dark/side{
 	dir = 1
@@ -7892,7 +7878,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "Iw" = (
 /obj/machinery/light{
@@ -7929,7 +7915,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/girder/displaced,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/aft)
 "IC" = (
 /obj/structure/cable{
@@ -7946,7 +7932,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/disposal)
 "IE" = (
 /obj/machinery/firealarm/directional/south,
@@ -7960,7 +7946,7 @@
 	icon_state = "crateopen"
 	},
 /turf/open/floor/monotile/dark,
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "II" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -7975,7 +7961,7 @@
 	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
 	width = 3
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/space/nearstation)
 "IL" = (
 /obj/machinery/vending/coffee,
@@ -7988,6 +7974,7 @@
 /obj/effect/turf_decal/ship/techfloor{
 	dir = 1
 	},
+/obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile,
 /area/bridge)
 "IO" = (
@@ -8010,7 +7997,7 @@
 	icon_state = "0-2"
 	},
 /turf/open/floor/monotile/dark,
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "IW" = (
 /obj/structure/sign/poster/official/soft_cap_pop_art,
 /turf/closed/wall/r_wall,
@@ -8064,7 +8051,7 @@
 	},
 /obj/item/trash/energybar,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "Jk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -8089,7 +8076,7 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "Jm" = (
 /obj/structure/table/wood,
@@ -8115,7 +8102,6 @@
 /turf/open/floor/monotile,
 /area/nsv/weapons/fore)
 "Jp" = (
-/obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
 /obj/machinery/light/small{
 	dir = 4
@@ -8157,7 +8143,7 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/department/medical)
 "JE" = (
 /obj/effect/turf_decal/stripes/line{
@@ -8189,7 +8175,7 @@
 /area/crew_quarters/kitchen)
 "JQ" = (
 /obj/effect/decal/cleanable/robot_debris/old,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/disposal)
 "JU" = (
 /obj/structure/cable{
@@ -8210,7 +8196,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile,
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "JZ" = (
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
@@ -8235,8 +8221,9 @@
 /turf/open/floor/plasteel/checker,
 /area/crew_quarters/kitchen)
 "Kd" = (
-/turf/closed/wall/steel,
-/area/crew_quarters/heads/captain/private)
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/plating/airless,
+/area/science/xenobiology)
 "Kf" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -8304,7 +8291,7 @@
 /area/crew_quarters/bar)
 "Kt" = (
 /obj/structure/grille,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/disposal)
 "Kz" = (
 /obj/structure/table/reinforced,
@@ -8434,7 +8421,7 @@
 /turf/open/floor/plasteel/dark/side{
 	dir = 8
 	},
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "KX" = (
 /obj/structure/chair/sofa,
 /obj/effect/landmark/start/assistant,
@@ -8462,7 +8449,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "Lk" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
@@ -8690,7 +8677,7 @@
 	dir = 6
 	},
 /turf/open/floor/monotile/dark,
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "Mo" = (
 /obj/structure/window/plasma/reinforced{
 	dir = 1
@@ -8736,14 +8723,14 @@
 	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
 	width = 3
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/space/nearstation)
 "Ms" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/layer_manifold/visible,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/aft)
 "Mt" = (
 /mob/living/simple_animal/pet/cat{
@@ -8855,7 +8842,7 @@
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
 "MP" = (
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "MR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -8961,7 +8948,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "Ng" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
@@ -9056,7 +9043,7 @@
 /turf/open/floor/plasteel/dark/side{
 	dir = 4
 	},
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "Nx" = (
 /obj/structure/table,
 /obj/item/seeds/wheat,
@@ -9170,7 +9157,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/disposal)
 "NS" = (
 /obj/effect/turf_decal/tile/blue,
@@ -9216,7 +9203,7 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/crew_quarters/cryopods)
 "Ob" = (
 /obj/machinery/door/firedoor/border_only/directional/north,
@@ -9267,7 +9254,7 @@
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/east,
-/turf/open/floor/plasteel/airless/white/side{
+/turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
 /area/science/xenobiology)
@@ -9276,7 +9263,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plasteel/airless/white/side{
+/turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
 /area/science/xenobiology)
@@ -9307,7 +9294,7 @@
 "OB" = (
 /obj/machinery/monkey_recycler,
 /obj/machinery/computer/ship/viewscreen,
-/turf/open/floor/plasteel/airless/white/side{
+/turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
 /area/science/xenobiology)
@@ -9315,7 +9302,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "OE" = (
 /obj/machinery/airalarm/directional/north,
@@ -9336,9 +9323,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/techmaint{
-	initial_gas_mix = "TEMP=2.7"
-	},
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "OI" = (
 /obj/machinery/power/apc/auto_name/west,
@@ -9396,7 +9381,7 @@
 /area/medical/surgery)
 "OT" = (
 /obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "OV" = (
 /turf/closed/wall/r_wall,
@@ -9559,7 +9544,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "PJ" = (
 /obj/machinery/light{
@@ -9618,7 +9603,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/aft)
 "PX" = (
 /obj/machinery/camera/autoname,
@@ -9639,7 +9624,7 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/crew_quarters/kitchen)
 "Qd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -9731,7 +9716,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "Qw" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -9769,7 +9754,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/disposal)
 "QH" = (
 /obj/structure/cable{
@@ -9797,7 +9782,7 @@
 /area/hallway/secondary/entry)
 "QO" = (
 /turf/open/floor/monotile,
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "QP" = (
 /obj/effect/turf_decal/box/corners,
 /turf/open/floor/monotile/dark,
@@ -9853,7 +9838,7 @@
 /area/hallway/primary/fore)
 "Rb" = (
 /obj/structure/closet/emcloset,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/disposal)
 "Rc" = (
 /obj/machinery/camera/autoname{
@@ -9945,7 +9930,7 @@
 /turf/open/floor/plasteel/dark/side{
 	dir = 8
 	},
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "Ru" = (
 /obj/machinery/vending/hydroseeds,
 /turf/open/floor/plasteel/checker,
@@ -9964,7 +9949,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/disposal)
 "RB" = (
 /turf/open/floor/plasteel/dark/side{
@@ -10120,7 +10105,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/department/medical)
 "So" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -10140,7 +10125,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/fore)
 "Ss" = (
 /obj/structure/cable{
@@ -10256,7 +10241,7 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "SL" = (
 /obj/effect/turf_decal/ship/techfloor{
@@ -10281,7 +10266,7 @@
 "SQ" = (
 /obj/item/toy/plush/lizardplushie,
 /obj/item/trash/raisins,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "SS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -10351,7 +10336,7 @@
 	},
 /obj/item/circuitboard/machine/stacking_machine,
 /obj/item/stack/cable_coil/red,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/disposal)
 "SZ" = (
 /turf/open/floor/plasteel/dark/side{
@@ -10441,7 +10426,7 @@
 /area/science/xenobiology)
 "Tt" = (
 /obj/structure/grille,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/fore)
 "Tx" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -10467,7 +10452,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/disposal)
 "TD" = (
 /obj/machinery/door/firedoor/border_only/directional/north,
@@ -10485,7 +10470,7 @@
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/four,
 /turf/open/floor/monotile/dark,
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "TG" = (
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
@@ -10519,7 +10504,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/ship/maintenance,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/department/medical)
 "TK" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -10550,14 +10535,12 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/monotile/dark,
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "TS" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel/techmaint{
-	initial_gas_mix = "TEMP=2.7"
-	},
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "TT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -10658,7 +10641,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/department/medical)
 "Ut" = (
 /obj/structure/cable{
@@ -10667,7 +10650,7 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/aft)
 "Uu" = (
 /obj/machinery/holopad,
@@ -10697,7 +10680,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "UB" = (
 /obj/structure/rack,
@@ -10716,7 +10699,7 @@
 /turf/open/floor/plasteel/dark/side{
 	dir = 8
 	},
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "UD" = (
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/plasteel/dark/side,
@@ -10832,7 +10815,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/aft)
 "Vb" = (
 /obj/machinery/suit_storage_unit/mining/eva,
@@ -10875,9 +10858,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/techmaint{
-	initial_gas_mix = "TEMP=2.7"
-	},
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "Vh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -10926,7 +10907,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/girder/displaced,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "Vr" = (
 /obj/structure/closet/firecloset,
@@ -11140,7 +11121,7 @@
 /turf/open/floor/plasteel/checker,
 /area/crew_quarters/kitchen)
 "Wo" = (
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/space/nearstation)
 "Wq" = (
 /obj/structure/chair{
@@ -11171,7 +11152,7 @@
 	name = "cargo shutters"
 	},
 /turf/open/floor/plating/airless,
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "Wv" = (
 /obj/machinery/door/airlock/ship/hatch{
 	dir = 4
@@ -11193,6 +11174,7 @@
 /turf/open/floor/plating/airless,
 /area/bridge)
 "Wz" = (
+/obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/plasteel/dark/corner,
 /area/hallway/primary/aft)
 "WA" = (
@@ -11250,7 +11232,7 @@
 /area/engine/engine_smes)
 "WK" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "WL" = (
 /obj/effect/turf_decal/stripes/line{
@@ -11264,7 +11246,7 @@
 "WN" = (
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/monotile,
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "WP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
@@ -11473,9 +11455,8 @@
 /obj/effect/turf_decal/ship/outline,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
 /turf/open/floor/monotile/dark,
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "Yf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4;
@@ -11494,7 +11475,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "Yi" = (
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
@@ -11561,7 +11542,7 @@
 /area/nsv/weapons/fore)
 "Yv" = (
 /obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "Yw" = (
 /obj/machinery/door/firedoor/border_only/directional/west,
@@ -11613,9 +11594,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/techmaint{
-	initial_gas_mix = "TEMP=2.7"
-	},
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "YG" = (
 /obj/structure/sign/departments/restroom,
@@ -11623,14 +11602,14 @@
 /area/crew_quarters/toilet/restrooms)
 "YH" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/fore)
 "YI" = (
 /obj/structure/grille,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/disposal)
 "YJ" = (
 /obj/machinery/power/apc/auto_name/east,
@@ -11747,7 +11726,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/disposal)
 "Zl" = (
 /obj/structure/cable{
@@ -11755,7 +11734,7 @@
 	},
 /obj/effect/landmark/start/quartermaster,
 /turf/open/floor/monotile/dark,
-/area/quartermaster/storage)
+/area/quartermaster/warehouse)
 "Zm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -11849,7 +11828,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "ZB" = (
 /obj/machinery/computer/upload/ai,
@@ -11898,7 +11877,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/disposal)
 "ZP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -11945,10 +11924,6 @@
 	},
 /turf/open/floor/plasteel/dark/side,
 /area/hallway/primary/fore)
-"ZZ" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/space/nearstation)
 
 (1,1,1) = {"
 gX
@@ -30064,7 +30039,7 @@ Rs
 Rs
 br
 Rs
-Kd
+dG
 dG
 Wv
 dG
@@ -30321,7 +30296,7 @@ uF
 Uc
 fS
 ju
-Kd
+dG
 Wm
 BP
 Bd
@@ -30578,7 +30553,7 @@ UN
 ct
 Mo
 Fk
-Kd
+dG
 cB
 Uu
 Jn
@@ -30835,7 +30810,7 @@ Bi
 jI
 bM
 Gz
-Kd
+dG
 ls
 BG
 ZI
@@ -31092,7 +31067,7 @@ wh
 Rs
 br
 Rs
-Kd
+dG
 dG
 dG
 dG
@@ -35690,7 +35665,7 @@ gX
 gX
 gX
 gX
-ZZ
+le
 Ti
 Ti
 Ti
@@ -36204,7 +36179,7 @@ gX
 gX
 gX
 gX
-ZZ
+le
 Lm
 Lm
 Lm
@@ -36461,7 +36436,7 @@ gX
 gX
 gX
 gX
-ZZ
+le
 Lm
 Lm
 Lm
@@ -36472,7 +36447,7 @@ Lm
 Lm
 Lm
 VY
-Pi
+mL
 jp
 wj
 zA
@@ -36480,7 +36455,7 @@ XV
 XV
 WP
 Dd
-Dd
+Kd
 Dd
 WP
 XV
@@ -38003,7 +37978,7 @@ gX
 gX
 gX
 gX
-ZZ
+le
 Lm
 Lm
 Lm
@@ -38260,7 +38235,7 @@ gX
 gX
 gX
 gX
-ZZ
+le
 Lm
 Lm
 Lm
@@ -38542,7 +38517,7 @@ WP
 Tq
 WP
 zA
-ip
+nk
 Hv
 Eu
 uo
@@ -39802,7 +39777,7 @@ gX
 gX
 gX
 gX
-ZZ
+le
 Ti
 Ti
 Ti
@@ -49609,7 +49584,7 @@ XZ
 XZ
 XZ
 XZ
-ie
+HS
 XZ
 XZ
 XZ
@@ -50086,7 +50061,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 XZ
 XZ
@@ -50129,7 +50104,7 @@ XZ
 XZ
 XZ
 XZ
-eO
+HS
 XZ
 gX
 gX
@@ -50343,7 +50318,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 Lm
 Lm
@@ -50386,7 +50361,7 @@ Lm
 Lm
 qx
 XZ
-eO
+HS
 XZ
 gX
 gX
@@ -50600,7 +50575,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 Lm
 Lm
@@ -50643,7 +50618,7 @@ Lm
 Lm
 Lm
 XZ
-eO
+HS
 XZ
 gX
 gX
@@ -50857,7 +50832,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 Lm
 Lm
@@ -50900,7 +50875,7 @@ Lm
 Lm
 Lm
 XZ
-eO
+HS
 XZ
 gX
 gX
@@ -51114,7 +51089,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 Lm
 Lm
@@ -51157,7 +51132,7 @@ Lm
 Lm
 Lm
 XZ
-eO
+HS
 XZ
 gX
 gX
@@ -51371,7 +51346,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 Lm
 Lm
@@ -51414,7 +51389,7 @@ Lm
 Lm
 Lm
 XZ
-eO
+HS
 XZ
 gX
 gX
@@ -51628,7 +51603,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 Lm
 Lm
@@ -51671,7 +51646,7 @@ Lm
 Lm
 Lm
 XZ
-eO
+HS
 XZ
 gX
 gX
@@ -51885,7 +51860,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 Lm
 Lm
@@ -51928,7 +51903,7 @@ Lm
 Lm
 Lm
 XZ
-eO
+HS
 XZ
 gX
 gX
@@ -52142,7 +52117,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 Lm
 Lm
@@ -52185,7 +52160,7 @@ Lm
 Lm
 Lm
 XZ
-eO
+HS
 XZ
 gX
 gX
@@ -52399,7 +52374,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 Lm
 Lm
@@ -52442,7 +52417,7 @@ Lm
 Lm
 Lm
 XZ
-eO
+HS
 XZ
 gX
 gX
@@ -52656,7 +52631,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 Lm
 Lm
@@ -52699,7 +52674,7 @@ Lm
 Lm
 Lm
 XZ
-eO
+HS
 XZ
 gX
 gX
@@ -52913,7 +52888,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 Lm
 Lm
@@ -52956,7 +52931,7 @@ Lm
 Lm
 Lm
 XZ
-eO
+HS
 XZ
 gX
 gX
@@ -53170,7 +53145,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 Lm
 Lm
@@ -53213,7 +53188,7 @@ Lm
 Lm
 Lm
 XZ
-eO
+HS
 XZ
 gX
 gX
@@ -53427,7 +53402,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 Lm
 Lm
@@ -53470,7 +53445,7 @@ Lm
 Lm
 Lm
 XZ
-eO
+HS
 XZ
 gX
 gX
@@ -53684,7 +53659,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 Lm
 Lm
@@ -53727,7 +53702,7 @@ Lm
 Lm
 Lm
 XZ
-eO
+HS
 XZ
 gX
 gX
@@ -53941,7 +53916,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 Lm
 Lm
@@ -53984,7 +53959,7 @@ Lm
 Lm
 Lm
 XZ
-eO
+HS
 XZ
 gX
 gX
@@ -54198,7 +54173,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 Lm
 Lm
@@ -54241,7 +54216,7 @@ Lm
 Lm
 Lm
 XZ
-eO
+HS
 XZ
 gX
 gX
@@ -54455,7 +54430,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 Lm
 Lm
@@ -54498,7 +54473,7 @@ Lm
 Lm
 Lm
 XZ
-eO
+HS
 XZ
 gX
 gX
@@ -54712,7 +54687,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 Lm
 Lm
@@ -54755,7 +54730,7 @@ Lm
 Lm
 Lm
 XZ
-eO
+HS
 XZ
 gX
 gX
@@ -54969,7 +54944,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 Lm
 Lm
@@ -55012,7 +54987,7 @@ Lm
 Lm
 Lm
 XZ
-eO
+HS
 XZ
 gX
 gX
@@ -55226,7 +55201,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 Lm
 Lm
@@ -55269,7 +55244,7 @@ Lm
 Lm
 Lm
 XZ
-eO
+HS
 XZ
 gX
 gX
@@ -55483,7 +55458,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 Lm
 Lm
@@ -55526,7 +55501,7 @@ Lm
 Lm
 Lm
 XZ
-eO
+HS
 XZ
 gX
 gX
@@ -55740,7 +55715,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 Lm
 Lm
@@ -55783,7 +55758,7 @@ Lm
 Lm
 Lm
 XZ
-eO
+HS
 XZ
 gX
 gX
@@ -55997,7 +55972,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 Lm
 Lm
@@ -56040,7 +56015,7 @@ Lm
 Lm
 Lm
 XZ
-eO
+HS
 XZ
 gX
 gX
@@ -56254,7 +56229,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 Lm
 Lm
@@ -56297,7 +56272,7 @@ Lm
 Lm
 Lm
 XZ
-eO
+HS
 XZ
 gX
 gX
@@ -56511,7 +56486,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 Lm
 Lm
@@ -56554,7 +56529,7 @@ Lm
 Lm
 Lm
 XZ
-eO
+HS
 XZ
 gX
 gX
@@ -56768,7 +56743,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 Lm
 Lm
@@ -56811,7 +56786,7 @@ Lm
 Lm
 Lm
 XZ
-eO
+HS
 XZ
 gX
 gX
@@ -57025,7 +57000,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 Lm
 Lm
@@ -57068,7 +57043,7 @@ Lm
 Lm
 Lm
 XZ
-eO
+HS
 XZ
 gX
 gX
@@ -57282,7 +57257,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 Lm
 Lm
@@ -57325,7 +57300,7 @@ Lm
 Lm
 Lm
 XZ
-eO
+HS
 XZ
 gX
 gX
@@ -57539,7 +57514,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 Lm
 Lm
@@ -57582,7 +57557,7 @@ Lm
 Lm
 Lm
 XZ
-eO
+HS
 XZ
 gX
 gX
@@ -57796,7 +57771,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 Lm
 Lm
@@ -57839,7 +57814,7 @@ Lm
 Lm
 Lm
 XZ
-eO
+HS
 XZ
 gX
 gX
@@ -58053,7 +58028,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 Lm
 Lm
@@ -58096,7 +58071,7 @@ Lm
 Lm
 Lm
 XZ
-eO
+HS
 XZ
 gX
 gX
@@ -58310,7 +58285,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 Lm
 Lm
@@ -58353,7 +58328,7 @@ Lm
 Lm
 Lm
 XZ
-eO
+HS
 XZ
 gX
 gX
@@ -58567,7 +58542,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 Lm
 Lm
@@ -58610,7 +58585,7 @@ Lm
 Lm
 Lm
 XZ
-eO
+HS
 XZ
 gX
 gX
@@ -58824,7 +58799,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 Lm
 Lm
@@ -58867,7 +58842,7 @@ Lm
 Lm
 Lm
 XZ
-eO
+HS
 XZ
 gX
 gX
@@ -59081,7 +59056,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 Lm
 Lm
@@ -59124,7 +59099,7 @@ Lm
 Lm
 Lm
 XZ
-eO
+HS
 XZ
 gX
 gX
@@ -59338,7 +59313,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 Lm
 Lm
@@ -59381,7 +59356,7 @@ Lm
 Lm
 Lm
 XZ
-eO
+HS
 XZ
 gX
 gX
@@ -59595,7 +59570,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 Lm
 Lm
@@ -59638,7 +59613,7 @@ Lm
 Lm
 Lm
 XZ
-eO
+HS
 XZ
 gX
 gX
@@ -59852,7 +59827,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 Lm
 Lm
@@ -59895,7 +59870,7 @@ Lm
 Lm
 Lm
 XZ
-eO
+HS
 XZ
 gX
 gX
@@ -60109,7 +60084,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 Lm
 Lm
@@ -60152,7 +60127,7 @@ Lm
 Lm
 Lm
 XZ
-eO
+HS
 XZ
 gX
 gX
@@ -60366,7 +60341,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 Lm
 Lm
@@ -60409,7 +60384,7 @@ Lm
 Lm
 Lm
 XZ
-eO
+HS
 XZ
 gX
 gX
@@ -60623,7 +60598,7 @@ gX
 gX
 gX
 XZ
-eO
+HS
 XZ
 XZ
 XZ
@@ -60666,7 +60641,7 @@ XZ
 XZ
 XZ
 XZ
-eO
+HS
 XZ
 gX
 gX


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds various items needed for traitors to succeed on the map and removes various spots in space that accidentally had air in them, leading to fewer atmos reactions roundstart.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Although traitors are not intended for the Eclipse, at some higher populations they may spawn. This PR makes it so admin intervention is not needed for some of their objectives to be achievable.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added the Captain's laser and jetpack to his office
fix: fixed some of the airless variants of tiles not being used on the exterior of the Eclipse
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
