### PR TITLE
Armour pump buff

### DIFF
--- a/nsv13/code/modules/overmap/armour/nano_well.dm
+++ b/nsv13/code/modules/overmap/armour/nano_well.dm
@@ -63,7 +63,7 @@ Starting Materials
 	var/repair_resources_processing = FALSE
 	var/repair_efficiency = 0 //modifier for how much repairs we get per cycle
 	var/power_allocation = 0 //how much power we are pumping into the system
-	var/maximum_power_allocation = 1000000 //1MW
+	var/maximum_power_allocation = 3000000 //3MW
 	var/system_allocation = 0 //the load on the system
 	var/system_stress = 0 //how overloaded the system has been over time
 	var/system_stress_threshold = 100 //Threshold at which stress beings to build up
@@ -137,8 +137,8 @@ Starting Materials
 
 /obj/machinery/armour_plating_nanorepair_well/proc/handle_repair_efficiency() //Sigmoidal Curve
 	repair_efficiency = ((1 / (0.01 + (NUM_E ** (-0.00001 * power_allocation)))) * material_modifier) / 100
-	if(power_allocation > 1e6) //If overclocking
-		repair_efficiency += ((power_allocation - 1e6) / 1e7) / 2
+	if(power_allocation > 3e6) //If overclocking
+		repair_efficiency += ((power_allocation - 3e6) / 3e7) / 2
 
 /obj/machinery/armour_plating_nanorepair_well/proc/handle_system_stress()
 	system_allocation = 0
@@ -179,7 +179,7 @@ Starting Materials
 
 /obj/machinery/armour_plating_nanorepair_well/proc/handle_power_allocation()
 	active_power_usage = power_allocation
-	if(power_allocation >= 1e6) //If overlocking
+	if(power_allocation >= 3e6) //If overlocking
 		var/turf/open/L = get_turf(src)
 		if(!istype(L) || !(L.air))
 			return
@@ -204,7 +204,7 @@ Starting Materials
 					if(materials.has_enough_of_material(/datum/material/iron, iron_amount))
 						materials.use_amount_mat(iron_amount, /datum/material/iron)
 						repair_resources += iron_amount / 8
-						material_modifier = 0.125 //Very Low modifier
+						material_modifier = 0.225 //Very Low modifier
 						repair_resources_processing = TRUE
 				if(2) //Ferrotitanium
 					var/datum/component/material_container/materials = GetComponent(/datum/component/material_container)
@@ -214,7 +214,7 @@ Starting Materials
 						materials.use_amount_mat(iron_amount, /datum/material/iron)
 						materials.use_amount_mat(titanium_amount, /datum/material/titanium)
 						repair_resources += (iron_amount + titanium_amount) / 8
-						material_modifier = 0.33 //Low Modifier
+						material_modifier = 0.55 //Low Modifier
 						repair_resources_processing = TRUE
 				if(3) //Durasteel
 					var/datum/component/material_container/materials = GetComponent(/datum/component/material_container)
@@ -226,7 +226,7 @@ Starting Materials
 						materials.use_amount_mat(silver_amount, /datum/material/silver)
 						materials.use_amount_mat(titanium_amount, /datum/material/titanium)
 						repair_resources += (iron_amount + silver_amount + titanium_amount) / 8
-						material_modifier = 0.66 //Moderate Modifier
+						material_modifier = 0.75 //Moderate Modifier
 						repair_resources_processing = TRUE
 				if(4) //Duranium
 					var/datum/component/material_container/materials = GetComponent(/datum/component/material_container)
@@ -240,7 +240,7 @@ Starting Materials
 						materials.use_amount_mat(plasma_amount, /datum/material/plasma)
 						materials.use_amount_mat(titanium_amount, /datum/material/titanium)
 						repair_resources += (iron_amount + silver_amount + plasma_amount + titanium_amount) / 8
-						material_modifier = 1 //High Modifier
+						material_modifier = 1.25 //High Modifier
 						repair_resources_processing = TRUE
 	else
 		repair_resources_processing = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

* I've been notified that it's far too easy to get put into SScrit.

This PR is a straight buff to the NanoWell. I've tripled the input power cap to reward engineers running creative SD / RB setups. With this tripled power, you can now repair the ship at a far higher rate.

* All materials have had a slight boost to their base repairing capability. 

This should help crews without competent engineering still be able to recover from SScrit and so on.

I'm quite keen to keep the threat of missiles extremely high to give the AMS a reason to exist, but I'll re-evaluate how easy it is to die after this has been in effect for a while.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Kmc2000
add: The APNW now has a vastly higher input power cap
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
