### PR TITLE
allows atmos techs to change the pipe layer of a thermomachine

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -110,6 +110,7 @@ Class Procs:
 	var/list/component_parts = null //list of all the parts used to build it, if made from certain kinds of frames.
 	var/panel_open = FALSE
 	var/state_open = FALSE
+	var/wrench_action_changed = FALSE //used for changing the action of a wrench upon a machine when panel_open = TRUE
 	var/critical_machine = FALSE //If this machine is critical to station operation and should have the area be excempted from power failures.
 	var/list/occupant_typecache //if set, turned into typecache in Initialize, other wise, defaults to mob/living typecache
 	var/atom/movable/occupant = null
@@ -426,6 +427,18 @@ Class Procs:
 		I.play_tool_sound(src, 50)
 		setDir(turn(dir,-90))
 		to_chat(user, "<span class='notice'>You rotate [src].</span>")
+		return 1
+	return 0
+
+/obj/machinery/proc/default_change_wrench_action_wirecutter(mob/user, obj/item/I)
+	if(panel_open && I.tool_behaviour == TOOL_WIRECUTTER)
+		I.play_tool_sound(src,50)
+		if(!wrench_action_changed)
+			wrench_action_changed = TRUE
+			to_chat(user, "<span class='notice'>You change the action of the wrench upon [src].</span>")
+		else
+			wrench_action_changed = FALSE
+			to_chat(user, "<span class='notice'>You reset the action of the wrench upon [src].</span>")
 		return 1
 	return 0
 

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -430,18 +430,6 @@ Class Procs:
 		return 1
 	return 0
 
-/obj/machinery/proc/default_change_wrench_action_wirecutter(mob/user, obj/item/I)
-	if(panel_open && I.tool_behaviour == TOOL_WIRECUTTER)
-		I.play_tool_sound(src,50)
-		if(!wrench_action_changed)
-			wrench_action_changed = TRUE
-			to_chat(user, "<span class='notice'>You change the action of the wrench upon [src].</span>")
-		else
-			wrench_action_changed = FALSE
-			to_chat(user, "<span class='notice'>You reset the action of the wrench upon [src].</span>")
-		return 1
-	return 0
-
 /obj/proc/can_be_unfasten_wrench(mob/user, silent) //if we can unwrench this object; returns SUCCESSFUL_UNFASTEN and FAILED_UNFASTEN, which are both TRUE, or CANT_UNFASTEN, which isn't.
 	if(!(isfloorturf(loc) || istype(loc, /turf/open/indestructible)) && !anchored)
 		to_chat(user, "<span class='warning'>[src] needs to be on the floor to be secured!</span>")

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -110,7 +110,6 @@ Class Procs:
 	var/list/component_parts = null //list of all the parts used to build it, if made from certain kinds of frames.
 	var/panel_open = FALSE
 	var/state_open = FALSE
-	var/wrench_action_changed = FALSE //used for changing the action of a wrench upon a machine when panel_open = TRUE
 	var/critical_machine = FALSE //If this machine is critical to station operation and should have the area be excempted from power failures.
 	var/list/occupant_typecache //if set, turned into typecache in Initialize, other wise, defaults to mob/living typecache
 	var/atom/movable/occupant = null

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -95,7 +95,7 @@
 	if(!on)
 		if(default_deconstruction_screwdriver(user, icon_state_open, icon_state_off, I))
 			return
-	if(default_change_wrench_action_wirecutter(user,I))
+	if(multitool_act(user,I))
 		return
 	if(default_change_direction_wrench(user, I))
 		return
@@ -103,15 +103,15 @@
 		return
 	return ..()
 
-/obj/machinery/atmospherics/components/unary/thermomachine/proc/default_change_wrench_action_wirecutter(mob/user, obj/item/I)
-	if(panel_open && I.tool_behaviour == TOOL_WIRECUTTER)
+/obj/machinery/atmospherics/components/unary/thermomachine/multitool_act(mob/living/user, obj/item/I)
+	if(panel_open && I.tool_behaviour == TOOL_MULTITOOL)
 		I.play_tool_sound(src,50)
 		if(!wrench_action_changed)
 			wrench_action_changed = TRUE
-			to_chat(user, "<span class='notice'>The wrench will now change the pipe layer of [src].</span>")
+			to_chat(user, "<span class='notice'>Wrenching will now change the pipe layer of [src].</span>")
 		else
 			wrench_action_changed = FALSE
-			to_chat(user, "<span class='notice'>The wrench will now change the pipe direction of [src].</span>")
+			to_chat(user, "<span class='notice'>Wrenching will now change the pipe direction of [src].</span>")
 		return 1
 	return 0
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -103,6 +103,19 @@
 		return
 	return ..()
 
+/obj/machinery/atmospherics/components/unary/thermomachine/proc/default_change_wrench_action_wirecutter(mob/user, obj/item/I)
+	if(panel_open && I.tool_behaviour == TOOL_WIRECUTTER)
+		I.play_tool_sound(src,50)
+		if(!wrench_action_changed)
+			wrench_action_changed = TRUE
+			to_chat(user, "<span class='notice'>The wrench will now change the pipe layer of [src].</span>")
+		else
+			wrench_action_changed = FALSE
+			to_chat(user, "<span class='notice'>The wrench will now change the pipe direction of [src].</span>")
+		return 1
+	return 0
+
+
 /obj/machinery/atmospherics/components/unary/thermomachine/default_change_direction_wrench(mob/user, obj/item/I)
 	if(panel_open && I.tool_behaviour == TOOL_WRENCH)
 		I.play_tool_sound(src, 50)

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -18,7 +18,7 @@
 	var/icon_state_off = "freezer"
 	var/icon_state_on = "freezer_1"
 	var/icon_state_open = "freezer-o"
-
+	var/wrench_action_changed = FALSE //used for changing the action of a wrench upon the thermomachine when panel_open = TRUE
 	var/min_temperature = 0
 	var/max_temperature = 0
 	var/target_temperature = T20C

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -95,6 +95,8 @@
 	if(!on)
 		if(default_deconstruction_screwdriver(user, icon_state_open, icon_state_off, I))
 			return
+	if(default_change_wrench_action_wirecutter(user,I))
+		return
 	if(default_change_direction_wrench(user, I))
 		return
 	if(default_deconstruction_crowbar(I))
@@ -102,22 +104,45 @@
 	return ..()
 
 /obj/machinery/atmospherics/components/unary/thermomachine/default_change_direction_wrench(mob/user, obj/item/I)
-	if(!..())
-		return FALSE
-	SetInitDirections()
-	var/obj/machinery/atmospherics/node = nodes[1]
-	if(node)
-		node.disconnect(src)
-		nodes[1] = null
-	nullifyPipenet(parents[1])
+	if(panel_open && I.tool_behaviour == TOOL_WRENCH)
+		I.play_tool_sound(src, 50)
+		if(!wrench_action_changed)
+			setDir(turn(dir,-90))
+			to_chat(user, "<span class='notice'>You rotate [src].</span>")
+			SetInitDirections()
+			var/obj/machinery/atmospherics/node = nodes[1]
+			if(node)
+				node.disconnect(src)
+				nodes[1] = null
+			nullifyPipenet(parents[1])
 
-	atmosinit()
-	node = nodes[1]
-	if(node)
-		node.atmosinit()
-		node.addMember(src)
-	build_network()
-	return TRUE
+			atmosinit()
+			node = nodes[1]
+			if(node)
+				node.atmosinit()
+				node.addMember(src)
+			build_network()
+			return TRUE
+		else
+			to_chat(user, "<span class='notice'>You change the pipe layer of [src].</span>")
+			if(piping_layer < PIPING_LAYER_MAX)
+				piping_layer++
+			else
+				piping_layer = PIPING_LAYER_MIN
+			var/obj/machinery/atmospherics/node = nodes[1]
+			if(node)
+				node.disconnect(src)
+				nodes[1] = null
+			nullifyPipenet(parents[1])
+
+			atmosinit()
+			node = nodes[1]
+			if(node)
+				node.atmosinit()
+				node.addMember(src)
+			build_network()
+			return TRUE
+	return FALSE
 
 /obj/machinery/atmospherics/components/unary/thermomachine/ui_status(mob/user)
 	if(interactive)


### PR DESCRIPTION
## About The Pull Request

This PR allows atmos techs to change the pipe layer of thermomachines. To do this, open the panel of the machine, and use a multitool once. This will make the wrench action upon it cause the piping layer to change. Use the multitool again to revert the wrench action back to changing the piping direction.

## Why It's Good For The Game

This adds massive utility for atmosians and engineers to use heaters more compactly and more effectively, now not requiring layer 2, or a map edit by a mapper.

## Changelog
:cl:
add: Added the ability for atmosians to change the piping layer of thermomachines by opening the panel, and using a multitool, which will allow you to use the wrench to change the layer of the pipes. Use the multitool again to revert the wrench back to changing direction of the pipes.
/:cl: