### PR TITLE
makes PDA server rebooting time much faster

### DIFF
--- a/code/game/machinery/telecomms/machines/message_server.dm
+++ b/code/game/machinery/telecomms/machines/message_server.dm
@@ -33,7 +33,7 @@
 	var/list/datum/data_pda_msg/pda_msgs = list()
 	var/list/datum/data_rc_msg/rc_msgs = list()
 	var/decryptkey = "password"
-	var/calibrating = 15 MINUTES //Init reads this and adds world.time, then becomes 0 when that time has passed and the machine works
+	var/calibrating = 1 MINUTES //Init reads this and adds world.time, then becomes 0 when that time has passed and the machine works
 
 /obj/machinery/telecomms/message_server/Initialize(mapload)
 	. = ..()

--- a/code/game/machinery/telecomms/machines/message_server.dm
+++ b/code/game/machinery/telecomms/machines/message_server.dm
@@ -33,7 +33,7 @@
 	var/list/datum/data_pda_msg/pda_msgs = list()
 	var/list/datum/data_rc_msg/rc_msgs = list()
 	var/decryptkey = "password"
-	var/calibrating = 5 MINUTES //Init reads this and adds world.time, then becomes 0 when that time has passed and the machine works
+	var/calibrating = 5 MINUTES //NSV13 - Init reads this and adds world.time, then becomes 0 when that time has passed and the machine works 
 
 /obj/machinery/telecomms/message_server/Initialize(mapload)
 	. = ..()

--- a/code/game/machinery/telecomms/machines/message_server.dm
+++ b/code/game/machinery/telecomms/machines/message_server.dm
@@ -33,7 +33,7 @@
 	var/list/datum/data_pda_msg/pda_msgs = list()
 	var/list/datum/data_rc_msg/rc_msgs = list()
 	var/decryptkey = "password"
-	var/calibrating = 1 MINUTES //Init reads this and adds world.time, then becomes 0 when that time has passed and the machine works
+	var/calibrating = 5 MINUTES //Init reads this and adds world.time, then becomes 0 when that time has passed and the machine works
 
 /obj/machinery/telecomms/message_server/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

This PR changes the PDA server reboot time after it has been fixed from 15 minutes to 5 minute

## Why It's Good For The Game

the PDA server reboot time is way too long to go without essential PDA functions during combat, and I was also told to do it by staff.

## Changelog
:cl:
tweak: PDA server reboot time is now 5 minute instead of 15 minutes
/:cl:
