### PR TITLE
[s] Fixes firing electronics being able to skip most construction steps of ALL main ship weapons

### DIFF
--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/mac_construction.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/mac_construction.dm
@@ -126,7 +126,7 @@
 		state = BS_WIRED
 		return TRUE
 
-	else if((istype(W, /obj/item/ship_weapon/parts/firing_electronics)) && (state = BS_WIRES_SOLDERED))
+	else if((istype(W, /obj/item/ship_weapon/parts/firing_electronics)) && (state == BS_WIRES_SOLDERED))
 		if(!do_after(user, 2 SECONDS, target=src))
 			return
 		W.forceMove(src)
@@ -232,13 +232,13 @@
 				to_chat(user, "<span class='notice'>You solder the barrel to the frame.</span>")
 				state = BS_BARREL_SOLDERED
 				return TRUE
-		
+
 		if(BS_BARREL_SOLDERED)
 			if(tool.use_tool(src, user, 2 SECONDS, amount=2, volume=100))
 				to_chat(user, "<span class='notice'>You cut the barrel free from the frame.</span>")
 				state = BS_BARREL_PLACED
 				return TRUE
-		
+
 		if(BS_WIRED)
 			if(tool.use_tool(src, user, 2 SECONDS, amount=2, volume=100))
 				to_chat(user, "<span class='notice'>You solder the wiring into place.</span>")

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/railgun_construction.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/railgun_construction.dm
@@ -131,7 +131,7 @@
 		state = BS_WIRED
 		return TRUE
 
-	else if((istype(W, /obj/item/ship_weapon/parts/firing_electronics)) && (state = BS_WIRES_SOLDERED))
+	else if((istype(W, /obj/item/ship_weapon/parts/firing_electronics)) && (state == BS_WIRES_SOLDERED))
 		if(!do_after(user, 2 SECONDS, target=src))
 			return
 		W.forceMove(src)

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/torpedo_launcher_construction.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/torpedo_launcher_construction.dm
@@ -112,7 +112,7 @@
 		state = BS_WIRED
 		return TRUE
 
-	else if((istype(W, /obj/item/ship_weapon/parts/firing_electronics)) && (state = BS_WIRED))
+	else if((istype(W, /obj/item/ship_weapon/parts/firing_electronics)) && (state == BS_WIRED))
 		if(!do_after(user, 2 SECONDS, target=src))
 			return
 		W.forceMove(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. As of now, the firing electronics step has a = instead of a == for the stage check, allowing people to bypass all previous steps via just adding firing electronics first / before the step they should usually be added at. This applies for all three main weapons, being Railguns, MACs and torp launchers. WOW.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Pretty much free MACs / Railguns / Torp launchers bad, fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: You can no longer skip most steps of MAC construction via use of firing electronics.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
