### PR TITLE
Fixes the reason recapturing systems didn't work.

### DIFF
--- a/nsv13/code/modules/overmap/ai-skynet2.dm
+++ b/nsv13/code/modules/overmap/ai-skynet2.dm
@@ -213,6 +213,7 @@ GLOBAL_LIST_EMPTY(ai_goals)
 
 /datum/fleet/proc/defeat()
 	minor_announce("[name] has been defeated in battle", "White Rapids Fleet Command")
+	current_system.fleets -= src
 	if(current_system.fleets && current_system.fleets.len)
 		var/datum/fleet/F = pick(current_system.fleets)
 		current_system.alignment = F.alignment
@@ -223,7 +224,6 @@ GLOBAL_LIST_EMPTY(ai_goals)
 	else
 		current_system.alignment = initial(current_system.alignment)
 		current_system.mission_sector = FALSE
-	current_system.fleets -= src
 	faction = SSstar_system.faction_by_id(faction_id)
 	faction?.lose_influence(reward)
 	for(var/obj/structure/overmap/OOM in current_system.system_contents)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When defeated, it picked from the fleets currently in the system. Including the just defeated one since it didn't get removed beforehand. And since there's usually just one fleet in a contested system, the system retained its color.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Systems no longer stay controlled by already defeated fleets.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
