### PR TITLE
Adds Munitions (Orange) colored turf decals for mapping

### DIFF
--- a/nsv13/game/custom_turfs.dm
+++ b/nsv13/game/custom_turfs.dm
@@ -416,6 +416,10 @@
 /turf/open/floor/plasteel/grid/techfloor/grid/airless
 	initial_gas_mix = AIRLESS_ATMOS
 
+/obj/effect/turf_decal/tile/orange
+	name = "orange corner"
+	color = "#ff7f00"
+
 /obj/effect/turf_decal/tile/ship
 	name = "tile decal"
 	icon = 'nsv13/icons/turf/decals.dmi'
@@ -437,6 +441,10 @@
 /obj/effect/turf_decal/tile/ship/red
 	name = "red corner"
 	color = "#DE3A3A"
+
+/obj/effect/turf_decal/tile/ship/orange
+	name = "orange corner"
+	color = "#ff7f00"
 
 /obj/effect/turf_decal/tile/ship/bar
 	name = "bar corner"
@@ -476,6 +484,10 @@
 	name = "red corner"
 	color = "#DE3A3A"
 
+/obj/effect/turf_decal/tile/ship/half/orange
+	name = "orange corner"
+	color = "#ff7f00"
+
 /obj/effect/turf_decal/tile/ship/half/bar
 	name = "bar corner"
 	color = "#791500"
@@ -513,6 +525,10 @@
 /obj/effect/turf_decal/tile/ship/full/red
 	name = "red corner"
 	color = "#DE3A3A"
+
+/obj/effect/turf_decal/tile/ship/full/orange
+	name = "orange corner"
+	color = "#ff7f00"
 
 /obj/effect/turf_decal/tile/ship/full/bar
 	name = "bar corner"


### PR DESCRIPTION
## About The Pull Request

Adds colored turf decals to use for munitions flooring.

## Why It's Good For The Game

No longer forces mappers to use red decals for marking their munitions departments.

## Changelog
:cl:
add: Adds orange turf decals
/:cl:
