### PR TITLE
fixes tactical computer and gauss gun ssding breaking them

### DIFF
--- a/code/modules/mob/living/logout.dm
+++ b/code/modules/mob/living/logout.dm
@@ -3,3 +3,6 @@
 	..()
 	if(!key && mind)	//key and mind have become separated.
 		mind.active = 0	//This is to stop say, a mind.transfer_to call on a corpse causing a ghost to re-enter its body.
+	if(istype(src.loc,/obj/machinery/ship_weapon/gauss_gun/))
+		var/obj/machinery/ship_weapon/gauss_gun/gun = locate() in src.loc
+		gun.remove_gunner()

--- a/nsv13/code/modules/overmap/components.dm
+++ b/nsv13/code/modules/overmap/components.dm
@@ -133,6 +133,8 @@ GLOBAL_LIST_INIT(computer_beeps, list('nsv13/sound/effects/computer/beep.ogg','n
 		return
 	ui_interact(user)
 	playsound(src, 'nsv13/sound/effects/computer/startup.ogg', 75, 1)
+	if(linked.gunner && !linked.gunner.client)
+		linked.stop_piloting(linked.gunner)
 	if(!linked.gunner && isliving(user))
 		return linked.start_piloting(user, position)
 


### PR DESCRIPTION
## About The Pull Request

This PR makes it so logging out in a gauss gun will lower the gauss gun chair and make it so you arent piloting the gun anymore. This PR also makes it so logging out of the server while in the tactical computer will make it possible for another person to click on it, and disconnect the operator of the tactical console while opening it yourself.
Closes #1017 
Closes #918
## Why It's Good For The Game

This is a highly needed fix

## Changelog
:cl:
fix: fixed disconnecting while the tactical console is open; you will now be able to click on it and take over tactical operations while disconnecting the other person.
fix: fixed people disconnecting while in gauss turrets, if you logout while in the gauss turret, you will be lowered from the gauss turret and others will be able to unbuckle you and take over operation of the turret.
/:cl: