### PR TITLE
Improves the RCL by making it a radial dial selection of kinds of wires

### DIFF
--- a/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
@@ -15253,7 +15253,7 @@
 /obj/item/circuitboard/machine/shuttle/heater,
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer3,
 /obj/machinery/atmospherics/pipe/simple/orange/visible/layer1,
-/obj/item/twohanded/rcl/pre_loaded,
+/obj/item/rcl/pre_loaded,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
 "jRA" = (
@@ -24353,7 +24353,7 @@
 "pXT" = (
 /obj/machinery/airalarm/directional/west,
 /obj/structure/table,
-/obj/item/twohanded/rcl/pre_loaded,
+/obj/item/rcl/pre_loaded,
 /turf/open/floor/carpet/orange,
 /area/engine/shield_generator)
 "pYe" = (
@@ -28647,7 +28647,7 @@
 	desc = "A high quality and decorated medal to show you are appreciated!";
 	name = "custom medal"
 	},
-/obj/item/twohanded/rcl/pre_loaded,
+/obj/item/rcl/pre_loaded,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/crew_quarters/heads/chief)
 "sVN" = (

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -40009,8 +40009,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/item/twohanded/rcl/pre_loaded,
-/obj/item/twohanded/rcl/pre_loaded,
+/obj/item/rcl/pre_loaded,
+/obj/item/rcl/pre_loaded,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cnC" = (
@@ -42826,7 +42826,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high/plus,
-/obj/item/twohanded/rcl/pre_loaded,
+/obj/item/rcl/pre_loaded,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "cBN" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -51705,7 +51705,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/twohanded/rcl/pre_loaded,
+/obj/item/rcl/pre_loaded,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -77190,8 +77190,8 @@
 	pixel_x = 26
 	},
 /obj/effect/turf_decal/bot,
-/obj/item/twohanded/rcl/pre_loaded,
-/obj/item/twohanded/rcl/pre_loaded,
+/obj/item/rcl/pre_loaded,
+/obj/item/rcl/pre_loaded,
 /turf/open/floor/plasteel,
 /area/engine/storage)
 "czz" = (

--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -53790,8 +53790,8 @@
 /obj/item/storage/box/lights/mixed,
 /obj/item/clothing/glasses/meson,
 /obj/item/clothing/glasses/meson,
-/obj/item/twohanded/rcl/pre_loaded,
-/obj/item/twohanded/rcl/pre_loaded,
+/obj/item/rcl/pre_loaded,
+/obj/item/rcl/pre_loaded,
 /obj/item/crowbar/large,
 /turf/open/floor/plasteel,
 /area/engine/engineering)

--- a/_maps/map_files/Eclipse/Eclipse.dmm
+++ b/_maps/map_files/Eclipse/Eclipse.dmm
@@ -3212,7 +3212,7 @@
 	dir = 1
 	},
 /obj/structure/table,
-/obj/item/twohanded/rcl/pre_loaded,
+/obj/item/rcl/pre_loaded,
 /obj/item/pipe_dispenser,
 /obj/item/tank/internals/plasma/full,
 /obj/machinery/firealarm/directional/west,

--- a/_maps/map_files/Gladius/Gladius2.dmm
+++ b/_maps/map_files/Gladius/Gladius2.dmm
@@ -10801,7 +10801,7 @@
 	charge = 100;
 	maxcharge = 15000
 	},
-/obj/item/twohanded/rcl/pre_loaded,
+/obj/item/rcl/pre_loaded,
 /obj/machinery/light,
 /turf/open/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
@@ -37778,8 +37778,8 @@
 /area/quartermaster/qm)
 "wYO" = (
 /obj/structure/rack,
-/obj/item/twohanded/rcl/pre_loaded,
-/obj/item/twohanded/rcl/pre_loaded,
+/obj/item/rcl/pre_loaded,
+/obj/item/rcl/pre_loaded,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},

--- a/_maps/map_files/Hammerhead/Hammerhead.dmm
+++ b/_maps/map_files/Hammerhead/Hammerhead.dmm
@@ -4032,7 +4032,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/item/twohanded/rcl,
+/obj/item/rcl,
 /obj/structure/extinguisher_cabinet/east,
 /turf/open/floor/plasteel,
 /area/storage/primary)
@@ -43217,8 +43217,8 @@
 	pixel_x = -5;
 	pixel_y = 6
 	},
-/obj/item/twohanded/rcl/pre_loaded,
-/obj/item/twohanded/rcl/pre_loaded,
+/obj/item/rcl/pre_loaded,
+/obj/item/rcl/pre_loaded,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -17442,8 +17442,8 @@
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
-/obj/item/twohanded/rcl/pre_loaded,
-/obj/item/twohanded/rcl/pre_loaded,
+/obj/item/rcl/pre_loaded,
+/obj/item/rcl/pre_loaded,
 /turf/open/floor/plasteel{
 	dir = 1
 	},
@@ -26876,7 +26876,7 @@
 	charge = 100;
 	maxcharge = 15000
 	},
-/obj/item/twohanded/rcl/pre_loaded,
+/obj/item/rcl/pre_loaded,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},

--- a/_maps/map_files/NSV Storage/Mining/Hephaestus/Hephaestus1.dmm
+++ b/_maps/map_files/NSV Storage/Mining/Hephaestus/Hephaestus1.dmm
@@ -269,7 +269,7 @@
 /area/maintenance/nsv/mining_ship/forward)
 "aV" = (
 /obj/structure/rack,
-/obj/item/twohanded/rcl/pre_loaded,
+/obj/item/rcl/pre_loaded,
 /obj/item/stack/cable_coil/red,
 /obj/item/stack/cable_coil/red,
 /turf/open/floor/plasteel/techmaint,

--- a/_maps/map_files/Pegasus/pegasus1.dmm
+++ b/_maps/map_files/Pegasus/pegasus1.dmm
@@ -4454,7 +4454,7 @@
 /area/security/main)
 "cCc" = (
 /obj/structure/rack,
-/obj/item/twohanded/rcl/pre_loaded,
+/obj/item/rcl/pre_loaded,
 /obj/item/reagent_containers/pill/patch/silver_sulf,
 /turf/open/floor/monotile,
 /area/crew_quarters/heads/chief)
@@ -27110,7 +27110,7 @@
 	pixel_x = -3;
 	pixel_y = -2
 	},
-/obj/item/twohanded/rcl/pre_loaded,
+/obj/item/rcl/pre_loaded,
 /obj/item/stack/cable_coil/red,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -46930,7 +46930,7 @@
 /area/engine/engineering)
 "caw" = (
 /obj/structure/table,
-/obj/item/twohanded/rcl/pre_loaded,
+/obj/item/rcl/pre_loaded,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/engine/engineering)

--- a/_maps/map_files/Tycoon/Tycoon2.dmm
+++ b/_maps/map_files/Tycoon/Tycoon2.dmm
@@ -8501,8 +8501,8 @@
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
-/obj/item/twohanded/rcl/pre_loaded,
-/obj/item/twohanded/rcl/pre_loaded,
+/obj/item/rcl/pre_loaded,
+/obj/item/rcl/pre_loaded,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -18194,7 +18194,7 @@
 /area/crew_quarters/heads/chief)
 "aSj" = (
 /obj/structure/table/reinforced,
-/obj/item/twohanded/rcl/pre_loaded,
+/obj/item/rcl/pre_loaded,
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/monotile,
 /area/crew_quarters/heads/chief)

--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -800,15 +800,6 @@
 				  /obj/item/assembly/igniter = 1)
 	category = CAT_MISC
 
-
-/datum/crafting_recipe/rcl
-	name = "Makeshift Rapid Cable Layer"
-	result = /obj/item/twohanded/rcl/ghetto
-	time = 40
-	tools = list(TOOL_WELDER, TOOL_SCREWDRIVER, TOOL_WRENCH)
-	reqs = list(/obj/item/stack/sheet/iron = 15)
-	category = CAT_MISC
-
 /datum/crafting_recipe/mummy
 	name = "Mummification Bandages (Mask)"
 	result = /obj/item/clothing/mask/mummy

--- a/code/game/objects/items/RCL.dm
+++ b/code/game/objects/items/RCL.dm
@@ -19,7 +19,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
 	var/direction_one = 1
 	var/direction_two = 2
-	var/datum/radial_menu/wiring_menu
+	var/wiring_choice
 
 /obj/item/twohanded/rcl/Initialize()
 	. = ..()
@@ -75,11 +75,15 @@
 		img.color = GLOB.cable_colors[colors[current_color_index]]
 		wiredirs[icondir] = img
 	return wiredirs
-
+//setting of choice
 /obj/item/twohanded/rcl/attack_self(mob/user)
 	. = ..()
 	var/list/choices = generate_choices(user)
-	wiring_menu = show_radial_menu(user, src, choices, radius = 42, custom_check = CALLBACK(src, .proc/use_select, user), require_near = TRUE, tooltips = TRUE)
+	wiring_choice = show_radial_menu(user, src, choices, radius = 42, require_near = TRUE)
+	direction_one = wiring_choice[1]
+	direction_two = wiring_choice[3]
+	direction_one = text2num(direction_one)
+	direction_two = text2num(direction_two)
 
 // Actual deployment of wiring
 /obj/item/twohanded/rcl/afterattack(atom/target, mob/user)
@@ -88,13 +92,6 @@
 
 /obj/item/twohanded/rcl/attack(mob/living/M, mob/living/user)
 	return
-
-obj/item/twohanded/rcl/proc/use_select(mob/living/user, choice)
-	direction_one = choice[1]
-	direction_two = choice[3]
-	direction_one = text2num(direction_one)
-	direction_two = text2num(direction_two)
-	return TRUE
 
 /obj/item/twohanded/rcl/examine(mob/user)
 	. = ..()

--- a/code/game/objects/items/RCL.dm
+++ b/code/game/objects/items/RCL.dm
@@ -89,7 +89,7 @@
 // Actual deployment of wiring
 /obj/item/rcl/afterattack(atom/target, mob/user)
 	. = ..()
-	loaded.place_turf_dir_range(target,user,direction_two, direction_one, 3)
+	loaded.place_turf_dir(target,user,direction_two, direction_one)
 
 /obj/item/rcl/attack(mob/living/M, mob/living/user)
 	return

--- a/code/game/objects/items/RCL.dm
+++ b/code/game/objects/items/RCL.dm
@@ -79,7 +79,7 @@
 /obj/item/twohanded/rcl/attack_self(mob/user)
 	. = ..()
 	var/list/choices = generate_choices(user)
-+	wiring_menu = show_radial_menu_persistent(user, src, choices, select_proc = CALLBACK(src, .proc/use_select, user), require_near = TRUE)♣
+	wiring_menu = show_radial_menu_persistent(user, src, choices, select_proc = CALLBACK(src, .proc/use_select, user), require_near = TRUE)♣
 
 // Actual deployment of wiring
 /obj/item/twohanded/rcl/afterattack(atom/target, mob/user)

--- a/code/game/objects/items/RCL.dm
+++ b/code/game/objects/items/RCL.dm
@@ -1,4 +1,4 @@
-/obj/item/twohanded/rcl
+/obj/item/rcl
 	name = "rapid cable layer"
 	desc = "A device used to rapidly deploy cables. It has screws on the side which can be removed to slide off the cables. Do not use without insulation!"
 	icon = 'icons/obj/tools.dmi'
@@ -21,11 +21,11 @@
 	var/direction_two = 2
 	var/wiring_choice
 
-/obj/item/twohanded/rcl/Initialize()
+/obj/item/rcl/Initialize()
 	. = ..()
-	AddComponent(/datum/component/twohanded)
+	update_icon()
 
-/obj/item/twohanded/rcl/attackby(obj/item/W, mob/user)
+/obj/item/rcl/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/stack/cable_coil))
 		var/obj/item/stack/cable_coil/C = W
 
@@ -67,16 +67,17 @@
 	else
 		..()
 
-/obj/item/twohanded/rcl/proc/generate_choices(mob/user)
-	var/list/wiredirs = list("1-2","5-10","4-8","6-9","1-4","2-4","2-8","1-8")
+/obj/item/rcl/proc/generate_choices(mob/user)
+	var/list/wiredirs = list("1-2","5-10","1-4","2-4","4-8","2-8","1-8", "6-9")
 	for(var/icondir in wiredirs)
 		var/cablesuffix = icondir
 		var/image/img = image(icon = 'icons/mob/radial.dmi', icon_state = "cable_[cablesuffix]")
 		img.color = GLOB.cable_colors[colors[current_color_index]]
 		wiredirs[icondir] = img
 	return wiredirs
+
 //setting of choice
-/obj/item/twohanded/rcl/attack_self(mob/user)
+/obj/item/rcl/attack_self(mob/user)
 	. = ..()
 	var/list/choices = generate_choices(user)
 	wiring_choice = show_radial_menu(user, src, choices, radius = 42, require_near = TRUE)
@@ -86,23 +87,23 @@
 	direction_two = text2num(direction_two)
 
 // Actual deployment of wiring
-/obj/item/twohanded/rcl/afterattack(atom/target, mob/user)
+/obj/item/rcl/afterattack(atom/target, mob/user)
 	. = ..()
 	loaded.place_turf_dir_range(target,user,direction_two, direction_one, 3)
 
-/obj/item/twohanded/rcl/attack(mob/living/M, mob/living/user)
+/obj/item/rcl/attack(mob/living/M, mob/living/user)
 	return
 
-/obj/item/twohanded/rcl/examine(mob/user)
+/obj/item/rcl/examine(mob/user)
 	. = ..()
 	if(loaded)
 		. += "<span class='info'>It contains [loaded.amount]/[max_amount] cables.</span>"
 
-/obj/item/twohanded/rcl/Destroy()
+/obj/item/rcl/Destroy()
 	QDEL_NULL(loaded)
 	return ..()
 
-/obj/item/twohanded/rcl/update_icon()
+/obj/item/rcl/update_icon()
 	if(!loaded)
 		icon_state = "rcl-0"
 		item_state = "rcl-0"
@@ -121,7 +122,7 @@
 			icon_state = "rcl-0"
 			item_state = "rcl-0"
 
-/obj/item/twohanded/rcl/proc/is_empty(mob/user, loud = 1)
+/obj/item/rcl/proc/is_empty(mob/user, loud = 1)
 	update_icon()
 	if(!loaded || !loaded.amount)
 		if(loud)
@@ -132,18 +133,14 @@
 		return TRUE
 	return FALSE
 
-/obj/item/twohanded/rcl/pre_loaded/Initialize() //Comes preloaded with cable, for testing stuff
+/obj/item/rcl/pre_loaded/Initialize() //Comes preloaded with cable, for testing stuff
 	. = ..()
 	loaded = new()
 	loaded.max_amount = max_amount
 	loaded.amount = max_amount
 	update_icon()
 
-/obj/item/twohanded/rcl/Initialize()
-	. = ..()
-	update_icon()
-
-/obj/item/twohanded/rcl/ui_action_click(mob/user, action)
+/obj/item/rcl/ui_action_click(mob/user, action)
 	if(istype(action, /datum/action/item_action/rcl_col))
 		current_color_index++;
 		if (current_color_index > colors.len)
@@ -152,4 +149,5 @@
 		to_chat(user, "Color changed to [cwname]!")
 		if(loaded)
 			loaded.item_color= colors[current_color_index]
-
+	if(istype(action, /datum/action/item_action/rcl_gui))
+		attack_self(user)

--- a/code/game/objects/items/RCL.dm
+++ b/code/game/objects/items/RCL.dm
@@ -79,7 +79,7 @@
 /obj/item/twohanded/rcl/attack_self(mob/user)
 	. = ..()
 	var/list/choices = generate_choices(user)
-	wiring_menu = show_radial_menu_persistent(user, src, choices, select_proc = CALLBACK(src, .proc/use_select, user), radius = 42)
+	wiring_menu = show_radial_menu(user, src, choices, radius = 42, custom_check = CALLBACK(src, .proc/use_select, user), require_near = TRUE, tooltips = TRUE)
 
 // Actual deployment of wiring
 /obj/item/twohanded/rcl/afterattack(atom/target, mob/user)
@@ -94,6 +94,7 @@ obj/item/twohanded/rcl/proc/use_select(mob/living/user, choice)
 	direction_two = choice[3]
 	direction_one = text2num(direction_one)
 	direction_two = text2num(direction_two)
+	return TRUE
 
 /obj/item/twohanded/rcl/examine(mob/user)
 	. = ..()

--- a/code/game/objects/items/RCL.dm
+++ b/code/game/objects/items/RCL.dm
@@ -20,7 +20,7 @@
 	var/direction_one = 1
 	var/direction_two = 2
 	var/datum/radial_menu/wiring_menu
-♣
+
 /obj/item/twohanded/rcl/Initialize()
 	. = ..()
 	AddComponent(/datum/component/twohanded)
@@ -70,8 +70,7 @@
 /obj/item/twohanded/rcl/proc/generate_choices(mob/user)
 	var/list/wiredirs = list("1-2","5-10","4-8","6-9","1-4","2-4","2-8","1-8")
 	for(var/icondir in wiredirs)
-		var/dirnum = text2num(icondir)
-		var/cablesuffix = "[dirnum]"
+		var/cablesuffix = icondir
 		var/image/img = image(icon = 'icons/mob/radial.dmi', icon_state = "cable_[cablesuffix]")
 		img.color = GLOB.cable_colors[colors[current_color_index]]
 		wiredirs[icondir] = img
@@ -80,7 +79,7 @@
 /obj/item/twohanded/rcl/attack_self(mob/user)
 	. = ..()
 	var/list/choices = generate_choices(user)
-	direction_one = text2num(show_radial_menu(user, src, choices, custom_check = CALLBACK(src, .proc/check_menu, user), require_near = TRUE))
++	wiring_menu = show_radial_menu_persistent(user, src, choices, select_proc = CALLBACK(src, .proc/use_select, user), require_near = TRUE)♣
 
 // Actual deployment of wiring
 /obj/item/twohanded/rcl/afterattack(atom/target, mob/user)
@@ -90,12 +89,11 @@
 /obj/item/twohanded/rcl/attack(mob/living/M, mob/living/user)
 	return
 
-obj/item/twohanded/rcl/proc/check_menu(mob/living/user)
-	if(!istype(user))
-		return FALSE
-	if(user.incapacitated() || !user.Adjacent(src))
-		return FALSE
-	return TRUE
+obj/item/twohanded/rcl/proc/use_select(mob/living/user, choice)
+	direction_one = choice[1]
+	direction_two = choice[3]
+	direction_one = text2num(direction_one)
+	direction_two = text2num(direction_two)
 
 /obj/item/twohanded/rcl/examine(mob/user)
 	. = ..()

--- a/code/game/objects/items/RCL.dm
+++ b/code/game/objects/items/RCL.dm
@@ -4,7 +4,6 @@
 	icon = 'icons/obj/tools.dmi'
 	icon_state = "rcl-0"
 	item_state = "rcl-0"
-	var/obj/structure/cable/last
 	var/obj/item/stack/cable_coil/loaded
 	opacity = FALSE
 	force = 5 //Plastic is soft
@@ -13,16 +12,15 @@
 	throw_range = 7
 	w_class = WEIGHT_CLASS_NORMAL
 	var/max_amount = 90
-	var/active = FALSE
 	actions_types = list(/datum/action/item_action/rcl_col,/datum/action/item_action/rcl_gui,)
 	var/list/colors = list("red", "yellow", "green", "blue", "pink", "orange", "cyan", "white")
 	var/current_color_index = 1
-	var/ghetto = FALSE
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
-	var/datum/radial_menu/persistent/wiring_gui_menu
-	var/mob/listeningTo
-
+	var/direction_one = 1
+	var/direction_two = 2
+	var/datum/radial_menu/wiring_menu
+♣
 /obj/item/twohanded/rcl/Initialize()
 	. = ..()
 	AddComponent(/datum/component/twohanded)
@@ -51,19 +49,6 @@
 	else if(W.tool_behaviour == TOOL_SCREWDRIVER)
 		if(!loaded)
 			return
-		if(ghetto && prob(10)) //Is it a ghetto RCL? If so, give it a 10% chance to fall apart
-			to_chat(user, "<span class='warning'>You attempt to loosen the securing screws on the side, but it falls apart!</span>")
-			while(loaded.amount > 30) //There are only two kinds of situations: "nodiff" (60,90), or "diff" (31-59, 61-89)
-				var/diff = loaded.amount % 30
-				if(diff)
-					loaded.use(diff)
-					new /obj/item/stack/cable_coil(get_turf(user), diff)
-				else
-					loaded.use(30)
-					new /obj/item/stack/cable_coil(get_turf(user), 30)
-			qdel(src)
-			return
-
 		to_chat(user, "<span class='notice'>You loosen the securing screws on the side, allowing you to lower the guiding edge and retrieve the wires.</span>")
 		while(loaded.amount > 30) //There are only two kinds of situations: "nodiff" (60,90), or "diff" (31-59, 61-89)
 			var/diff = loaded.amount % 30
@@ -82,6 +67,36 @@
 	else
 		..()
 
+/obj/item/twohanded/rcl/proc/generate_choices(mob/user)
+	var/list/wiredirs = list("1-2","5-10","4-8","6-9","1-4","2-4","2-8","1-8")
+	for(var/icondir in wiredirs)
+		var/dirnum = text2num(icondir)
+		var/cablesuffix = "[dirnum]"
+		var/image/img = image(icon = 'icons/mob/radial.dmi', icon_state = "cable_[cablesuffix]")
+		img.color = GLOB.cable_colors[colors[current_color_index]]
+		wiredirs[icondir] = img
+	return wiredirs
+
+/obj/item/twohanded/rcl/attack_self(mob/user)
+	. = ..()
+	var/list/choices = generate_choices(user)
+	direction_one = text2num(show_radial_menu(user, src, choices, custom_check = CALLBACK(src, .proc/check_menu, user), require_near = TRUE))
+
+// Actual deployment of wiring
+/obj/item/twohanded/rcl/afterattack(atom/target, mob/user)
+	. = ..()
+	loaded.place_turf_dir_range(target,user,direction_two, direction_one, 3)
+
+/obj/item/twohanded/rcl/attack(mob/living/M, mob/living/user)
+	return
+
+obj/item/twohanded/rcl/proc/check_menu(mob/living/user)
+	if(!istype(user))
+		return FALSE
+	if(user.incapacitated() || !user.Adjacent(src))
+		return FALSE
+	return TRUE
+
 /obj/item/twohanded/rcl/examine(mob/user)
 	. = ..()
 	if(loaded)
@@ -89,9 +104,6 @@
 
 /obj/item/twohanded/rcl/Destroy()
 	QDEL_NULL(loaded)
-	last = null
-	listeningTo = null
-	QDEL_NULL(wiring_gui_menu)
 	return ..()
 
 /obj/item/twohanded/rcl/update_icon()
@@ -121,168 +133,8 @@
 		if(loaded)
 			QDEL_NULL(loaded)
 			loaded = null
-		QDEL_NULL(wiring_gui_menu)
-		SEND_SIGNAL(src, COMSIG_ITEM_UNWIELD, user, FALSE)
-		active = SEND_SIGNAL(src, COMSIG_ITEM_IS_WIELDED) & COMPONENT_WIELDED
 		return TRUE
 	return FALSE
-
-/obj/item/twohanded/rcl/pickup(mob/user)
-	..()
-	getMobhook(user)
-
-
-/obj/item/twohanded/rcl/dropped(mob/wearer)
-	..()
-	UnregisterSignal(wearer, COMSIG_MOVABLE_MOVED)
-	listeningTo = null
-	last = null
-	QDEL_NULL(wiring_gui_menu)
-
-/obj/item/twohanded/rcl/attack_self(mob/user)
-	..()
-	active = SEND_SIGNAL(src, COMSIG_ITEM_IS_WIELDED) & COMPONENT_WIELDED
-	if(!active)
-		last = null
-	else if(!last)
-		for(var/obj/structure/cable/C in get_turf(user))
-			if(C.d1 == FALSE || C.d2 == FALSE)
-				last = C
-				break
-
-/obj/item/twohanded/rcl/proc/getMobhook(mob/to_hook)
-	if(listeningTo == to_hook)
-		return
-	if(listeningTo)
-		UnregisterSignal(listeningTo, COMSIG_MOVABLE_MOVED)
-	listeningTo = to_hook
-	RegisterSignal(listeningTo, COMSIG_MOVABLE_MOVED, .proc/trigger)
-
-/obj/item/twohanded/rcl/proc/trigger(mob/user)
-	if(active)
-		layCable(user)
-	if(wiring_gui_menu) //update the wire options as you move
-		wiringGuiUpdate(user)
-
-
-//previous contents of trigger(), lays cable each time the player moves
-/obj/item/twohanded/rcl/proc/layCable(mob/user)
-	if(!isturf(user.loc))
-		return
-	if(is_empty(user, 0))
-		to_chat(user, "<span class='warning'>\The [src] is empty!</span>")
-		return
-
-	if(prob(2) && ghetto) //Give ghetto RCLs a 2% chance to jam, requiring it to be reactviated manually.
-		to_chat(user, "<span class='warning'>[src]'s wires jam!</span>")
-		active = FALSE
-		return
-	else
-		if(last)
-			if(get_dist(last, user) == 1) //hacky, but it works
-				var/turf/T = get_turf(user)
-				if(T.intact || !T.can_have_cabling())
-					last = null
-					return
-				if(get_dir(last, user) == last.d2)
-					//Did we just walk backwards? Well, that's the one direction we CAN'T complete a stub.
-					last = null
-					return
-				loaded.cable_join(last, user, FALSE)
-				if(is_empty(user))
-					return //If we've run out, display message and exit
-			else
-				last = null
-		loaded.item_color	 = colors[current_color_index]
-		last = loaded.place_turf(get_turf(src), user, turn(user.dir, 180))
-		is_empty(user) //If we've run out, display message
-	update_icon()
-
-
-//searches the current tile for a stub cable of the same colour
-/obj/item/twohanded/rcl/proc/findLinkingCable(mob/user)
-	var/turf/T
-	if(!isturf(user.loc))
-		return
-
-	T = get_turf(user)
-	if(T.intact || !T.can_have_cabling())
-		return
-
-	for(var/obj/structure/cable/C in T)
-		if(!C)
-			continue
-		if(C.cable_color != GLOB.cable_colors[colors[current_color_index]])
-			continue
-		if(C.d1 == 0)
-			return C
-	return
-
-
-/obj/item/twohanded/rcl/proc/wiringGuiGenerateChoices(mob/user)
-	var/fromdir = 0
-	var/obj/structure/cable/linkingCable = findLinkingCable(user)
-	if(linkingCable)
-		fromdir = linkingCable.d2
-
-	var/list/wiredirs = list("1","5","4","6","2","10","8","9")
-	for(var/icondir in wiredirs)
-		var/dirnum = text2num(icondir)
-		var/cablesuffix = "[min(fromdir,dirnum)]-[max(fromdir,dirnum)]"
-		if(fromdir == dirnum) //cables can't loop back on themselves
-			cablesuffix = "invalid"
-		var/image/img = image(icon = 'icons/mob/radial.dmi', icon_state = "cable_[cablesuffix]")
-		img.color = GLOB.cable_colors[colors[current_color_index]]
-		wiredirs[icondir] = img
-	return wiredirs
-
-/obj/item/twohanded/rcl/proc/showWiringGui(mob/user)
-	var/list/choices = wiringGuiGenerateChoices(user)
-
-	wiring_gui_menu = show_radial_menu_persistent(user, src , choices, select_proc = CALLBACK(src, .proc/wiringGuiReact, user), radius = 42)
-
-/obj/item/twohanded/rcl/proc/wiringGuiUpdate(mob/user)
-	if(!wiring_gui_menu)
-		return
-
-	wiring_gui_menu.entry_animation = FALSE //stop the open anim from playing each time we update
-	var/list/choices = wiringGuiGenerateChoices(user)
-
-	wiring_gui_menu.change_choices(choices,FALSE)
-
-
-//Callback used to respond to interactions with the wiring menu
-/obj/item/twohanded/rcl/proc/wiringGuiReact(mob/living/user,choice)
-	if(!choice) //close on a null choice (the center button)
-		QDEL_NULL(wiring_gui_menu)
-		return
-
-	choice = text2num(choice)
-
-	if(!isturf(user.loc))
-		return
-	if(is_empty(user, 0))
-		to_chat(user, "<span class='warning'>\The [src] is empty!</span>")
-		return
-
-	var/turf/T = get_turf(user)
-	if(T.intact || !T.can_have_cabling())
-		return
-
-	loaded.item_color	 = colors[current_color_index]
-
-	var/obj/structure/cable/linkingCable = findLinkingCable(user)
-	if(linkingCable)
-		if(choice != linkingCable.d2)
-			loaded.cable_join(linkingCable, user, FALSE, choice)
-			last = null
-	else
-		last = loaded.place_turf(get_turf(src), user, choice)
-
-	is_empty(user) //If we've run out, display message
-
-	wiringGuiUpdate(user)
-
 
 /obj/item/twohanded/rcl/pre_loaded/Initialize() //Comes preloaded with cable, for testing stuff
 	. = ..()
@@ -304,29 +156,4 @@
 		to_chat(user, "Color changed to [cwname]!")
 		if(loaded)
 			loaded.item_color= colors[current_color_index]
-		if(wiring_gui_menu)
-			wiringGuiUpdate(user)
-	else if(istype(action, /datum/action/item_action/rcl_gui))
-		if(wiring_gui_menu) //The menu is already open, close it
-			QDEL_NULL(wiring_gui_menu)
-		else //open the menu
-			showWiringGui(user)
 
-/obj/item/twohanded/rcl/ghetto
-	actions_types = list()
-	max_amount = 30
-	name = "makeshift rapid cable layer"
-	ghetto = TRUE
-
-/obj/item/twohanded/rcl/ghetto/update_icon()
-	if(!loaded)
-		icon_state = "rclg-0"
-		item_state = "rclg-0"
-		return
-	switch(loaded.amount)
-		if(1 to INFINITY)
-			icon_state = "rclg-1"
-			item_state = "rcl"
-		else
-			icon_state = "rclg-1"
-			item_state = "rclg-1"

--- a/code/game/objects/items/RCL.dm
+++ b/code/game/objects/items/RCL.dm
@@ -79,7 +79,7 @@
 /obj/item/twohanded/rcl/attack_self(mob/user)
 	. = ..()
 	var/list/choices = generate_choices(user)
-	wiring_menu = show_radial_menu_persistent(user, src, choices, select_proc = CALLBACK(src, .proc/use_select, u♣♣ser), radius = 42)
+	wiring_menu = show_radial_menu_persistent(user, src, choices, select_proc = CALLBACK(src, .proc/use_select, user), radius = 42)
 
 // Actual deployment of wiring
 /obj/item/twohanded/rcl/afterattack(atom/target, mob/user)

--- a/code/game/objects/items/RCL.dm
+++ b/code/game/objects/items/RCL.dm
@@ -79,7 +79,7 @@
 /obj/item/twohanded/rcl/attack_self(mob/user)
 	. = ..()
 	var/list/choices = generate_choices(user)
-	wiring_menu = show_radial_menu_persistent(user, src, choices, select_proc = CALLBACK(src, .proc/use_select, user), require_near = TRUE)♣
+	wiring_menu = show_radial_menu_persistent(user, src, choices, select_proc = CALLBACK(src, .proc/use_select, u♣♣ser), radius = 42)
 
 // Actual deployment of wiring
 /obj/item/twohanded/rcl/afterattack(atom/target, mob/user)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -189,17 +189,6 @@
 	target.zImpact(A, levels, src)
 	return TRUE
 
-/turf/proc/handleRCL(obj/item/twohanded/rcl/C, mob/user)
-	if(C.loaded)
-		for(var/obj/structure/cable/LC in src)
-			if(!LC.d1 || !LC.d2)
-				LC.handlecable(C, user)
-				return
-		C.loaded.place_turf(src, user)
-		if(C.wiring_gui_menu)
-			C.wiringGuiUpdate(user)
-		C.is_empty(user)
-
 /turf/attackby(obj/item/C, mob/user, params)
 	if(..())
 		return TRUE
@@ -211,9 +200,6 @@
 				return
 		coil.place_turf(src, user)
 		return TRUE
