### PR TITLE
Adds an atmos holofan backpack

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -252,6 +252,9 @@
 /datum/action/item_action/toggle_mister
 	name = "Toggle Mister"
 
+/datum/action/item_action/toggle_powerpack
+	name = "Toggle Powerpack"
+
 /datum/action/item_action/activate_injector
 	name = "Activate Injector"
 

--- a/code/game/objects/items/holosign_creator.dm
+++ b/code/game/objects/items/holosign_creator.dm
@@ -17,10 +17,11 @@
 	var/creation_time = 0 //time to create a holosign in deciseconds.
 	var/holosign_type = /obj/structure/holosign/wetsign
 	var/holocreator_busy = FALSE //to prevent placing multiple holo barriers at once
+	var/create_distance = FALSE // create holosigns from a distance
 
 /obj/item/holosign_creator/afterattack(atom/target, mob/user, flag)
 	. = ..()
-	if(flag)
+	if(flag || create_distance)
 		if(!check_allowed_items(target, 1))
 			return
 		var/turf/T = get_turf(target)
@@ -89,6 +90,30 @@
 	holosign_type = /obj/structure/holosign/barrier/atmos
 	creation_time = 0
 	max_signs = 6
+
+/obj/item/holosign_creator/atmos/powerpack
+	name = "ATMOS powerpack projector"
+	desc = "A larger, more powerful version of the ATMOS holofan projector that can create more holographic barriers from a distance."
+	icon_state = "signmaker_atmos"
+	max_signs = 12
+	create_distance = TRUE
+	w_class = WEIGHT_CLASS_BULKY
+	item_flags = NOBLUDGEON | ABSTRACT // don't put in storage
+	slot_flags = 0
+	var/obj/item/powerpack/powerpack
+
+/obj/item/holosign_creator/atmos/powerpack/Initialize()
+	. = ..()
+	powerpack = loc
+	if(!istype(powerpack))
+		return INITIALIZE_HINT_QDEL
+
+/obj/item/holosign_creator/atmos/powerpack/doMove(atom/destination)
+	if(destination && (destination != powerpack.loc || !ismob(destination)))
+		if(loc != powerpack)
+			to_chat(powerpack.loc, "<span class='notice'>The holofan snaps back onto the powerpack!</span>")
+		destination = powerpack
+	..()
 
 /obj/item/holosign_creator/medical
 	name = "\improper PENLITE barrier projector"

--- a/code/game/objects/items/tanks/powerpack.dm
+++ b/code/game/objects/items/tanks/powerpack.dm
@@ -1,0 +1,96 @@
+// Atmos holofan powerpack code
+/obj/item/powerpack
+	name = "ATMOS Holofan Backpack"
+	desc = "A portable powerpack system connected to an ATMOS holofan projector that is intended for massive breaches. Able to be used at a distance."
+	icon = 'icons/obj/hydroponics/equipment.dmi'
+	item_state = "waterbackpackatmos"
+	icon_state = "waterbackpackatmos"
+	lefthand_file = 'icons/mob/inhands/equipment/backpack_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/equipment/backpack_righthand.dmi'
+	w_class = WEIGHT_CLASS_BULKY
+	slot_flags = ITEM_SLOT_BACK
+	slowdown = 0
+	actions_types = list(/datum/action/item_action/toggle_powerpack)
+	max_integrity = 200
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 30)
+	resistance_flags = FIRE_PROOF
+	var/obj/item/holofan
+
+/obj/item/powerpack/Initialize()
+	. = ..()
+	holofan = make_holofan()
+
+/obj/item/powerpack/ui_action_click(mob/user)
+	toggle_powerpack(user)
+
+/obj/item/powerpack/item_action_slot_check(slot, mob/user)
+	if(slot == user.getBackSlot())
+		return 1
+
+/obj/item/powerpack/proc/toggle_powerpack(mob/living/user)
+	if(!istype(user))
+		return
+	if(user.get_item_by_slot(user.getBackSlot()) != src)
+		to_chat(user, "<span class='warning'>The powerpack must be worn properly to use!</span>")
+		return
+	if(user.incapacitated())
+		return
+
+	if(QDELETED(holofan))
+		holofan = make_holofan()
+	if(holofan in src)
+		//Detach the holofan into the user's hands
+		if(!user.put_in_hands(holofan))
+			to_chat(user, "<span class='warning'>You need a free hand to hold the holofan!</span>")
+			return
+	else
+		//Remove from their hands and put back "into" the powerpack
+		remove_holofan()
+
+/obj/item/powerpack/verb/toggle_powerpack_verb()
+	set name = "Toggle Powerpack"
+	set category = "Object"
+	toggle_powerpack(usr)
+
+/obj/item/powerpack/proc/make_holofan()
+	return new /obj/item/holosign_creator/atmos/powerpack(src)
+
+/obj/item/powerpack/equipped(mob/user, slot)
+	..()
+	if(slot != SLOT_BACK)
+		remove_holofan()
+
+/obj/item/powerpack/proc/remove_holofan()
+	if(!QDELETED(holofan))
+		if(ismob(holofan.loc))
+			var/mob/M = holofan.loc
+			M.temporarilyRemoveItemFromInventory(holofan, TRUE)
+		holofan.forceMove(src)
+
+/obj/item/powerpack/Destroy()
+	QDEL_NULL(holofan)
+	return ..()
+
+/obj/item/powerpack/attack_hand(mob/user)
+	if (user.get_item_by_slot(user.getBackSlot()) == src)
+		toggle_powerpack(user)
+	else
+		return ..()
+
+/obj/item/powerpack/MouseDrop(obj/over_object)
+	var/mob/M = loc
+	if(istype(M) && istype(over_object, /obj/screen/inventory/hand))
+		var/obj/screen/inventory/hand/H = over_object
+		M.putItemFromInventoryInHandIfPossible(src, H.held_index)
+	return ..()
+
+/obj/item/powerpack/attackby(obj/item/W, mob/user, params)
+	if(W == holofan)
+		remove_holofan()
+		return 1
+	else
+		return ..()
+
+/obj/item/powerpack/dropped(mob/user)
+	..()
+	remove_holofan()

--- a/nsv13.dme
+++ b/nsv13.dme
@@ -1070,6 +1070,7 @@
 #include "code\game\objects\items\storage\uplink_kits.dm"
 #include "code\game\objects\items\storage\wallets.dm"
 #include "code\game\objects\items\tanks\jetpack.dm"
+#include "code\game\objects\items\tanks\powerpack.dm"
 #include "code\game\objects\items\tanks\tank_types.dm"
 #include "code\game\objects\items\tanks\tanks.dm"
 #include "code\game\objects\items\tanks\watertank.dm"


### PR DESCRIPTION

## About The Pull Request

This PR adds an atmos holofan backpack that can deploy 12 holofans from a distance (viewrange). It works off the same principle as an atmos water tank, but instead of water it works off the principles of the atmos holofan.

## Why It's Good For The Game

It adds a new tool for engineers to use and can be used for massive breaches that so often happen. The normal holofan is often limited by range and number and mainly good for preventative measures, this one is more responsive to imminent danger and removes your backpack storage in exchange for breach stopping much like the atmos water tank removes back page storage for fire suppressing. 

## Changelog
:cl:
add:  New atmos holofan backpack that allows holofans to be placed from a distance 
/:cl: