### PR TITLE
Removes fleet and grand admiral gear in the stateroom on the gladius, and replaces it with normal admiral clothes 

### DIFF
--- a/_maps/map_files/Gladius/Gladius1.dmm
+++ b/_maps/map_files/Gladius/Gladius1.dmm
@@ -14140,10 +14140,10 @@
 /area/nsv/weapons/starboard)
 "gVA" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
-/obj/item/clothing/suit/ship/officer/admiral/fleet,
-/obj/item/clothing/under/ship/officer/admiral/fleet,
 /obj/item/clothing/head/beret/ship/admiral,
 /obj/item/storage/fancy/cigarettes/cigars/havana,
+/obj/item/clothing/under/ship/officer/admiral,
+/obj/item/clothing/suit/ship/officer/admiral,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms/nsv/state_room)
 "gVB" = (
@@ -19209,13 +19209,6 @@
 /obj/structure/extinguisher_cabinet/east,
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/frame1/central)
-"jnU" = (
-/obj/structure/displaycase/trophy{
-	req_access_txt = "101"
-	},
-/obj/item/clothing/neck/cloak/ship/admiral,
-/turf/open/floor/carpet/ship,
-/area/crew_quarters/dorms/nsv/state_room)
 "jnZ" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	name = "Maintenance Access Hangar Bay";
@@ -95296,7 +95289,7 @@ rgl
 gRX
 hSQ
 pZy
-jnU
+pZy
 cWq
 wvQ
 xBx


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the fleet and grand admiral gear on the Gladius,  and changes it to normal admiral gear


## Why It's Good For The Game

Makes all the admiral stuff into normal admiral gear.

## Changelog
:cl:
tweak: Changed the grand and fleet admiral gear and replaces it with admiral gear in the Gladius's stateroom
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