-
-	else if(istype(C, /obj/item/twohanded/rcl))
-		handleRCL(C, user)
 
 	return FALSE
 

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -167,8 +167,8 @@ By design, d1 is the smallest direction and d2 is the highest
 			return
 		coil.cable_join(src, user)
 
-	else if(istype(W, /obj/item/twohanded/rcl))
-		var/obj/item/twohanded/rcl/R = W
+	else if(istype(W, /obj/item/rcl))
+		var/obj/item/rcl/R = W
 		if(R.loaded)
 			R.loaded.cable_join(src, user)
 			R.is_empty(user)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -656,7 +656,7 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe("cable restrai
 	return C
 
 // called when cable_coil is clicked on a turf
-/obj/item/stack/cable_coil/proc/place_turf_dir_range(turf/T, mob/user, dir2, dir1, range)
+/obj/item/stack/cable_coil/proc/place_turf_dir(turf/T, mob/user, dir2, dir1)
 	if(!isturf(user.loc))
 		return
 
@@ -668,7 +668,7 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe("cable restrai
 		to_chat(user, "<span class='warning'>There is no cable left!</span>")
 		return
 
-	if(get_dist(T,user) > range) // Out of range
+	if(get_dist(T,user) > 1) // Out of range
 		to_chat(user, "<span class='warning'>You can't lay cable at a place that far away!</span>")
 		return
 
@@ -702,6 +702,11 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe("cable restrai
 		C.mergeDiagonalsNetworks(C.d2)
 
 	use(1)
+
+	if(C.shock(user, 50))
+		if(prob(50)) //fail
+			new /obj/item/stack/cable_coil(get_turf(C), 1, C.color)
+			C.deconstruct()
 
 	return C
 

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -692,9 +692,12 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe("cable restrai
 	var/datum/powernet/PN = new()
 	PN.add_cable(C)
 
-	C.mergeConnectedNetworks(C.d2) //merge the powernet with adjacents powernets
+	C.mergeConnectedNetworks(C.d1) //merge the powernet with adjacents powernets
+	C.mergeConnectedNetworks(C.d2)
 	C.mergeConnectedNetworksOnTurf() //merge the powernet with on turf powernets
 
+	if(C.d1 & (C.d1 - 1))// if the cable is layed diagonally, check the others 2 possible directions
+		C.mergeDiagonalsNetworks(C.d1)
 	if(C.d2 & (C.d2 - 1))// if the cable is layed diagonally, check the others 2 possible directions
 		C.mergeDiagonalsNetworks(C.d2)
 

--- a/code/modules/research/designs/tool_designs.dm
+++ b/code/modules/research/designs/tool_designs.dm
@@ -52,6 +52,15 @@
 	category = list("Tool Designs")
 	departmental_flags =  DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_CARGO
 
+/datum/design/rcl
+	name = "Rapid Cable Layer (RCL)"
+	id = "rcl_loaded"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 10000, /datum/material/glass = 5000)
+	build_path = /obj/item/rcl/pre_loaded
+	category = list("Tool Designs")
+	departmental_flags =  DEPARTMENTAL_FLAG_ENGINEERING
+
 /datum/design/rcd_loaded
 	name = "Rapid Construction Device"
 	desc = "A tool that can construct and deconstruct walls, airlocks and floors on the fly."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -162,7 +162,7 @@
 	display_name = "Advanced Engineering"
 	description = "Pushing the boundaries of physics, one chainsaw-fist at a time."
 	prereq_ids = list("engineering", "emp_basic")
-	design_ids = list("engine_goggles", "magboots", "forcefield_projector", "weldingmask", "rcd_loaded", "rpd_loaded")
+	design_ids = list("engine_goggles", "magboots", "forcefield_projector", "weldingmask", "rcd_loaded", "rpd_loaded", "rcl_loaded")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 


### PR DESCRIPTION
## About The Pull Request

This PR makes the RCL use a Radial Dial upon attack_self or z in hotkey mode to select wires to then place around yourself.

![image](https://user-images.githubusercontent.com/33578623/101590918-edb4ab80-39b0-11eb-89ba-b2c69053782a.png)
![image](https://user-images.githubusercontent.com/33578623/101591072-3ec49f80-39b1-11eb-821d-137df9c88f94.png)

## Why It's Good For The Game

Requested by veteran engineers as the old RCL is just walking and does not have as much complexity to it. This would allow for faster wiring while also allowing more choice.

## Changelog
:cl:
tweak: The RCL now has a radial dial menu open up when attack_self is called or in hotkey mode, Z, you can also use the action icon in the top left corner. This radial dial menu allows you to select different kinds of wiring to place next to you.
tweak: added the RCL to the engineering protolathe.
/:cl: