### PR TITLE
Kudzu Fixu

### DIFF
--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -502,7 +502,7 @@
 			if(S.density && !istype(S, /obj/structure/reagent_dispensers/fueltank)) //don't breach the station!
 				S.take_damage(25)
 		for(var/obj/machinery/M in stepturf)
-			if(M.density && !istype(M, /obj/machinery/power/smes) && !istype(M, /obj/machinery/door/airlock/external) && !istype(M, /obj/machinery/door/firedoor)) //please don't sabotage power or cause a hullbreach!
+			if(M.density && !istype(M, /obj/machinery/power/smes)) //please don't sabotage power!
 				M.take_damage(40) //more damage, because machines are more commonplace and tend to be more durable
 	if (!isspaceturf(stepturf) && stepturf.Enter(src))
 		for(var/datum/spacevine_mutation/SM in mutations)

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -10,6 +10,7 @@
 	canSmoothWith = list()
 	smooth = SMOOTH_FALSE
 	var/growth_time = 1200
+	pressure_resistance = 200
 
 
 /obj/structure/alien/resin/flower_bud_enemy/Initialize()
@@ -60,6 +61,7 @@
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	unsuitable_atmos_damage = 0
+	pressure_resistance = 200
 	faction = list("hostile","vines","plants")
 	var/list/grasping = list()
 	var/list/tethers = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes Kudzu flowers and Venus human traps being susceptible to pressure and dying before even being able to spawn. Also allows Kudzu to break firelocks to be better balanced for NSV13. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Kudzu is an old event originating from TG code in which they only had the full-tile firelocks, which were present only in hallways - not in maintenance. By allowing Kudzu to destroy the directional firelocks that plague maintenance, Kudzu no longer shoots itself in the foot when it creates a breach and can spread more wildly as was the original vision. It also makes the flowers and their Venus human trap offspring immune to pressure, which was frequently killing them before or shortly after they spawn. By allowing these to spawn it makes Kudzu more aggressive and properly brings back a feature I believe few realize was present. For balancing purposes I did not add the flowers to the list of objects Kudzu will not attack as the flowers will often transform into a human trap with a remaining 50% (100) HP. This means players can examine the flowers to figure out how close they are to producing a fly trap and it progressively weakens the flowers making it easier to kill them before they do. With this slightly more aggressive form of Kudzu, I believe it will better represent what Kudzu was supposed to be when made on TG while taking some small liberties to remain relevant to NSV13.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Kudzu vines can now break firelocks
fix:  Venus Human traps and Kudzu flowers no longer die to pressure damage
code: Added pressure resistance to the Kudzu flower + Human trap
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
