### PR TITLE
Makes it so fighter pilot armor is no longer the second strongest armor you can get.

### DIFF
--- a/nsv13/code/modules/clothing/custom_clothes.dm
+++ b/nsv13/code/modules/clothing/custom_clothes.dm
@@ -634,7 +634,7 @@
 	icon_state = "trekjacket_formal"
 	item_color = "trekjacket_formal"
 	item_state = "trekjacket_formal"
-
+ 
 /datum/action/item_action/nsv13_jacket_swap
 	name = "Toggle jacket style"
 	desc = "Display or hide your departmental colours for your suit jacket by reversing its shoulder pads."

--- a/nsv13/code/modules/clothing/custom_clothes.dm
+++ b/nsv13/code/modules/clothing/custom_clothes.dm
@@ -209,7 +209,7 @@
 	item_state = "pilot_helmet"
 	item_color = "pilot_helmet"
 	desc = "A lightweight space-helmet designed to protect fighter pilots in combat situations."
-	armor = list("melee" = 20, "bullet" = 12, "laser" = 10, "energy" = 10, "bomb" = 70, "bio" = 100, "rad" = 50, "fire" = 80, "acid" = 75)
+	armor = list("melee" = 20, "bullet" = 12, "laser" = 10, "energy" = 10, "bomb" = 10, "bio" = 100, "rad" = 50, "fire" = 80, "acid" = 75)
 
 /obj/item/clothing/suit/space/hardsuit/pilot
 	name = "fighter pilot flightsuit"
@@ -220,7 +220,7 @@
 	item_state = "pilot"
 	item_color = "pilot"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/pilot
-	armor = list("melee" = 20, "bullet" = 12, "laser" = 10, "energy" = 10, "bomb" = 60, "bio" = 100, "rad" = 50, "fire" = 90, "acid" = 75)
+	armor = list("melee" = 20, "bullet" = 12, "laser" = 10, "energy" = 10, "bomb" = 10, "bio" = 100, "rad" = 50, "fire" = 90, "acid" = 75)
 
 /obj/item/clothing/under/ship/pilot
 	name = "Pilot's combat jumpsuit"

--- a/nsv13/code/modules/clothing/custom_clothes.dm
+++ b/nsv13/code/modules/clothing/custom_clothes.dm
@@ -209,11 +209,7 @@
 	item_state = "pilot_helmet"
 	item_color = "pilot_helmet"
 	desc = "A lightweight space-helmet designed to protect fighter pilots in combat situations."
-	armor = list("melee" = 20, "bullet" = 30, "laser" = 10, "energy" = 10, "bomb" = 70, "bio" = 100, "rad" = 50, "fire" = 100, "acid" = 100)
-	resistance_flags = FIRE_PROOF | ACID_PROOF
-	flags_inv = HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR //we want to see the mask
-	heat_protection = HEAD
-	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
+	armor = list("melee" = 20, "bullet" = 12, "laser" = 10, "energy" = 10, "bomb" = 70, "bio" = 100, "rad" = 50, "fire" = 80, "acid" = 75)
 
 /obj/item/clothing/suit/space/hardsuit/pilot
 	name = "fighter pilot flightsuit"
@@ -224,10 +220,7 @@
 	item_state = "pilot"
 	item_color = "pilot"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/pilot
-	armor = list("melee" = 40, "bullet" = 50, "laser" = 50, "energy" = 25, "bomb" = 50, "bio" = 100, "rad" = 50, "fire" = 100, "acid" = 100)
-	resistance_flags = FIRE_PROOF | ACID_PROOF
-	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
-	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT //this needed to be added a long fucking time ago
+	armor = list("melee" = 20, "bullet" = 12, "laser" = 10, "energy" = 10, "bomb" = 60, "bio" = 100, "rad" = 50, "fire" = 90, "acid" = 75)
 
 /obj/item/clothing/under/ship/pilot
 	name = "Pilot's combat jumpsuit"


### PR DESCRIPTION
## About The Pull Request

Makes the fighter pilot spacesuit way less armored because  it was both fireproof and had the same armor rating as the captain's space suit.
Also makes it so your mask fits under the helmet instead of going through the mask.

## Why It's Good For The Game

Fighter pilots already have giant brr machines, they do not need to be one aswell.

## Changelog
:cl:
balance: Made fighter pilot spacesuits less armored
/:cl:
