### PR TITLE
Fixes torps being able to be transported in crates. 

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -176,6 +176,8 @@
 
 	else if(istype(AM, /obj/structure/closet))
 		return FALSE
+	else if(istype(AM, /obj/item/ship_weapon/ammunition/torpedo))
+		return FALSE
 	else if(isobj(AM))
 		if((!allow_dense && AM.density) || AM.anchored || AM.has_buckled_mobs())
 			return FALSE


### PR DESCRIPTION
Related to issue #1087 

## About The Pull Request

Fixing bugs good.

## Why It's Good For The Game

Lets not make the munitions trolley useless.

## Changelog
:cl:
fix: Fixed torps being able to be put in crates. We're back to using trolleys!
/:cl:

