### PR TITLE
Fixes some issues on the Tycoon

### DIFF
--- a/_maps/map_files/Tycoon/Tycoon1.dmm
+++ b/_maps/map_files/Tycoon/Tycoon1.dmm
@@ -203,10 +203,18 @@
 /turf/open/openspace/airless,
 /area/space/nearstation)
 "aA" = (
-/turf/open/floor/monotile/dark/airless,
-/area/nsv/hanger/deck3{
-	name = "Air traffic control pod"
-	})
+/obj/effect/turf_decal/ship/delivery/yellow,
+/obj/structure/closet/secure_closet/engineering_welding{
+	anchored = 1;
+	name = "pitstop locker";
+	req_access = null;
+	req_one_access_txt = "69"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/engine/airless,
+/area/space/nearstation)
 "aB" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -462,6 +470,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/heads/captain)
 "bp" = (
@@ -567,9 +579,10 @@
 /area/teleporter)
 "bF" = (
 /turf/closed/wall/ship,
-/area/maintenance/department/bridge)
+/area/maintenance/nsv/deck1/central)
 "bG" = (
 /obj/machinery/door/airlock/ship/command{
+	dir = 4;
 	name = "Captain's Quarters";
 	req_one_access_txt = "20"
 	},
@@ -834,6 +847,7 @@
 /area/shuttle/turbolift/secondary)
 "cn" = (
 /obj/machinery/door/airlock/ship/command{
+	dir = 4;
 	name = "Captain's Quarters";
 	req_one_access_txt = "20"
 	},
@@ -873,7 +887,7 @@
 /area/hallway/nsv/deck1/hallway)
 "cr" = (
 /obj/machinery/door/airlock/ship{
-	dir = 1;
+	dir = 4;
 	name = "Deck 2 Access"
 	},
 /obj/structure/disposalpipe/segment{
@@ -969,7 +983,9 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/dark/airless,
-/area/space/nearstation)
+/area/nsv/hanger/deck3{
+	name = "Air traffic control pod"
+	})
 "cG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1037,7 +1053,15 @@
 /turf/open/openspace,
 /area/shuttle/turbolift/secondary)
 "cN" = (
-/obj/machinery/door/airlock/ship/public/glass/turbolift,
+/obj/machinery/door/airlock/ship/public/glass/turbolift{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/floor/monotile,
 /area/shuttle/turbolift/secondary)
 "cO" = (
@@ -1074,7 +1098,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/multiz,
 /turf/open/floor/plating,
-/area/maintenance/department/bridge)
+/area/maintenance/nsv/deck1/central)
 "cT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -1102,6 +1126,7 @@
 /area/crew_quarters/heads/captain)
 "cV" = (
 /obj/machinery/door/airlock/ship{
+	dir = 4;
 	name = "Secure Systems"
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -1115,6 +1140,7 @@
 /area/hallway/nsv/deck1/hallway)
 "cW" = (
 /obj/machinery/door/airlock/ship{
+	dir = 4;
 	name = "Deck 2"
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -1197,7 +1223,7 @@
 	dir = 5
 	},
 /turf/closed/wall/ship,
-/area/maintenance/department/bridge)
+/area/maintenance/nsv/deck1/central)
 "dj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -1223,7 +1249,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
-/area/maintenance/department/bridge)
+/area/maintenance/nsv/deck1/central)
 "dl" = (
 /obj/structure/railing{
 	dir = 8
@@ -1444,7 +1470,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
-/area/maintenance/department/bridge)
+/area/maintenance/nsv/deck1/central)
 "dI" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1486,6 +1512,12 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/hallway)
 "dM" = (
@@ -1550,6 +1582,7 @@
 /area/nsv/briefingroom)
 "dU" = (
 /obj/machinery/door/airlock/ship/hatch{
+	dir = 4;
 	name = "Intelligence Core";
 	req_one_access_txt = "16"
 	},
@@ -1582,11 +1615,19 @@
 /area/hallway/nsv/deck1/hallway)
 "dW" = (
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "Squad Equipment"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/hallway)
 "dX" = (
@@ -1651,7 +1692,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/bridge)
+/area/maintenance/nsv/deck1/central)
 "ee" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -1734,7 +1775,7 @@
 "en" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/closed/wall/r_wall/ship,
-/area/maintenance/department/bridge)
+/area/maintenance/nsv/deck1/central)
 "eo" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -2168,15 +2209,11 @@
 /turf/open/floor/monotile,
 /area/nsv/briefingroom)
 "fq" = (
-/obj/machinery/power/deck_relay,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/bridge)
+/area/maintenance/nsv/deck1/central)
 "fr" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -2241,15 +2278,12 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/bridge)
+/area/maintenance/nsv/deck1/central)
 "fy" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/light{
@@ -2495,6 +2529,7 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "fW" = (
 /obj/machinery/door/airlock/ship/hatch{
+	dir = 4;
 	name = "AI Upload";
 	req_one_access_txt = "16";
 	security_level = 6
@@ -2569,6 +2604,7 @@
 /area/ai_monitored/turret_protected/aisat)
 "gd" = (
 /obj/machinery/door/airlock/ship/hatch{
+	dir = 4;
 	name = "Intelligence Core";
 	req_one_access_txt = "16"
 	},
@@ -2692,6 +2728,7 @@
 	},
 /obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "Briefing Room"
 	},
 /turf/open/floor/plasteel/grid/steel,
@@ -3071,6 +3108,7 @@
 /area/hallway/primary/aft)
 "gS" = (
 /obj/machinery/door/airlock/ship{
+	dir = 4;
 	name = "Secure Systems"
 	},
 /obj/structure/cable{
@@ -3134,8 +3172,16 @@
 /area/hallway/nsv/deck1/hallway)
 "gX" = (
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "Squad Equipment"
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/hallway)
 "gY" = (
@@ -3231,7 +3277,7 @@
 	dir = 6
 	},
 /turf/closed/wall/r_wall/ship,
-/area/maintenance/department/bridge)
+/area/maintenance/nsv/deck1/central)
 "hh" = (
 /obj/machinery/computer/ship/dradis/minor{
 	dir = 1
@@ -3332,14 +3378,12 @@
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
 "ht" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/ship/delivery/yellow,
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/monotile/dark/airless,
-/area/nsv/hanger/deck3{
-	name = "Air traffic control pod"
-	})
+/turf/open/floor/engine/airless,
+/area/space/nearstation)
 "hu" = (
 /obj/machinery/camera/autoname,
 /obj/effect/turf_decal/stripes/line{
@@ -3914,7 +3958,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
-/area/maintenance/department/bridge)
+/area/maintenance/nsv/deck1/central)
 "iR" = (
 /obj/structure/railing{
 	dir = 4
@@ -3966,7 +4010,7 @@
 	},
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
-/area/maintenance/department/bridge)
+/area/maintenance/nsv/deck1/central)
 "iW" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3980,7 +4024,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
-/area/maintenance/department/bridge)
+/area/maintenance/nsv/deck1/central)
 "iX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/tile/neutral{
@@ -4051,7 +4095,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/multiz,
 /turf/open/floor/plating,
-/area/maintenance/department/bridge)
+/area/maintenance/nsv/deck1/central)
 "jf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4065,7 +4109,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/ladder,
 /turf/open/floor/plating,
-/area/maintenance/department/bridge)
+/area/maintenance/nsv/deck1/central)
 "jg" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -4075,7 +4119,7 @@
 	},
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
-/area/maintenance/department/bridge)
+/area/maintenance/nsv/deck1/central)
 "jh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4094,7 +4138,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/bridge)
+/area/maintenance/nsv/deck1/central)
 "ji" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4116,7 +4160,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/bridge)
+/area/maintenance/nsv/deck1/central)
 "jj" = (
 /obj/structure/hull_plate/end{
 	dir = 4
@@ -4193,7 +4237,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
-/area/maintenance/department/bridge)
+/area/maintenance/nsv/deck1/central)
 "jq" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -4394,12 +4438,20 @@
 	name = "Executive Officer's Desk";
 	req_access_txt = "57"
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile,
 /area/crew_quarters/heads/hop{
 	name = "Executive officer's Office"
 	})
 "jG" = (
 /obj/machinery/door/airlock/ship/command{
+	dir = 4;
 	name = "Executive Officer's Quarters";
 	req_one_access_txt = "57"
 	},
@@ -4407,6 +4459,12 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
 /turf/open/floor/carpet/ship,
@@ -4716,6 +4774,7 @@
 	},
 /obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "Briefing Room"
 	},
 /turf/open/floor/plasteel/grid/steel,
@@ -4781,6 +4840,7 @@
 	})
 "kr" = (
 /obj/machinery/door/airlock/ship/command{
+	dir = 4;
 	name = "Executive Officer's Quarters";
 	req_one_access_txt = "57"
 	},
@@ -4853,6 +4913,7 @@
 /area/hallway/primary/aft)
 "kx" = (
 /obj/machinery/door/airlock/ship/hatch{
+	dir = 4;
 	name = "AI Upload Access";
 	req_one_access_txt = "19"
 	},
@@ -5050,6 +5111,7 @@
 /area/nsv/briefingroom)
 "kR" = (
 /obj/machinery/door/airlock/ship{
+	dir = 4;
 	name = "Spare Suit Storage";
 	req_access_txt = "69"
 	},
@@ -5229,7 +5291,7 @@
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/bridge)
+/area/maintenance/nsv/deck1/central)
 "li" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
@@ -5406,11 +5468,19 @@
 /area/hallway/nsv/deck1/hallway)
 "lB" = (
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "Squad Equipment"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/hallway)
 "lC" = (
@@ -5473,11 +5543,11 @@
 /area/space/nearstation)
 "lK" = (
 /turf/open/floor/plating,
-/area/space/nearstation)
+/area/maintenance/nsv/deck1/aft)
 "lL" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
-/area/space/nearstation)
+/area/maintenance/nsv/deck1/aft)
 "lM" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/structure/closet/secure_closet/engineering_welding{
@@ -5489,11 +5559,11 @@
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
 "lN" = (
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/light/runway,
+/obj/machinery/light/floor,
 /turf/open/floor/monotile/dark/airless,
-/area/nsv/hanger/deck3{
-	name = "Air traffic control pod"
-	})
+/area/space/nearstation)
 "lO" = (
 /obj/machinery/light{
 	dir = 4
@@ -6420,6 +6490,21 @@
 	},
 /turf/open/floor/monotile,
 /area/storage/eva)
+"oQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck1/hallway)
 "pq" = (
 /obj/structure/fighter_launcher{
 	dir = 4;
@@ -6579,7 +6664,9 @@
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/grid/steel,
-/area/space/nearstation)
+/area/nsv/hanger/deck3{
+	name = "Air traffic control pod"
+	})
 "wm" = (
 /obj/machinery/light,
 /turf/open/floor/monotile/dark,
@@ -6588,7 +6675,7 @@
 	})
 "wG" = (
 /turf/closed/wall/r_wall/ship,
-/area/maintenance/department/bridge)
+/area/maintenance/nsv/deck1/central)
 "wT" = (
 /obj/structure/overmap/fighter/light/flight_leader,
 /turf/open/floor/engine/airless,
@@ -6643,13 +6730,10 @@
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
 "Aw" = (
-/obj/structure/munitions_trolley,
-/obj/effect/turf_decal/ship/delivery/yellow,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/engine/airless,
-/area/space/nearstation)
+/turf/closed/wall/ship,
+/area/nsv/hanger/deck3{
+	name = "Air traffic control pod"
+	})
 "AF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -6755,6 +6839,21 @@
 	},
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
+"Fb" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck1/hallway)
 "Fm" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/light,
@@ -6806,7 +6905,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/bridge)
+/area/maintenance/nsv/deck1/central)
 "Ie" = (
 /obj/structure/fighter_launcher{
 	dir = 4;
@@ -6948,6 +7047,10 @@
 /obj/machinery/light/floor,
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
+"Pa" = (
+/obj/structure/grille,
+/turf/open/floor/monotile/dark,
+/area/maintenance/nsv/deck1/aft)
 "Pf" = (
 /obj/machinery/light{
 	dir = 4
@@ -6993,7 +7096,9 @@
 	},
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/monotile/dark/airless,
-/area/space/nearstation)
+/area/nsv/hanger/deck3{
+	name = "Air traffic control pod"
+	})
 "Rm" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -7087,6 +7192,18 @@
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
 	})
+"Uj" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck1/hallway)
 "Up" = (
 /obj/structure/fighter_launcher{
 	dir = 4;
@@ -7118,11 +7235,8 @@
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/hallway)
 "VB" = (
-/obj/vehicle/sealed/car/realistic/fighter_tug,
-/turf/open/floor/monotile/dark/airless,
-/area/nsv/hanger/deck3{
-	name = "Air traffic control pod"
-	})
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/nsv/deck1/aft)
 "Wi" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
 /turf/open/floor/plating,
@@ -30196,8 +30310,8 @@ iC
 hA
 iC
 ie
-aI
-aI
+VB
+VB
 ce
 ek
 cx
@@ -30207,8 +30321,8 @@ ct
 cx
 ek
 ce
-aI
-aI
+VB
+VB
 ie
 iC
 hA
@@ -30453,8 +30567,8 @@ iC
 hA
 iC
 ie
-aI
-mA
+VB
+Pa
 ce
 el
 ct
@@ -30464,8 +30578,8 @@ ce
 ct
 He
 ce
-mA
-aI
+Pa
+VB
 ie
 iC
 hA
@@ -30710,8 +30824,8 @@ iC
 hA
 iC
 ie
-aI
-mA
+VB
+Pa
 ce
 cz
 ct
@@ -30721,8 +30835,8 @@ ce
 ct
 cy
 ce
-mA
-aI
+Pa
+VB
 ie
 iC
 hA
@@ -30967,8 +31081,8 @@ iC
 hA
 iC
 ie
-aI
-mA
+VB
+Pa
 ce
 cA
 ct
@@ -30978,8 +31092,8 @@ ce
 ct
 CA
 ce
-mA
-aI
+Pa
+VB
 ie
 iC
 hA
@@ -31224,8 +31338,8 @@ iC
 hA
 iC
 is
-aI
-mA
+VB
+Pa
 ce
 cB
 ct
@@ -31235,8 +31349,8 @@ IV
 ct
 cy
 ce
-mA
-aI
+Pa
+VB
 nm
 iC
 hA
@@ -31481,8 +31595,8 @@ iC
 hA
 iC
 ie
-aI
-mA
+VB
+Pa
 ce
 lg
 cx
@@ -31492,8 +31606,8 @@ ct
 cx
 lg
 ce
-mA
-aI
+Pa
+VB
 ie
 iC
 hA
@@ -31738,8 +31852,8 @@ iC
 iC
 iC
 ie
-aI
-mA
+VB
+Pa
 ce
 cy
 cy
@@ -31749,8 +31863,8 @@ qB
 cy
 cy
 ce
-mA
-aI
+Pa
+VB
 ie
 iC
 iC
@@ -31995,8 +32109,8 @@ ie
 ie
 ie
 ie
-aI
-mA
+VB
+Pa
 ce
 ce
 ce
@@ -32006,8 +32120,8 @@ ce
 ce
 ce
 ce
-mA
-aI
+Pa
+VB
 ie
 ie
 ie
@@ -32248,11 +32362,11 @@ ax
 ax
 iy
 ie
-aI
-aI
-aI
-aI
-aI
+VB
+VB
+VB
+VB
+VB
 cs
 cs
 em
@@ -32263,12 +32377,12 @@ ea
 RE
 cs
 cs
-aI
-aI
-aI
-aI
-aI
-aI
+VB
+VB
+VB
+VB
+VB
+VB
 ie
 iC
 no
@@ -32505,7 +32619,7 @@ ax
 ax
 iy
 ie
-aI
+VB
 lK
 lK
 lK
@@ -32525,7 +32639,7 @@ lK
 lK
 lK
 lK
-aI
+VB
 ie
 iC
 no
@@ -32762,10 +32876,10 @@ ax
 ax
 iy
 ie
-aI
+VB
 lK
-aI
-aI
+VB
+VB
 lK
 cs
 cC
@@ -32779,10 +32893,10 @@ Bp
 cs
 lK
 lK
-aI
-aI
+VB
+VB
 lK
-aI
+VB
 ie
 iC
 no
@@ -33019,9 +33133,9 @@ ax
 ax
 iy
 ie
-aI
+VB
 lL
-aI
+VB
 lL
 lK
 cs
@@ -33037,9 +33151,9 @@ cs
 lK
 lK
 lL
-aI
+VB
 lL
-aI
+VB
 ie
 iC
 no
@@ -33276,9 +33390,9 @@ ax
 ax
 iy
 is
-aI
+VB
 lL
-aI
+VB
 lL
 lK
 cs
@@ -33294,9 +33408,9 @@ cs
 lK
 lK
 lL
-aI
+VB
 lL
-aI
+VB
 ie
 iC
 no
@@ -33533,11 +33647,11 @@ ax
 ax
 iy
 ie
-aI
+VB
 lK
-aI
+VB
 lK
-aI
+VB
 cs
 cs
 cs
@@ -33548,12 +33662,12 @@ cs
 cs
 cs
 cs
-aI
-aI
+VB
+VB
 lK
-aI
+VB
 lK
-aI
+VB
 ie
 iC
 no
@@ -33790,27 +33904,27 @@ iA
 iA
 iy
 ie
-aI
+VB
 lL
-aI
+VB
 lL
-aI
-mA
-mA
-mA
+VB
+Pa
+Pa
+Pa
 cD
 gj
 gE
 cD
-mA
-mA
-mA
-mA
-aI
+Pa
+Pa
+Pa
+Pa
+VB
 lL
-aI
+VB
 lL
-aI
+VB
 ie
 iC
 no
@@ -34047,27 +34161,27 @@ iB
 lD
 ie
 ie
-aI
+VB
 lK
 lK
 lK
-aI
-mA
-mA
-mA
+VB
+Pa
+Pa
+Pa
 cD
 kx
 ku
 cD
-mA
-mA
-mA
-mA
-aI
+Pa
+Pa
+Pa
+Pa
+VB
 lK
-aI
+VB
 lK
-aI
+VB
 nm
 iC
 no
@@ -34324,7 +34438,7 @@ dR
 lK
 lK
 lK
-aI
+VB
 ie
 iC
 no
@@ -35569,9 +35683,9 @@ av
 cc
 cp
 cN
-cc
-cY
-aI
+aC
+Aw
+aC
 ax
 ax
 ax
@@ -36084,8 +36198,8 @@ cd
 cL
 cO
 aC
-aI
-aI
+aC
+aC
 ax
 ax
 ax
@@ -40486,8 +40600,8 @@ iT
 cb
 ke
 bN
-lq
-mG
+oQ
+Fb
 Jd
 iF
 iF
@@ -40735,7 +40849,7 @@ iy
 iC
 Wi
 dL
-es
+Uj
 bN
 dm
 cb
@@ -41993,7 +42107,7 @@ bR
 bR
 bR
 YB
-ht
+hs
 ax
 ax
 Mt
@@ -43018,14 +43132,14 @@ ac
 af
 ax
 ax
-aA
-aA
-aA
-aA
-lN
-aA
-aA
-lN
+ax
+ax
+ax
+ax
+hz
+ax
+ax
+hz
 ax
 ax
 hz
@@ -45588,14 +45702,14 @@ ac
 af
 ax
 ax
-aA
-aA
-aA
-aA
-lN
-VB
-aA
-lN
+ax
+ax
+ax
+ax
+hz
+qg
+ax
+hz
 ax
 ax
 hz
@@ -48160,7 +48274,7 @@ Da
 hA
 hA
 hA
-mw
+lN
 hA
 hA
 hA
@@ -48669,7 +48783,7 @@ ac
 af
 lJ
 lM
-lM
+aA
 ax
 hA
 ac
@@ -48931,7 +49045,7 @@ ax
 hA
 hA
 hA
-mw
+lN
 hA
 hA
 hA
@@ -49439,7 +49553,7 @@ ac
 ac
 af
 lJ
-Aw
+wV
 af
 ax
 hA
@@ -49702,7 +49816,7 @@ ax
 hA
 hA
 hA
-mw
+lN
 hA
 hA
 hA
@@ -49954,7 +50068,7 @@ ac
 af
 lJ
 DP
-QF
+ht
 ax
 hA
 ac
@@ -50473,7 +50587,7 @@ UH
 hA
 hA
 hA
-mw
+lN
 hA
 hA
 hA
@@ -51244,7 +51358,7 @@ ax
 hA
 hA
 hA
-mw
+lN
 hA
 hA
 hA
@@ -52015,7 +52129,7 @@ ax
 hA
 hA
 hA
-mw
+lN
 hA
 hA
 hA
@@ -52786,7 +52900,7 @@ EI
 hA
 hA
 hA
-mw
+lN
 hA
 hA
 hA
@@ -53557,7 +53671,7 @@ ax
 hA
 hA
 hA
-mw
+lN
 hA
 hA
 hA

--- a/_maps/map_files/Tycoon/Tycoon1.dmm
+++ b/_maps/map_files/Tycoon/Tycoon1.dmm
@@ -616,23 +616,6 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/heads/captain)
-"bM" = (
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Executive Officer Queue Line";
-	req_one_access_txt = "57"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "hopqueue";
-	name = "HoP Queue Shutters"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/monotile,
-/area/hallway/nsv/deck1/hallway)
 "bN" = (
 /turf/closed/wall/ship,
 /area/hallway/nsv/deck1/hallway)
@@ -914,10 +897,6 @@
 "cy" = (
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat)
-"cz" = (
-/obj/machinery/computer/ship/viewscreen,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat)
 "cA" = (
 /obj/machinery/camera/autoname,
 /obj/machinery/firealarm{
@@ -1011,18 +990,6 @@
 	dir = 8
 	},
 /turf/open/openspace,
-/area/shuttle/turbolift/secondary)
-"cN" = (
-/obj/machinery/door/airlock/ship/public/glass/turbolift{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/monotile,
 /area/shuttle/turbolift/secondary)
 "cO" = (
 /obj/machinery/light{
@@ -1253,30 +1220,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
-"dr" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/ship/preopen{
-	id = "captainofficeshutters"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/door/window/brigdoor/northleft{
-	name = "Captain's Desk";
-	req_one_access_txt = "20"
-	},
-/obj/machinery/door/window/southright{
-	name = "Captain's Desk"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/monotile,
-/area/crew_quarters/heads/captain)
 "ds" = (
 /obj/machinery/camera/autoname,
 /obj/structure/railing/corner{
@@ -1304,13 +1247,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/hallway)
-"dv" = (
-/obj/effect/landmark/start/ai/secondary,
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/turf/open/floor/monotile/dark,
-/area/ai_monitored/turret_protected/aisat)
 "dw" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -1447,23 +1383,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/hallway)
-"dL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/camera/autoname,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/monotile,
-/area/hallway/nsv/deck1/hallway)
 "dM" = (
 /obj/machinery/power/apc/auto_name/north{
 	pixel_y = 24
@@ -1501,13 +1420,6 @@
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/hallway)
-"dP" = (
-/obj/machinery/computer/ship/viewscreen,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/monotile/dark,
-/area/ai_monitored/turret_protected/aisat)
 "dQ" = (
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/ai_monitored/turret_protected/aisat)
@@ -1526,33 +1438,6 @@
 	},
 /turf/open/floor/plating,
 /area/nsv/briefingroom)
-"dU" = (
-/obj/machinery/door/airlock/ship/hatch{
-	dir = 4;
-	name = "Intelligence Core";
-	req_one_access_txt = "16"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/ship/preopen{
-	dir = 8;
-	id = "outeraicore"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/monotile/dark,
-/area/ai_monitored/turret_protected/aisat)
 "dV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -1697,11 +1582,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/aisat)
-"ek" = (
-/obj/effect/turf_decal/stripes/box,
-/obj/machinery/porta_turret/ai,
-/turf/open/floor/circuit/red,
-/area/ai_monitored/turret_protected/aisat)
 "el" = (
 /obj/machinery/light{
 	dir = 1
@@ -1826,12 +1706,6 @@
 	dir = 1
 	},
 /obj/machinery/light,
-/turf/open/floor/monotile,
-/area/ai_monitored/nuke_storage)
-"eD" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /turf/open/floor/monotile,
 /area/ai_monitored/nuke_storage)
 "eE" = (
@@ -2149,15 +2023,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
-"fp" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
-	},
-/turf/open/floor/monotile,
-/area/nsv/briefingroom)
 "fq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
@@ -2200,21 +2065,6 @@
 /area/crew_quarters/heads/hop{
 	name = "Executive officer's Office"
 	})
-"fv" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Executive Officer Queue Line"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "hopqueue";
-	name = "HoP Queue Shutters"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/monotile,
-/area/hallway/nsv/deck1/hallway)
 "fw" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -2241,12 +2091,6 @@
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/hallway)
-"fz" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/closed/wall/r_wall/ship,
-/area/nsv/hanger/deck3{
-	name = "Air traffic control pod"
-	})
 "fA" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4;
@@ -2527,22 +2371,6 @@
 	},
 /turf/closed/wall/ship,
 /area/hallway/nsv/deck1/hallway)
-"gb" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/monotile,
-/area/hallway/nsv/deck1/hallway)
 "gc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
@@ -2603,29 +2431,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/primary/aft)
-"gg" = (
-/obj/machinery/ore_silo,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/open/floor/monotile,
-/area/ai_monitored/nuke_storage)
-"gh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/turf/open/floor/monotile/dark,
-/area/hallway/nsv/deck1/hallway)
 "gi" = (
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -2645,74 +2450,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
-"gk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/monotile,
-/area/hallway/nsv/deck1/hallway)
-"gl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
-	name = "Briefing Room"
-	},
-/turf/open/floor/plasteel/grid/steel,
-/area/nsv/briefingroom)
-"gm" = (
-/obj/machinery/power/apc/auto_name/north{
-	pixel_y = 24
-	},
-/obj/structure/safe,
-/obj/item/bikehorn/golden,
-/obj/item/book/random,
-/obj/item/fakeartefact,
-/obj/item/grenade/clusterbuster/smoke,
-/obj/item/documents/nanotrasen,
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/monotile,
-/area/ai_monitored/nuke_storage)
-"gn" = (
-/obj/machinery/computer/bank_machine,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/airalarm{
-	pixel_y = 26
-	},
-/turf/open/floor/monotile,
-/area/ai_monitored/nuke_storage)
 "go" = (
 /obj/machinery/door/airlock/ship/hatch{
 	name = "Teleporter Room";
@@ -3511,10 +3248,6 @@
 /obj/machinery/light/runway,
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
-"hY" = (
-/obj/machinery/telecomms/relay/preset/station,
-/turf/open/floor/monotile/dark,
-/area/ai_monitored/turret_protected/aisat)
 "hZ" = (
 /obj/machinery/light/runway/delay2,
 /turf/open/floor/monotile/dark/airless,
@@ -3559,21 +3292,6 @@
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
 	})
-"ii" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/monotile,
-/area/hallway/nsv/deck1/hallway)
 "ij" = (
 /obj/effect/turf_decal/ship/delivery{
 	color = "#8B0000"
@@ -3630,24 +3348,6 @@
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
 	})
-"io" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/monotile,
-/area/hallway/nsv/deck1/hallway)
 "ip" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -3751,24 +3451,10 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/nsv/deck1/hallway)
-"iE" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/nsv/briefingroom)
 "iF" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/nsv/deck1/hallway)
-"iG" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/monotile,
-/area/nsv/briefingroom)
 "iH" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4;
@@ -3898,12 +3584,6 @@
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/hallway)
 "iT" = (
-/turf/open/floor/monotile/dark,
-/area/hallway/nsv/deck1/hallway)
-"iU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
 "iV" = (
@@ -4571,12 +4251,6 @@
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/hallway)
-"kb" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/turf/open/floor/monotile/dark,
-/area/hallway/nsv/deck1/hallway)
 "kc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
@@ -4646,44 +4320,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
-"kj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/monotile,
-/area/hallway/nsv/deck1/hallway)
-"kk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
-	name = "Briefing Room"
-	},
-/turf/open/floor/plasteel/grid/steel,
-/area/nsv/briefingroom)
 "kl" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -5014,28 +4650,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/briefingroom)
-"kR" = (
-/obj/machinery/door/airlock/ship{
-	dir = 4;
-	name = "Spare Suit Storage";
-	req_access_txt = "69"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/monotile,
-/area/nsv/hanger/deck3{
-	name = "Air traffic control pod"
-	})
 "kS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5197,17 +4811,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/central)
-"li" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/monotile,
-/area/nsv/hanger/deck3{
-	name = "Air traffic control pod"
-	})
 "lj" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/security/telescreen/atc,
@@ -5522,20 +5125,6 @@
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
 	})
-"lR" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/monotile/dark,
-/area/nsv/hanger/deck3{
-	name = "Air traffic control pod"
-	})
 "lS" = (
 /obj/structure/sign/directions/command{
 	dir = 4;
@@ -5708,18 +5297,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/storage/eva)
-"mm" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/item/radio/intercom{
-	name = "intra ship intercom";
-	pixel_y = 26
-	},
-/obj/machinery/camera/autoname,
-/turf/open/floor/monotile/dark,
-/area/teleporter)
 "mn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
@@ -6004,15 +5581,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/monotile,
 /area/nsv/briefingroom)
-"mX" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/monotile,
-/area/nsv/briefingroom)
 "mY" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4;
@@ -6049,17 +5617,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/ai_upload)
-"nc" = (
-/obj/structure/table/reinforced,
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/obj/item/paper_bin,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/monotile/dark,
-/area/ai_monitored/turret_protected/aisat)
 "nd" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -6068,16 +5625,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/ship/techfloor/alt,
-/area/ai_monitored/turret_protected/aisat)
-"ne" = (
-/obj/machinery/door/poddoor/ship/preopen{
-	dir = 8;
-	id = "inneraicore"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat)
 "nf" = (
 /obj/effect/landmark/start/ai,
@@ -6137,18 +5684,6 @@
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
-/turf/open/floor/monotile/dark,
-/area/ai_monitored/turret_protected/aisat)
-"nh" = (
-/obj/machinery/power/apc/highcap/fifteen_k{
-	auto_name = 1;
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/landmark/start/ai/secondary,
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/aisat)
 "ni" = (
@@ -6386,21 +5921,12 @@
 	},
 /turf/open/floor/monotile,
 /area/storage/eva)
-"oQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
+"pe" = (
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
-/area/hallway/nsv/deck1/hallway)
+/area/ai_monitored/turret_protected/aisat)
 "pq" = (
 /obj/structure/fighter_launcher{
 	dir = 4;
@@ -6415,6 +5941,30 @@
 /obj/item/fighter_component/targeting_sensor,
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
+"pU" = (
+/obj/machinery/door/airlock/ship/hatch{
+	dir = 4;
+	name = "Intelligence Core";
+	req_one_access_txt = "16"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/ship/preopen{
+	dir = 8;
+	id = "outeraicore"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/ai_monitored/turret_protected/aisat)
 "qg" = (
 /obj/vehicle/sealed/car/realistic/fighter_tug,
 /turf/open/floor/monotile/dark/airless,
@@ -6456,6 +6006,10 @@
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
 	})
+"ra" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/monotile,
+/area/nsv/briefingroom)
 "rb" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	req_one_access_txt = "13"
@@ -6476,15 +6030,39 @@
 /obj/item/aiModule/core/full/custom,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
-"rt" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/layer3{
-	dir = 1
+"rl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/machinery/advanced_airlock_controller{
-	pixel_y = 24
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
 	},
-/turf/open/floor/monotile,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
+"rA" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_y = 26
+	},
+/obj/machinery/camera/autoname,
+/obj/structure/closet/crate,
+/obj/item/stack/sheet/rglass{
+	amount = 50
+	},
+/obj/item/stack/sheet/iron/fifty,
+/turf/open/floor/monotile/dark,
+/area/teleporter)
 "rQ" = (
 /obj/effect/turf_decal/ship/delivery,
 /turf/open/floor/monotile/dark/airless,
@@ -6504,6 +6082,12 @@
 /obj/item/fighter_component/engine,
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
+"sS" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat)
 "sT" = (
 /obj/machinery/door/airlock/vault/ship{
 	name = "Vault";
@@ -6529,6 +6113,44 @@
 	},
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
+"uo" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/ship/preopen{
+	id = "captainofficeshutters"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/door/window/brigdoor/northleft{
+	name = "Captain's Desk";
+	req_one_access_txt = "20"
+	},
+/obj/machinery/door/window/southright{
+	name = "Captain's Desk"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile,
+/area/crew_quarters/heads/captain)
+"uy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck1/hallway)
 "vi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6542,6 +6164,24 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/primary/aft)
+"vC" = (
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Executive Officer Queue Line";
+	req_one_access_txt = "57"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "hopqueue";
+	name = "HoP Queue Shutters"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck1/hallway)
 "vF" = (
 /obj/machinery/camera/autoname{
 	dir = 1;
@@ -6550,14 +6190,6 @@
 	},
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
-"vO" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 26
-	},
-/turf/closed/wall/r_wall/ship,
-/area/nsv/hanger/deck3{
-	name = "Air traffic control pod"
-	})
 "vQ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6571,25 +6203,83 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/ai_upload)
-"vX" = (
-/obj/machinery/advanced_airlock_controller{
-	pixel_y = 24
+"vW" = (
+/obj/structure/table/reinforced,
+/obj/machinery/camera/autoname{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel/grid/steel,
-/area/nsv/hanger/deck3{
-	name = "Air traffic control pod"
-	})
+/obj/item/paper_bin,
+/obj/machinery/power/apc/highcap/fifteen_k{
+	auto_name = 1;
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/newscaster/security_unit{
+	pixel_x = -32;
+	pixel_y = 32
+	},
+/obj/machinery/requests_console{
+	department = "AI";
+	departmentType = 5;
+	pixel_x = -30;
+	pixel_y = -30
+	},
+/turf/open/floor/monotile/dark,
+/area/ai_monitored/turret_protected/aisat)
 "wm" = (
 /obj/machinery/light,
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
 	})
+"wr" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck1/hallway)
 "wG" = (
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/nsv/deck1/central)
+"wK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
+	name = "Briefing Room"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grid/steel,
+/area/nsv/briefingroom)
 "wT" = (
 /obj/structure/overmap/fighter/light/flight_leader,
 /turf/open/floor/engine/airless,
@@ -6599,6 +6289,13 @@
 /obj/effect/turf_decal/ship/delivery/yellow,
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
+"xw" = (
+/obj/machinery/door/poddoor/ship/preopen{
+	dir = 8;
+	id = "inneraicore"
+	},
+/turf/open/floor/monotile/dark,
+/area/ai_monitored/turret_protected/aisat)
 "xy" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/tile/neutral{
@@ -6611,13 +6308,25 @@
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/monotile/dark,
 /area/teleporter)
-"yn" = (
-/obj/machinery/newscaster/security_unit{
-	pixel_x = -32;
-	pixel_y = 32
+"xz" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/airalarm{
+	pixel_y = 26
+	},
+/turf/open/floor/monotile,
+/area/ai_monitored/nuke_storage)
+"yF" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 26
+	},
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/central)
 "yG" = (
 /obj/machinery/power/apc/auto_name/east{
 	pixel_x = 24
@@ -6657,6 +6366,24 @@
 	},
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
+"zD" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/monotile,
+/area/ai_monitored/nuke_storage)
+"zM" = (
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/machinery/porta_turret/ai,
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/circuit/red,
+/area/ai_monitored/turret_protected/aisat)
 "AF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -6715,12 +6442,6 @@
 	},
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
-"Dc" = (
-/obj/structure/closet/secure_closet/fighter_pilot,
-/turf/open/floor/monotile/dark,
-/area/nsv/hanger/deck3{
-	name = "Air traffic control pod"
-	})
 "Dk" = (
 /obj/machinery/light{
 	dir = 8
@@ -6732,6 +6453,15 @@
 /obj/structure/reagent_dispensers/fueltank/aviation_fuel,
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
+"DR" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck1/hallway)
 "Ey" = (
 /obj/structure/overmap/fighter/light,
 /turf/open/floor/engine/airless,
@@ -6750,21 +6480,6 @@
 	},
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
-"Fb" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/monotile,
-/area/hallway/nsv/deck1/hallway)
 "Fm" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/light,
@@ -6777,6 +6492,18 @@
 	},
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
+"FC" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "FG" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -6784,15 +6511,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/monotile/dark,
-/area/teleporter)
-"FU" = (
-/obj/structure/closet/crate,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/rglass{
-	amount = 50
-	},
-/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/monotile/dark,
 /area/teleporter)
 "Gg" = (
@@ -6812,6 +6530,29 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/primary/aft)
+"Gj" = (
+/obj/machinery/door/airlock/ship{
+	dir = 4;
+	name = "Spare Suit Storage";
+	req_access_txt = "69"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile,
+/area/nsv/hanger/deck3{
+	name = "Air traffic control pod"
+	})
 "Gv" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
 /turf/open/floor/plating,
@@ -6843,6 +6584,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/central)
+"HC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck1/hallway)
 "Ie" = (
 /obj/structure/fighter_launcher{
 	dir = 4;
@@ -6853,6 +6606,19 @@
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
 	})
+"Im" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck1/hallway)
 "IC" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	req_one_access_txt = "13"
@@ -6885,17 +6651,6 @@
 /obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall/ship,
 /area/hallway/nsv/deck1/hallway)
-"JA" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "JE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6905,6 +6660,10 @@
 	},
 /turf/open/floor/monotile,
 /area/ai_monitored/turret_protected/ai_upload)
+"JS" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/monotile/dark,
+/area/ai_monitored/turret_protected/aisat)
 "JT" = (
 /obj/machinery/teleport/hub,
 /obj/effect/turf_decal/tile/neutral{
@@ -6915,11 +6674,35 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/teleporter)
+"Kn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
+	name = "Briefing Room"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/grid/steel,
+/area/nsv/briefingroom)
 "Kz" = (
 /obj/structure/fighter_frame,
 /obj/effect/turf_decal/ship/delivery/yellow,
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
+"KD" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/monotile,
+/area/nsv/briefingroom)
 "KQ" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	name = "Flight deck access";
@@ -6932,6 +6715,32 @@
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
 	})
+"KS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera/autoname,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck1/hallway)
+"Ld" = (
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/box,
+/obj/machinery/porta_turret/ai,
+/turf/open/floor/circuit/red,
+/area/ai_monitored/turret_protected/aisat)
 "Lh" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/ship/delivery,
@@ -6983,6 +6792,22 @@
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
 	})
+"Mg" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck1/hallway)
 "Mj" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6997,10 +6822,21 @@
 /obj/structure/reagent_dispensers/foamtank/hull_repair_juice,
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
+"MM" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/monotile,
+/area/nsv/briefingroom)
 "Ne" = (
 /obj/machinery/light/floor,
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
+"NP" = (
+/obj/effect/landmark/start/ai/secondary,
+/turf/open/floor/monotile/dark,
+/area/ai_monitored/turret_protected/aisat)
 "NS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -7021,6 +6857,21 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/primary/aft)
+"OF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/monotile/dark,
+/area/nsv/hanger/deck3{
+	name = "Air traffic control pod"
+	})
 "Pa" = (
 /obj/structure/grille,
 /turf/open/floor/monotile/dark,
@@ -7031,6 +6882,41 @@
 	},
 /turf/open/openspace,
 /area/shuttle/turbolift/shaft)
+"PJ" = (
+/obj/machinery/door/airlock/ship/public/glass/turbolift{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile,
+/area/shuttle/turbolift/secondary)
+"PN" = (
+/obj/structure/closet/secure_closet/fighter_pilot,
+/turf/open/floor/monotile,
+/area/nsv/hanger/deck3{
+	name = "Air traffic control pod"
+	})
+"PT" = (
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Executive Officer Queue Line"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "hopqueue";
+	name = "HoP Queue Shutters"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck1/hallway)
 "Qx" = (
 /obj/structure/table,
 /obj/item/stack/packageWrap,
@@ -7062,6 +6948,13 @@
 /obj/item/pen/fourcolor,
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/aisat)
+"QV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck1/hallway)
 "Rc" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	name = "Flight deck access";
@@ -7099,6 +6992,17 @@
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
 	})
+"Rx" = (
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/computer/bank_machine,
+/turf/open/floor/monotile,
+/area/ai_monitored/nuke_storage)
 "Ry" = (
 /turf/open/floor/monotile/dark/airless,
 /area/nsv/weapons/gauss)
@@ -7122,6 +7026,57 @@
 /area/crew_quarters/heads/hop{
 	name = "Executive officer's Office"
 	})
+"Sa" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/layer3{
+	dir = 1
+	},
+/obj/machinery/advanced_airlock_controller/directional/west{
+	pixel_y = 24
+	},
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck1/hallway)
+"Sg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/nsv/hanger/deck3{
+	name = "Air traffic control pod"
+	})
+"Ss" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck1/hallway)
+"SD" = (
+/obj/machinery/computer/ship/viewscreen,
+/turf/open/floor/monotile/dark,
+/area/ai_monitored/turret_protected/aisat)
 "Tl" = (
 /obj/structure/rack,
 /obj/item/fighter_component/armour_plating,
@@ -7144,19 +7099,35 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/teleporter)
-"TN" = (
-/obj/machinery/requests_console{
-	department = "AI";
-	departmentType = 5;
-	pixel_x = -30;
-	pixel_y = -30
+"TL" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat)
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck1/hallway)
 "TQ" = (
 /obj/machinery/suit_storage_unit/pilot,
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/monotile,
+/area/nsv/hanger/deck3{
+	name = "Air traffic control pod"
+	})
+"TY" = (
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/advanced_airlock_controller/directional/east{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/grid/steel,
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
 	})
@@ -7168,18 +7139,6 @@
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
 	})
-"Uj" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/monotile/dark,
-/area/hallway/nsv/deck1/hallway)
 "Up" = (
 /obj/structure/fighter_launcher{
 	dir = 4;
@@ -7190,6 +7149,33 @@
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
 	})
+"Uq" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck1/hallway)
+"Ur" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/monotile,
+/area/nsv/briefingroom)
 "UH" = (
 /obj/machinery/camera/autoname{
 	name = "Fighter Tarmac #2";
@@ -7201,6 +7187,11 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
+"UX" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/telecomms/relay/preset/station,
+/turf/open/floor/monotile/dark,
+/area/teleporter)
 "Va" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/layer1{
 	dir = 1
@@ -7284,6 +7275,30 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/teleporter)
+"ZJ" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/safe,
+/obj/item/documents/nanotrasen,
+/obj/item/grenade/clusterbuster/smoke,
+/obj/item/fakeartefact,
+/obj/item/book/random,
+/obj/item/bikehorn/golden,
+/turf/open/floor/monotile,
+/area/ai_monitored/nuke_storage)
+"ZX" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/monotile,
+/area/nsv/briefingroom)
 
 (1,1,1) = {"
 aa
@@ -27977,11 +27992,11 @@ iC
 ie
 ie
 aI
-mA
-mA
-mA
-mA
-mA
+aI
+aI
+aI
+aI
+aI
 aI
 ie
 ie
@@ -28234,11 +28249,11 @@ iC
 ie
 ce
 ce
+NP
 ce
 ce
 ce
-ce
-ce
+NP
 ce
 ce
 ie
@@ -28490,13 +28505,13 @@ hA
 iC
 ie
 ce
-dv
-ce
-hY
+zM
+ct
+JS
 gs
 ng
-ce
-dv
+ct
+Ld
 ce
 ie
 iC
@@ -28749,9 +28764,9 @@ ie
 ce
 ct
 ni
-yn
+cy
 LI
-TN
+cy
 ni
 ct
 ce
@@ -29004,10 +29019,10 @@ hA
 iC
 ie
 ce
-dP
+pe
 cy
 ce
-nh
+NP
 ce
 cy
 ll
@@ -29264,7 +29279,7 @@ ce
 cu
 cy
 ce
-dz
+ce
 ce
 cy
 ej
@@ -29521,7 +29536,7 @@ ce
 ct
 cy
 Tn
-nc
+vW
 QL
 cy
 ct
@@ -29775,7 +29790,7 @@ iC
 iC
 ie
 ce
-ct
+SD
 cy
 dQ
 nd
@@ -30032,13 +30047,13 @@ ie
 ie
 ie
 ce
-cw
-cw
-cw
-ne
-cw
-cw
-cw
+cy
+cy
+cy
+sS
+cy
+cy
+cy
 ce
 ie
 ie
@@ -30289,13 +30304,13 @@ ie
 VB
 VB
 ce
-ek
+cy
 cx
 ct
 eb
 ct
 cx
-ek
+cy
 ce
 VB
 VB
@@ -30803,13 +30818,13 @@ ie
 VB
 Pa
 ce
-cz
-ct
+cw
+xw
 ce
 dz
 ce
-ct
-cy
+xw
+cw
 ce
 Pa
 VB
@@ -31574,13 +31589,13 @@ ie
 VB
 Pa
 ce
-lg
+cy
 cx
 df
 eb
 ct
 cx
-lg
+cy
 ce
 Pa
 VB
@@ -31831,13 +31846,13 @@ ie
 VB
 Pa
 ce
-cy
+lg
 cy
 dg
 gc
 qB
 cy
-cy
+lg
 ce
 Pa
 VB
@@ -32090,7 +32105,7 @@ Pa
 ce
 ce
 ce
-dU
+pU
 gd
 ce
 ce
@@ -34656,14 +34671,14 @@ bm
 bv
 yP
 bE
-FU
+UX
 mt
 WF
 bE
 kU
 gF
 dR
-gm
+Rx
 eo
 eo
 eA
@@ -34920,7 +34935,7 @@ bE
 cT
 gF
 dR
-gn
+xz
 ep
 ep
 eB
@@ -35427,14 +35442,14 @@ bG
 aP
 aP
 bE
-mm
+rA
 mz
 JT
 bE
 eh
 gH
 dR
-gg
+zD
 ep
 ep
 lk
@@ -35654,11 +35669,11 @@ aE
 aM
 dC
 bQ
-fz
+dC
 av
 cc
 cp
-cN
+PJ
 aC
 aC
 aC
@@ -35694,7 +35709,7 @@ dR
 ef
 eq
 eq
-eD
+ZJ
 dR
 eR
 fh
@@ -35911,13 +35926,13 @@ ac
 af
 Xd
 bS
-JA
+FC
 bl
 ho
 cH
 Ba
 KQ
-vX
+TY
 Rc
 ax
 ax
@@ -36168,7 +36183,7 @@ aG
 aN
 dC
 bQ
-fz
+dC
 bO
 cd
 cL
@@ -36425,10 +36440,10 @@ ac
 af
 Xd
 Xd
-vO
+yF
 aC
 hn
-kR
+Gj
 hn
 aC
 ax
@@ -36681,11 +36696,11 @@ an
 ac
 af
 aC
-Dc
-Dc
-Dc
+PN
+PN
+PN
 lu
-li
+OF
 hq
 aC
 hL
@@ -36942,7 +36957,7 @@ Mb
 as
 bU
 as
-lR
+Sg
 as
 hn
 ax
@@ -39024,7 +39039,7 @@ aZ
 aZ
 aZ
 cK
-dr
+uo
 du
 ei
 eX
@@ -39807,7 +39822,7 @@ bN
 bN
 lr
 mH
-bM
+vC
 ld
 fd
 jK
@@ -40321,7 +40336,7 @@ kd
 bN
 ls
 mJ
-fv
+PT
 le
 fd
 fy
@@ -40576,8 +40591,8 @@ iT
 cb
 ke
 bN
-oQ
-Fb
+rl
+Mg
 Jd
 iF
 iF
@@ -40824,8 +40839,8 @@ ax
 iy
 iC
 Wi
-dL
-Uj
+KS
+Im
 bN
 dm
 cb
@@ -42369,8 +42384,8 @@ yZ
 dM
 et
 fl
-gb
-ii
+wr
+HC
 iS
 dY
 kh
@@ -42378,7 +42393,7 @@ kL
 lz
 mH
 lU
-rt
+Sa
 IC
 iC
 iC
@@ -42626,11 +42641,11 @@ yZ
 dN
 eu
 fo
-gh
-es
-iU
-iT
-kb
+uy
+eu
+QV
+eu
+DR
 kG
 lA
 mJ
@@ -42883,11 +42898,11 @@ yZ
 dO
 ev
 ev
-gk
-io
+Uq
+TL
 iY
 jy
-kj
+Ss
 gW
 lT
 mM
@@ -43140,11 +43155,11 @@ yZ
 dS
 dS
 dS
-gl
-iE
+Kn
+iZ
 mZ
 iZ
-kk
+wK
 dS
 dS
 dS
@@ -43397,13 +43412,13 @@ iC
 dS
 ew
 mW
-fp
-iG
+Ur
+ra
 na
 eE
-mX
-eE
-eE
+ZX
+KD
+MM
 dS
 iC
 no

--- a/_maps/map_files/Tycoon/Tycoon1.dmm
+++ b/_maps/map_files/Tycoon/Tycoon1.dmm
@@ -91,7 +91,9 @@
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
 "ap" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -122,30 +124,6 @@
 	},
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
-"ar" = (
-/obj/structure/closet/secure_closet/fighter_pilot,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/head/hardhat,
-/obj/item/clothing/head/hardhat,
-/obj/item/radio/headset/heads/captain/alt{
-	desc = "A special headset that protects ears from some loud noises.";
-	keyslot = null;
-	name = "noise cancelling headphones"
-	},
-/obj/item/radio/headset/heads/captain/alt{
-	desc = "A special headset that protects ears from some loud noises.";
-	keyslot = null;
-	name = "noise cancelling headphones"
-	},
-/obj/item/clothing/ears/earmuffs,
-/obj/item/clothing/ears/earmuffs,
-/obj/item/encryptionkey/atc,
-/obj/item/encryptionkey/atc,
-/turf/open/floor/monotile/dark,
-/area/nsv/hanger/deck3{
-	name = "Air traffic control pod"
-	})
 "as" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -254,16 +232,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
-"aH" = (
-/obj/structure/closet/crate,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/rglass{
-	amount = 50
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/item/storage/toolbox/emergency,
-/turf/open/floor/monotile/dark,
-/area/teleporter)
 "aI" = (
 /turf/closed/wall/r_wall/ship,
 /area/space/nearstation)
@@ -334,7 +302,9 @@
 /obj/structure/toilet{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -978,14 +948,6 @@
 	},
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
-"cF" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/monotile/dark/airless,
-/area/nsv/hanger/deck3{
-	name = "Air traffic control pod"
-	})
 "cG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1003,8 +965,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8;
-	icon_state = "manifold-3"
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck3{
@@ -1036,8 +997,7 @@
 /area/crew_quarters/heads/captain)
 "cL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4;
-	icon_state = "pipe11-1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -1161,9 +1121,6 @@
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
 	})
-"cY" = (
-/turf/closed/wall/ship,
-/area/shuttle/turbolift/secondary)
 "cZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -1237,19 +1194,6 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/heads/captain)
-"dk" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_access_txt = "20"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck1/central)
 "dl" = (
 /obj/structure/railing{
 	dir = 8
@@ -1521,7 +1465,9 @@
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/hallway)
 "dM" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -1721,7 +1667,9 @@
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/hallway)
 "eh" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -1831,7 +1779,9 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /turf/open/floor/monotile,
 /area/nsv/briefingroom)
 "ex" = (
@@ -2734,7 +2684,9 @@
 /turf/open/floor/plasteel/grid/steel,
 /area/nsv/briefingroom)
 "gm" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/safe,
 /obj/item/bikehorn/golden,
 /obj/item/book/random,
@@ -2915,22 +2867,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/briefingroom)
-"gD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/monotile/dark,
-/area/hallway/primary/aft)
 "gE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -2946,7 +2882,9 @@
 	pixel_y = -24
 	},
 /obj/machinery/recharge_station,
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -3020,26 +2958,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/monotile/dark,
 /area/nsv/briefingroom)
-"gM" = (
-/obj/machinery/door/airlock/glass_large/ship{
-	bound_height = 64;
-	bound_width = 32;
-	dir = 4;
-	name = "Secure Systems";
-	pixel_x = -32
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/monotile/dark,
-/area/hallway/primary/aft)
 "gN" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -3202,7 +3120,9 @@
 	name = "Executive officer's Office"
 	})
 "ha" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/machinery/photocopier,
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -3704,7 +3624,7 @@
 	dir = 4
 	},
 /obj/machinery/advanced_airlock_controller{
-	pixel_y = -26
+	pixel_y = 24
 	},
 /turf/open/floor/plasteel/grid/steel,
 /area/nsv/hanger/deck3{
@@ -3857,23 +3777,6 @@
 /obj/effect/landmark/start/librarian,
 /turf/open/floor/monotile/dark,
 /area/nsv/briefingroom)
-"iI" = (
-/obj/machinery/door/airlock/vault/ship{
-	name = "Vault";
-	req_access_txt = "53"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/monotile,
-/area/ai_monitored/nuke_storage)
 "iJ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4004,7 +3907,9 @@
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
 "iV" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -5774,7 +5679,9 @@
 /turf/open/floor/monotile,
 /area/storage/eva)
 "mj" = (
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -6090,17 +5997,6 @@
 /obj/structure/window/reinforced/spawner/north,
 /turf/open/floor/monotile,
 /area/storage/eva)
-"mV" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/open/floor/monotile/dark,
-/area/teleporter)
 "mW" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6554,6 +6450,12 @@
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
 	})
+"qX" = (
+/obj/structure/closet/secure_closet/atc,
+/turf/open/floor/monotile,
+/area/nsv/hanger/deck3{
+	name = "Air traffic control pod"
+	})
 "rb" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	req_one_access_txt = "13"
@@ -6579,8 +6481,7 @@
 	dir = 1
 	},
 /obj/machinery/advanced_airlock_controller{
-	pixel_x = -26;
-	pixel_y = 2
+	pixel_y = 24
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/hallway)
@@ -6603,6 +6504,20 @@
 /obj/item/fighter_component/engine,
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
+"sT" = (
+/obj/machinery/door/airlock/vault/ship{
+	name = "Vault";
+	req_access_txt = "53"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/monotile,
+/area/ai_monitored/nuke_storage)
 "tx" = (
 /obj/structure/hull_plate/end{
 	dir = 1
@@ -6610,7 +6525,7 @@
 /obj/machinery/camera/autoname{
 	dir = 1;
 	name = "AWACS Tarmac";
-	network = list("ss13", "hangar")
+	network = list("ss13","hangar")
 	},
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
@@ -6631,7 +6546,7 @@
 /obj/machinery/camera/autoname{
 	dir = 1;
 	name = "Gold Magcats";
-	network = list("ss13", "hangar")
+	network = list("ss13","hangar")
 	},
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
@@ -6658,8 +6573,7 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "vX" = (
 /obj/machinery/advanced_airlock_controller{
-	pixel_x = 26;
-	pixel_y = 2
+	pixel_y = 24
 	},
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -6685,6 +6599,18 @@
 /obj/effect/turf_decal/ship/delivery/yellow,
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
+"xy" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/item/storage/toolbox/emergency,
+/turf/open/floor/monotile/dark,
+/area/teleporter)
 "yn" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_x = -32;
@@ -6693,7 +6619,9 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat)
 "yG" = (
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -6725,15 +6653,10 @@
 /obj/machinery/camera/autoname{
 	dir = 1;
 	name = "White Magcats";
-	network = list("ss13", "hangar")
+	network = list("ss13","hangar")
 	},
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
-"Aw" = (
-/turf/closed/wall/ship,
-/area/nsv/hanger/deck3{
-	name = "Air traffic control pod"
-	})
 "AF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -6779,37 +6702,25 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat)
-"CJ" = (
-/obj/item/encryptionkey/atc,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/head/hardhat,
-/obj/item/clothing/head/hardhat,
-/obj/item/radio/headset/heads/captain/alt{
-	desc = "A special headset that protects ears from some loud noises.";
-	keyslot = null;
-	name = "noise cancelling headphones"
-	},
-/obj/item/radio/headset/heads/captain/alt{
-	desc = "A special headset that protects ears from some loud noises.";
-	keyslot = null;
-	name = "noise cancelling headphones"
-	},
-/obj/item/clothing/ears/earmuffs,
-/obj/item/clothing/ears/earmuffs,
-/obj/structure/closet/secure_closet/atc,
-/obj/item/encryptionkey/atc,
-/turf/open/floor/monotile,
-/area/nsv/hanger/deck3{
-	name = "Air traffic control pod"
-	})
-"Da" = (
-/obj/machinery/camera/autoname{
-	name = "Fighter Tarmac";
-	network = list("ss13", "hangar")
+"CH" = (
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
+"Da" = (
+/obj/machinery/camera/autoname{
+	name = "Fighter Tarmac";
+	network = list("ss13","hangar")
+	},
+/turf/open/floor/monotile/dark/airless,
+/area/space/nearstation)
+"Dc" = (
+/obj/structure/closet/secure_closet/fighter_pilot,
+/turf/open/floor/monotile/dark,
+/area/nsv/hanger/deck3{
+	name = "Air traffic control pod"
+	})
 "Dk" = (
 /obj/machinery/light{
 	dir = 8
@@ -6835,7 +6746,7 @@
 "EI" = (
 /obj/machinery/camera/autoname{
 	name = "Fighter Tarmac #3";
-	network = list("ss13", "hangar")
+	network = list("ss13","hangar")
 	},
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
@@ -6862,7 +6773,7 @@
 "Fz" = (
 /obj/machinery/camera/autoname{
 	name = "Gold Magcats";
-	network = list("ss13", "hangar")
+	network = list("ss13","hangar")
 	},
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
@@ -6875,6 +6786,32 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/teleporter)
+"FU" = (
+/obj/structure/closet/crate,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/rglass{
+	amount = 50
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/monotile/dark,
+/area/teleporter)
+"Gg" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
+	name = "Command Hallway"
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/primary/aft)
 "Gv" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
 /turf/open/floor/plating,
@@ -7000,6 +6937,23 @@
 /obj/effect/turf_decal/ship/delivery,
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
+"Ll" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_access_txt = "20"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/poddoor/preopen{
+	id = "captainshutters";
+	name = "Captain blast doors"
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck1/central)
 "Lw" = (
 /obj/item/fighter_component/avionics,
 /obj/item/fighter_component/avionics,
@@ -7047,6 +7001,26 @@
 /obj/machinery/light/floor,
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
+"NS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
+	name = "Command Hallway"
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/primary/aft)
 "Pa" = (
 /obj/structure/grille,
 /turf/open/floor/monotile/dark,
@@ -7070,7 +7044,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -7217,7 +7193,7 @@
 "UH" = (
 /obj/machinery/camera/autoname{
 	name = "Fighter Tarmac #2";
-	network = list("ss13", "hangar")
+	network = list("ss13","hangar")
 	},
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
@@ -34393,7 +34369,7 @@ ac
 af
 bY
 cj
-cF
+CH
 db
 do
 ax
@@ -34680,7 +34656,7 @@ bm
 bv
 yP
 bE
-aH
+FU
 mt
 WF
 bE
@@ -35200,7 +35176,7 @@ Rm
 go
 gq
 gr
-iI
+sT
 kv
 kT
 ex
@@ -35427,7 +35403,7 @@ cc
 cm
 cm
 cm
-cY
+cc
 Mt
 ax
 hX
@@ -35684,7 +35660,7 @@ cc
 cp
 cN
 aC
-Aw
+aC
 aC
 ax
 ax
@@ -35708,7 +35684,7 @@ kV
 kY
 bJ
 bE
-mV
+xy
 Hb
 zk
 bE
@@ -36226,8 +36202,8 @@ bE
 bE
 bE
 bE
-gD
-gM
+NS
+Gg
 hg
 iV
 je
@@ -36705,9 +36681,9 @@ an
 ac
 af
 aC
-ar
-ar
-ar
+Dc
+Dc
+Dc
 lu
 li
 hq
@@ -36735,7 +36711,7 @@ bg
 kW
 cZ
 dj
-dk
+Ll
 dH
 Hr
 ed
@@ -43906,7 +43882,7 @@ ax
 ij
 hn
 hB
-CJ
+qX
 lj
 hH
 hn
@@ -44934,7 +44910,7 @@ ax
 ij
 hn
 hB
-CJ
+qX
 lj
 hH
 hn

--- a/_maps/map_files/Tycoon/Tycoon2.dmm
+++ b/_maps/map_files/Tycoon/Tycoon2.dmm
@@ -10631,13 +10631,6 @@
 	},
 /turf/open/floor/monotile,
 /area/security/prison)
-"aEp" = (
-/obj/machinery/door/poddoor/shutters/ship{
-	id = "firingsquad";
-	name = "security shutters"
-	},
-/turf/open/floor/monotile/dark,
-/area/security/prison)
 "aEq" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -37642,16 +37635,6 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/monotile/dark,
 /area/security/brig)
-"bHR" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/techmaint,
-/area/quartermaster/warehouse)
 "bHU" = (
 /obj/machinery/light{
 	dir = 1
@@ -47917,14 +47900,6 @@
 /obj/machinery/newscaster,
 /turf/closed/wall/ship,
 /area/medical/genetics)
-"pTD" = (
-/obj/machinery/door/airlock/ship/security/glass{
-	dir = 4;
-	name = "Security Equipment";
-	req_one_access_txt = "2"
-	},
-/turf/open/floor/monotile/dark,
-/area/security/brig)
 "pVi" = (
 /obj/machinery/airalarm{
 	pixel_y = 26
@@ -50338,6 +50313,26 @@
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/monotile/dark,
 /area/engine/atmospherics_engine)
+"uKa" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/ore_silo,
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced/spawner/north,
+/obj/machinery/door/window/eastleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Ore Silo";
+	req_access_txt = "41"
+	},
+/turf/open/floor/plasteel/techmaint,
+/area/quartermaster/warehouse)
 "uKm" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	dir = 4;
@@ -51883,6 +51878,17 @@
 	pixel_x = -28
 	},
 /turf/open/floor/plasteel/ship,
+/area/security/prison)
+"xQu" = (
+/obj/machinery/door/poddoor/shutters/ship{
+	id = "firingsquad";
+	name = "security shutters"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/monotile/dark,
 /area/security/prison)
 "xQF" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -63295,7 +63301,7 @@ aXR
 aXR
 aHW
 aHW
-aEp
+xQu
 aFo
 bnp
 aFA
@@ -63552,7 +63558,7 @@ aXR
 aHW
 aHW
 aHW
-aEp
+xQu
 aFo
 aFw
 aFB
@@ -63809,7 +63815,7 @@ aXS
 aHW
 aXX
 aHW
-aEp
+xQu
 aFo
 aFw
 aFA
@@ -72550,7 +72556,7 @@ aHv
 aHX
 aFP
 bdr
-pTD
+aFP
 bCU
 bKL
 bHQ
@@ -90811,8 +90817,8 @@ aaY
 bnv
 adr
 adx
+adr
 ajg
-adx
 ajm
 ajo
 ajs
@@ -91067,9 +91073,9 @@ ccW
 aaY
 adl
 adr
-adr
+ajg
 aWG
-adr
+aji
 adr
 ajp
 ajs
@@ -91325,8 +91331,8 @@ aaY
 adm
 adr
 adx
-aji
-ajg
+adr
+adx
 adr
 ajq
 ajw
@@ -91580,10 +91586,10 @@ aVU
 ccV
 aaY
 adn
-adr
 ady
-adr
-adr
+adp
+adp
+adp
 adr
 adp
 iuA
@@ -91839,7 +91845,7 @@ aaY
 adp
 ohw
 adp
-bHR
+uKa
 adp
 adp
 adp

--- a/_maps/map_files/Tycoon/Tycoon2.dmm
+++ b/_maps/map_files/Tycoon/Tycoon2.dmm
@@ -112,10 +112,11 @@
 /turf/open/floor/carpet/ship,
 /area/nsv/crew_quarters/heads/maa)
 "aar" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/turf_decal/tile/orange{
+	dir = 4
 	},
-/turf/open/floor/monotile,
+/obj/effect/turf_decal/tile/orange,
+/turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck2)
 "aas" = (
 /obj/machinery/suit_storage_unit/pilot,
@@ -492,10 +493,13 @@
 /turf/closed/wall/ship,
 /area/crew_quarters/heads/hor)
 "abC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/effect/turf_decal/tile/orange{
+	dir = 1
 	},
-/turf/open/floor/monotile,
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck2)
 "abD" = (
 /obj/machinery/airalarm{
@@ -764,7 +768,6 @@
 /area/hallway/nsv/deck2/frame1/central)
 "aco" = (
 /obj/machinery/door/airlock/ship/security/glass{
-	dir = 4;
 	req_one_access_txt = "2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -971,13 +974,13 @@
 /turf/open/floor/carpet/ship,
 /area/chapel/office)
 "acQ" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 26
+	},
+/obj/effect/turf_decal/tile/orange,
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
@@ -1031,6 +1034,12 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
+	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
 	},
 /turf/open/floor/monotile,
 /area/nsv/weapons/fore)
@@ -1316,7 +1325,6 @@
 /area/hallway/nsv/deck2/frame1/central)
 "adH" = (
 /obj/machinery/computer/lore_terminal,
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck2)
 "adI" = (
@@ -1346,6 +1354,10 @@
 	})
 "adL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/tile/orange{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/orange,
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck2)
 "adM" = (
@@ -1820,11 +1832,6 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
 "aeQ" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
-	name = "Virology";
-	req_one_access_txt = "39"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -1839,6 +1846,10 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Virology";
+	req_one_access_txt = "39"
 	},
 /turf/open/floor/monotile/light,
 /area/medical/virology)
@@ -2012,7 +2023,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "afk" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Engineering lobby"
 	},
 /obj/structure/disposalpipe/segment{
@@ -2398,6 +2408,12 @@
 /area/security/brig)
 "agg" = (
 /obj/machinery/vending/wardrobe/muni_wardrobe,
+/obj/effect/turf_decal/tile/orange{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck2)
 "agh" = (
@@ -2425,6 +2441,15 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck2)
@@ -2543,7 +2568,6 @@
 /area/medical/virology)
 "agA" = (
 /obj/machinery/door/airlock/ship/public{
-	dir = 4;
 	name = "Bunk 1-A"
 	},
 /obj/structure/cable{
@@ -2573,6 +2597,9 @@
 	dir = 5
 	},
 /obj/machinery/computer/deckgun,
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/nsv/weapons/fore)
 "agD" = (
@@ -2789,7 +2816,6 @@
 /area/medical/genetics)
 "ahd" = (
 /obj/machinery/door/airlock/ship/maintenance{
-	dir = 4;
 	name = "Hangar rescue"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -3054,7 +3080,6 @@
 /area/medical/medbay/central)
 "ahK" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Patient Room A"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -3170,7 +3195,6 @@
 /area/chapel/main)
 "ahY" = (
 /obj/machinery/door/airlock/ship/maintenance{
-	dir = 4;
 	name = "Crematorium";
 	req_one_access_txt = "22;27"
 	},
@@ -3224,7 +3248,6 @@
 /area/medical/morgue)
 "aid" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Morgue"
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -3360,6 +3383,12 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/tile/orange{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
+	},
 /turf/open/floor/monotile,
 /area/nsv/weapons/fore)
 "aiv" = (
@@ -3410,7 +3439,6 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/ship/maintenance{
-	dir = 4;
 	name = "Incinerator";
 	req_access_txt = "24"
 	},
@@ -4311,7 +4339,6 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Cloning Lab";
 	req_access_txt = "5; 68"
 	},
@@ -4349,7 +4376,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Cryogenics Freezer";
 	req_one_access_txt = "5"
 	},
@@ -4582,7 +4608,6 @@
 /area/medical/medbay/central)
 "alr" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Medbay Lobby";
 	req_one_access_txt = "5"
 	},
@@ -4673,11 +4698,6 @@
 /turf/open/floor/monotile/light,
 /area/medical/virology)
 "alA" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
-	name = "Virology";
-	req_one_access_txt = "39"
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
@@ -4686,6 +4706,10 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Virology";
+	req_one_access_txt = "39"
 	},
 /turf/open/floor/monotile/light,
 /area/medical/virology)
@@ -4756,12 +4780,12 @@
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/heads/cmo)
 "alI" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/camera/autoname,
 /obj/machinery/computer/ship/viewscreen,
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/orange,
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
 "alJ" = (
@@ -4914,7 +4938,6 @@
 /area/science/nanite)
 "ama" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Medbay Lobby";
 	req_one_access_txt = "5"
 	},
@@ -5153,7 +5176,6 @@
 /area/medical/surgery)
 "amO" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Surgery";
 	req_one_access_txt = "5"
 	},
@@ -5566,7 +5588,6 @@
 /area/crew_quarters/heads/chief)
 "anV" = (
 /obj/machinery/door/airlock/ship/command{
-	dir = 4;
 	name = "Chief Engineer";
 	req_one_access_txt = "56"
 	},
@@ -6027,7 +6048,6 @@
 /area/maintenance/department/engine)
 "apa" = (
 /obj/machinery/door/airlock/ship/maintenance{
-	dir = 4;
 	name = "Virology maintenance"
 	},
 /obj/structure/cable{
@@ -7132,7 +7152,6 @@
 /area/engine/engineering)
 "asp" = (
 /obj/machinery/door/airlock/ship/engineering/glass{
-	dir = 4;
 	name = "Reactor control Room";
 	req_one_access_txt = "10; 24"
 	},
@@ -7724,7 +7743,6 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Library"
 	},
 /turf/open/floor/carpet/ship,
@@ -8054,7 +8072,6 @@
 /area/crew_quarters/dorms)
 "avg" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Crew Lounge"
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -8150,7 +8167,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/highsecurity/ship{
-	dir = 4;
 	name = "Naval Artillery";
 	req_one_access_txt = "69"
 	},
@@ -8340,6 +8356,10 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/orange,
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck2)
 "axi" = (
@@ -8468,12 +8488,9 @@
 	dir = 5
 	},
 /obj/structure/closet/crate/solarpanel_small,
-/obj/item/stack/sheet/durasteel/fifty,
-/obj/item/stack/sheet/duranium/fifty,
 /obj/machinery/airalarm{
 	pixel_y = 26
 	},
-/obj/item/stack/sheet/nanocarbon_glass/fifty,
 /obj/item/stack/cable_coil,
 /turf/open/floor/plasteel/ship,
 /area/engine/engineering)
@@ -8531,10 +8548,6 @@
 	pixel_y = -2
 	},
 /obj/machinery/camera/autoname,
-/obj/item/radio/intercom{
-	name = "intra ship intercom";
-	pixel_y = 26
-	},
 /turf/open/floor/plasteel/ship,
 /area/engine/engineering)
 "ayL" = (
@@ -8964,7 +8977,6 @@
 /area/maintenance/starboard/fore)
 "azY" = (
 /obj/machinery/door/airlock/ship/external/glass{
-	dir = 4;
 	req_one_access_txt = "24"
 	},
 /turf/open/floor/plating,
@@ -9118,9 +9130,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
-	dir = 4
-	},
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
@@ -9263,16 +9273,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
-/obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
-	name = "Virology Decontamination";
-	req_one_access_txt = "39"
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
+	},
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Virology Decontamination";
+	req_one_access_txt = "39"
 	},
 /turf/open/floor/monotile/dark,
 /area/medical/virology)
@@ -9565,17 +9574,15 @@
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
 "aBv" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/machinery/deck_turret/powder_gate,
+/obj/effect/turf_decal/tile/orange{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
+/obj/effect/turf_decal/tile/orange{
+	dir = 1
 	},
-/turf/open/floor/plasteel/ship,
-/area/engine/storage_shared)
+/turf/open/floor/plating,
+/area/nsv/weapons/fore)
 "aBw" = (
 /turf/open/floor/plasteel/ship,
 /area/engine/engineering)
@@ -9639,7 +9646,6 @@
 /area/tcommsat/server)
 "aBE" = (
 /obj/machinery/door/airlock/ship/engineering/glass{
-	dir = 4;
 	name = "Reactor core access";
 	req_one_access_txt = "10; 24"
 	},
@@ -9856,7 +9862,6 @@
 /area/medical/virology)
 "aCp" = (
 /obj/machinery/door/airlock/ship/hatch{
-	dir = 4;
 	name = "Network Administration";
 	req_one_access_txt = "61;65"
 	},
@@ -10455,7 +10460,6 @@
 /area/tcommsat/server)
 "aDX" = (
 /obj/machinery/door/airlock/ship/hatch{
-	dir = 4;
 	name = "Network Administration";
 	req_one_access_txt = "61;65"
 	},
@@ -10511,7 +10515,6 @@
 /area/tcommsat/computer)
 "aEb" = (
 /obj/machinery/door/airlock/ship/hatch{
-	dir = 4;
 	name = "Network Administration";
 	req_one_access_txt = "61;65"
 	},
@@ -10592,7 +10595,6 @@
 /area/ai_monitored/security/armory)
 "aEk" = (
 /obj/machinery/door/airlock/ship/security/glass{
-	dir = 4;
 	name = "Evidence lockup";
 	req_one_access_txt = "3"
 	},
@@ -11202,6 +11204,10 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/orange,
+/obj/effect/turf_decal/tile/orange{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/nsv/weapons/fore)
 "aFw" = (
@@ -11632,7 +11638,6 @@
 /area/gateway)
 "aGv" = (
 /obj/machinery/door/airlock/ship{
-	dir = 4;
 	name = "Gateway";
 	req_one_access_txt = "62"
 	},
@@ -11824,6 +11829,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/nsv/weapons/fore)
 "aGR" = (
@@ -11840,7 +11851,6 @@
 /area/security/execution/transfer)
 "aGS" = (
 /obj/machinery/door/airlock/ship/external/glass{
-	dir = 4;
 	req_one_access_txt = "2"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -11933,7 +11943,6 @@
 /area/security/detectives_office)
 "aHe" = (
 /obj/machinery/door/airlock/ship/security{
-	dir = 4;
 	name = "Head of Security";
 	req_one_access_txt = "58"
 	},
@@ -12803,7 +12812,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Gateway Chamber";
 	req_one_access_txt = "62"
 	},
@@ -12899,7 +12907,6 @@
 /area/maintenance/department/engine)
 "aJs" = (
 /obj/machinery/door/airlock/ship/maintenance{
-	dir = 4;
 	name = "Engineering wing maintenance";
 	req_one_access_txt = "10"
 	},
@@ -13075,7 +13082,6 @@
 /area/science/test_area)
 "aJN" = (
 /obj/machinery/door/airlock/ship/public{
-	dir = 4;
 	name = "Quiet Room"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -13162,7 +13168,6 @@
 /area/science/research)
 "aJW" = (
 /obj/machinery/door/airlock/ship{
-	dir = 4;
 	name = "Robotics Lab";
 	req_one_access_txt = "29"
 	},
@@ -13478,6 +13483,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/structure/lattice/catwalk/over/ship,
 /obj/machinery/deck_turret/powder_gate,
+/obj/effect/turf_decal/tile/orange{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/nsv/weapons/fore)
 "aKE" = (
@@ -14268,6 +14276,12 @@
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/heads/hor)
 "aMn" = (
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 1
+	},
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck2)
 "aMo" = (
@@ -14331,10 +14345,10 @@
 /turf/open/floor/plating,
 /area/engine/engineering/reactor_core)
 "aMv" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/orange{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/orange{
 	dir = 4
 	},
 /turf/open/floor/monotile,
@@ -14650,7 +14664,6 @@
 	})
 "aNd" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Engineering lobby"
 	},
 /obj/structure/disposalpipe/segment{
@@ -15647,7 +15660,6 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Aft Primary Hallway"
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -15719,7 +15731,6 @@
 /area/engine/break_room)
 "aPm" = (
 /obj/machinery/door/airlock/ship/command{
-	dir = 4;
 	name = "Decontamination Shower";
 	req_one_access_txt = "56"
 	},
@@ -16046,7 +16057,6 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/ship/external/glass{
-	dir = 4;
 	req_one_access_txt = "10"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -16056,7 +16066,6 @@
 /area/engine/engineering/hangar)
 "aQo" = (
 /obj/machinery/door/airlock/ship/external/glass{
-	dir = 4;
 	req_one_access_txt = "10"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -16089,7 +16098,6 @@
 /area/engine/engineering/hangar)
 "aQu" = (
 /obj/machinery/door/airlock/ship/engineering/glass{
-	dir = 4;
 	name = "Reactor control Room";
 	req_one_access_txt = "10; 24"
 	},
@@ -16189,7 +16197,6 @@
 /area/engine/engine_smes)
 "aQC" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Medical Storage";
 	req_one_access_txt = "5"
 	},
@@ -16215,7 +16222,6 @@
 /area/medical/medbay/central)
 "aQD" = (
 /obj/machinery/door/airlock/ship/command{
-	dir = 4;
 	name = "Gravity Generator";
 	req_one_access_txt = "56"
 	},
@@ -16238,7 +16244,6 @@
 /area/engine/gravity_generator)
 "aQE" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "FTL navigation";
 	req_access_txt = "10"
 	},
@@ -16549,7 +16554,6 @@
 /area/crew_quarters/dorms/nsv/dorms_1)
 "aRn" = (
 /obj/machinery/door/airlock/ship/public{
-	dir = 4;
 	id_tag = "erp1";
 	name = "Showers"
 	},
@@ -16630,7 +16634,6 @@
 /area/crew_quarters/dorms/nsv/dorms_2)
 "aRA" = (
 /obj/machinery/door/airlock/ship/public{
-	dir = 4;
 	id_tag = "erp2";
 	name = "Showers"
 	},
@@ -17272,6 +17275,9 @@
 	dir = 10
 	},
 /obj/machinery/deck_turret/powder_gate,
+/obj/effect/turf_decal/tile/orange{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/nsv/weapons/fore)
 "aTb" = (
@@ -17373,10 +17379,10 @@
 "aTm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/orange{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/orange,
 /turf/open/floor/monotile,
 /area/nsv/weapons/fore)
 "aTp" = (
@@ -17392,6 +17398,10 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/orange,
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck2)
 "aTr" = (
@@ -17652,7 +17662,6 @@
 /area/medical/morgue)
 "aUg" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Paramedic Station";
 	req_one_access_txt = "5"
 	},
@@ -18129,7 +18138,6 @@
 	})
 "aVh" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Morale Office"
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -18275,7 +18283,6 @@
 	})
 "aVx" = (
 /obj/machinery/door/airlock/ship/hatch{
-	dir = 4;
 	name = "Network Administration";
 	req_one_access_txt = "61;65"
 	},
@@ -19591,9 +19598,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
-	dir = 4
-	},
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "aYq" = (
@@ -19809,7 +19814,6 @@
 	})
 "aYU" = (
 /obj/machinery/door/airlock/ship/maintenance{
-	dir = 4;
 	name = "Virology maintenance"
 	},
 /obj/structure/cable{
@@ -20015,7 +20019,6 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Library"
 	},
 /turf/open/floor/carpet/ship,
@@ -20250,11 +20253,11 @@
 	id = "shellThree";
 	name = "Shell Rack 3"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/orange{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/nsv/weapons/fore)
@@ -20375,11 +20378,23 @@
 /turf/open/floor/plating,
 /area/nsv/weapons/fore)
 "bad" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/monotile,
-/area/nsv/hanger/deck2)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/ship/engineering/glass{
+	req_one_access_txt = "10;24"
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/engineering)
 "bae" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -20408,7 +20423,6 @@
 /area/nsv/weapons/fore)
 "bah" = (
 /obj/machinery/door/airlock/highsecurity/ship{
-	dir = 4;
 	name = "Missile Bay";
 	req_one_access_txt = "69"
 	},
@@ -20574,6 +20588,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/effect/turf_decal/tile/orange,
 /turf/open/floor/plating,
 /area/nsv/weapons/fore)
 "baw" = (
@@ -20673,7 +20688,6 @@
 /area/maintenance/department/medical)
 "baF" = (
 /obj/machinery/door/airlock/ship/maintenance{
-	dir = 4;
 	name = "Medbay maintenance";
 	req_one_access_txt = "5"
 	},
@@ -20791,9 +20805,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
-	dir = 4
-	},
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
@@ -20810,7 +20822,6 @@
 /area/medical/medbay/central)
 "baS" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Patient rooms"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -20899,7 +20910,6 @@
 /area/medical/morgue)
 "bbb" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Morgue"
 	},
 /obj/structure/cable{
@@ -21431,14 +21441,14 @@
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
 "bcb" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/junction,
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/orange,
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
 "bcc" = (
@@ -21454,10 +21464,11 @@
 /area/hydroponics)
 "bcd" = (
 /obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/orange{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/orange,
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
 "bce" = (
@@ -21883,12 +21894,6 @@
 /turf/open/floor/monotile,
 /area/medical/medbay/lobby)
 "bcV" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -21896,6 +21901,12 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/tile/orange{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 1
+	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
 "bcW" = (
@@ -21910,12 +21921,6 @@
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "bcX" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
@@ -21926,6 +21931,12 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/tile/orange{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 1
+	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
 "bcY" = (
@@ -21990,14 +22001,14 @@
 /turf/open/floor/monotile,
 /area/hallway/secondary/exit)
 "bdc" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
@@ -22519,7 +22530,6 @@
 /area/science/robotics)
 "bdW" = (
 /obj/machinery/door/airlock/ship{
-	dir = 4;
 	name = "Robotics Lab";
 	req_one_access_txt = "29"
 	},
@@ -22628,7 +22638,6 @@
 /area/security/warden)
 "beg" = (
 /obj/machinery/door/airlock/ship/security/glass{
-	dir = 4;
 	name = "Forensics";
 	req_one_access_txt = "4"
 	},
@@ -23202,6 +23211,12 @@
 	},
 /obj/machinery/camera/autoname,
 /obj/structure/ladder,
+/obj/effect/turf_decal/tile/orange{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck2)
 "bfk" = (
@@ -23288,22 +23303,22 @@
 	id = "shellTwo";
 	name = "Shell Rack 2"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/orange{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/nsv/weapons/fore)
 "bft" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/airalarm{
 	pixel_y = 26
 	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/orange,
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
 "bfu" = (
@@ -23409,7 +23424,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Morale Office"
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -23641,7 +23655,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bgc" = (
 /obj/machinery/door/airlock/ship/external{
-	dir = 4;
 	name = "Mining Shuttle Airlock";
 	req_one_access_txt = "31;48"
 	},
@@ -23743,15 +23756,14 @@
 	external_pressure_bound = 120;
 	name = "server vent"
 	},
-/obj/structure/sign/warning/securearea{
-	desc = "A warning sign which reads 'SERVER ROOM'.";
-	name = "SERVER ROOM";
-	pixel_z = 26
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
 /obj/machinery/camera/autoname,
+/obj/structure/sign/warning/securearea{
+	name = "SERVER ROOM";
+	pixel_y = 26
+	},
 /turf/open/floor/circuit/telecomms/server,
 /area/science/server)
 "bgn" = (
@@ -23871,7 +23883,6 @@
 /area/hallway/nsv/deck2/frame1/port)
 "bgz" = (
 /obj/machinery/door/airlock/highsecurity/ship{
-	dir = 4;
 	name = "Missile Bay";
 	req_one_access_txt = "69"
 	},
@@ -24010,6 +24021,10 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/tile/orange{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/orange,
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck2)
 "bgV" = (
@@ -24060,9 +24075,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
@@ -24075,6 +24087,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "bhb" = (
@@ -24533,7 +24546,6 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/ship/security/glass{
-	dir = 4;
 	name = "Detective's Office";
 	req_one_access_txt = "4"
 	},
@@ -24887,15 +24899,15 @@
 	name = "CIC"
 	})
 "biK" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/button/door{
 	id = "gaussgang";
 	name = "public gauss access";
 	pixel_y = 26;
 	req_one_access_txt = "69"
+	},
+/obj/effect/turf_decal/tile/orange,
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
@@ -24932,13 +24944,13 @@
 	name = "CIC"
 	})
 "biO" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/status_display/evac{
 	pixel_y = 26
 	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/orange,
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
 "biP" = (
@@ -25203,7 +25215,6 @@
 /area/crew_quarters/kitchen)
 "bjp" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Service Break Room";
 	req_one_access_txt = "28;35;25;46;26"
 	},
@@ -25252,10 +25263,6 @@
 /turf/open/floor/plasteel/techmaint,
 /area/medical/chemistry)
 "bjt" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/item/radio/intercom{
 	name = "intra ship intercom";
 	pixel_y = 26
@@ -25263,6 +25270,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/orange,
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
 "bju" = (
@@ -26244,7 +26255,6 @@
 /area/maintenance/starboard/fore)
 "blr" = (
 /obj/machinery/door/airlock/ship/maintenance{
-	dir = 4;
 	name = "Atmospherics maintenance";
 	req_one_access_txt = "24"
 	},
@@ -26623,7 +26633,6 @@
 /area/hallway/nsv/deck2/frame1/port)
 "bmn" = (
 /obj/machinery/door/airlock/ship/security/glass{
-	dir = 4;
 	req_one_access_txt = "2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -27559,6 +27568,12 @@
 	dir = 8;
 	icon_state = "camera"
 	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck2)
 "bok" = (
@@ -27722,7 +27737,6 @@
 /area/quartermaster/storage)
 "boD" = (
 /obj/machinery/door/airlock/ship/station/mining{
-	dir = 4;
 	name = "Warehouse";
 	req_one_access_txt = "31;48"
 	},
@@ -28049,7 +28063,6 @@
 /area/janitor)
 "bpl" = (
 /obj/machinery/door/airlock/ship/public{
-	dir = 4;
 	name = "Janitorial Storage";
 	req_one_access_txt = "26"
 	},
@@ -28176,6 +28189,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "bpy" = (
@@ -28390,7 +28404,6 @@
 /area/quartermaster/storage)
 "bpQ" = (
 /obj/machinery/door/airlock/ship/station/mining{
-	dir = 4;
 	name = "Quartermaster's Office";
 	req_one_access_txt = "41"
 	},
@@ -28412,19 +28425,9 @@
 /turf/open/floor/plasteel/ship,
 /area/quartermaster/qm)
 "bpR" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/rack,
-/obj/item/ship_weapon/ammunition/gauss{
-	pixel_y = -4
-	},
-/obj/item/ship_weapon/ammunition/gauss,
-/obj/item/ship_weapon/ammunition/gauss{
-	pixel_y = 6
-	},
-/obj/machinery/light,
-/turf/open/floor/monotile,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/plating,
 /area/nsv/weapons/gauss)
 "bpS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -28626,7 +28629,6 @@
 /area/quartermaster/qm)
 "bqj" = (
 /obj/machinery/door/airlock/ship{
-	dir = 4;
 	name = "Experimental munitions";
 	req_one_access_txt = "8"
 	},
@@ -29137,6 +29139,7 @@
 	},
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/three,
+/obj/effect/spawner/lootdrop/glowstick,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "brj" = (
@@ -29159,7 +29162,6 @@
 /area/maintenance/disposal)
 "brl" = (
 /obj/machinery/door/airlock/ship/maintenance{
-	dir = 4;
 	name = "Disposals"
 	},
 /obj/structure/cable{
@@ -29394,7 +29396,6 @@
 /area/maintenance/starboard)
 "brK" = (
 /obj/machinery/door/airlock/ship/maintenance{
-	dir = 4;
 	name = "Crematorium";
 	req_one_access_txt = "22;27"
 	},
@@ -29664,7 +29665,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/ship/maintenance{
-	dir = 4;
 	name = "Trash compactor"
 	},
 /obj/structure/disposalpipe/segment{
@@ -29723,7 +29723,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/ship/maintenance{
-	dir = 4;
 	name = "Trash compactor"
 	},
 /obj/structure/disposalpipe/segment{
@@ -30152,6 +30151,7 @@
 /obj/structure/rack,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/mineral/titanium/fifty,
+/obj/item/stack/sheet/duranium/twenty,
 /turf/open/floor/monotile,
 /area/engine/engineering)
 "btq" = (
@@ -30300,7 +30300,6 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Aft Primary Hallway"
 	},
 /obj/structure/disposalpipe/segment{
@@ -30528,7 +30527,6 @@
 /area/crew_quarters/dorms/nsv/dorms_2)
 "btW" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Crew Lounge"
 	},
 /obj/structure/disposalpipe/segment{
@@ -30962,7 +30960,6 @@
 /area/crew_quarters/kitchen/coldroom)
 "buI" = (
 /obj/machinery/door/airlock/ship/security/glass{
-	dir = 4;
 	name = "Long Term Confinement";
 	req_one_access_txt = "2"
 	},
@@ -31047,7 +31044,6 @@
 /area/security/brig)
 "buN" = (
 /obj/machinery/door/airlock/ship/security/glass{
-	dir = 4;
 	req_one_access_txt = "2"
 	},
 /obj/structure/cable{
@@ -31072,7 +31068,6 @@
 /area/security/brig)
 "buO" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Engineering section"
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -31169,7 +31164,6 @@
 /area/hallway/nsv/deck2/frame1/central)
 "buW" = (
 /obj/machinery/door/airlock/highsecurity/ship{
-	dir = 4;
 	name = "CIC";
 	req_one_access_txt = "19"
 	},
@@ -31232,7 +31226,6 @@
 /area/nsv/hanger/deck2)
 "bvc" = (
 /obj/machinery/door/airlock/highsecurity/ship{
-	dir = 4;
 	name = "CIC";
 	req_one_access_txt = "19"
 	},
@@ -31386,7 +31379,6 @@
 /area/medical/medbay/lobby)
 "bvq" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Medical Storage";
 	req_one_access_txt = "5"
 	},
@@ -31558,7 +31550,6 @@
 /area/medical/virology)
 "bvJ" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Surgery";
 	req_one_access_txt = "5"
 	},
@@ -32795,7 +32786,6 @@
 /area/chapel/main)
 "byj" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Engineering section"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -33007,7 +32997,6 @@
 /area/security/brig)
 "byJ" = (
 /obj/machinery/door/airlock/ship/security/glass{
-	dir = 4;
 	name = "Security Equipment";
 	req_one_access_txt = "1;4"
 	},
@@ -33498,7 +33487,6 @@
 /area/crew_quarters/dorms)
 "bzE" = (
 /obj/machinery/door/airlock/ship/external/glass{
-	dir = 4;
 	req_one_access_txt = "10"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -33585,7 +33573,6 @@
 	})
 "bzO" = (
 /obj/machinery/door/airlock/highsecurity/ship{
-	dir = 8;
 	name = "CIC";
 	req_one_access_txt = "19"
 	},
@@ -33607,7 +33594,6 @@
 	})
 "bzP" = (
 /obj/machinery/door/airlock/highsecurity/ship{
-	dir = 4;
 	name = "CIC";
 	req_one_access_txt = "19"
 	},
@@ -33782,7 +33768,6 @@
 /area/engine/engineering)
 "bAs" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Engineering Hangar Bay"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -33984,7 +33969,6 @@
 /area/crew_quarters/dorms)
 "bAM" = (
 /obj/machinery/door/airlock/ship/public{
-	dir = 4;
 	name = "Bunk 1-B"
 	},
 /obj/structure/cable{
@@ -34124,9 +34108,6 @@
 /turf/open/floor/carpet/blue,
 /area/nsv/hanger/deck2)
 "bAY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/monotile,
 /area/nsv/hanger/deck2)
@@ -34186,9 +34167,13 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 9
+	dir = 1
 	},
-/turf/open/floor/monotile,
+/obj/effect/turf_decal/tile/orange{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/orange,
+/turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck2)
 "bBh" = (
 /obj/effect/turf_decal/stripes/line{
@@ -34264,12 +34249,17 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/deck_turret/powder_gate,
+/obj/effect/turf_decal/tile/orange{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/nsv/weapons/fore)
 "bBr" = (
 /obj/structure/lattice/catwalk/over/ship,
 /obj/machinery/door/airlock/highsecurity/ship{
-	dir = 4;
 	name = "Munitions Control Room";
 	req_one_access_txt = "69"
 	},
@@ -34334,9 +34324,6 @@
 /turf/open/floor/monotile,
 /area/nsv/hanger/deck2)
 "bBx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -34356,11 +34343,16 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck2)
 "bBz" = (
 /obj/machinery/door/airlock/ship{
-	dir = 4;
 	name = "Munitions Briefing Room";
 	req_access_txt = "69"
 	},
@@ -34390,6 +34382,10 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/tile/orange{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/orange,
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck2)
 "bBB" = (
@@ -34425,6 +34421,12 @@
 /area/shuttle/turbolift/secondary)
 "bBF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/orange{
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
@@ -34628,13 +34630,13 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
 "bCb" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/orange,
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
+	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
 "bCc" = (
@@ -35276,7 +35278,6 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/ship/station/mining{
-	dir = 4;
 	name = "Warehouse";
 	req_one_access_txt = "31;48"
 	},
@@ -35520,6 +35521,12 @@
 /area/nsv/weapons/fore)
 "bDK" = (
 /obj/machinery/camera/autoname,
+/obj/effect/turf_decal/tile/orange{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck2)
 "bDN" = (
@@ -35578,6 +35585,12 @@
 "bDS" = (
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck2)
@@ -36327,7 +36340,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/ship/security/glass{
-	dir = 4;
 	req_one_access_txt = "2"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -36471,7 +36483,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/ship/security/glass{
-	dir = 4;
 	req_one_access_txt = "2"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -36724,6 +36735,7 @@
 	pixel_x = -22
 	},
 /obj/structure/reagent_dispensers/fueltank,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "bFX" = (
@@ -37419,7 +37431,6 @@
 /area/hallway/nsv/deck2/frame1/central)
 "bHt" = (
 /obj/machinery/door/airlock/ship{
-	dir = 4;
 	name = "Deck 1 access"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -37731,7 +37742,6 @@
 /area/medical/virology)
 "bIe" = (
 /obj/machinery/door/airlock/ship/external/glass{
-	dir = 4;
 	name = "Auxiliary Shuttle Dock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -37747,7 +37757,6 @@
 /area/hallway/secondary/exit)
 "bIf" = (
 /obj/machinery/door/airlock/ship/external/glass{
-	dir = 4;
 	name = "Auxiliary Shuttle Dock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -38684,6 +38693,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 4
+	},
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/storage{
 	name = "Munitions Control Room"
@@ -38692,11 +38707,23 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 4
+	},
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/storage{
 	name = "Munitions Control Room"
 	})
 "bKH" = (
+/obj/effect/turf_decal/tile/orange{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 4
+	},
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/storage{
 	name = "Munitions Control Room"
@@ -39191,28 +39218,24 @@
 	name = "CIC"
 	})
 "bLK" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/orange{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/orange{
 	dir = 4
 	},
-/obj/machinery/light,
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
 "bLL" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/effect/turf_decal/tile/orange{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/effect/turf_decal/tile/orange,
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
 "bLM" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/extinguisher_cabinet{
@@ -39221,6 +39244,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/orange,
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
 "bLN" = (
@@ -39436,6 +39463,12 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/nsv/weapons/fore)
 "bPM" = (
@@ -39536,13 +39569,13 @@
 /turf/closed/wall/r_wall/ship,
 /area/nsv/weapons/gauss)
 "bXG" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/structure/sign/ship/plaque/light{
 	pixel_y = 26
 	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/orange,
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
 "bXH" = (
@@ -39710,10 +39743,10 @@
 /turf/open/floor/monotile,
 /area/nsv/weapons/gauss)
 "bYI" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/orange{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/orange,
 /turf/open/floor/monotile,
 /area/nsv/weapons/fore)
 "bYK" = (
@@ -39766,6 +39799,7 @@
 /obj/item/ship_weapon/ammunition/gauss{
 	pixel_y = 6
 	},
+/obj/machinery/light,
 /turf/open/floor/monotile,
 /area/nsv/weapons/gauss)
 "bYU" = (
@@ -39782,6 +39816,12 @@
 "bYW" = (
 /obj/machinery/computer/ship/munitions_computer/west,
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/orange{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 1
+	},
 /turf/open/floor/monotile,
 /area/nsv/weapons/fore)
 "bYZ" = (
@@ -40309,6 +40349,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 1
+	},
 /turf/open/floor/monotile,
 /area/nsv/weapons/fore)
 "cfo" = (
@@ -40316,16 +40359,22 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/tile/orange{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
+	},
 /turf/open/floor/monotile,
 /area/nsv/weapons/fore)
 "cfq" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/structure/sign/nanotrasen{
 	pixel_y = 26
 	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/orange,
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
 "cfx" = (
@@ -40390,13 +40439,12 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/ship/maintenance{
-	name = "Arrivals maintenance"
+	name = "Virology maintenance"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "cjB" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Arrivals"
 	},
 /obj/structure/cable{
@@ -40551,8 +40599,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/ship/maintenance{
-	dir = 4;
-	name = "Trash compactor"
+	name = "Virology maintenance"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
@@ -40589,7 +40636,6 @@
 /area/engine/engineering/reactor_core)
 "csW" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Chapel"
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -40617,13 +40663,13 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "cve" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/orange,
 /turf/open/floor/monotile,
 /area/nsv/weapons/fore)
 "cwi" = (
@@ -40871,7 +40917,6 @@
 /area/maintenance/starboard)
 "cUM" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Chemistry";
 	req_one_access_txt = "33"
 	},
@@ -40905,7 +40950,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess{
-	dir = 4;
 	name = "Munitions Projects"
 	},
 /turf/open/floor/monotile/dark,
@@ -41002,7 +41046,7 @@
 	id = "shellOne";
 	name = "Shell Rack 1"
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/orange{
 	dir = 8
 	},
 /turf/open/floor/monotile,
@@ -41132,6 +41176,10 @@
 	},
 /turf/closed/wall/r_wall/ship,
 /area/engine/atmospherics_engine)
+"dxN" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/space)
 "dyj" = (
 /obj/structure/bookcase/manuals/medical,
 /obj/machinery/camera/autoname{
@@ -41268,7 +41316,6 @@
 /area/engine/engine_room)
 "dRf" = (
 /obj/machinery/door/airlock/highsecurity/ship{
-	dir = 4;
 	name = "Naval Artillery";
 	req_one_access_txt = "69"
 	},
@@ -41284,7 +41331,6 @@
 /area/nsv/weapons/fore)
 "dSD" = (
 /obj/machinery/door/airlock/ship/external/glass{
-	dir = 4;
 	req_one_access_txt = "2"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -41297,7 +41343,6 @@
 /area/security/execution/transfer)
 "dTk" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Crew Lounge"
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -41362,7 +41407,6 @@
 /area/engine/engineering)
 "dXv" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Patient Room B"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -41391,6 +41435,14 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"eba" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/orange,
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
+	},
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck2/frame1/central)
 "ecX" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -41460,11 +41512,11 @@
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
 "efA" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/orange{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/nsv/weapons/fore)
@@ -41480,7 +41532,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/ship/hatch{
-	dir = 4;
 	name = "Funeral Parlour"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -41852,7 +41903,6 @@
 /area/crew_quarters/fitness/recreation)
 "eEA" = (
 /obj/machinery/door/airlock/ship/external/glass{
-	dir = 4;
 	req_one_access_txt = "13"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -41866,6 +41916,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"eEX" = (
+/obj/structure/sign/poster/official/wtf_is_co2,
+/turf/closed/wall/r_wall/ship,
+/area/engine/atmos)
 "eFj" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -41985,7 +42039,6 @@
 /area/nsv/weapons/gauss)
 "eQZ" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Diplomatic Reception Area"
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -42082,6 +42135,10 @@
 "fbx" = (
 /turf/closed/wall/r_wall/ship,
 /area/shuttle/turbolift/shaft)
+"fcD" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "fcO" = (
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/monotile/light,
@@ -42119,7 +42176,6 @@
 /area/maintenance/starboard)
 "fjB" = (
 /obj/machinery/door/airlock/ship{
-	dir = 4;
 	name = "Exothermic Chamber";
 	req_one_access_txt = "8"
 	},
@@ -42189,7 +42245,6 @@
 /area/engine/engineering/reactor_core)
 "fpL" = (
 /obj/machinery/door/airlock/ship/station/mining{
-	dir = 4;
 	name = "Cargo Bay";
 	req_one_access_txt = "31; 48"
 	},
@@ -42216,6 +42271,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/orange,
 /turf/open/floor/monotile,
 /area/nsv/weapons/fore)
 "ful" = (
@@ -42269,7 +42328,6 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/ship/engineering/glass{
-	dir = 4;
 	name = "Engineering Equipment";
 	req_one_access_txt = "11;24"
 	},
@@ -42377,6 +42435,16 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/engine/atmos)
+"fPJ" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "fPU" = (
 /obj/structure/shuttle/engine/huge{
 	dir = 8
@@ -42519,7 +42587,6 @@
 /area/nsv/weapons/fore)
 "giC" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Crew Lounge"
 	},
 /obj/structure/disposalpipe/segment{
@@ -42659,9 +42726,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
-	dir = 4
-	},
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
@@ -42672,7 +42737,6 @@
 /area/maintenance/nsv/hangar)
 "guw" = (
 /obj/machinery/door/airlock/ship/external/glass{
-	dir = 4;
 	req_one_access_txt = "24"
 	},
 /turf/open/floor/plating/airless,
@@ -42845,7 +42909,6 @@
 /area/engine/engineering/hangar)
 "gJJ" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Examination Room"
 	},
 /obj/structure/cable{
@@ -42902,6 +42965,16 @@
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/wood,
 /area/library)
+"gNA" = (
+/obj/machinery/status_display/evac{
+	pixel_y = 26
+	},
+/obj/effect/turf_decal/tile/orange,
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
+	},
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck2/frame1/central)
 "gNY" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/computer/ship/viewscreen,
@@ -43036,7 +43109,6 @@
 /area/security/brig)
 "gZZ" = (
 /obj/machinery/door/airlock/highsecurity/ship{
-	dir = 4;
 	name = "Ordnance Production";
 	req_one_access_txt = "69"
 	},
@@ -43349,6 +43421,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/orange,
 /turf/open/floor/monotile,
 /area/nsv/weapons/fore)
 "hzd" = (
@@ -43358,6 +43434,10 @@
 "hzO" = (
 /obj/machinery/deck_turret/payload_gate,
 /obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/orange,
+/obj/effect/turf_decal/tile/orange{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -43616,7 +43696,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/ship/security/glass{
-	dir = 4;
 	name = "Security Equipment";
 	req_one_access_txt = "2"
 	},
@@ -43773,6 +43852,7 @@
 	dir = 9
 	},
 /obj/machinery/computer/deckgun,
+/obj/effect/turf_decal/tile/orange,
 /turf/open/floor/plating,
 /area/nsv/weapons/fore)
 "irj" = (
@@ -43783,7 +43863,6 @@
 	})
 "iry" = (
 /obj/machinery/door/airlock/ship/external/glass{
-	dir = 4;
 	req_one_access_txt = "10"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -43881,7 +43960,6 @@
 /area/nsv/hanger/deck2)
 "iDf" = (
 /obj/machinery/door/airlock/highsecurity/ship{
-	dir = 4;
 	name = "Gauss rounds";
 	req_one_access_txt = "69"
 	},
@@ -43909,6 +43987,11 @@
 	},
 /turf/open/floor/monotile/light,
 /area/medical/medbay/lobby)
+"iFe" = (
+/obj/structure/mopbucket,
+/obj/item/mop,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "iFf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43923,6 +44006,15 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
+"iFi" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel/techmaint,
+/area/quartermaster/warehouse)
 "iGz" = (
 /obj/effect/turf_decal/bot_red/left,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -43938,7 +44030,6 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/ship{
-	dir = 4;
 	name = "Hangar Bay";
 	req_access_txt = "69"
 	},
@@ -44049,7 +44140,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/ship/public{
-	dir = 4;
 	name = "Arrivals Emergency Storage"
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -44185,9 +44275,7 @@
 /turf/open/floor/plasteel/techmaint,
 /area/engine/engine_room)
 "jbU" = (
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
-	dir = 4
-	},
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -44306,7 +44394,6 @@
 	},
 /obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Mess Hall"
 	},
 /turf/open/floor/monotile,
@@ -44502,7 +44589,6 @@
 /area/engine/engine_room)
 "jHU" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Chemistry Access"
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -44583,6 +44669,13 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
+"jRa" = (
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/orange,
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck2/frame1/central)
 "jSc" = (
 /turf/open/floor/carpet/green,
 /area/engine/engineering/reactor_control)
@@ -44655,13 +44748,13 @@
 	name = "CIC"
 	})
 "jZc" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/camera/autoname,
 /obj/structure/sign/nanotrasen{
 	pixel_y = 26
+	},
+/obj/effect/turf_decal/tile/orange,
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
@@ -44669,6 +44762,9 @@
 /obj/machinery/deck_turret/powder_gate,
 /obj/structure/lattice/catwalk/over/ship,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/orange{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/nsv/weapons/fore)
 "jZR" = (
@@ -44729,7 +44825,6 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess{
-	dir = 4;
 	name = "Munitions Projects"
 	},
 /turf/open/floor/plating,
@@ -45106,7 +45201,6 @@
 	},
 /obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Mess Hall"
 	},
 /turf/open/floor/monotile,
@@ -45164,12 +45258,12 @@
 	},
 /area/tcommsat/server)
 "kEU" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/newscaster{
 	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/orange,
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
@@ -45384,6 +45478,15 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/engine/atmos)
+"kYm" = (
+/obj/effect/turf_decal/tile/orange{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 1
+	},
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck2/frame1/central)
 "kZu" = (
 /obj/machinery/portable_atmospherics/scrubber/huge,
 /obj/machinery/light{
@@ -45484,7 +45587,6 @@
 /area/maintenance/starboard)
 "lgi" = (
 /obj/machinery/door/airlock/ship/external/glass{
-	dir = 4;
 	req_one_access_txt = "10; 24"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -45605,18 +45707,24 @@
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
 "lvt" = (
-/obj/machinery/door/airlock/ship/engineering/glass{
-	dir = 4;
-	name = "Atmospherics Storage";
-	req_one_access_txt = "10; 24"
+/obj/machinery/firealarm{
+	pixel_y = 24
 	},
-/turf/open/floor/plasteel/tech/grid{
-	initial_gas_mix = "TEMP=2.7"
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
 	},
-/area/engine/atmos)
+/obj/effect/turf_decal/tile/orange,
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck2/frame1/central)
 "lwA" = (
 /obj/machinery/ship_weapon/vls,
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/orange{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 1
+	},
 /turf/open/floor/monotile,
 /area/nsv/weapons/fore)
 "lwJ" = (
@@ -45887,6 +45995,9 @@
 /obj/machinery/door/airlock/ship/engineering/glass{
 	req_one_access_txt = "10;24"
 	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
 "lVx" = (
@@ -45981,6 +46092,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
+	},
 /turf/open/floor/monotile,
 /area/nsv/weapons/fore)
 "meb" = (
@@ -46004,6 +46121,9 @@
 "meB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
+	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/nsv/weapons/fore)
@@ -46095,6 +46215,10 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible,
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
+"mrB" = (
+/obj/structure/sign/poster/official/science,
+/turf/closed/wall/ship,
+/area/science/robotics)
 "mrY" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	req_one_access_txt = "8;13"
@@ -46176,6 +46300,16 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/engine/atmos)
+"mzE" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/tile/orange,
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
+	},
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck2/frame1/central)
 "mzP" = (
 /obj/machinery/requests_console{
 	department = "Chapel";
@@ -46197,7 +46331,6 @@
 /area/crew_quarters/fitness/recreation)
 "mBj" = (
 /obj/machinery/door/airlock/ship/external/glass{
-	dir = 4;
 	req_one_access_txt = "10"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -46393,6 +46526,7 @@
 /area/engine/engineering/reactor_core)
 "mPw" = (
 /obj/structure/reagent_dispensers/watertank,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "mPU" = (
@@ -46534,9 +46668,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "neD" = (
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
-	dir = 4
-	},
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
@@ -46596,6 +46728,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/orange,
 /turf/open/floor/monotile,
 /area/nsv/weapons/fore)
 "npw" = (
@@ -46705,6 +46841,17 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/starboard)
+"nzE" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"nBM" = (
+/obj/structure/rack,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/glasses/cold,
+/obj/item/clothing/suit/toggle/labcoat,
+/turf/open/floor/plating,
+/area/space)
 "nBS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -47046,6 +47193,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
+	},
 /turf/open/floor/monotile,
 /area/nsv/weapons/fore)
 "ohf" = (
@@ -47079,7 +47229,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/ship/engineering/glass{
-	dir = 4;
 	name = "Turbine Hall Access";
 	req_one_access_txt = "10; 24"
 	},
@@ -47256,7 +47405,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/ship/maintenance{
-	name = "Arrivals maintenance"
+	name = "Virology maintenance"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
@@ -47326,6 +47475,14 @@
 /area/bridge{
 	name = "CIC"
 	})
+"oJa" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/orange,
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck2/frame1/central)
 "oMj" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -47481,10 +47638,20 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/machinery/shower,
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/item/stack/sheet/duranium/fifty,
+/obj/structure/table,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	name = "intra ship intercom";
+	pixel_y = 26
+	},
+/obj/item/stack/sheet/nanocarbon_glass/fifty,
+/obj/item/stack/sheet/durasteel/fifty,
 /turf/open/floor/plasteel/ship,
 /area/engine/engineering)
 "peN" = (
@@ -47777,6 +47944,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"pGe" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/machinery/iv_drip,
+/turf/open/floor/plating,
+/area/space)
 "pHv" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -47904,7 +48076,6 @@
 /obj/machinery/airalarm{
 	pixel_y = 26
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck2)
 "pVN" = (
@@ -48016,7 +48187,6 @@
 /area/maintenance/starboard/fore)
 "qlU" = (
 /obj/machinery/door/airlock/ship/maintenance{
-	dir = 4;
 	name = "Kitchen maintenance";
 	req_access_txt = "12;28"
 	},
@@ -48152,7 +48322,6 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/ship/engineering/glass{
-	dir = 4;
 	name = "Turbine Hall Access";
 	req_one_access_txt = "10; 24"
 	},
@@ -48233,6 +48402,12 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/effect/turf_decal/tile/orange{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
+	},
 /turf/open/floor/monotile,
 /area/nsv/weapons/fore)
 "qKe" = (
@@ -48354,28 +48529,38 @@
 /turf/open/floor/monotile/dark,
 /area/gateway)
 "qRr" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/item/radio/intercom{
 	name = "intra ship intercom";
 	pixel_y = 26
 	},
+/obj/effect/turf_decal/tile/orange,
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
+	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
 "qVj" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/munitions_trolley,
+/obj/effect/turf_decal/tile/orange{
 	dir = 8
 	},
-/obj/structure/munitions_trolley,
+/obj/effect/turf_decal/tile/orange,
 /turf/open/floor/monotile,
 /area/nsv/weapons/fore)
 "qWB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/ship,
 /area/engine/storage_shared)
+"qXR" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/orange{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 1
+	},
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck2/frame1/central)
 "qZd" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -48483,7 +48668,6 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/ship/maintenance{
-	dir = 4;
 	name = "Munitions Control";
 	req_one_access_txt = "69"
 	},
@@ -48534,7 +48718,6 @@
 /area/engine/engine_room)
 "rlJ" = (
 /obj/machinery/door/airlock/ship/external/glass{
-	dir = 4;
 	req_one_access_txt = "10; 24"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -48562,6 +48745,14 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/monotile,
 /area/security/brig)
+"rou" = (
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "rpx" = (
 /turf/open/floor/plasteel/grid/lino,
 /area/engine/engineering/reactor_control)
@@ -48793,7 +48984,6 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/ship/engineering/glass{
-	dir = 4;
 	name = "Engineering Storage";
 	req_one_access_txt = "11;24"
 	},
@@ -48830,11 +49020,14 @@
 	name = "weapon officer"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/orange,
 /turf/open/floor/plating,
 /area/nsv/weapons/fore)
 "rJv" = (
 /obj/machinery/door/airlock/ship/engineering/glass{
-	dir = 4;
 	name = "Reactor core access";
 	req_one_access_txt = "10; 24"
 	},
@@ -48906,6 +49099,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/hangar)
+"rSI" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "rST" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -48994,6 +49194,9 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
+"sdB" = (
+/turf/open/floor/plating,
+/area/space)
 "sdX" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -49094,7 +49297,6 @@
 /area/engine/engineering/hangar)
 "snt" = (
 /obj/machinery/door/airlock/ship/maintenance{
-	dir = 4;
 	name = "Deck 1 access maintenance"
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -49466,6 +49668,11 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/engine/atmos)
+"teV" = (
+/obj/structure/table,
+/obj/item/clothing/gloves/color/latex/nitrile,
+/turf/open/floor/plating,
+/area/space)
 "tfj" = (
 /obj/machinery/power/apc/auto_name/south{
 	pixel_y = -24
@@ -49513,6 +49720,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"tgV" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/effect/turf_decal/tile/orange,
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
+	},
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck2/frame1/central)
 "thO" = (
 /obj/machinery/light,
 /obj/structure/reagent_dispensers/watertank,
@@ -49528,7 +49743,6 @@
 /area/medical/genetics)
 "tjC" = (
 /obj/machinery/door/airlock/ship/external/glass{
-	dir = 4;
 	req_one_access_txt = "13"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -49571,7 +49785,6 @@
 /area/engine/break_room)
 "tnq" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Aft Primary Hallway"
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -49588,7 +49801,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Prison Sleepers"
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -49782,6 +49994,9 @@
 /area/library)
 "tBR" = (
 /obj/machinery/deck_turret/powder_gate,
+/obj/effect/turf_decal/tile/orange{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/nsv/weapons/fore)
 "tCu" = (
@@ -49795,7 +50010,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/ship{
-	dir = 4;
 	name = "Hangar Bay";
 	req_access_txt = "69"
 	},
@@ -49878,15 +50092,20 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/engine/atmos)
+"tLt" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel/techmaint,
+/area/quartermaster/warehouse)
 "tLT" = (
 /obj/structure/girder/reinforced,
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "tMg" = (
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
-	dir = 4
-	},
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -49900,7 +50119,6 @@
 /area/maintenance/nsv/hangar)
 "tNt" = (
 /obj/machinery/door/airlock/ship/station/mining{
-	dir = 4;
 	name = "Cargo Bay";
 	req_one_access_txt = "31; 48"
 	},
@@ -49967,7 +50185,6 @@
 "tRF" = (
 /obj/structure/barricade/wooden/crude,
 /obj/machinery/door/airlock/ship/engineering{
-	dir = 4;
 	name = "Abandoned Reactor Control Chamber";
 	req_one_access_txt = "10;24"
 	},
@@ -50045,6 +50262,10 @@
 	},
 /turf/open/space/basic,
 /area/engine/atmos)
+"ubq" = (
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel/techmaint,
+/area/quartermaster/warehouse)
 "ucc" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
@@ -50116,7 +50337,6 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/ship/engineering/glass{
-	dir = 4;
 	name = "Engineering Equipment";
 	req_one_access_txt = "11;24"
 	},
@@ -50273,7 +50493,6 @@
 /area/maintenance/starboard/fore)
 "uDu" = (
 /obj/machinery/door/airlock/ship/external{
-	dir = 4;
 	name = "Mining Shuttle Airlock";
 	req_one_access_txt = "31;48"
 	},
@@ -50331,11 +50550,20 @@
 	name = "Ore Silo";
 	req_access_txt = "41"
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/warehouse)
 "uKm" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Chapel"
 	},
 /obj/structure/cable{
@@ -50696,6 +50924,13 @@
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
+"vyU" = (
+/obj/effect/turf_decal/tile/orange,
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
+	},
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck2/frame1/central)
 "vzs" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -50838,15 +51073,15 @@
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "vOG" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/machinery/airalarm{
 	pixel_y = 26
+	},
+/obj/effect/turf_decal/tile/orange,
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
@@ -50875,6 +51110,11 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/engine/atmos)
+"vTY" = (
+/obj/structure/table/optable,
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plating,
+/area/space)
 "vUD" = (
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
@@ -51116,15 +51356,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "wvu" = (
@@ -51185,6 +51423,12 @@
 	color = "#696969";
 	dir = 1;
 	name = "AMS coordinator"
+	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/orange{
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/storage{
@@ -51288,7 +51532,6 @@
 /area/hallway/secondary/exit)
 "wHH" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
 	name = "Aft Primary Hallway"
 	},
 /obj/structure/disposalpipe/segment{
@@ -51384,7 +51627,6 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/ship/engineering/glass{
-	dir = 4;
 	name = "Engineering Storage";
 	req_one_access_txt = "11;24"
 	},
@@ -51407,6 +51649,10 @@
 /obj/structure/lattice/catwalk/over/ship,
 /turf/open/floor/monotile,
 /area/nsv/weapons/fore)
+"wSx" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "wSK" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -51669,6 +51915,13 @@
 	},
 /turf/open/floor/monotile,
 /area/gateway)
+"xrq" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel/techmaint,
+/area/quartermaster/warehouse)
 "xrD" = (
 /obj/machinery/door/airlock/ship/engineering{
 	name = "Abandoned Reactor Core";
@@ -51797,6 +52050,12 @@
 /obj/machinery/holopad,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms)
+"xGc" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel/techmaint,
+/area/quartermaster/warehouse)
 "xGo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -51958,6 +52217,10 @@
 	color = "#696969";
 	name = "weapon officer"
 	},
+/obj/effect/turf_decal/tile/orange,
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/nsv/weapons/fore)
 "xWy" = (
@@ -51989,7 +52252,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/ship/security/glass{
-	dir = 4;
 	name = "Security Equipment";
 	req_one_access_txt = "2"
 	},
@@ -68710,9 +68972,9 @@ beJ
 aYr
 beK
 aDL
-aaa
-aaa
-aaa
+pGe
+vTY
+teV
 aCJ
 aaD
 aLC
@@ -68967,9 +69229,9 @@ aFT
 aFT
 aYs
 aDL
-aaa
-aaa
-aaa
+sdB
+sdB
+nBM
 aCJ
 bgm
 aJY
@@ -69225,7 +69487,7 @@ blx
 bme
 aDL
 aaw
-aaw
+mrB
 aaw
 aCJ
 aLB
@@ -74382,7 +74644,7 @@ bqw
 bwQ
 bqN
 brd
-bli
+fPJ
 aXi
 aJD
 aLG
@@ -75143,12 +75405,12 @@ aOO
 aaI
 abL
 afM
-bcO
+rSI
 bcO
 bcO
 bpw
 acs
-acs
+nzE
 bls
 bFW
 aah
@@ -75157,7 +75419,7 @@ brt
 bbv
 lTI
 aah
-acs
+iFe
 mPw
 aXi
 aMc
@@ -75401,8 +75663,8 @@ bLy
 afA
 acs
 acs
-acs
-acs
+wSx
+fcD
 bpx
 bgE
 bgE
@@ -81799,7 +82061,7 @@ bBu
 bBu
 rix
 bBu
-ahz
+lvt
 bbr
 bdc
 aad
@@ -82315,7 +82577,7 @@ bKG
 bBu
 biO
 bbF
-aMv
+kYm
 aaf
 abk
 acL
@@ -82829,7 +83091,7 @@ wxB
 bBu
 cfq
 bbF
-aMv
+kYm
 aaf
 abk
 adG
@@ -83084,9 +83346,9 @@ bBe
 bCe
 bKH
 bKI
-aeT
+jRa
 bbF
-aMv
+kYm
 aad
 abp
 adQ
@@ -83341,9 +83603,9 @@ sRt
 bHq
 bKH
 bKJ
-bwt
+oJa
 bca
-aMv
+kYm
 aad
 abq
 abq
@@ -83600,7 +83862,7 @@ bKH
 bLS
 bLL
 bce
-aMv
+kYm
 aaj
 abs
 adW
@@ -83855,7 +84117,7 @@ bBr
 pHv
 bLO
 bKK
-aeT
+jRa
 bcf
 bir
 biw
@@ -84114,7 +84376,7 @@ tNz
 bXF
 bXG
 bcq
-aMv
+kYm
 abG
 abG
 abG
@@ -84371,7 +84633,7 @@ bYS
 bXH
 bLM
 bct
-aMv
+kYm
 abG
 abG
 bfZ
@@ -84624,11 +84886,11 @@ dDv
 fHB
 aTg
 hfS
+bYN
 bpR
-bXF
-aeT
+jRa
 bcq
-aMv
+kYm
 abG
 kCd
 jYY
@@ -84882,10 +85144,10 @@ bYr
 aTg
 bYF
 bYN
-bXF
-aeT
+bpR
+jRa
 bcq
-aMv
+kYm
 abG
 biN
 bmC
@@ -85399,7 +85661,7 @@ eQi
 bXF
 biK
 bcw
-aMv
+kYm
 abG
 biQ
 bzN
@@ -85656,7 +85918,7 @@ aTt
 cbh
 bcd
 bcx
-aMv
+kYm
 abG
 biT
 bBU
@@ -85913,7 +86175,7 @@ aTi
 cbi
 bCb
 bcy
-bLK
+qXR
 abI
 biZ
 bBU
@@ -86168,9 +86430,9 @@ aTg
 bYL
 aWk
 cbh
-bcd
+eba
 bcD
-aMv
+kYm
 abG
 bji
 bBU
@@ -86425,9 +86687,9 @@ aTg
 uzi
 aWl
 cbj
-aeT
+vyU
 bcq
-aMv
+kYm
 abG
 bjQ
 bTR
@@ -86660,9 +86922,9 @@ wVw
 bip
 bip
 bDY
-abC
-bad
-bad
+abA
+abx
+abx
 bAY
 bBx
 ago
@@ -86684,7 +86946,7 @@ aXP
 cbk
 acQ
 bcL
-aMv
+kYm
 abH
 bmE
 bYe
@@ -86918,9 +87180,9 @@ fbx
 fbx
 seE
 bDK
-aMn
+abC
 bDS
-aMn
+abC
 bBy
 ago
 aMJ
@@ -86939,9 +87201,9 @@ bja
 aYL
 cbe
 bLT
-bwt
+tgV
 bcM
-aMv
+kYm
 abG
 bkq
 bmE
@@ -87198,7 +87460,7 @@ ago
 agm
 kEU
 bcq
-aMv
+kYm
 abG
 abG
 abG
@@ -87453,7 +87715,7 @@ aWm
 udK
 aST
 agm
-biO
+gNA
 bcN
 blZ
 bBK
@@ -87969,7 +88231,7 @@ xgv
 agm
 vOG
 bcq
-aMv
+kYm
 aad
 aad
 aad
@@ -88226,7 +88488,7 @@ dmS
 agm
 qRr
 bcq
-aMv
+kYm
 aad
 abJ
 azD
@@ -88481,9 +88743,9 @@ agy
 agy
 aZk
 bHr
-aeT
+vyU
 bcq
-aMv
+kYm
 aad
 acl
 acl
@@ -88727,7 +88989,7 @@ aeO
 bXL
 xWj
 bBb
-tBR
+aBv
 kgo
 abV
 ddD
@@ -88738,9 +89000,9 @@ efA
 efA
 efA
 hxW
-aeT
+vyU
 bcq
-aMv
+kYm
 pZe
 acm
 acl
@@ -88995,9 +89257,9 @@ aTr
 aTr
 aTr
 prp
-aeT
+vyU
 bcq
-aMv
+kYm
 pZe
 acl
 acl
@@ -89045,7 +89307,7 @@ aij
 aij
 aij
 aij
-aaa
+bKQ
 aaa
 aaa
 aaa
@@ -89252,9 +89514,9 @@ jvI
 jvI
 jvI
 agm
-ahz
+mzE
 bcq
-aMv
+kYm
 fHb
 acI
 aAk
@@ -89299,10 +89561,10 @@ aij
 bJH
 aim
 aij
-aaa
-aaa
-aaa
-aaa
+sdB
+sdB
+sdB
+dxN
 aaa
 aaa
 aaa
@@ -89555,11 +89817,11 @@ aaa
 aij
 bJH
 aim
-aij
-aaa
-aaa
-aaa
-aaa
+rou
+sdB
+sdB
+sdB
+dxN
 aaa
 aaa
 aaa
@@ -89813,10 +90075,10 @@ aij
 bJH
 bjF
 aij
-aaa
-aaa
-aaa
-aaa
+sdB
+sdB
+sdB
+dxN
 aaa
 aaa
 aaa
@@ -90070,10 +90332,10 @@ aij
 bJH
 aim
 aij
-aaa
-aaa
-aaa
-aaa
+bKQ
+bKQ
+bKQ
+bKQ
 aaa
 aaa
 aaa
@@ -91587,9 +91849,9 @@ ccV
 aaY
 adn
 ady
-adp
-adp
-adp
+ubq
+xrq
+xGc
 adr
 adp
 iuA
@@ -91844,9 +92106,9 @@ aVV
 aaY
 adp
 ohw
-adp
+tLt
 uKa
-adp
+iFi
 adp
 adp
 iuA
@@ -92101,9 +92363,9 @@ aaY
 iuA
 iuA
 iuA
-iuA
-iuA
-iuA
+oyi
+oyi
+oyi
 iuA
 iuA
 iuA
@@ -97756,7 +98018,7 @@ vfz
 aml
 kHI
 kHI
-lvt
+hbD
 kHI
 kHI
 aml
@@ -98516,7 +98778,7 @@ azr
 edN
 edN
 aQd
-aml
+eEX
 aml
 qHG
 vfz
@@ -98751,7 +99013,7 @@ aXb
 aXp
 aOl
 aNu
-hxF
+bad
 aOX
 aPq
 aPq
@@ -100547,7 +100809,7 @@ aQV
 amC
 bfN
 biS
-aBv
+aBB
 azl
 aOa
 amz

--- a/_maps/map_files/Tycoon/Tycoon2.dmm
+++ b/_maps/map_files/Tycoon/Tycoon2.dmm
@@ -41517,6 +41517,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"cjU" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/camera/autoname{
+	c_tag = "Atmos - West #2"
+	},
+/turf/open/space/basic,
+/area/engine/atmos)
 "ckc" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -42169,15 +42176,6 @@
 	},
 /turf/closed/wall/r_wall/ship,
 /area/engine/atmospherics_engine)
-"dvN" = (
-/obj/structure/window/reinforced/spawner,
-/obj/machinery/computer/atmos_control/tank/nitrogen_tank{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech/grid{
-	initial_gas_mix = "TEMP=2.7"
-	},
-/area/engine/atmos)
 "dyj" = (
 /obj/structure/bookcase/manuals/medical,
 /obj/machinery/camera/autoname{
@@ -43054,6 +43052,16 @@
 	},
 /turf/open/floor/monotile,
 /area/nsv/weapons/fore)
+"fub" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "ful" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
@@ -43206,6 +43214,21 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"fPW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/structure/lattice/catwalk,
+/obj/machinery/camera/autoname{
+	c_tag = "Atmos - East #1";
+	dir = 8
+	},
+/obj/machinery/computer/atmos_control/tank/mix_tank{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/engine/atmos)
 "fPZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -44702,6 +44725,17 @@
 	},
 /turf/closed/wall/ship,
 /area/maintenance/nsv/weapons)
+"jdl" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/camera/autoname{
+	c_tag = "Atmos - Storage #1";
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "jeX" = (
 /obj/structure/cable,
 /obj/structure/cable{
@@ -46637,6 +46671,18 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/monotile,
 /area/engine/engineering/hangar)
+"mQp" = (
+/obj/structure/window/reinforced/spawner,
+/obj/machinery/computer/atmos_control/tank/nitrogen_tank{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "mRi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -47491,17 +47537,13 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/fitness/recreation)
-"oJQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/structure/lattice/catwalk,
-/obj/machinery/camera/autoname{
-	c_tag = "Atmos - East #1";
+"oLa" = (
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/computer/atmos_control/tank/mix_tank{
-	dir = 8
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
 	},
-/turf/open/space/basic,
 /area/engine/atmos)
 "oMj" = (
 /obj/machinery/space_heater,
@@ -47661,6 +47703,14 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/medical/medbay/lobby)
+"peo" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/structure/lattice/catwalk,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/engine/atmos)
 "per" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -48068,6 +48118,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"qce" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/engine/atmos)
 "qcm" = (
 /obj/machinery/light{
 	dir = 1
@@ -48098,14 +48155,6 @@
 "qeW" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/engine/atmos)
-"qgo" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/camera/autoname{
-	c_tag = "Atmos - West #2";
 	dir = 4
 	},
 /turf/open/space/basic,
@@ -49058,6 +49107,13 @@
 /obj/machinery/lazylift_button,
 /turf/closed/wall/r_wall/ship,
 /area/shuttle/turbolift/shaft)
+"sff" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/engine/atmos)
 "sfx" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -96652,8 +96708,8 @@ aml
 aml
 aml
 npw
-npw
-stP
+jdl
+fub
 stP
 nqT
 aml
@@ -97418,7 +97474,7 @@ aml
 asG
 asG
 aml
-rhe
+cjU
 vfz
 vfz
 aml
@@ -97673,18 +97729,18 @@ axY
 ucr
 asG
 rhe
-qgo
 rhe
 rhe
+rhe
+vfz
+vfz
+oLa
 vfz
 vfz
 vfz
 vfz
 vfz
-vfz
-vfz
-vfz
-dvN
+mQp
 rwL
 apG
 asG
@@ -98186,7 +98242,7 @@ edN
 aQd
 aml
 aml
-rhe
+qce
 vfz
 vfz
 vfz
@@ -98698,7 +98754,7 @@ rhe
 rhe
 rhe
 pDN
-rhe
+sff
 rhe
 rhe
 vfz
@@ -100496,13 +100552,13 @@ aoW
 apJ
 aqg
 hRh
-oJQ
+fPW
 edO
 aqg
 kpf
 uaW
 awe
-aqg
+peo
 svT
 ewO
 fBs
@@ -100511,7 +100567,7 @@ dlD
 aqg
 eso
 aqg
-aqg
+peo
 aqg
 azL
 aml

--- a/_maps/map_files/Tycoon/Tycoon2.dmm
+++ b/_maps/map_files/Tycoon/Tycoon2.dmm
@@ -3359,17 +3359,6 @@
 /obj/machinery/suit_storage_unit/ce,
 /turf/open/floor/monotile,
 /area/crew_quarters/heads/chief)
-"air" = (
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/monotile/dark,
-/area/maintenance/starboard/fore)
 "ais" = (
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /obj/machinery/door/firedoor/border_only,
@@ -3459,13 +3448,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"aiF" = (
-/obj/effect/spawner/lootdrop/grille_or_trash,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "aiG" = (
 /turf/open/floor/plasteel/chapel{
 	dir = 1
@@ -3493,12 +3475,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"aiN" = (
-/obj/structure/table,
-/obj/item/stock_parts/manipulator,
-/obj/item/disk/holodisk/enterprise_log,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "aiO" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -6344,18 +6320,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering/hangar)
-"apY" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "apZ" = (
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/monotile/dark,
@@ -8320,10 +8284,6 @@
 /obj/machinery/air_sensor/atmos/toxin_tank,
 /turf/open/floor/engine/plasma,
 /area/engine/atmos)
-"awR" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/turf/open/floor/engine/plasma,
-/area/engine/atmos)
 "awS" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/firealarm{
@@ -8915,6 +8875,11 @@
 /obj/structure/closet/radiation,
 /turf/open/floor/monotile/dark,
 /area/engine/atmospherics_engine)
+"azQ" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
 "azR" = (
 /obj/machinery/power/smes{
 	capacity = 9e+006;
@@ -8999,6 +8964,18 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/starboard/fore)
+"aAc" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "aAd" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -9022,9 +8999,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/engine_smes)
-"aAf" = (
-/turf/closed/wall/r_wall/ship,
-/area/hallway/nsv/deck2/frame1/central)
 "aAg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/door/firedoor/border_only,
@@ -9446,20 +9420,6 @@
 "aBf" = (
 /turf/closed/wall/r_wall/ship,
 /area/security/detectives_office)
-"aBg" = (
-/obj/structure/table,
-/obj/item/clothing/glasses/meson/engine,
-/obj/item/clothing/glasses/meson/engine,
-/obj/item/clothing/glasses/meson/engine,
-/obj/item/pipe_dispenser,
-/obj/item/pipe_dispenser,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/ship,
-/area/engine/engineering)
 "aBh" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -10000,10 +9960,6 @@
 "aCM" = (
 /turf/open/floor/engine/n2,
 /area/engine/atmos)
-"aCN" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/floor/engine/n2,
-/area/engine/atmos)
 "aCO" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank - N2";
@@ -10012,10 +9968,6 @@
 /turf/open/floor/engine/n2,
 /area/engine/atmos)
 "aCP" = (
-/turf/open/floor/engine/o2,
-/area/engine/atmos)
-"aCQ" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/engine/o2,
 /area/engine/atmos)
 "aCR" = (
@@ -11581,23 +11533,6 @@
 	},
 /turf/open/floor/monotile,
 /area/gateway)
-"aGp" = (
-/obj/structure/table,
-/obj/item/stack/sheet/mineral/copper{
-	amount = 10
-	},
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/glass/fifty{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/ship_weapon/parts/missile/warhead/probe,
-/obj/item/ship_weapon/parts/missile/warhead/probe,
-/obj/item/ship_weapon/parts/missile/warhead/probe,
-/obj/item/ship_weapon/parts/missile/warhead/probe,
-/obj/item/ship_weapon/parts/missile/warhead/probe,
-/turf/open/floor/plasteel/techmaint,
-/area/science/research)
 "aGq" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -12564,18 +12499,6 @@
 	},
 /turf/open/floor/monotile,
 /area/engine/gravity_generator)
-"aIz" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/power/apc/auto_name/north{
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "aIA" = (
 /obj/machinery/camera/autoname,
 /turf/open/floor/monotile/dark,
@@ -18049,11 +17972,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile,
 /area/medical/morgue)
-"aUX" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "aUZ" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -18375,13 +18293,6 @@
 	},
 /turf/open/floor/monotile,
 /area/hallway/secondary/service)
-"aVI" = (
-/obj/structure/table/reinforced,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/turf/open/floor/monotile/dark,
-/area/hallway/secondary/service)
 "aVJ" = (
 /obj/structure/chair/sofa/right{
 	dir = 4
@@ -18516,11 +18427,6 @@
 	},
 /turf/open/floor/monotile,
 /area/hydroponics)
-"aVW" = (
-/obj/item/crowbar,
-/obj/structure/table,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "aVX" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19585,22 +19491,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/security/detectives_office)
-"aYp" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "aYq" = (
 /obj/structure/closet/secure_closet/warden,
 /obj/machinery/airalarm{
@@ -19685,10 +19575,6 @@
 /obj/item/crowbar,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"aYC" = (
-/obj/machinery/portable_atmospherics/canister,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "aYD" = (
 /obj/structure/closet/secure_closet/freezer/kitchen/maintenance,
 /turf/open/floor/plating,
@@ -19705,16 +19591,6 @@
 	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
-	},
-/area/maintenance/starboard/fore)
-"aYG" = (
-/obj/item/paper{
-	desc = "You can make out a few squiggles that look like a ragnarok class heavy cruiser with an approval seal hastily crayon'd in. The ship looks like a mess.";
-	name = "Nsv Aegis construction blueprints"
-	},
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
 	},
 /area/maintenance/starboard/fore)
 "aYH" = (
@@ -19827,15 +19703,6 @@
 	},
 /turf/open/floor/monotile,
 /area/maintenance/department/medical)
-"aYV" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "aYW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
@@ -19872,10 +19739,6 @@
 /area/maintenance/starboard/secondary{
 	name = "Munitions Projects"
 	})
-"aYY" = (
-/obj/structure/rack,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "aYZ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -20650,39 +20513,9 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/nsv/crew_quarters/heads/maa)
-"baB" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "baC" = (
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
-"baD" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
-"baE" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
@@ -20801,19 +20634,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/monotile/dark,
 /area/engine/break_room)
-"baP" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "baQ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -20959,18 +20779,6 @@
 	},
 /turf/open/floor/engine,
 /area/medical/medbay/lobby)
-"bbf" = (
-/obj/structure/table/reinforced,
-/obj/structure/disposalpipe/segment,
-/obj/effect/landmark/zebra_interlock_point,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/monotile,
-/area/crew_quarters/cafeteria{
-	name = "Mess hall"
-	})
 "bbg" = (
 /obj/machinery/dna_scannernew,
 /obj/structure/cable{
@@ -21009,11 +20817,6 @@
 	},
 /turf/open/floor/monotile/light,
 /area/medical/genetics)
-"bbk" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/multiz,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "bbl" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -21104,21 +20907,6 @@
 	},
 /turf/open/floor/monotile/light,
 /area/medical/medbay/central)
-"bby" = (
-/obj/structure/table/reinforced,
-/obj/item/lighter,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/monotile,
-/area/crew_quarters/cafeteria{
-	name = "Mess hall"
-	})
 "bbz" = (
 /obj/machinery/door/airlock/ship/command/glass{
 	name = "Officer's Mess"
@@ -22610,18 +22398,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/dark,
 /area/medical/medbay/lobby)
-"bec" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "bed" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -24418,31 +24194,6 @@
 	},
 /turf/open/floor/monotile/light,
 /area/medical/medbay/lobby)
-"bhL" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
-"bhM" = (
-/obj/effect/spawner/lootdrop/grille_or_trash,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
-"bhN" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "bhO" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -25809,24 +25560,6 @@
 	},
 /turf/open/floor/monotile,
 /area/ai_monitored/security/armory)
-"bky" = (
-/obj/machinery/power/apc/auto_name/north{
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
-"bkz" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "bkA" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -26205,12 +25938,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"blj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "blk" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -27128,9 +26855,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile,
 /area/janitor)
-"bnm" = (
-/turf/open/floor/plating,
-/area/maintenance/port)
 "bno" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
@@ -30673,22 +30397,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/dark,
 /area/hydroponics)
-"bug" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/matches{
-	pixel_y = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/landmark/zebra_interlock_point,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/monotile,
-/area/crew_quarters/cafeteria{
-	name = "Mess hall"
-	})
 "buh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -34063,20 +33771,6 @@
 /obj/structure/window/reinforced/fulltile/ship/interior,
 /turf/open/floor/grass,
 /area/hallway/secondary/exit)
-"bAT" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/ship/maintenance{
-	req_access_txt = "12;35"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/maintenance/starboard/fore)
 "bAU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -35557,15 +35251,6 @@
 /obj/machinery/light,
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit/departure_lounge)
-"bDQ" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "bDR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/decal/cleanable/oil,
@@ -35594,12 +35279,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck2)
-"bDT" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "bDU" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -36700,18 +36379,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"bFS" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/airalarm{
-	pixel_y = 26
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "bFT" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -36872,6 +36539,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"bGl" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "bGm" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -37180,15 +36857,6 @@
 	id_tag = "virology_airlock_exterior";
 	name = "Virology Exterior Airlock";
 	req_access_txt = "39"
-	},
-/turf/open/floor/monotile/dark,
-/area/medical/virology)
-"bGP" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/obj/machinery/camera/autoname{
-	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/medical/virology)
@@ -37610,12 +37278,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
-"bHM" = (
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/maintenance/starboard/fore)
 "bHN" = (
 /obj/machinery/computer/bounty{
 	dir = 1
@@ -37954,13 +37616,6 @@
 /turf/open/floor/monotile/light,
 /area/security/prison)
 "bIM" = (
-/turf/open/floor/monotile/light,
-/area/security/prison)
-"bIN" = (
-/obj/structure/window/reinforced,
-/obj/structure/closet/secure_closet/brig_phys,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/monotile/light,
 /area/security/prison)
 "bIO" = (
@@ -39471,10 +39126,6 @@
 	},
 /turf/open/floor/plating,
 /area/nsv/weapons/fore)
-"bPM" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/maintenance/port)
 "bRy" = (
 /obj/item/beacon,
 /turf/open/floor/engine,
@@ -39525,12 +39176,13 @@
 /obj/effect/turf_decal/ship/delivery/yellow,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
-"bVc" = (
-/obj/item/trash/can,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
+"bVl" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/area/maintenance/starboard)
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "bVw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -40429,20 +40081,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"cjd" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/ship/maintenance{
-	name = "Virology maintenance"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/science)
 "cjB" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Arrivals"
@@ -40505,10 +40143,6 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/engine/atmos)
-"cms" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "cmZ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -40585,24 +40219,6 @@
 /obj/item/trash/popcorn,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"cqJ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/airlock/ship/maintenance{
-	name = "Virology maintenance"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/science)
 "cri" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -40656,12 +40272,6 @@
 	},
 /turf/open/floor/plasteel/grid/techfloor,
 /area/engine/engineering/reactor_control)
-"cuG" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "cve" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -40681,6 +40291,16 @@
 	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
+"cxy" = (
+/obj/structure/table/reinforced,
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/monotile,
+/area/crew_quarters/bar)
 "cAn" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -40799,6 +40419,14 @@
 /obj/structure/bookcase/random/religion,
 /turf/open/floor/wood,
 /area/library)
+"cIi" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/item/storage/fancy/donut_box,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "cJz" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 8
@@ -40843,6 +40471,10 @@
 /area/bridge{
 	name = "CIC"
 	})
+"cNV" = (
+/obj/effect/spawner/room/fivexfour,
+/turf/template_noop,
+/area/maintenance/department/medical)
 "cOu" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -41087,6 +40719,26 @@
 /obj/item/fuel_rod,
 /turf/open/indestructible/sound/pool/spentfuel/wall,
 /area/engine/engineering/reactor_core)
+"die" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	pixel_y = 26
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/port)
+"djJ" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "dlA" = (
 /obj/structure/ladder,
 /turf/open/floor/plating,
@@ -41176,10 +40828,6 @@
 	},
 /turf/closed/wall/r_wall/ship,
 /area/engine/atmospherics_engine)
-"dxN" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/space)
 "dyj" = (
 /obj/structure/bookcase/manuals/medical,
 /obj/machinery/camera/autoname{
@@ -41236,6 +40884,10 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
+"dFv" = (
+/obj/structure/sign/poster/contraband/donut_corp,
+/turf/closed/wall/ship,
+/area/maintenance/starboard/fore)
 "dFO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -41265,6 +40917,13 @@
 	},
 /turf/open/floor/plasteel/grid/steel,
 /area/engine/engineering/reactor_core)
+"dIj" = (
+/obj/item/trash/can,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/starboard)
 "dIo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -41304,6 +40963,11 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/monotile,
 /area/security/brig)
+"dLp" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "dNn" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
 /turf/open/floor/plating,
@@ -41423,6 +41087,14 @@
 	},
 /turf/open/floor/monotile,
 /area/medical/medbay/central)
+"dXJ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/maintenance/department/medical)
 "dXK" = (
 /obj/machinery/light{
 	dir = 8
@@ -41443,6 +41115,10 @@
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
+"ebT" = (
+/obj/structure/closet/wardrobe/grey,
+/turf/open/floor/plasteel/ship/padded,
+/area/maintenance/port)
 "ecX" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -41697,6 +41373,12 @@
 /obj/structure/closet,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"eqv" = (
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "eqA" = (
 /obj/structure/table,
 /obj/item/clothing/suit/hazardvest,
@@ -41735,6 +41417,11 @@
 	},
 /turf/open/floor/monotile,
 /area/engine/engineering/reactor_core)
+"etE" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "etL" = (
 /obj/structure/sign/ship/securearea{
 	dir = 8;
@@ -41831,6 +41518,12 @@
 	},
 /turf/open/floor/plasteel/grid/steel,
 /area/engine/engineering/reactor_core)
+"eBC" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/template_noop,
+/area/maintenance/department/medical)
 "eCb" = (
 /obj/machinery/button/door{
 	id = "agcnr_purge";
@@ -41973,6 +41666,9 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/engine/atmos)
+"eLm" = (
+/turf/template_noop,
+/area/maintenance/department/cargo)
 "eLv" = (
 /obj/structure/bookcase,
 /turf/open/floor/wood,
@@ -42109,6 +41805,20 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/security/prison)
+"eZC" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
+	req_one_access_txt = "12;47"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "eZJ" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
@@ -42132,6 +41842,13 @@
 /obj/effect/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"faG" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "fbx" = (
 /turf/closed/wall/r_wall/ship,
 /area/shuttle/turbolift/shaft)
@@ -42243,6 +41960,12 @@
 	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
+"fpJ" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "fpL" = (
 /obj/machinery/door/airlock/ship/station/mining{
 	name = "Cargo Bay";
@@ -42281,14 +42004,34 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
+"fuW" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/ship,
+/area/maintenance/port)
 "fvp" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/monotile,
 /area/crew_quarters/fitness/recreation)
+"fwJ" = (
+/obj/item/crowbar,
+/obj/structure/table,
+/obj/item/storage/box/lights/mixed,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "fxX" = (
 /obj/structure/lattice,
 /turf/open/space,
 /area/science/mixing/chamber)
+"fyq" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/starboard/fore)
 "fyJ" = (
 /obj/structure/lattice/catwalk/over/ship,
 /obj/machinery/camera/autoname,
@@ -42359,6 +42102,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/closed/wall/r_wall/ship,
 /area/engine/atmospherics_engine)
+"fEH" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/maintenance/department/medical)
 "fHb" = (
 /obj/machinery/paystand,
 /obj/machinery/door/poddoor/ship{
@@ -42414,6 +42166,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"fLt" = (
+/obj/structure/table,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "fNY" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -42534,6 +42290,16 @@
 "fYc" = (
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
+"gbA" = (
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "gbD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -42561,6 +42327,14 @@
 	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
+"gcf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/item/storage/box/lights/mixed,
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "gdZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -42665,6 +42439,11 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/heads/hor)
+"gmV" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "gom" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -42722,6 +42501,11 @@
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"gsa" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/techmaint,
+/area/maintenance/starboard)
 "gtM" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -42756,12 +42540,35 @@
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating,
 /area/maintenance/nsv/weapons)
+"gAp" = (
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
+	req_one_access_txt = "28;35;25;46;26"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/monotile/dark,
+/area/maintenance/starboard/fore)
 "gAS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
+"gBG" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
+"gCo" = (
+/obj/structure/mopbucket,
+/obj/item/mop,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "gCz" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Medbay Lobby Access"
@@ -42990,13 +42797,6 @@
 /obj/machinery/status_display/evac,
 /turf/closed/wall/ship,
 /area/security/brig)
-"gPJ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/spawner/lootdrop/maintenance/two,
-/turf/open/floor/plating,
-/area/maintenance/nsv/hangar)
 "gRe" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -43081,6 +42881,11 @@
 	},
 /turf/open/floor/monotile,
 /area/hallway/secondary/exit)
+"gWU" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/atmospherics/miner/oxygen,
+/turf/open/floor/engine/o2,
+/area/engine/atmos)
 "gYf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -43099,14 +42904,24 @@
 	},
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
-"gZK" = (
-/obj/structure/closet/radiation,
-/turf/open/floor/plating,
-/area/maintenance/nsv/hangar)
 "gZS" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/monotile/dark,
 /area/security/brig)
+"gZU" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
+	req_one_access_txt = "12;47"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "gZZ" = (
 /obj/machinery/door/airlock/highsecurity/ship{
 	name = "Ordnance Production";
@@ -43183,6 +42998,10 @@
 	},
 /turf/open/floor/monotile,
 /area/nsv/weapons/gauss)
+"hhh" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "hhv" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8;
@@ -43217,6 +43036,10 @@
 	},
 /turf/open/floor/monotile,
 /area/janitor)
+"hjm" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "hjP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/ship/preopen{
@@ -43249,6 +43072,18 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/science/mixing/chamber)
+"hnE" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/department/medical)
+"hox" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/closet/radiation,
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
 "hpX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
@@ -43403,6 +43238,12 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
+"hxL" = (
+/obj/machinery/light/small,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/department/medical)
 "hxW" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -43431,6 +43272,10 @@
 /obj/machinery/status_display/evac,
 /turf/closed/wall/ship,
 /area/medical/genetics)
+"hzH" = (
+/obj/effect/spawner/room/threexthree,
+/turf/template_noop,
+/area/maintenance/department/cargo)
 "hzO" = (
 /obj/machinery/deck_turret/payload_gate,
 /obj/effect/turf_decal/loading_area{
@@ -43457,6 +43302,14 @@
 /obj/structure/closet/secure_closet/medical1,
 /turf/open/floor/monotile/dark,
 /area/gateway)
+"hAC" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "hBe" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Hydroponics";
@@ -43649,6 +43502,12 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
+"hPI" = (
+/obj/structure/railing,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/minor/pirate_or_bandana,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "hRh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/structure/lattice/catwalk,
@@ -43688,6 +43547,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile,
 /area/hallway/secondary/exit)
+"hVw" = (
+/obj/structure/window/reinforced,
+/obj/structure/closet/secure_closet/brig_phys,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/machinery/door/firedoor/border_only,
+/obj/item/reagent_containers/blood/OMinus,
+/turf/open/floor/monotile/light,
+/area/security/prison)
 "hWb" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -43753,16 +43620,20 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"idG" = (
+"ieG" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
 	},
-/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/item/storage/box/lights/mixed,
+/obj/structure/table,
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/department/engine)
 "ife" = (
 /obj/machinery/light/small,
 /obj/machinery/advanced_airlock_controller{
@@ -43776,6 +43647,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/hangar)
+"igg" = (
+/obj/structure/table/reinforced,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/item/storage/box/lights/mixed,
+/turf/open/floor/monotile/dark,
+/area/hallway/secondary/service)
 "iiq" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel/tech/grid{
@@ -43817,6 +43696,9 @@
 /area/bridge{
 	name = "CIC"
 	})
+"ilV" = (
+/turf/template_noop,
+/area/maintenance/nsv/hangar)
 "inb" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -43943,11 +43825,34 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
+"iyN" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
+	req_one_access_txt = "12;5"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
+"iCC" = (
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "iCD" = (
 /obj/structure/closet/lasertag/blue,
 /obj/machinery/light,
 /turf/open/floor/monotile,
 /area/crew_quarters/fitness/recreation)
+"iCG" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "iDb" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -43973,13 +43878,6 @@
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/nsv/weapons/gauss)
-"iDH" = (
-/obj/structure/closet/radiation,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/nsv/hangar)
 "iDJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/newscaster{
@@ -43987,11 +43885,19 @@
 	},
 /turf/open/floor/monotile/light,
 /area/medical/medbay/lobby)
-"iFe" = (
-/obj/structure/mopbucket,
-/obj/item/mop,
-/turf/open/floor/plating,
-/area/maintenance/department/science)
+"iDR" = (
+/obj/structure/table/reinforced,
+/obj/item/lighter,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/monotile,
+/area/crew_quarters/bar)
 "iFf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -44210,6 +44116,20 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/maintenance/nsv/weapons)
+"iUA" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/matches{
+	pixel_y = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/monotile,
+/area/crew_quarters/bar)
 "iVI" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
@@ -44456,6 +44376,18 @@
 /obj/item/ship_weapon/ammunition/missile,
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2)
+"jqT" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
+"jrr" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/item/trash/sosjerky,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "jsb" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -44468,10 +44400,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
-"jtt" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/plating,
-/area/maintenance/port)
 "jtu" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -44504,6 +44432,21 @@
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile,
 /area/medical/medbay/central)
+"jve" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/maintenance/port)
+"jvE" = (
+/obj/effect/spawner/lootdrop,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "jvI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -44531,6 +44474,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/template_noop,
 /area/maintenance/department/science)
+"jzy" = (
+/obj/structure/grille,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "jAE" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -44545,10 +44493,14 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/break_room)
-"jBs" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plasteel/techmaint,
-/area/maintenance/starboard)
+"jCX" = (
+/obj/structure/closet/toolcloset,
+/obj/item/clothing/head/hardhat/orange,
+/obj/item/clothing/head/hardhat/orange,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/ship/padded,
+/area/maintenance/port)
 "jEa" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible/layer1{
 	dir = 4
@@ -44845,10 +44797,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel/techmaint,
 /area/maintenance/starboard)
-"kdX" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/nsv/hangar)
 "kes" = (
 /obj/machinery/atmospherics/components/binary/magnetic_constrictor{
 	dir = 1;
@@ -44991,10 +44939,23 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
+"kmR" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/machinery/iv_drip,
+/obj/item/reagent_containers/blood/random,
+/turf/open/floor/plating,
+/area/space)
 "kmS" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/engine/engine_room)
+"kmV" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/storage/toolbox/emergency,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "kmX" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -45094,6 +45055,16 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"krH" = (
+/obj/structure/table,
+/obj/item/tank/internals/air,
+/obj/item/tank/internals/air,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/storage/toolbox/emergency,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/techmaint,
+/area/maintenance/starboard)
 "ksk" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /turf/open/floor/monotile/dark,
@@ -45499,9 +45470,23 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
+"lay" = (
+/obj/structure/closet/firecloset,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/ship/padded,
+/area/maintenance/port)
 "laZ" = (
 /turf/closed/wall/ship,
 /area/maintenance/starboard)
+"lbt" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/template_noop,
+/area/maintenance/department/medical)
 "lca" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -45535,6 +45520,19 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"leE" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "lff" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -27
@@ -45649,12 +45647,44 @@
 	},
 /turf/open/floor/plating,
 /area/nsv/weapons/fore)
+"llg" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
+"llI" = (
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
+	req_one_access_txt = "12;5"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
+"lmR" = (
+/obj/structure/closet/firecloset,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/item/storage/toolbox/emergency,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "lmX" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
+"loC" = (
+/obj/machinery/space_heater,
+/obj/item/storage/box/lights/mixed,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/department/medical)
 "loN" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/visible{
 	dir = 4
@@ -45683,12 +45713,11 @@
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/space/nearstation)
-"lsG" = (
-/obj/structure/closet/firecloset,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating,
+"lrR" = (
+/obj/structure/rack,
+/obj/item/weldingtool,
+/obj/item/wirecutters,
+/turf/open/floor/plasteel/ship/padded,
 /area/maintenance/port)
 "ltH" = (
 /obj/machinery/light,
@@ -45844,6 +45873,13 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
+"lGr" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "lJd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
@@ -45881,6 +45917,11 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"lLc" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "lLt" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -45898,6 +45939,13 @@
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/ship,
 /area/engine/atmos)
+"lLK" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/item/trash/pistachios,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "lLZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/structure/lattice/catwalk,
@@ -45963,10 +46011,6 @@
 /obj/structure/lattice/catwalk/over/ship,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/gauss)
-"lQU" = (
-/obj/effect/spawner/lootdrop/maintenance/two,
-/turf/open/floor/plating,
-/area/maintenance/nsv/hangar)
 "lRd" = (
 /obj/structure/sink{
 	dir = 8;
@@ -45985,6 +46029,13 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/engine/atmos)
+"lUI" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "lUM" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -46174,6 +46225,18 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/space,
 /area/engine/atmos)
+"mmh" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/closet/radiation,
+/obj/item/tank/internals/oxygen/yellow,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "mmu" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 6
@@ -46183,6 +46246,12 @@
 	},
 /turf/open/floor/monotile,
 /area/engine/engineering/reactor_core)
+"mnn" = (
+/obj/structure/chair,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/department/medical)
 "moE" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -46215,6 +46284,11 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible,
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
+"mpX" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "mrB" = (
 /obj/structure/sign/poster/official/science,
 /turf/closed/wall/ship,
@@ -46254,6 +46328,15 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/storage_shared)
+"mut" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/obj/item/stock_parts/scanning_module,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "muV" = (
 /obj/machinery/computer/communications/console{
 	dir = 1;
@@ -46357,6 +46440,25 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
+"mCz" = (
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/department/medical)
+"mCU" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/department/medical)
 "mDA" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -46446,6 +46548,13 @@
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
+"mLR" = (
+/obj/structure/closet/firecloset,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/department/medical)
 "mMg" = (
 /obj/machinery/atmospherics/components/binary/valve,
 /turf/open/floor/plasteel/tech/grid{
@@ -46477,6 +46586,14 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard)
+"mOc" = (
+/obj/structure/closet/crate/trashcart,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/trash/boritos,
+/obj/item/trash/plate,
+/turf/open/floor/plasteel/ship/padded,
+/area/maintenance/port)
 "mOp" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -46573,11 +46690,26 @@
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/engine/engine_room)
+"mTM" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/spawner/lootdrop/maintenance/five,
+/obj/structure/closet/cardboard,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "mTR" = (
 /turf/closed/wall/ship,
 /area/nsv/hanger/storage{
 	name = "Munitions Control Room"
 	})
+"mTV" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "mUv" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
 	dir = 4
@@ -46589,6 +46721,13 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/engine/atmos)
+"mUy" = (
+/obj/structure/table,
+/obj/item/stock_parts/manipulator,
+/obj/item/disk/holodisk/enterprise_log,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "mVt" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -46654,6 +46793,23 @@
 /obj/item/ship_weapon/ammunition/naval_artillery,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
+"nbH" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/obj/item/wrench,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"ncH" = (
+/obj/item/paper{
+	desc = "You can make out a few squiggles that look like a ragnarok class heavy cruiser with an approval seal hastily crayon'd in. The ship looks like a mess.";
+	name = "Nsv Aegis construction blueprints"
+	},
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/starboard/fore)
 "ndL" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1{
@@ -46781,10 +46937,6 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/engine/atmos)
-"nsk" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plating,
-/area/maintenance/nsv/hangar)
 "ntS" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/ship,
@@ -46841,10 +46993,19 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/starboard)
-"nzE" = (
-/obj/effect/decal/cleanable/dirt,
+"nxK" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
+	req_one_access_txt = "12;5"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/plating,
-/area/maintenance/department/science)
+/area/maintenance/department/medical)
 "nBM" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/surgical,
@@ -46892,6 +47053,13 @@
 /area/bridge{
 	name = "CIC"
 	})
+"nDB" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
 "nDD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -46969,6 +47137,10 @@
 /obj/structure/bookcase/random/adult,
 /turf/open/floor/wood,
 /area/library)
+"nJZ" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "nKT" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	req_one_access_txt = "13"
@@ -47009,6 +47181,15 @@
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/grid/steel,
 /area/hallway/secondary/exit)
+"nNn" = (
+/obj/structure/grille{
+	layer = 3.001
+	},
+/obj/item/reagent_containers/food/snacks/canned/beans,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/maintenance/department/medical)
 "nNs" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -47168,6 +47349,12 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"nZA" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/clothing/glasses/meson,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "obU" = (
 /obj/structure/sign/ship/securearea{
 	dir = 4;
@@ -47246,6 +47433,12 @@
 	},
 /turf/open/floor/plasteel/grid/steel,
 /area/engine/engineering/reactor_core)
+"ojM" = (
+/obj/structure/closet/crate/secure/loot,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/ship/padded,
+/area/maintenance/port)
 "okI" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/light{
@@ -47269,6 +47462,10 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"opF" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "opK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -47388,27 +47585,6 @@
 	},
 /turf/open/floor/monotile,
 /area/engine/engineering/reactor_core)
-"oBT" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
-"oCE" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/ship/maintenance{
-	name = "Virology maintenance"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/science)
 "oDq" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
@@ -47475,6 +47651,20 @@
 /area/bridge{
 	name = "CIC"
 	})
+"oII" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/ship/maintenance{
+	req_access_txt = "35"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/maintenance/starboard/fore)
 "oJa" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/effect/turf_decal/tile/orange{
@@ -47549,6 +47739,16 @@
 /obj/machinery/atmospherics/pipe/manifold4w/purple/visible,
 /turf/open/floor/monotile,
 /area/engine/engineering/reactor_core)
+"oUH" = (
+/obj/structure/closet/firecloset,
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
+"oUI" = (
+/obj/structure/grille,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "oUM" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -27
@@ -47573,6 +47773,24 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/medical/virology)
+"oWy" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
+	req_one_access_txt = "12;5"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "oXH" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank - Toxins";
@@ -47614,6 +47832,17 @@
 	},
 /turf/open/floor/monotile,
 /area/crew_quarters/fitness/recreation)
+"pcG" = (
+/obj/machinery/atmospherics/pipe/simple/multiz,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/weapons)
+"pcI" = (
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/maintenance/nsv/weapons)
 "pdT" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Cryogenics";
@@ -47704,16 +47933,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/hangar)
-"pla" = (
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
-	name = "Damage control closet"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/nsv/hangar)
 "plm" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -47769,6 +47988,16 @@
 	},
 /turf/open/floor/monotile,
 /area/hallway/secondary/exit)
+"pqs" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "prp" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -47786,15 +48015,6 @@
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile,
 /area/nsv/weapons/fore)
-"psk" = (
-/obj/structure/table,
-/obj/item/tank/internals/air,
-/obj/item/tank/internals/air,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/storage/toolbox/emergency,
-/turf/open/floor/plasteel/techmaint,
-/area/maintenance/starboard)
 "psx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -47818,6 +48038,24 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms)
+"pxf" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
+	req_one_access_txt = "12;47"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "pxx" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -47833,6 +48071,15 @@
 /obj/machinery/newscaster,
 /turf/closed/wall/ship,
 /area/quartermaster/qm)
+"pxF" = (
+/obj/structure/table,
+/obj/item/storage/box/lights/tubes,
+/obj/effect/spawner/lootdrop/glowstick,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/ship/padded,
+/area/maintenance/port)
 "pxL" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -47871,6 +48118,12 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/monotile,
 /area/security/brig)
+"pBU" = (
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/starboard/fore)
 "pBW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -47883,6 +48136,12 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
+"pCo" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "pCv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -47929,10 +48188,6 @@
 	},
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2)
-"pFQ" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "pFX" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess,
@@ -47944,11 +48199,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"pGe" = (
-/obj/effect/decal/cleanable/greenglow,
-/obj/machinery/iv_drip,
-/turf/open/floor/plating,
-/area/space)
+"pHr" = (
+/obj/effect/spawner/room/tenxfive,
+/turf/template_noop,
+/area/maintenance/nsv/hangar)
 "pHv" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -47969,6 +48223,9 @@
 /area/nsv/hanger/storage{
 	name = "Munitions Control Room"
 	})
+"pHV" = (
+/turf/template_noop,
+/area/maintenance/department/medical)
 "pIA" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/computer/atmos_control/tank/carbon_tank{
@@ -47994,6 +48251,16 @@
 	},
 /turf/open/floor/monotile,
 /area/engine/engineering/reactor_core)
+"pJP" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/ship,
+/area/maintenance/port)
 "pJY" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/door/poddoor/shutters/ship/preopen{
@@ -48091,12 +48358,6 @@
 	},
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
-"pXO" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/turf/open/floor/plating,
-/area/maintenance/nsv/hangar)
 "pZe" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/ship{
@@ -48126,12 +48387,16 @@
 "pZC" = (
 /turf/open/floor/engine/vacuum,
 /area/engine/engineering/reactor_core)
-"qbw" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
+"qbU" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/techmaint,
+/area/maintenance/starboard)
 "qcm" = (
 /obj/machinery/light{
 	dir = 1
@@ -48139,6 +48404,12 @@
 /obj/machinery/lazylift/master/aircraft_elevator,
 /turf/open/floor/monotile/dark,
 /area/shuttle/turbolift/shaft)
+"qcn" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "qcy" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel/tech/grid{
@@ -48185,28 +48456,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"qlU" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	name = "Kitchen maintenance";
-	req_access_txt = "12;28"
+"qlR" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/structure/fans/tiny,
+/obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"qmJ" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/nsv/hangar)
 "qnR" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
@@ -48253,6 +48509,11 @@
 	},
 /turf/open/floor/monotile,
 /area/engine/atmos)
+"qqN" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/maintenance/starboard/fore)
 "qqT" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -48270,6 +48531,16 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
+"qrP" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "qvd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
@@ -48300,6 +48571,10 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/service)
+"qzT" = (
+/obj/effect/turf_decal/loading_area,
+/turf/open/floor/plasteel/ship,
+/area/maintenance/port)
 "qAP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -48333,6 +48608,11 @@
 	},
 /turf/open/floor/plasteel/grid/steel,
 /area/engine/engineering/reactor_core)
+"qCp" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/atmospherics/miner/nitrogen,
+/turf/open/floor/engine/n2,
+/area/engine/atmos)
 "qDQ" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
@@ -48471,6 +48751,15 @@
 	},
 /turf/open/floor/monotile,
 /area/security/brig)
+"qNT" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 32
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "qOb" = (
 /obj/effect/turf_decal/box,
 /obj/machinery/requests_console{
@@ -48582,6 +48871,25 @@
 	},
 /turf/closed/wall/r_wall/ship,
 /area/engine/engineering/reactor_core)
+"raN" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
+"rbR" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "rbT" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/effect/turf_decal/bot_red,
@@ -48703,6 +49011,20 @@
 	},
 /turf/open/floor/carpet/green,
 /area/engine/engineering/reactor_control)
+"rjt" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/atmospherics/miner/toxins,
+/turf/open/floor/engine/plasma,
+/area/engine/atmos)
+"rjS" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "rkQ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/loading_area,
@@ -48745,6 +49067,12 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/monotile,
 /area/security/brig)
+"roq" = (
+/obj/structure/chair/comfy{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "rou" = (
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /obj/machinery/door/firedoor/border_only,
@@ -48753,6 +49081,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"roC" = (
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/department/medical)
 "rpx" = (
 /turf/open/floor/plasteel/grid/lino,
 /area/engine/engineering/reactor_control)
@@ -48873,6 +49206,14 @@
 	},
 /turf/open/floor/monotile,
 /area/engine/engineering/reactor_core)
+"ryh" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/item/storage/box/lights/mixed,
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
 "ryW" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -48976,6 +49317,12 @@
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile,
 /area/crew_quarters/bar)
+"rGm" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/multiz,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "rGX" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -49080,6 +49427,13 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/science/nanite)
+"rNb" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/effect/spawner/lootdrop/maintenance/four,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "rNN" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/visible,
 /obj/machinery/meter,
@@ -49115,6 +49469,10 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck2)
+"rTg" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "rUi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -49159,10 +49517,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"saO" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/maintenance/nsv/hangar)
 "sbl" = (
 /obj/structure/bookcase/random/reference,
 /turf/open/floor/wood,
@@ -49266,6 +49620,11 @@
 	},
 /turf/open/floor/monotile,
 /area/medical/chemistry)
+"sgN" = (
+/obj/machinery/space_heater,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/techmaint,
+/area/maintenance/starboard)
 "shm" = (
 /obj/machinery/door/morgue{
 	name = "Confession Booth"
@@ -49409,6 +49768,14 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/visible,
 /turf/open/space/basic,
 /area/engine/engineering/reactor_core)
+"svh" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/spawner/lootdrop/maintenance/three,
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "svo" = (
 /obj/machinery/light{
 	dir = 4
@@ -49489,6 +49856,12 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"sAj" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "sBR" = (
 /obj/machinery/camera/autoname,
 /obj/machinery/vending/games,
@@ -49576,6 +49949,11 @@
 /area/bridge{
 	name = "CIC"
 	})
+"sRd" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "sRt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -49587,10 +49965,6 @@
 /area/nsv/hanger/storage{
 	name = "Munitions Control Room"
 	})
-"sSl" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/port)
 "sTi" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
@@ -49598,6 +49972,13 @@
 	},
 /turf/open/floor/monotile,
 /area/engine/engineering/reactor_core)
+"sYJ" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "sYQ" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -49932,10 +50313,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo)
-"tyd" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "tyr" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -49999,6 +50376,18 @@
 	},
 /turf/open/floor/plating,
 /area/nsv/weapons/fore)
+"tBW" = (
+/obj/structure/table,
+/obj/item/stack/sheet/mineral/copper{
+	amount = 10
+	},
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/techmaint,
+/area/science/research)
 "tCu" = (
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/nsv/hangar)
@@ -50099,6 +50488,10 @@
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/warehouse)
+"tLu" = (
+/obj/item/trash/semki,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "tLT" = (
 /obj/structure/girder/reinforced,
 /obj/structure/grille,
@@ -50117,6 +50510,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/hangar)
+"tMn" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "tNt" = (
 /obj/machinery/door/airlock/ship/station/mining{
 	name = "Cargo Bay";
@@ -50208,6 +50611,11 @@
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/light,
 /area/medical/medbay/lobby)
+"tSY" = (
+/obj/structure/disposalpipe/segment,
+/obj/item/trash/chips,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "tUT" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -50355,6 +50763,13 @@
 	},
 /turf/open/floor/monotile,
 /area/crew_quarters/fitness/recreation)
+"ueI" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "ufF" = (
 /turf/closed/wall/r_wall/ship,
 /area/science/mixing/chamber)
@@ -50364,6 +50779,17 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/engine/atmos)
+"ugg" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "ugz" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -50395,6 +50821,11 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
+"uhJ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel/ship/padded,
+/area/maintenance/port)
 "uir" = (
 /obj/machinery/computer/shuttle/mining{
 	dir = 8
@@ -50432,6 +50863,17 @@
 "uoW" = (
 /turf/closed/wall/ship,
 /area/maintenance/nsv/weapons)
+"uqe" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/maintenance/four,
+/obj/machinery/light,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/port)
 "uqx" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -50484,13 +50926,10 @@
 	},
 /turf/open/floor/plating,
 /area/nsv/weapons/gauss)
-"uDe" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
+"uBx" = (
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/nsv/weapons)
 "uDu" = (
 /obj/machinery/door/airlock/ship/external{
 	name = "Mining Shuttle Airlock";
@@ -50498,6 +50937,16 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
+"uEb" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/monotile/dark,
+/area/medical/virology)
 "uFW" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 4
@@ -50850,6 +51299,11 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
+"vmJ" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/structure/railing,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "vnY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -50882,6 +51336,12 @@
 	},
 /turf/open/floor/monotile,
 /area/engine/atmos)
+"vtk" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/sealant,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "vtl" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -50911,6 +51371,13 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"vvH" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
 "vwu" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -50950,6 +51417,19 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"vDb" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"vFo" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/ship,
+/area/maintenance/port)
 "vGG" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
 /obj/machinery/atmospherics/pipe/layer_manifold/visible,
@@ -51192,6 +51672,11 @@
 	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
+"waN" = (
+/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
 "wcq" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
 /obj/structure/lattice/catwalk,
@@ -51217,6 +51702,18 @@
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
+"wfY" = (
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/item/screwdriver,
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
 "wgS" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/toxin,
@@ -51265,13 +51762,6 @@
 /area/bridge{
 	name = "CIC"
 	})
-"wiW" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/plating,
-/area/maintenance/nsv/weapons)
 "wjv" = (
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 4
@@ -51304,6 +51794,15 @@
 	},
 /turf/open/floor/monotile,
 /area/security/warden)
+"wmn" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "wpd" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -51559,16 +52058,15 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
+"wIM" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space)
 "wKR" = (
 /obj/machinery/computer/ship/munitions_computer/west,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
-"wLq" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "wLz" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -51610,6 +52108,14 @@
 	},
 /turf/open/floor/monotile,
 /area/engine/engineering/reactor_core)
+"wQi" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/department/medical)
 "wQk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -51744,6 +52250,12 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/nsv/observation)
+"xab" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/ship/padded,
+/area/maintenance/port)
 "xbj" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -51753,20 +52265,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/hangar)
-"xbG" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Bar";
-	req_one_access_txt = "25"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/monotile,
-/area/crew_quarters/cafeteria{
-	name = "Mess hall"
-	})
 "xbZ" = (
 /obj/machinery/meter/atmos/distro_loop,
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
@@ -51792,6 +52290,21 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"xeF" = (
+/obj/structure/table,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/item/storage/box/lights/mixed,
+/turf/open/floor/plasteel/ship,
+/area/engine/engineering)
 "xgv" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
@@ -51835,6 +52348,22 @@
 	},
 /turf/open/floor/monotile,
 /area/engine/engineering/reactor_core)
+"xlL" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/glowstick,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
+"xmr" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/starboard/fore)
 "xmt" = (
 /obj/machinery/newscaster{
 	pixel_x = -28
@@ -51947,6 +52476,12 @@
 /obj/machinery/vending/wardrobe/viro_wardrobe,
 /turf/open/floor/monotile/light,
 /area/medical/virology)
+"xue" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/template_noop,
+/area/maintenance/department/medical)
 "xui" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -51964,6 +52499,23 @@
 /obj/machinery/atmospherics/pipe/manifold/green/visible,
 /turf/open/floor/monotile,
 /area/engine/engineering/reactor_core)
+"xuu" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	name = "Kitchen maintenance";
+	req_access_txt = "28"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "xuS" = (
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/nsv/weapons)
@@ -51990,12 +52542,33 @@
 /area/bridge{
 	name = "CIC"
 	})
-"xxg" = (
-/obj/structure/sign/barsign,
-/turf/closed/wall/ship,
-/area/crew_quarters/cafeteria{
-	name = "Mess hall"
-	})
+"xvQ" = (
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Bar";
+	req_one_access_txt = "25"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile,
+/area/crew_quarters/bar)
+"xwC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/box/lights/mixed,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"xwM" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "xyX" = (
 /obj/effect/spawner/lootdrop/gloves,
 /turf/open/floor/plating,
@@ -52080,6 +52653,10 @@
 /obj/item/ship_weapon/ammunition/missile/missile_casing,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
+"xGt" = (
+/obj/structure/sign/barsign,
+/turf/closed/wall/ship,
+/area/crew_quarters/bar)
 "xHc" = (
 /obj/machinery/airalarm/directional/north,
 /obj/structure/table/wood,
@@ -52098,6 +52675,14 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"xJX" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
 "xMG" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -52121,6 +52706,12 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
+"xOX" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/starboard/fore)
 "xPq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -52177,18 +52768,13 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/engine/plasma,
 /area/engine/atmos)
+"xRR" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plasteel/ship/padded,
+/area/maintenance/port)
 "xSZ" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/nsv/hangar)
-"xTj" = (
-/obj/machinery/power/apc/auto_name/north{
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/hangar)
 "xTP" = (
@@ -52380,6 +52966,13 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/engine/atmos)
+"ykh" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 
 (1,1,1) = {"
 aaa
@@ -66641,7 +67234,7 @@ apq
 aFA
 beD
 wAa
-bIN
+hVw
 bIP
 bIT
 bIU
@@ -68972,7 +69565,7 @@ beJ
 aYr
 beK
 aDL
-pGe
+kmR
 vTY
 teV
 aCJ
@@ -72292,8 +72885,8 @@ apq
 aaa
 apq
 aZa
-bky
-qbw
+mCz
+djJ
 aZa
 bfC
 bas
@@ -72549,7 +73142,7 @@ apq
 apq
 apq
 aZa
-bkz
+tMn
 baC
 bDU
 bDW
@@ -72806,7 +73399,7 @@ apq
 aaa
 apq
 aZa
-baD
+qrP
 agX
 aZa
 aFD
@@ -73064,7 +73657,7 @@ apq
 apq
 aZa
 akL
-agX
+oMj
 aZa
 bDX
 beh
@@ -73321,7 +73914,7 @@ apq
 aaa
 aZa
 akL
-oMj
+mLR
 aZa
 acX
 bEb
@@ -73574,11 +74167,11 @@ aEE
 aac
 apq
 aaa
-apq
-aaa
 aZa
-akL
-cms
+aZa
+aZa
+leE
+afw
 aZa
 bgu
 bei
@@ -73607,7 +74200,7 @@ bog
 aWr
 boI
 amR
-aGp
+tBW
 bpd
 aKH
 jKS
@@ -73831,11 +74424,11 @@ aac
 aac
 apq
 apq
-apq
-apq
 aZa
-akL
-pFQ
+pHV
+pHV
+eBC
+cNV
 aZa
 aGE
 bCZ
@@ -74088,11 +74681,11 @@ apq
 apq
 apq
 aaa
-apq
-aaa
 aZa
-baD
-uqx
+pHV
+pHV
+eBC
+pHV
 aZa
 ayX
 bEc
@@ -74346,10 +74939,10 @@ aZa
 aZa
 aZa
 aZa
-aZa
-aZa
-baP
-afw
+pHV
+pHV
+eBC
+pHV
 aZa
 bJj
 bej
@@ -74588,25 +75181,25 @@ aaJ
 aaJ
 aaJ
 anb
-agX
-aiF
+gBG
+mmh
+ueI
+baC
+ueI
+baC
+dXJ
 baC
 baC
-bhL
-baC
-baC
-baC
-bhM
 baC
 bFN
+ueI
+ueI
 baC
-baC
-baC
-bhL
-baC
-baC
-baE
-tyd
+nxK
+xue
+xue
+lbt
+pHV
 aZa
 aFF
 bej
@@ -74853,17 +75446,17 @@ agX
 agX
 agX
 agX
+aLW
+aLW
+gBG
+pCo
 agX
-agX
-agX
-agX
-agX
-agX
-agX
-agX
-agX
-akL
-agX
+mpX
+afw
+pHV
+pHV
+eBC
+pHV
 aZa
 aFG
 bel
@@ -74901,7 +75494,7 @@ aKl
 aKu
 aLp
 aah
-bkw
+pqs
 aXi
 aJB
 aLF
@@ -75103,13 +75696,13 @@ aaJ
 aaJ
 anb
 bYd
-akL
+ykh
 agX
 aLW
-aUX
-aYY
-aUX
-aYY
+nZA
+dLp
+xlL
+eqv
 aLW
 afw
 afw
@@ -75119,8 +75712,8 @@ afw
 afw
 afw
 afw
-akL
-agX
+iyN
+afw
 aZa
 aZa
 aZa
@@ -75158,7 +75751,7 @@ aah
 aah
 aah
 aah
-cqJ
+pxf
 aXi
 aXi
 aXi
@@ -75360,7 +75953,7 @@ bKQ
 bKQ
 bKQ
 aZa
-baD
+akL
 agX
 afw
 ahm
@@ -75377,23 +75970,23 @@ ahP
 ahP
 afw
 akL
+tLu
+aLW
+aLW
 agX
-afw
-qZd
-bhN
-agX
-agX
-agX
+bYd
+mCU
+hAC
 bFO
-bhN
-agX
-agX
-agX
-agX
-pFQ
-bhN
-agX
-cms
+nJZ
+dLp
+gmV
+qZd
+mnn
+etE
+lLK
+hnE
+oUH
 afw
 bmo
 bCS
@@ -75406,11 +75999,11 @@ aaI
 abL
 afM
 rSI
-bcO
+vDb
 bcO
 bpw
 acs
-nzE
+xwC
 bls
 bFW
 aah
@@ -75419,7 +76012,7 @@ brt
 bbv
 lTI
 aah
-iFe
+gCo
 mPw
 aXi
 aMc
@@ -75617,7 +76210,7 @@ aaa
 aaa
 aaa
 aZa
-akL
+lUI
 agX
 afw
 abK
@@ -75635,19 +76228,19 @@ ahQ
 afw
 aXw
 aZL
-bec
+aZL
 aZL
 bcm
 aZL
 aZL
+aAc
+aZL
+fEH
 aZL
 aZL
+xwM
 aZL
-aZL
-aZL
-aZL
-aZL
-aZL
+raN
 aZL
 aZL
 aZL
@@ -75668,14 +76261,14 @@ fcD
 bpx
 bgE
 bgE
+bGl
 bgE
-bgE
-oCE
+gZU
 nlR
 bru
 jyj
 jyj
-cjd
+eZC
 bgE
 bli
 aXi
@@ -75874,7 +76467,7 @@ apq
 apq
 apq
 aZa
-baD
+akL
 agX
 afw
 abQ
@@ -75891,7 +76484,7 @@ aic
 aic
 bGk
 aXN
-agX
+hxL
 afw
 afw
 baF
@@ -75901,7 +76494,7 @@ afw
 afw
 afw
 afw
-afw
+llI
 aZa
 aZa
 aZa
@@ -75934,7 +76527,7 @@ bbv
 bbv
 aah
 acs
-bkw
+ugg
 aXi
 blv
 blD
@@ -76148,7 +76741,7 @@ aic
 bhf
 afw
 aXN
-agX
+uqx
 afw
 aZb
 aZc
@@ -76158,7 +76751,7 @@ bed
 bff
 akk
 afV
-agX
+aLW
 acF
 all
 akl
@@ -76190,7 +76783,7 @@ bbv
 bbv
 bbv
 aah
-acs
+rTg
 bkw
 bIF
 bIF
@@ -76389,7 +76982,7 @@ aaa
 apq
 aZa
 akL
-agX
+jqT
 afw
 ahm
 ahK
@@ -76405,7 +76998,7 @@ aic
 aUx
 afw
 aXN
-oBT
+rNb
 afw
 agW
 aki
@@ -76415,7 +77008,7 @@ ajZ
 aTK
 aTV
 afV
-agX
+nNn
 acF
 alt
 alF
@@ -76447,7 +77040,7 @@ bbv
 bbv
 bbv
 aah
-acs
+nbH
 kuF
 chs
 gqO
@@ -76645,8 +77238,8 @@ apq
 aaa
 apq
 aZa
-baD
-agX
+wmn
+jqT
 afw
 aTX
 aoH
@@ -76661,7 +77254,7 @@ aUf
 qdo
 aUy
 afw
-aYp
+oWy
 afw
 afw
 agP
@@ -77158,9 +77751,9 @@ aaa
 apq
 aaa
 aZa
-qZd
+uqx
 akL
-agX
+roC
 afw
 aoB
 ahN
@@ -77415,9 +78008,9 @@ aaa
 apq
 aaa
 aZa
-qbw
-akL
-oMj
+mut
+wQi
+loC
 afw
 ayI
 aAG
@@ -78445,7 +79038,7 @@ abY
 abY
 aUU
 aoM
-bGP
+uEb
 aUS
 aaK
 ahq
@@ -78502,7 +79095,7 @@ brl
 bre
 bre
 lJd
-bDQ
+rjS
 bsl
 brZ
 laZ
@@ -78761,7 +79354,7 @@ mIj
 mIj
 dno
 ffH
-wLq
+kmV
 laZ
 afL
 adh
@@ -78955,11 +79548,11 @@ aUM
 aUO
 apq
 aaa
-aaa
-aaa
 bHp
-brm
-jtt
+bHp
+bHp
+pJP
+lay
 bne
 ahk
 ahi
@@ -79212,11 +79805,11 @@ bvI
 aUO
 apq
 aaa
-aaa
-aaa
 bHp
-brm
-bnm
+lrR
+vFo
+fuW
+ojM
 bne
 ahp
 amL
@@ -79469,11 +80062,11 @@ aoK
 aUO
 apq
 aaa
-aaa
-aaa
 bHp
-idG
-bnm
+pxF
+vFo
+pJP
+xRR
 bne
 ahq
 ahq
@@ -79726,11 +80319,11 @@ abY
 abY
 aaa
 aaa
-aaa
-aaa
 bHp
-brm
-bnm
+jCX
+qzT
+fuW
+uhJ
 bne
 bfv
 amM
@@ -79986,8 +80579,8 @@ bsW
 bsW
 bsW
 bsW
-bFS
-bnm
+die
+ebT
 bne
 ahR
 amM
@@ -80243,8 +80836,8 @@ bsX
 bBE
 bCf
 bsW
-apY
-bnm
+fuW
+mOc
 bne
 akC
 bzX
@@ -80312,8 +80905,8 @@ ahW
 bDw
 aNg
 aNk
-aaa
-aaa
+opF
+opF
 aaa
 aaa
 aaa
@@ -80500,8 +81093,8 @@ bBm
 bCf
 bCf
 bLH
-brm
-cuG
+pJP
+uqe
 bne
 akD
 amM
@@ -80540,13 +81133,13 @@ bEa
 xMG
 laZ
 nWr
-nWr
-psk
+sgN
+krH
 laZ
 iNZ
 qxg
-bVc
-mIj
+dIj
+faG
 bpm
 mIj
 qBl
@@ -80570,7 +81163,7 @@ bDy
 ado
 aNk
 aaa
-aaa
+wIM
 aaa
 aaa
 aaa
@@ -80746,9 +81339,9 @@ aal
 aal
 aal
 xuS
-ddW
+pcI
 jHw
-wiW
+uBx
 qIN
 iLE
 giV
@@ -80757,8 +81350,8 @@ bsW
 bLG
 ced
 bLH
-brm
-bPM
+fuW
+jzy
 bne
 akH
 amM
@@ -80827,7 +81420,7 @@ bDz
 bGw
 aNk
 aaa
-aaa
+wIM
 aaa
 aaa
 aaa
@@ -81015,7 +81608,7 @@ vXM
 rEt
 bsV
 brm
-sSl
+xab
 bne
 amK
 amM
@@ -81053,7 +81646,7 @@ afS
 bDp
 bmQ
 laZ
-asF
+qbU
 thO
 laZ
 boq
@@ -81083,8 +81676,8 @@ aia
 ado
 ado
 aNk
-aaa
-aaa
+opF
+wIM
 aaa
 aaa
 aaa
@@ -81263,7 +81856,7 @@ xuS
 gzY
 oPR
 wWN
-qIN
+pcG
 iSP
 gOn
 ahD
@@ -81311,7 +81904,7 @@ bEd
 btC
 laZ
 xTP
-jBs
+gsa
 boq
 aaa
 aaa
@@ -81341,7 +81934,7 @@ aNb
 aNh
 aNk
 aaa
-aaa
+opF
 aaa
 aaa
 aaa
@@ -81530,16 +82123,16 @@ xAS
 anu
 aqU
 akb
+sYJ
 bsy
 bsy
-bsy
-bsy
+tSY
 jxT
 bsy
 bsy
 bsy
 bsy
-bsy
+sRd
 jxT
 bsy
 bsy
@@ -81551,12 +82144,12 @@ bcb
 bay
 bcV
 aab
-bbk
+rGm
 bbo
 bdC
 beN
-qmJ
-asv
+qcn
+jrr
 bjc
 asv
 bsm
@@ -81785,24 +82378,24 @@ bBa
 twB
 gGP
 bsV
-baB
+rbR
 asK
-cer
+mTV
 krf
-cer
-cer
+mTV
+mTV
 fJZ
 cer
-krf
+mTM
+svh
+bVl
+bVl
+bVl
+mTV
 cer
 cer
-cer
-cer
-cer
-cer
-cer
-aYV
-lsG
+jve
+lmR
 bHp
 bjt
 baG
@@ -83566,8 +84159,8 @@ aal
 aal
 aal
 aal
-aal
-aal
+adF
+adF
 adF
 aal
 ssX
@@ -83822,8 +84415,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+tCu
+tCu
 tCu
 tCu
 tCu
@@ -83911,7 +84504,7 @@ isx
 acc
 aOg
 aaa
-aaa
+wIM
 aaa
 aaa
 aaa
@@ -84079,14 +84672,14 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 tCu
-mlM
-keO
-mlM
+ilV
+ilV
+ilV
+ilV
+pHr
 cOK
-kdX
+azQ
 xsc
 fbx
 bip
@@ -84168,7 +84761,7 @@ bGG
 acc
 aOg
 aaa
-aaa
+wIM
 aaa
 aaa
 aaa
@@ -84336,13 +84929,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 tCu
-eVR
-keO
-keO
-pla
+ilV
+ilV
+ilV
+ilV
+ilV
+xJX
 keO
 xsc
 fbx
@@ -84425,7 +85018,7 @@ isx
 acc
 aOg
 aaa
-aaa
+wIM
 aaa
 aaa
 aaa
@@ -84593,12 +85186,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 tCu
-luJ
-keO
-keO
+ilV
+ilV
+ilV
+ilV
+ilV
 cOK
 keO
 xsc
@@ -84850,12 +85443,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 tCu
-gZK
-keO
-saO
+ilV
+ilV
+ilV
+ilV
+ilV
 cOK
 kuw
 xsc
@@ -85107,12 +85700,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 tCu
-gZK
-keO
-nsk
+ilV
+ilV
+ilV
+ilV
+ilV
 cOK
 keO
 xsc
@@ -85364,12 +85957,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 tCu
-iDH
-keO
-nsk
+ilV
+ilV
+ilV
+ilV
+ilV
 cOK
 pkP
 xsc
@@ -85621,14 +86214,14 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 tCu
-gZK
-keO
-nsk
+ilV
+ilV
+ilV
+ilV
+ilV
 cOK
-lQU
+waN
 xsc
 fbx
 bip
@@ -85878,12 +86471,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 tCu
-gZK
-keO
-keO
+ilV
+ilV
+ilV
+ilV
+ilV
 cOK
 keO
 xsc
@@ -86135,13 +86728,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 tCu
-luJ
-keO
-keO
-cOK
+ilV
+ilV
+ilV
+ilV
+ilV
+xJX
 keO
 xsc
 fbx
@@ -86392,13 +86985,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 tCu
-eVR
-keO
-keO
-pla
+ilV
+ilV
+ilV
+ilV
+ilV
+cOK
 keO
 xsc
 fbx
@@ -86649,14 +87242,14 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 tCu
-saO
-saO
-mlM
-cOK
-eVR
+tCu
+tCu
+tCu
+tCu
+tCu
+tCu
+vvH
 xsc
 fbx
 bip
@@ -86908,10 +87501,10 @@ aaa
 aaa
 aaa
 aaa
-tCu
-tCu
-tCu
-tCu
+aaa
+aaa
+aaa
+aaa
 tCu
 hdo
 xsc
@@ -87686,7 +88279,7 @@ aaa
 arT
 tCu
 keO
-xsc
+nDB
 aam
 fjX
 aat
@@ -87943,7 +88536,7 @@ aaa
 arT
 tCu
 keO
-xsc
+hox
 aam
 aaE
 aav
@@ -88200,7 +88793,7 @@ aaa
 arT
 tCu
 keO
-xsc
+hox
 aam
 bBo
 aaz
@@ -88457,7 +89050,7 @@ aaa
 arT
 tCu
 eVR
-xsc
+ryh
 aam
 aam
 aam
@@ -88527,14 +89120,14 @@ bJx
 bJz
 bJA
 bJB
-blj
+gcf
 aij
 aij
 aij
 aYI
 aYI
 aYI
-aij
+aYI
 aij
 aaa
 aaa
@@ -88790,11 +89383,11 @@ bJF
 bJG
 aim
 aim
-aim
-wpd
-aij
-aaa
-aaa
+hPI
+fLt
+aYI
+opF
+oUI
 aaa
 aaa
 aaa
@@ -88971,7 +89564,7 @@ aaa
 arT
 tCu
 keO
-gPJ
+xsc
 aam
 aby
 aaF
@@ -89046,12 +89639,12 @@ aij
 aij
 bJH
 aim
-bDT
-mVt
-atf
-aij
+qNT
+vmJ
+roq
+aYI
 aaa
-aaa
+oUI
 aaa
 aaa
 aaa
@@ -89227,7 +89820,7 @@ aaa
 tCu
 nKT
 tCu
-xTj
+wfY
 xbj
 aam
 abD
@@ -89305,10 +89898,10 @@ wsH
 aih
 aij
 aij
+gbA
 aij
 aij
-bKQ
-aaa
+opF
 aaa
 aaa
 aaa
@@ -89484,7 +90077,7 @@ aaa
 tCu
 ife
 tCu
-pXO
+qlR
 xsc
 aam
 bIy
@@ -89559,12 +90152,12 @@ aaa
 aaa
 aij
 bJH
-aim
+atf
 aij
-sdB
-sdB
-sdB
-dxN
+eLm
+eLm
+hzH
+aYI
 aaa
 aaa
 aaa
@@ -89762,7 +90355,7 @@ bAP
 aKC
 bIk
 bKe
-aAf
+agm
 agm
 agm
 agm
@@ -89818,12 +90411,12 @@ aij
 bJH
 aim
 rou
-sdB
-sdB
-sdB
-dxN
+eLm
+eLm
+eLm
+aYI
 aaa
-aaa
+oUI
 aaa
 aaa
 aaa
@@ -90075,12 +90668,12 @@ aij
 bJH
 bjF
 aij
-sdB
-sdB
-sdB
-dxN
-aaa
-aaa
+eLm
+eLm
+eLm
+aYI
+opF
+oUI
 aaa
 aaa
 aaa
@@ -90332,12 +90925,12 @@ aij
 bJH
 aim
 aij
-bKQ
-bKQ
-bKQ
-bKQ
+aij
+aij
+aij
+aij
 aaa
-aaa
+oUI
 aaa
 aaa
 aaa
@@ -90798,7 +91391,7 @@ abd
 abd
 abd
 abd
-abZ
+abd
 abZ
 abZ
 bde
@@ -91055,7 +91648,7 @@ abR
 gvw
 ajS
 baI
-xxg
+xGt
 asX
 aVb
 bdf
@@ -91312,7 +91905,7 @@ bfO
 atl
 ats
 baK
-abZ
+abd
 dud
 atH
 aVd
@@ -91569,7 +92162,7 @@ ajQ
 atm
 att
 baL
-abZ
+abd
 ata
 bbC
 bdk
@@ -91826,7 +92419,7 @@ akn
 atm
 aty
 baM
-bbf
+cxy
 bck
 bcQ
 bdl
@@ -92083,7 +92676,7 @@ ajU
 apK
 aVi
 aVm
-bby
+iDR
 bbB
 bbC
 bbC
@@ -92112,7 +92705,7 @@ iFi
 adp
 adp
 iuA
-api
+xOX
 qEO
 vZc
 qEO
@@ -92340,7 +92933,7 @@ amS
 atm
 bup
 afb
-bug
+iUA
 bui
 blU
 blU
@@ -92369,7 +92962,7 @@ oyi
 iuA
 iuA
 iuA
-qEO
+fyq
 qEO
 bqD
 bcn
@@ -92597,7 +93190,7 @@ ath
 ato
 aVa
 aVe
-xbG
+xvQ
 asZ
 aOR
 aOR
@@ -92621,7 +93214,7 @@ iuA
 wXi
 dXL
 iuA
-aiN
+mUy
 bjH
 api
 apo
@@ -92854,7 +93447,7 @@ abd
 rFe
 rFe
 abd
-abZ
+abd
 aVT
 aPb
 aVg
@@ -92874,7 +93467,7 @@ atB
 bkf
 bsh
 bux
-bAT
+oII
 bnw
 qEO
 iuA
@@ -93135,7 +93728,7 @@ abr
 bnx
 qEO
 iuA
-qEO
+jvE
 qEO
 asa
 avp
@@ -93404,9 +93997,9 @@ eFj
 vjc
 iuA
 cpD
-qEO
-aBh
-aBh
+apl
+apl
+apl
 eZK
 oyi
 arT
@@ -93655,15 +94248,15 @@ dXL
 wXi
 iuA
 qEO
-qEO
+iCC
 brT
-qEO
+qqN
 vjc
 iuA
 azy
 aBh
-bHM
-aBh
+pBU
+fyq
 aYD
 oyi
 aaa
@@ -93918,8 +94511,8 @@ qEO
 vjc
 iuA
 azM
-aBh
-aBh
+apl
+qqN
 aBh
 aYE
 oyi
@@ -94164,8 +94757,8 @@ bnz
 bkZ
 bob
 blz
-bkZ
-bkZ
+sAj
+fpJ
 evG
 boW
 bkZ
@@ -94177,7 +94770,7 @@ iuA
 azN
 qEO
 qEO
-aYH
+xmr
 aYF
 oyi
 aaa
@@ -94435,7 +95028,7 @@ eNG
 aCh
 aBh
 aYB
-aYG
+ncH
 oyi
 aaa
 aaa
@@ -94670,7 +95263,7 @@ buC
 arb
 abr
 abr
-qlU
+xuu
 abr
 abr
 abr
@@ -94678,7 +95271,7 @@ bnA
 bkZ
 bob
 blz
-bkZ
+lLc
 boN
 dnZ
 boW
@@ -94691,7 +95284,7 @@ iuA
 azX
 aCi
 aYy
-aYC
+hjm
 aYH
 oyi
 aaa
@@ -95437,8 +96030,8 @@ amY
 aVE
 aVH
 aVJ
-iuA
-uDe
+dFv
+cIi
 iuA
 aiK
 apV
@@ -95460,7 +96053,7 @@ apV
 glh
 iuA
 aAa
-aVW
+fwJ
 aYz
 oyi
 aaa
@@ -95951,7 +96544,7 @@ qxl
 aMA
 aMA
 aMA
-air
+gAp
 blL
 ais
 qEO
@@ -96206,7 +96799,7 @@ hLd
 arz
 aVD
 aVG
-aVI
+igg
 bln
 iuA
 for
@@ -97213,7 +97806,7 @@ aey
 per
 ayR
 aAC
-aBg
+xeF
 aey
 arW
 arW
@@ -97450,7 +98043,7 @@ apq
 asL
 aYN
 aYK
-aYK
+lGr
 aYK
 aYM
 bzG
@@ -97967,7 +98560,7 @@ tzp
 rxn
 aIc
 bny
-aoZ
+hhh
 asL
 apP
 aqx
@@ -98224,7 +98817,7 @@ asL
 asL
 asL
 bJh
-aoZ
+llg
 asL
 aqj
 aqh
@@ -98285,7 +98878,7 @@ asG
 yeQ
 asH
 aCB
-aCN
+qCp
 aCM
 gDn
 aqk
@@ -98481,7 +99074,7 @@ aHJ
 aHJ
 asL
 bJh
-aoZ
+vtk
 asL
 apU
 aqe
@@ -98738,7 +99331,7 @@ aSs
 aHJ
 asL
 bJh
-aoZ
+iCG
 asL
 aqa
 aqe
@@ -98995,7 +99588,7 @@ aSt
 aSw
 asL
 bFR
-aoZ
+iCG
 bzI
 anT
 anU
@@ -99252,7 +99845,7 @@ aSu
 aHJ
 asL
 bJh
-aoZ
+iCG
 asL
 asL
 anV
@@ -99313,7 +99906,7 @@ asG
 yeQ
 asH
 aCE
-aCQ
+gWU
 aCP
 nkx
 aqk
@@ -100019,7 +100612,7 @@ amx
 aHM
 aIy
 ayv
-aIz
+ieG
 aYP
 aYK
 aJq
@@ -102383,7 +102976,7 @@ avN
 avt
 aqk
 awJ
-awR
+rjt
 awJ
 aqk
 axt

--- a/_maps/map_files/Tycoon/Tycoon2.dmm
+++ b/_maps/map_files/Tycoon/Tycoon2.dmm
@@ -358,18 +358,6 @@
 "abd" = (
 /turf/closed/wall/ship,
 /area/crew_quarters/bar)
-"abf" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/ship{
-	id = "maintshop";
-	layer = 3.1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/hallway/nsv/deck2/frame1/central)
 "abg" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -386,18 +374,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck2)
-"abi" = (
-/obj/machinery/paystand,
-/obj/machinery/door/poddoor/ship{
-	id = "maintshop";
-	layer = 3.1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/hallway/nsv/deck2/frame1/central)
 "abj" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/firealarm{
@@ -420,10 +396,6 @@
 	},
 /turf/open/floor/monotile/light,
 /area/medical/virology)
-"abm" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/crew_quarters/fitness/recreation)
 "abn" = (
 /obj/machinery/light{
 	dir = 1
@@ -949,21 +921,6 @@
 /obj/structure/closet/toolcloset,
 /turf/open/floor/plating,
 /area/hallway/nsv/deck2/frame1/central)
-"acJ" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
-	},
-/obj/machinery/computer/ship/dradis/minor,
-/obj/machinery/computer/ship/viewscreen,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
-	},
-/turf/open/floor/monotile/dark,
-/area/bridge{
-	name = "CIC"
-	})
 "acK" = (
 /obj/machinery/status_display/evac{
 	pixel_x = -32
@@ -1327,19 +1284,6 @@
 	},
 /turf/open/floor/monotile,
 /area/engine/engineering)
-"adC" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
-	name = "Chapel"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/main)
 "adD" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -1400,19 +1344,6 @@
 /area/maintenance/starboard/secondary{
 	name = "Munitions Projects"
 	})
-"adK" = (
-/obj/machinery/door/morgue{
-	name = "Confession Booth (Chaplain)";
-	req_access_txt = "22"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/main)
 "adL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/dark,
@@ -2293,11 +2224,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/tcommsat/computer)
-"afJ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/curtain/obscuring/grey,
-/turf/open/floor/plating,
-/area/chapel/main)
 "afK" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -2335,18 +2261,6 @@
 	frequency = 1481;
 	name = "Confessional Intercom";
 	pixel_x = -25
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/main)
-"afO" = (
-/obj/machinery/door/morgue{
-	name = "Confession Booth"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
@@ -2771,19 +2685,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/chapel/main)
-"agO" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/advanced_airlock_controller{
-	pixel_y = 24
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "agP" = (
 /turf/closed/wall/ship,
 /area/medical/exam_room)
@@ -3454,16 +3355,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"ait" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "aiu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -3492,14 +3383,6 @@
 	},
 /turf/open/floor/monotile,
 /area/nsv/hanger/deck2)
-"aix" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "aiz" = (
 /obj/machinery/computer/atmos_alert,
 /turf/open/floor/plasteel/grid/lino,
@@ -5154,16 +5037,6 @@
 "amq" = (
 /turf/closed/wall/ship,
 /area/lawoffice)
-"amr" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Gym"
-	},
-/turf/open/floor/carpet/ship,
-/area/crew_quarters/fitness/recreation)
 "ams" = (
 /turf/closed/wall/ship,
 /area/crew_quarters/dorms/nsv/dorms_1)
@@ -5214,19 +5087,6 @@
 /obj/structure/closet/secure_closet/brig,
 /turf/open/floor/monotile/dark,
 /area/security/prison)
-"amF" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Bar";
-	req_one_access_txt = "25"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/monotile,
-/area/crew_quarters/cafeteria{
-	name = "Mess hall"
-	})
 "amG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -6087,22 +5947,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/medical/virology)
-"aoN" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Atmospherics";
-	req_one_access_txt = "10; 24"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel/ship,
-/area/engine/atmos)
 "aoO" = (
 /obj/structure/table/optable,
 /obj/machinery/camera/autoname{
@@ -6661,22 +6505,6 @@
 	},
 /turf/open/floor/monotile/light,
 /area/crew_quarters/kitchen)
-"aqB" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Gym"
-	},
-/turf/open/floor/carpet/ship,
-/area/crew_quarters/fitness/recreation)
 "aqC" = (
 /turf/closed/wall/r_wall/ship,
 /area/crew_quarters/dorms)
@@ -7407,6 +7235,15 @@
 	},
 /turf/open/floor/carpet/green,
 /area/engine/engineering/reactor_control)
+"asF" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/techmaint,
+/area/maintenance/starboard)
 "asG" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
 /turf/open/floor/plating,
@@ -7451,6 +7288,21 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
+"asN" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "asV" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -7750,13 +7602,6 @@
 "atI" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
-	},
-/turf/open/floor/carpet/blue,
-/area/crew_quarters/nsv/observation)
-"atJ" = (
-/obj/structure/table/wood,
-/obj/item/toy/cards/deck{
-	pixel_y = 4
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/nsv/observation)
@@ -8242,19 +8087,6 @@
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
-"avj" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
-	name = "Crew Lounge"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/dorms)
 "avk" = (
 /obj/structure/table,
 /obj/item/storage/pill_bottle/dice,
@@ -8308,29 +8140,6 @@
 "avt" = (
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
-"avu" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/crew_quarters/dorms)
-"avv" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	dir = 4;
-	name = "Kitchen maintenance";
-	req_access_txt = "12;28"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plating,
-/area/crew_quarters/kitchen/coldroom)
 "avw" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light/runway,
@@ -8571,16 +8380,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
-"axG" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 3
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "axH" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -9188,9 +8987,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/starboard/fore)
-"aAc" = (
-/turf/open/floor/plating,
-/area/engine/atmos)
 "aAd" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -10075,16 +9871,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/tcommsat/server)
-"aCq" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/monotile/dark,
-/area/tcommsat/computer)
 "aCr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -10266,10 +10052,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/tcommsat/computer)
-"aCV" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/engine/gravity_generator)
 "aCW" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -10389,22 +10171,6 @@
 	},
 /turf/open/floor/circuit/green/telecomms,
 /area/tcommsat/server)
-"aDl" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/monotile/dark,
-/area/tcommsat/computer)
 "aDm" = (
 /obj/machinery/holopad,
 /obj/structure/cable{
@@ -14281,24 +14047,6 @@
 /obj/item/toy/plush/slimeplushie,
 /turf/open/floor/monotile/dark,
 /area/science/xenobiology)
-"aLL" = (
-/obj/machinery/door/window/westright{
-	dir = 1;
-	name = "Server Cage";
-	req_one_access_txt = "30"
-	},
-/obj/machinery/door/window/westright{
-	dir = 2;
-	name = "Server Cage";
-	req_one_access_txt = "30"
-	},
-/obj/machinery/atmospherics/pipe/simple,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/monotile/dark,
-/area/science/server)
 "aLM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -14398,13 +14146,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"aLX" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
 "aLY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/monotile,
@@ -14502,22 +14243,6 @@
 	},
 /turf/open/floor/monotile,
 /area/science/xenobiology)
-"aMk" = (
-/obj/machinery/door/airlock/ship/public{
-	name = "Crew Quarters"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/carpet/ship,
-/area/crew_quarters/dorms)
 "aMl" = (
 /obj/machinery/computer/nanite_cloud_controller,
 /turf/open/floor/monotile/dark,
@@ -14868,22 +14593,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/nsv/observation)
-"aMW" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/airlock/ship/public{
-	name = "Crew Quarters"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/carpet/ship,
-/area/crew_quarters/dorms)
 "aMX" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
@@ -15477,15 +15186,6 @@
 "aOe" = (
 /turf/closed/wall/r_wall/ship,
 /area/hallway/secondary/exit)
-"aOf" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/advanced_airlock_controller{
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/monotile/dark,
-/area/hallway/secondary/exit)
 "aOg" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
 /turf/open/floor/plating,
@@ -15692,17 +15392,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
-"aOG" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/advanced_airlock_controller{
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1,
-/turf/open/floor/plating,
-/area/hallway/secondary/exit)
 "aOH" = (
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/port)
@@ -16314,22 +16003,6 @@
 /obj/effect/turf_decal/delivery/red,
 /turf/open/floor/engine,
 /area/engine/engine_room)
-"aQa" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/ship/delivery/yellow,
-/obj/machinery/door/poddoor/shutters/ship{
-	id = "powderboys";
-	name = "Powder Rack Access"
-	},
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "naval"
-	},
-/turf/open/floor/monotile,
-/area/nsv/weapons/fore)
 "aQd" = (
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/effect/turf_decal/stripes/line{
@@ -16805,16 +16478,6 @@
 	},
 /turf/open/floor/carpet/green,
 /area/engine/engineering/reactor_control)
-"aRd" = (
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Telecomms Admin";
-	departmentType = 5;
-	name = "Telecomms RC";
-	pixel_y = -30
-	},
-/turf/open/floor/monotile/dark,
-/area/tcommsat/computer)
 "aRe" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -17745,21 +17408,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
-"aTs" = (
-/obj/machinery/door/airlock/highsecurity/ship{
-	dir = 4;
-	name = "Gauss rounds";
-	req_one_access_txt = "69"
-	},
-/obj/structure/lattice/catwalk/over/ship,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/nsv/weapons/gauss)
 "aTt" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/lattice/catwalk/over/ship,
@@ -18404,20 +18052,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"aUY" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Virology";
-	req_one_access_txt = "5"
-	},
-/turf/open/floor/monotile/dark,
-/area/medical/virology)
 "aUZ" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -21948,32 +21582,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/medical/medbay/central)
-"bcp" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
-	name = "Examination Room"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	dir = 4;
-	id = "medical_traitor_murder_hole"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/carpet/ship,
-/area/medical/medbay/lobby)
 "bcq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22079,23 +21687,6 @@
 	},
 /turf/open/floor/monotile,
 /area/hallway/secondary/exit)
-"bcA" = (
-/obj/machinery/door/airlock/ship/station/mining{
-	dir = 4;
-	name = "Cargo Bay";
-	req_one_access_txt = "31; 48"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/monotile/dark,
-/area/quartermaster/storage)
 "bcB" = (
 /obj/structure/chair/stool,
 /obj/structure/cable{
@@ -24428,21 +24019,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck2)
-"bgU" = (
-/obj/machinery/door/airlock/ship/public{
-	name = "Galley";
-	req_one_access_txt = "28"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/monotile,
-/area/crew_quarters/cafeteria{
-	name = "Mess hall"
-	})
 "bgV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
@@ -26160,26 +25736,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/monotile,
 /area/engine/engineering/hangar)
-"bko" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/window{
-	dir = 4;
-	name = "communications officer's station"
-	},
-/obj/structure/chair/office{
-	dir = 8;
-	name = "tactical chair"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
-	},
-/turf/open/floor/monotile/dark,
-/area/bridge{
-	name = "CIC"
-	})
 "bkq" = (
 /obj/structure/closet/emcloset,
 /obj/item/storage/toolbox/emergency,
@@ -26978,12 +26534,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
-"bmd" = (
-/obj/machinery/advanced_airlock_controller/directional/west{
-	pixel_y = 24
-	},
-/turf/open/floor/plating,
-/area/engine/atmos)
 "bme" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -27579,12 +27129,6 @@
 "bnm" = (
 /turf/open/floor/plating,
 /area/maintenance/port)
-"bnn" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "bno" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
@@ -27780,11 +27324,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
-"bnH" = (
-/obj/machinery/light,
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "bnI" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -27909,16 +27448,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
 /area/medical/chemistry)
-"bnY" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	name = "Arrivals maintenance"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "bnZ" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -29231,23 +28760,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/science/nanite)
-"bqt" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
-	},
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/machinery/light,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
-	},
-/turf/open/floor/monotile/dark,
-/area/bridge{
-	name = "CIC"
-	})
 "bqu" = (
 /obj/machinery/power/apc/auto_name/north{
 	pixel_y = 24
@@ -29680,18 +29192,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"brn" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/sorting/mail{
-	sortType = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "bro" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -29886,13 +29386,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"brI" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
 "brJ" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -30045,23 +29538,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"brX" = (
-/obj/machinery/light/small,
-/obj/structure/table,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
-"brY" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "brZ" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -30495,18 +29971,6 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
-"bsS" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "bsU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -30983,28 +30447,6 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/monotile,
-/area/crew_quarters/dorms)
-"btO" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
-	name = "Crew Lounge"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "btP" = (
 /obj/structure/cable{
@@ -32027,20 +31469,6 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/medical/medbay/central)
-"bvz" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Virology";
-	req_one_access_txt = "5"
-	},
-/turf/open/floor/monotile,
-/area/medical/virology)
 "bvA" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -33144,29 +32572,6 @@
 	},
 /turf/open/floor/monotile,
 /area/hallway/secondary/exit)
-"bxI" = (
-/obj/machinery/door/airlock/ship/station/mining{
-	dir = 4;
-	name = "Cargo Bay";
-	req_one_access_txt = "31; 48"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/monotile/dark,
-/area/quartermaster/storage)
 "bxJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -33193,42 +32598,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"bxL" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
-"bxM" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
-	name = "Chapel"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/main)
 "bxN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -33386,25 +32755,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/main)
-"byd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/door/airlock/ship/hatch{
-	dir = 4;
-	name = "Funeral Parlour"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
@@ -33569,27 +32919,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"byy" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
-	},
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/machinery/computer/ship/viewscreen,
-/obj/machinery/light{
-	dir = 1;
-	icon_state = "tube"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
-	},
-/turf/open/floor/monotile/dark,
-/area/bridge{
-	name = "CIC"
-	})
 "byz" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -34520,24 +33849,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/engine/break_room)
-"bAx" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Atmospherics";
-	req_one_access_txt = "10; 24"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel/ship,
-/area/engine/break_room)
 "bAy" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -35263,18 +34574,6 @@
 	dir = 1;
 	icon_state = "stairs-old"
 	},
-/area/bridge{
-	name = "CIC"
-	})
-"bBV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/holopad,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/monotile,
 /area/bridge{
 	name = "CIC"
 	})
@@ -37547,17 +36846,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
-"bGi" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "bGj" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -39409,25 +38697,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
-"bKE" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/poddoor/shutters/ship{
-	dir = 4;
-	id = "gaussgang";
-	name = "public gauss access shutters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/monotile,
-/area/nsv/hanger/storage{
-	name = "Munitions Control Room"
-	})
 "bKF" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -39603,18 +38872,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
-"bLb" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Primary Tool Storage"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/monotile/dark,
-/area/hallway/nsv/deck2/frame1/central)
 "bLc" = (
 /obj/structure/sign/directions/medical{
 	dir = 8
@@ -39637,56 +38894,6 @@
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/port)
-"bLe" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/window{
-	dir = 4;
-	name = "security station"
-	},
-/obj/structure/chair/office{
-	dir = 8;
-	name = "tactical chair"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
-	},
-/turf/open/floor/monotile/dark,
-/area/bridge{
-	name = "CIC"
-	})
-"bLf" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
-	},
-/obj/machinery/computer/ship/dradis/minor{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
-	},
-/turf/open/floor/monotile/dark,
-/area/bridge{
-	name = "CIC"
-	})
-"bLg" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Central Primary Hallway"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/monotile/dark,
-/area/hallway/nsv/deck2/frame1/central)
 "bLh" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1
@@ -39708,25 +38915,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/gauss)
-"bLj" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/ship/public{
-	dir = 4;
-	name = "Arrivals Emergency Storage"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "bLk" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -39848,46 +39036,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/turf/open/floor/monotile/dark,
-/area/hallway/secondary/exit)
-"bLs" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/turf/open/floor/monotile/dark,
-/area/hallway/secondary/exit)
-"bLt" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	dir = 4;
-	name = "Arrivals"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
@@ -40154,37 +39302,6 @@
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
-"bLV" = (
-/obj/machinery/computer/ship/dradis/minor/console{
-	dir = 1;
-	icon_state = "computer"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
-"bLW" = (
-/obj/machinery/computer/ship/dradis/console,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/monotile/dark,
-/area/bridge{
-	name = "CIC"
-	})
-"bLX" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/holopad,
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
 "bLY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -40313,6 +39430,11 @@
 "bNa" = (
 /turf/closed/wall/r_wall/ship,
 /area/library)
+"bNC" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/gambling,
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/nsv/observation)
 "bOr" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -40341,6 +39463,17 @@
 /obj/item/beacon,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"bTi" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile,
+/area/bridge{
+	name = "CIC"
+	})
 "bTR" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -40358,6 +39491,11 @@
 /area/bridge{
 	name = "CIC"
 	})
+"bUn" = (
+/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "bUM" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /turf/open/floor/plasteel/tech/grid{
@@ -40371,6 +39509,12 @@
 /obj/effect/turf_decal/ship/delivery/yellow,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
+"bVc" = (
+/obj/item/trash/can,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/starboard)
 "bVw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -40422,18 +39566,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/closed/wall/r_wall/ship,
-/area/nsv/weapons/gauss)
-"bXJ" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/highsecurity/ship{
-	name = "Weapons Bay";
-	req_one_access_txt = "69"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/monotile,
 /area/nsv/weapons/gauss)
 "bXL" = (
 /obj/structure/disposalpipe/segment{
@@ -40506,13 +39638,6 @@
 /area/bridge{
 	name = "CIC"
 	})
-"bYl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/nsv/weapons/gauss)
 "bYm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -40601,23 +39726,6 @@
 	},
 /turf/open/floor/monotile,
 /area/nsv/weapons/gauss)
-"bYG" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/poddoor/shutters/ship{
-	dir = 4;
-	id = "gaussgang";
-	name = "public gauss access shutters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/nsv/weapons/gauss)
 "bYI" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -40661,58 +39769,6 @@
 	},
 /turf/open/floor/monotile,
 /area/nsv/weapons/gauss)
-"bYO" = (
-/obj/machinery/modular_computer/console/preset/command{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
-"bYP" = (
-/obj/structure/chair/office,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
-"bYR" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/computer/monitor{
-	dir = 8;
-	name = "Bridge Power Monitoring Console"
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
-	},
-/turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
 "bYS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -40805,55 +39861,6 @@
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile/light,
 /area/medical/medbay/lobby)
-"bZG" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 10
-	},
-/turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
-"bZH" = (
-/obj/machinery/computer/communications/console{
-	dir = 1;
-	icon_state = "computer_end"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
-"bZJ" = (
-/obj/machinery/computer/crew/console{
-	dir = 1;
-	icon_state = "computer"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
-"bZK" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/railing{
-	dir = 6
-	},
-/turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
 "bZR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -40970,98 +39977,6 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
-	},
-/turf/open/floor/monotile/dark,
-/area/bridge{
-	name = "CIC"
-	})
-"cav" = (
-/obj/machinery/computer/console_placholder{
-	dir = 4;
-	icon_state = "computer"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/monotile/dark,
-/area/bridge{
-	name = "CIC"
-	})
-"caw" = (
-/obj/machinery/computer/ship/helm/console,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/monotile/dark,
-/area/bridge{
-	name = "CIC"
-	})
-"cay" = (
-/obj/machinery/computer/ship/tactical/console,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/monotile/dark,
-/area/bridge{
-	name = "CIC"
-	})
-"caz" = (
-/obj/machinery/computer/console_placholder{
-	dir = 8;
-	icon_state = "computer"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
-	},
-/turf/open/floor/monotile/dark,
-/area/bridge{
-	name = "CIC"
-	})
-"caC" = (
-/obj/machinery/computer/ship/navigation/console/end{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/monotile/dark,
-/area/bridge{
-	name = "CIC"
-	})
-"caD" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
-"caF" = (
-/obj/machinery/computer/security/console{
-	dir = 5;
-	icon_screen = null;
-	icon_state = "computer_end"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
 	},
 /turf/open/floor/monotile/dark,
 /area/bridge{
@@ -41231,18 +40146,6 @@
 	},
 /turf/closed/wall/r_wall/ship,
 /area/nsv/weapons/gauss)
-"cbX" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/ship/delivery/yellow,
-/obj/machinery/door/airlock/highsecurity/ship{
-	name = "Naval Artillery";
-	req_one_access_txt = "69"
-	},
-/turf/open/floor/monotile,
-/area/nsv/weapons/fore)
 "cbY" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -41473,15 +40376,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"ciA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/meter/atmos/distro_loop,
-/turf/open/floor/plasteel/tech/grid{
-	initial_gas_mix = "TEMP=2.7"
-	},
-/area/engine/atmos)
 "ciB" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 4
@@ -41517,20 +40411,32 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"cjU" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/camera/autoname{
-	c_tag = "Atmos - West #2"
+"cjB" = (
+/obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
+	name = "Arrivals"
 	},
-/turf/open/space/basic,
-/area/engine/atmos)
-"ckc" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 1
+	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/dark,
+/area/hallway/secondary/exit)
 "ckD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -41637,6 +40543,17 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering/hangar)
+"cpD" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3
+	},
+/obj/item/trash/popcorn,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "cqJ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -41687,6 +40604,20 @@
 	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
+"csW" = (
+/obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
+	name = "Chapel"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/plasteel/dark,
+/area/chapel/main)
 "ctl" = (
 /obj/machinery/shower{
 	name = "emergency shower"
@@ -41721,12 +40652,6 @@
 	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
-"czo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "cAn" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -41876,6 +40801,19 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/engine/storage)
+"cNT" = (
+/obj/structure/chair/office,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile,
+/area/bridge{
+	name = "CIC"
+	})
 "cOu" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -41936,6 +40874,18 @@
 	},
 /turf/open/floor/monotile,
 /area/crew_quarters/fitness/recreation)
+"cUs" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/obj/item/stock_parts/matter_bin,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "cUM" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	dir = 4;
@@ -42088,6 +41038,24 @@
 	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
+"dhL" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
+	},
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/machinery/light,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4;
+	icon_state = "door_open"
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/dark,
+/area/bridge{
+	name = "CIC"
+	})
 "dhX" = (
 /obj/item/fuel_rod,
 /turf/open/indestructible/sound/pool/spentfuel/wall,
@@ -42116,6 +41084,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
+"dmM" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "dmS" = (
 /obj/machinery/computer/ship/munitions_computer/east,
 /obj/effect/turf_decal/ship/delivery/yellow,
@@ -42128,6 +41100,16 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/monotile,
 /area/gateway)
+"dno" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "dnZ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/closet,
@@ -42135,23 +41117,6 @@
 /obj/effect/spawner/lootdrop/maintenance/four,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"dqx" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Medical Central";
-	req_one_access_txt = "5"
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/turf/open/floor/monotile,
-/area/medical/medbay/central)
 "drl" = (
 /obj/machinery/meter,
 /obj/structure/grille,
@@ -42160,6 +41125,14 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
+"dtG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/plating,
+/area/nsv/weapons/gauss)
 "dud" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -42199,9 +41172,30 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/nsv/hangar)
+"dDu" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "dDv" = (
 /turf/closed/wall/ship,
 /area/nsv/weapons/gauss)
+"dDO" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Gym"
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/fitness/recreation)
 "dDX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -42318,6 +41312,20 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
+"dTk" = (
+/obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
+	name = "Crew Lounge"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "dTo" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
@@ -42388,23 +41396,36 @@
 	},
 /turf/open/floor/monotile,
 /area/medical/medbay/central)
+"dXK" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "dXL" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"ecN" = (
+"ecX" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/tank/internals/air,
-/obj/item/tank/internals/air,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/secondary/exit)
 "edN" = (
 /obj/machinery/suit_storage_unit/atmos,
 /obj/effect/turf_decal/stripes/line{
@@ -42471,6 +41492,48 @@
 /area/nsv/hanger/storage{
 	name = "Munitions Control Room"
 	})
+"eiX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/hatch{
+	dir = 4;
+	name = "Funeral Parlour"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/plasteel/dark,
+/area/chapel/main)
+"ekv" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "elG" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
 	dir = 1
@@ -42567,6 +41630,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/engine/storage)
+"eot" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/plating,
+/area/crew_quarters/dorms)
 "eoU" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -42577,6 +41646,23 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
+"epE" = (
+/obj/machinery/advanced_airlock_controller/directional/south{
+	pixel_y = 24
+	},
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
+"epQ" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/maintenance/four,
+/obj/structure/closet,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "eqA" = (
 /obj/structure/table,
 /obj/item/clothing/suit/hazardvest,
@@ -42679,6 +41765,15 @@
 /obj/structure/lattice/catwalk/over/ship,
 /turf/open/floor/monotile,
 /area/nsv/weapons/fore)
+"ezQ" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/advanced_airlock_controller/directional/east{
+	pixel_y = 24
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/secondary/exit)
 "eAi" = (
 /obj/machinery/light{
 	dir = 8
@@ -42726,6 +41821,36 @@
 /obj/machinery/light,
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
+"eCs" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4;
+	icon_state = "door_open"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/railing{
+	dir = 6
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile,
+/area/bridge{
+	name = "CIC"
+	})
+"eCP" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Virology";
+	req_one_access_txt = "5"
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/dark,
+/area/medical/virology)
 "eDI" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -42815,6 +41940,21 @@
 /obj/structure/bookcase,
 /turf/open/floor/wood,
 /area/library)
+"eLS" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Virology";
+	req_one_access_txt = "5"
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile,
+/area/medical/virology)
 "eNG" = (
 /obj/structure/closet/cardboard,
 /obj/effect/turf_decal/stripes/line{
@@ -42823,6 +41963,19 @@
 /obj/effect/spawner/lootdrop/maintenance/four,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"eNN" = (
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Primary Tool Storage"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck2/frame1/central)
 "eOh" = (
 /obj/effect/turf_decal/stripes/red/line,
 /obj/effect/turf_decal/stripes/red/line{
@@ -42967,17 +42120,6 @@
 	},
 /turf/open/space/basic,
 /area/engine/atmos)
-"fdU" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "fex" = (
 /obj/structure/punching_bag,
 /obj/machinery/light_switch{
@@ -42985,6 +42127,13 @@
 	},
 /turf/open/floor/monotile,
 /area/crew_quarters/fitness/recreation)
+"ffH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "fjB" = (
 /obj/machinery/door/airlock/ship{
 	dir = 4;
@@ -43035,6 +42184,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"foY" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "fpo" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/visible,
 /obj/structure/cable/yellow{
@@ -43045,6 +42204,30 @@
 	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
+"fpL" = (
+/obj/machinery/door/airlock/ship/station/mining{
+	dir = 4;
+	name = "Cargo Bay";
+	req_one_access_txt = "31; 48"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/dark,
+/area/quartermaster/storage)
 "frs" = (
 /obj/machinery/computer/ship/munitions_computer/west,
 /obj/effect/turf_decal/stripes/line{
@@ -43052,16 +42235,6 @@
 	},
 /turf/open/floor/monotile,
 /area/nsv/weapons/fore)
-"fub" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/turf_decal/bot_white,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/tech/grid{
-	initial_gas_mix = "TEMP=2.7"
-	},
-/area/engine/atmos)
 "ful" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
@@ -43145,6 +42318,19 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/closed/wall/r_wall/ship,
 /area/engine/atmospherics_engine)
+"fHb" = (
+/obj/machinery/paystand,
+/obj/machinery/door/poddoor/ship{
+	id = "maintshop";
+	layer = 3.1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/plating,
+/area/hallway/nsv/deck2/frame1/central)
 "fHB" = (
 /obj/structure/lattice/catwalk/over/ship,
 /obj/machinery/computer/ship/viewscreen,
@@ -43214,21 +42400,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"fPW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/structure/lattice/catwalk,
-/obj/machinery/camera/autoname{
-	c_tag = "Atmos - East #1";
-	dir = 8
-	},
-/obj/machinery/computer/atmos_control/tank/mix_tank{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/engine/atmos)
 "fPZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -43254,6 +42425,23 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/engine/atmos)
+"fTr" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/airlock/ship/public{
+	name = "Crew Quarters"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "fUk" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
@@ -43346,6 +42534,29 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
+"giC" = (
+/obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
+	name = "Crew Lounge"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "giV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
@@ -43358,6 +42569,19 @@
 	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
+"gjO" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/monotile/dark,
+/area/tcommsat/computer)
 "gkP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -43433,6 +42657,21 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"grp" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/ship/maintenance{
+	name = "Arrivals maintenance"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "gtM" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -43497,6 +42736,23 @@
 	},
 /turf/open/floor/monotile,
 /area/engine/engineering/reactor_core)
+"gDl" = (
+/obj/machinery/computer/console_placholder{
+	dir = 8;
+	icon_state = "computer"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4;
+	icon_state = "door_open"
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/dark,
+/area/bridge{
+	name = "CIC"
+	})
 "gDn" = (
 /obj/machinery/light/small,
 /turf/open/floor/engine/n2,
@@ -43604,12 +42860,50 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
+"gJJ" = (
+/obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
+	name = "Examination Room"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "medical_traitor_murder_hole"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/carpet/ship,
+/area/medical/exam_room)
 "gJU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
+"gKB" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "gMn" = (
 /obj/machinery/requests_console{
 	department = "Medbay";
@@ -43647,6 +42941,13 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/nsv/hangar)
+"gRe" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/oil/streak,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "gSH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -43708,6 +43009,11 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
+"gWm" = (
+/obj/machinery/space_heater,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "gWy" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -43719,6 +43025,18 @@
 	},
 /turf/open/floor/monotile,
 /area/hallway/secondary/exit)
+"gYf" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "gZm" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -43897,6 +43215,40 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/engine/atmos)
+"hqj" = (
+/obj/machinery/door/window/westright{
+	dir = 1;
+	name = "Server Cage";
+	req_one_access_txt = "30"
+	},
+/obj/machinery/door/window/westright{
+	dir = 2;
+	name = "Server Cage";
+	req_one_access_txt = "30"
+	},
+/obj/machinery/atmospherics/pipe/simple,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/dark,
+/area/science/server)
+"hqs" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/structure/lattice/catwalk,
+/obj/machinery/camera/autoname{
+	c_tag = "Atmos - East #1";
+	dir = 8
+	},
+/obj/machinery/computer/atmos_control/tank/mix_tank{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/engine/atmos)
 "hrv" = (
 /obj/machinery/newscaster/security_unit,
 /turf/closed/wall/ship,
@@ -43910,6 +43262,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"htk" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/plating,
+/area/crew_quarters/fitness/recreation)
 "htl" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -43931,9 +43288,32 @@
 /obj/machinery/meter,
 /turf/open/space/basic,
 /area/engine/engineering/reactor_core)
+"hus" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/engine/atmos)
 "hvH" = (
 /turf/open/floor/wood,
 /area/library)
+"hvW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 5
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
+"hwO" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "hwT" = (
 /obj/machinery/power/turbine{
 	dir = 4
@@ -43968,6 +43348,19 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
+"hxW" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/ship/delivery/yellow,
+/obj/machinery/door/airlock/highsecurity/ship{
+	name = "Naval Artillery";
+	req_one_access_txt = "69"
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile,
+/area/nsv/weapons/fore)
 "hyv" = (
 /obj/machinery/ship_weapon/vls,
 /obj/effect/turf_decal/stripes/line{
@@ -44053,6 +43446,42 @@
 	},
 /turf/open/floor/monotile,
 /area/crew_quarters/theatre)
+"hFc" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Gym"
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/fitness/recreation)
+"hGU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "hHa" = (
 /obj/effect/turf_decal/pool/corner{
 	dir = 1
@@ -44166,6 +43595,11 @@
 	},
 /turf/open/space/basic,
 /area/engine/atmos)
+"hRE" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/plating,
+/area/engine/gravity_generator)
 "hRK" = (
 /obj/machinery/pool_filter{
 	id = "spentfuel2"
@@ -44184,19 +43618,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/monotile,
 /area/engine/engineering/reactor_core)
-"hSg" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/advanced_airlock_controller{
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plating,
-/area/hallway/secondary/exit)
 "hSP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
@@ -44250,6 +43671,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/weapons)
+"hZH" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/tcommsat/computer)
 "icy" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -44300,6 +43734,27 @@
 /obj/effect/spawner/structure/window/reinforced/ship,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"ilH" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/window{
+	dir = 4;
+	name = "security station"
+	},
+/obj/structure/chair/office{
+	dir = 8;
+	name = "tactical chair"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4;
+	icon_state = "door_open"
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/dark,
+/area/bridge{
+	name = "CIC"
+	})
 "inb" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -44378,6 +43833,19 @@
 	},
 /turf/open/floor/monotile,
 /area/hallway/secondary/exit)
+"itk" = (
+/obj/machinery/computer/ship/navigation/console/end{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/dark,
+/area/bridge{
+	name = "CIC"
+	})
 "iuh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -44413,10 +43881,6 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"iyL" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/crew_quarters/fitness/recreation)
 "iCD" = (
 /obj/structure/closet/lasertag/blue,
 /obj/machinery/light,
@@ -44432,6 +43896,22 @@
 	},
 /turf/open/floor/monotile,
 /area/nsv/hanger/deck2)
+"iDf" = (
+/obj/machinery/door/airlock/highsecurity/ship{
+	dir = 4;
+	name = "Gauss rounds";
+	req_one_access_txt = "69"
+	},
+/obj/structure/lattice/catwalk/over/ship,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/plating,
+/area/nsv/weapons/gauss)
 "iDH" = (
 /obj/structure/closet/radiation,
 /obj/machinery/light{
@@ -44576,6 +44056,26 @@
 /area/library)
 "iNZ" = (
 /obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"iPA" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/public{
+	dir = 4;
+	name = "Arrivals Emergency Storage"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "iQX" = (
@@ -44725,17 +44225,6 @@
 	},
 /turf/closed/wall/ship,
 /area/maintenance/nsv/weapons)
-"jdl" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/bot_white,
-/obj/machinery/camera/autoname{
-	c_tag = "Atmos - Storage #1";
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech/grid{
-	initial_gas_mix = "TEMP=2.7"
-	},
-/area/engine/atmos)
 "jeX" = (
 /obj/structure/cable,
 /obj/structure/cable{
@@ -44766,15 +44255,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"jhH" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "jiL" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -44849,6 +44329,23 @@
 /turf/open/floor/monotile,
 /area/crew_quarters/cafeteria{
 	name = "Mess hall"
+	})
+"jnA" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
+	},
+/obj/machinery/computer/ship/dradis/minor{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4;
+	icon_state = "door_open"
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/dark,
+/area/bridge{
+	name = "CIC"
 	})
 "jou" = (
 /obj/effect/turf_decal/stripes/line{
@@ -44978,6 +44475,10 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/break_room)
+"jBs" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plasteel/techmaint,
+/area/maintenance/starboard)
 "jEa" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible/layer1{
 	dir = 4
@@ -45055,6 +44556,24 @@
 	},
 /turf/open/floor/monotile,
 /area/science/research)
+"jLy" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/poddoor/shutters/ship{
+	dir = 4;
+	id = "gaussgang";
+	name = "public gauss access shutters"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/plating,
+/area/nsv/weapons/gauss)
 "jLQ" = (
 /obj/structure/lattice,
 /obj/structure/lattice,
@@ -45131,6 +44650,27 @@
 	},
 /turf/open/floor/monotile,
 /area/crew_quarters/dorms)
+"jYY" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/window{
+	dir = 4;
+	name = "communications officer's station"
+	},
+/obj/structure/chair/office{
+	dir = 8;
+	name = "tactical chair"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4;
+	icon_state = "door_open"
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/dark,
+/area/bridge{
+	name = "CIC"
+	})
 "jZc" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -45148,6 +44688,23 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/nsv/weapons/fore)
+"jZR" = (
+/obj/machinery/door/airlock/ship/public{
+	name = "Crew Quarters"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "kbg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -45206,6 +44763,10 @@
 	},
 /turf/open/floor/monotile,
 /area/gateway)
+"kdN" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/plasteel/techmaint,
+/area/maintenance/starboard)
 "kdX" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
@@ -45220,6 +44781,17 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/engine/atmos)
+"kez" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1,
+/obj/machinery/advanced_airlock_controller/directional/east{
+	pixel_y = 24
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
 "keI" = (
 /obj/machinery/camera/autoname{
 	dir = 1;
@@ -45232,10 +44804,6 @@
 "keO" = (
 /turf/open/floor/plating,
 /area/maintenance/nsv/hangar)
-"keR" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "kgo" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/conveyor{
@@ -45244,6 +44812,16 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
+"kgr" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "khE" = (
 /obj/structure/punching_bag,
 /obj/machinery/power/apc/auto_name/north{
@@ -45371,6 +44949,18 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/security/execution/transfer)
+"koR" = (
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Telecomms Admin";
+	departmentType = 5;
+	name = "Telecomms RC";
+	pixel_y = -30
+	},
+/obj/structure/table,
+/obj/item/folder/blue,
+/turf/open/floor/monotile/dark,
+/area/tcommsat/computer)
 "kpf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/structure/lattice/catwalk,
@@ -45387,6 +44977,19 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"kqi" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "kqI" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -45466,6 +45069,13 @@
 	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
+"kvZ" = (
+/obj/structure/closet/emcloset,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/techmaint,
+/area/maintenance/starboard)
 "kwI" = (
 /obj/machinery/light{
 	dir = 1
@@ -45540,6 +45150,22 @@
 /turf/open/floor/monotile/dark,
 /area/science/mixing{
 	name = "Prototype munitions bay"
+	})
+"kCd" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
+	},
+/obj/machinery/computer/ship/dradis/minor,
+/obj/machinery/computer/ship/viewscreen,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4;
+	icon_state = "door_open"
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/dark,
+/area/bridge{
+	name = "CIC"
 	})
 "kCP" = (
 /obj/machinery/light/small{
@@ -45690,13 +45316,6 @@
 /area/nsv/hanger/storage{
 	name = "Munitions Control Room"
 	})
-"kOA" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "kOJ" = (
 /obj/effect/turf_decal/stripes/red/line,
 /obj/effect/turf_decal/stripes/red/line{
@@ -45749,16 +45368,25 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
-"kSX" = (
+"kTY" = (
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Atmospherics";
+	req_one_access_txt = "10; 24"
 	},
-/obj/item/storage/toolbox/emergency,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/plasteel/ship,
+/area/engine/break_room)
 "kVE" = (
 /obj/structure/sign/ship/shock{
 	dir = 4
@@ -45788,6 +45416,24 @@
 "laZ" = (
 /turf/closed/wall/ship,
 /area/maintenance/starboard)
+"lca" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Medical Central";
+	req_one_access_txt = "5"
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile,
+/area/medical/medbay/central)
 "lcf" = (
 /obj/structure/table/wood,
 /obj/item/camera,
@@ -45831,6 +45477,28 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/engine/atmospherics_engine)
+"lge" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/holopad,
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile,
+/area/bridge{
+	name = "CIC"
+	})
+"lgg" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "lgi" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	dir = 4;
@@ -45902,6 +45570,24 @@
 	},
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
+"loN" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
+"lpe" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "lrx" = (
 /obj/machinery/power/solar{
 	id = "portsolar";
@@ -45966,6 +45652,41 @@
 /obj/structure/munitions_trolley,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
+"lxM" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1,
+/obj/machinery/advanced_airlock_controller/directional/west{
+	pixel_y = 24
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
+"lyW" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/computer/monitor{
+	dir = 8;
+	name = "Bridge Power Monitoring Console"
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4;
+	icon_state = "door_open"
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile,
+/area/bridge{
+	name = "CIC"
+	})
 "lzn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -46032,6 +45753,11 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
+"lJd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "lJZ" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	name = "Briefing room maintenance";
@@ -46051,12 +45777,44 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
+"lKg" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/techmaint,
+/area/maintenance/starboard)
 "lKI" = (
 /obj/structure/bookcase{
 	name = "Forbidden Knowledge"
 	},
 /turf/open/floor/wood,
 /area/library)
+"lLt" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Atmospherics";
+	req_one_access_txt = "10; 24"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/plasteel/ship,
+/area/engine/atmos)
+"lLZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/structure/lattice/catwalk,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/engine/atmos)
 "lNT" = (
 /obj/structure/lattice/catwalk/over/ship,
 /obj/machinery/light{
@@ -46114,27 +45872,6 @@
 /obj/structure/lattice/catwalk/over/ship,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/gauss)
-"lQE" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "lQU" = (
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
@@ -46240,6 +45977,17 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
+"mcA" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/item/trash/cheesie,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "mda" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -46345,6 +46093,11 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"moR" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/plating,
+/area/crew_quarters/fitness/recreation)
 "mpS" = (
 /obj/effect/turf_decal/pool/corner,
 /obj/effect/turf_decal/stripes/line{
@@ -46394,6 +46147,18 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/storage_shared)
+"muV" = (
+/obj/machinery/computer/communications/console{
+	dir = 1;
+	icon_state = "computer_end"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile,
+/area/bridge{
+	name = "CIC"
+	})
 "mvj" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/southright{
@@ -46422,29 +46187,6 @@
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile,
 /area/science/research)
-"mvU" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech/grid{
-	initial_gas_mix = "TEMP=2.7"
-	},
-/area/engine/atmos)
-"mwK" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/tech/grid{
-	initial_gas_mix = "TEMP=2.7"
-	},
-/area/engine/atmos)
-"mwO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/closed/wall/r_wall/ship,
-/area/maintenance/starboard/fore)
 "myk" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater,
 /turf/open/floor/plasteel/tech/grid{
@@ -46486,6 +46228,19 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
+"mCu" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/advanced_airlock_controller/directional/east{
+	pixel_y = 24
+	},
+/turf/open/floor/plating,
+/area/science/mixing{
+	name = "Prototype munitions bay"
+	})
 "mDA" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -46592,6 +46347,20 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard)
+"mNq" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/sorting/mail{
+	sortType = 1
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/starboard)
 "mOp" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -46671,18 +46440,6 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/monotile,
 /area/engine/engineering/hangar)
-"mQp" = (
-/obj/structure/window/reinforced/spawner,
-/obj/machinery/computer/atmos_control/tank/nitrogen_tank{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/tech/grid{
-	initial_gas_mix = "TEMP=2.7"
-	},
-/area/engine/atmos)
 "mRi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -46955,6 +46712,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/weapons)
+"nxI" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/starboard)
 "nBS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -46983,6 +46750,18 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
+"nDn" = (
+/obj/machinery/computer/crew/console{
+	dir = 1;
+	icon_state = "computer"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile,
+/area/bridge{
+	name = "CIC"
+	})
 "nDD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -47151,6 +46930,19 @@
 /obj/machinery/ship_weapon/vls,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
+"nPc" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/highsecurity/ship{
+	name = "Weapons Bay";
+	req_one_access_txt = "69"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile,
+/area/nsv/weapons/gauss)
 "nPv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
@@ -47229,6 +47021,10 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/visible,
 /turf/open/space/basic,
 /area/engine/atmos)
+"nWr" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plasteel/techmaint,
+/area/maintenance/starboard)
 "nYT" = (
 /obj/machinery/door/morgue{
 	name = "Private Study";
@@ -47428,18 +47224,6 @@
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/space/nearstation)
-"oyf" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
-/turf/open/floor/monotile,
-/area/hallway/secondary/exit)
 "oyi" = (
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/starboard/fore)
@@ -47511,6 +47295,15 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/science/mixing/chamber)
+"oES" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/starboard)
 "oHb" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
@@ -47537,14 +47330,19 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/fitness/recreation)
-"oLa" = (
-/obj/machinery/light{
-	dir = 8
+"oIf" = (
+/obj/machinery/computer/ship/dradis/console,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/plasteel/tech/grid{
-	initial_gas_mix = "TEMP=2.7"
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/area/engine/atmos)
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/dark,
+/area/bridge{
+	name = "CIC"
+	})
 "oMj" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -47559,6 +47357,12 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"oMQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/closed/wall/r_wall/ship,
+/area/engine/atmospherics_engine)
 "oOl" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -47670,19 +47474,6 @@
 	},
 /turf/open/floor/monotile,
 /area/crew_quarters/fitness/recreation)
-"pcI" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/advanced_airlock_controller{
-	pixel_y = 24
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/exit)
 "pdT" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Cryogenics";
@@ -47703,14 +47494,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/medical/medbay/lobby)
-"peo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/structure/lattice/catwalk,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/engine/atmos)
 "per" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -47836,11 +47619,31 @@
 	},
 /turf/open/floor/monotile,
 /area/hallway/secondary/exit)
-"psk" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
+"prp" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/turf/open/floor/plating,
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/ship/delivery/yellow,
+/obj/machinery/door/poddoor/shutters/ship{
+	id = "powderboys";
+	name = "Powder Rack Access"
+	},
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "naval"
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile,
+/area/nsv/weapons/fore)
+"psk" = (
+/obj/structure/table,
+/obj/item/tank/internals/air,
+/obj/item/tank/internals/air,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/storage/toolbox/emergency,
+/turf/open/floor/plasteel/techmaint,
 /area/maintenance/starboard)
 "psx" = (
 /obj/structure/disposalpipe/segment{
@@ -47892,6 +47695,18 @@
 	},
 /turf/open/floor/plasteel/grid/lino,
 /area/engine/engineering/reactor_control)
+"pzR" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/techmaint,
+/area/maintenance/starboard)
 "pBK" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -47979,6 +47794,26 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"pHv" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/poddoor/shutters/ship{
+	dir = 4;
+	id = "gaussgang";
+	name = "public gauss access shutters"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile,
+/area/nsv/hanger/storage{
+	name = "Munitions Control Room"
+	})
 "pIA" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/computer/atmos_control/tank/carbon_tank{
@@ -48017,6 +47852,19 @@
 /obj/machinery/suit_storage_unit/pilot,
 /turf/open/floor/plasteel/tech/grid,
 /area/nsv/weapons/fore)
+"pLb" = (
+/obj/machinery/portable_atmospherics/pump,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "pNz" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 1
@@ -48025,6 +47873,22 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/engine/atmos)
+"pOt" = (
+/obj/machinery/door/airlock/ship/public{
+	name = "Galley";
+	req_one_access_txt = "28"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile,
+/area/crew_quarters/cafeteria{
+	name = "Mess hall"
+	})
 "pOG" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
@@ -48045,15 +47909,6 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/engine/atmos)
-"pRQ" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "pSy" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/monotile/dark,
@@ -48096,6 +47951,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/hangar)
+"pZe" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/ship{
+	id = "maintshop";
+	layer = 3.1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/plating,
+/area/hallway/nsv/deck2/frame1/central)
 "pZr" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
@@ -48118,13 +47986,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"qce" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/space/basic,
-/area/engine/atmos)
 "qcm" = (
 /obj/machinery/light{
 	dir = 1
@@ -48178,6 +48039,24 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"qlU" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	dir = 4;
+	name = "Kitchen maintenance";
+	req_access_txt = "12;28"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "qmJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -48204,6 +48083,24 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmospherics_engine)
+"qoc" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Medical Central";
+	req_one_access_txt = "5"
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/dark,
+/area/medical/medbay/central)
 "qqk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
@@ -48271,6 +48168,10 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
+"qBl" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "qBT" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 1
@@ -48335,6 +48236,13 @@
 /obj/machinery/status_display/ai,
 /turf/closed/wall/ship,
 /area/security/brig)
+"qHG" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/engine/atmos)
 "qIe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
@@ -48368,19 +48276,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"qLh" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/advanced_airlock_controller{
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plating,
-/area/science/mixing{
-	name = "Prototype munitions bay"
-	})
 "qLS" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/structure/cable{
@@ -48494,17 +48389,6 @@
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
-"qRw" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "qVj" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -48556,6 +48440,20 @@
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile,
 /area/crew_quarters/fitness/recreation)
+"rew" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "rfE" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/conveyor/slow{
@@ -48602,6 +48500,31 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
+"rix" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/maintenance{
+	dir = 4;
+	name = "Munitions Control";
+	req_one_access_txt = "69"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
+"riN" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/starboard)
 "riT" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -48702,6 +48625,20 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
+"rsM" = (
+/obj/machinery/door/morgue{
+	name = "Confession Booth (Chaplain)";
+	req_access_txt = "22"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/plasteel/dark,
+/area/chapel/main)
 "rti" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/layer1{
 	dir = 1
@@ -48770,22 +48707,6 @@
 	},
 /turf/open/floor/monotile,
 /area/engine/engineering/reactor_core)
-"rxN" = (
-/obj/structure/chair/office,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	pixel_x = 32;
-	pixel_y = -32
-	},
-/turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
 "ryW" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -48831,6 +48752,19 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"rCv" = (
+/obj/machinery/computer/ship/helm/console,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/dark,
+/area/bridge{
+	name = "CIC"
+	})
 "rCH" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -49107,13 +49041,6 @@
 /obj/machinery/lazylift_button,
 /turf/closed/wall/r_wall/ship,
 /area/shuttle/turbolift/shaft)
-"sff" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/engine/atmos)
 "sfx" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -49161,6 +49088,26 @@
 	},
 /turf/open/floor/monotile,
 /area/medical/chemistry)
+"shm" = (
+/obj/machinery/door/morgue{
+	name = "Confession Booth"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/plasteel/dark,
+/area/chapel/main)
+"ska" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/camera/autoname{
+	c_tag = "Atmos - West #2"
+	},
+/turf/open/space/basic,
+/area/engine/atmos)
 "smz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
@@ -49205,6 +49152,15 @@
 	},
 /turf/open/floor/plasteel/grid/steel,
 /area/engine/engineering/reactor_core)
+"sqw" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/effect/spawner/lootdrop/minor/bowler_or_that,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/maintenance/starboard)
 "srs" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/structure/cable{
@@ -49296,6 +49252,15 @@
 	},
 /turf/open/space/basic,
 /area/engine/atmos)
+"svU" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/advanced_airlock_controller/directional/west{
+	pixel_y = 24
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/secondary/exit)
 "svX" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -49317,14 +49282,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"syz" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
+"sxT" = (
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/floor/plasteel/tech/grid{
-	initial_gas_mix = "TEMP=2.7"
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1{
+	dir = 1
 	},
-/area/engine/atmos)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/advanced_airlock_controller/directional/west{
+	pixel_y = 24
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
 "szH" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
 /obj/machinery/atmospherics/pipe/layer_manifold/visible{
@@ -49374,13 +49344,16 @@
 	id = "spentfuel2"
 	},
 /area/engine/engineering/reactor_core)
-"sHp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
+"sIU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/plasteel/tech/grid{
-	initial_gas_mix = "TEMP=2.7"
+/obj/machinery/advanced_airlock_controller/directional/west{
+	pixel_y = 24
 	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1,
+/turf/open/floor/plating,
 /area/engine/atmos)
 "sJI" = (
 /obj/machinery/status_display/evac,
@@ -49413,6 +49386,19 @@
 	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
+"sOm" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/holopad,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile,
+/area/bridge{
+	name = "CIC"
+	})
 "sRt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -49445,13 +49431,6 @@
 /obj/machinery/light,
 /turf/open/floor/wood,
 /area/library)
-"sYU" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "tar" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 5
@@ -49460,6 +49439,31 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/engine/atmos)
+"tbz" = (
+/obj/machinery/light/small,
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/gloves,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"tbX" = (
+/obj/machinery/computer/console_placholder{
+	dir = 4;
+	icon_state = "computer"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/dark,
+/area/bridge{
+	name = "CIC"
+	})
 "tcb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
@@ -49479,6 +49483,14 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
+"tdT" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/visible{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "tfj" = (
 /obj/machinery/power/apc/auto_name/south{
 	pixel_y = -24
@@ -49526,6 +49538,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"thO" = (
+/obj/machinery/light,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plasteel/techmaint,
+/area/maintenance/starboard)
 "tiu" = (
 /obj/machinery/requests_console{
 	department = "Genetics";
@@ -49615,6 +49632,20 @@
 	},
 /turf/open/floor/monotile,
 /area/engine/engineering/reactor_core)
+"tqh" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile,
+/area/bridge{
+	name = "CIC"
+	})
 "tqp" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -49645,6 +49676,17 @@
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/light,
 /area/medical/medbay/lobby)
+"tsS" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/camera/autoname{
+	c_tag = "Atmos - Storage #1";
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "tup" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/barricade/wooden,
@@ -49684,6 +49726,21 @@
 /area/maintenance/starboard/secondary{
 	name = "Munitions Projects"
 	})
+"twU" = (
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Central Primary Hallway"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck2/frame1/central)
 "txH" = (
 /obj/machinery/holopad,
 /turf/open/floor/carpet/blue,
@@ -49708,6 +49765,19 @@
 	},
 /turf/open/floor/monotile,
 /area/engine/engineering/hangar)
+"tzp" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/advanced_airlock_controller/directional/east{
+	pixel_y = 24
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "tzE" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -49833,6 +49903,11 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/engine/atmos)
+"tLT" = (
+/obj/structure/girder/reinforced,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "tMg" = (
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess{
 	dir = 4
@@ -49848,6 +49923,24 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/hangar)
+"tNt" = (
+/obj/machinery/door/airlock/ship/station/mining{
+	dir = 4;
+	name = "Cargo Bay";
+	req_one_access_txt = "31; 48"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/dark,
+/area/quartermaster/storage)
 "tNz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -49960,6 +50053,15 @@
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
+"tZE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/visible,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "uaW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/structure/lattice/catwalk,
@@ -50085,6 +50187,19 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"uha" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/advanced_airlock_controller/directional/east{
+	pixel_y = 24
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
 "uir" = (
 /obj/machinery/computer/shuttle/mining{
 	dir = 8
@@ -50223,14 +50338,29 @@
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/monotile/dark,
 /area/engine/atmospherics_engine)
-"uJx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/light{
+"uKm" = (
+/obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
+	name = "Chapel"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer1,
-/turf/open/floor/plating,
-/area/engine/atmos)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/plasteel/dark,
+/area/chapel/main)
 "uKU" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/visible{
 	dir = 4
@@ -50312,23 +50442,6 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/monotile,
 /area/engine/engineering/reactor_core)
-"uUz" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Medical Central";
-	req_one_access_txt = "5"
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/turf/open/floor/monotile/dark,
-/area/medical/medbay/central)
 "uWe" = (
 /obj/structure/chair{
 	dir = 8
@@ -50532,48 +50645,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"vpE" = (
-/obj/effect/landmark/zebra_interlock_point,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
+"vse" = (
+/obj/effect/spawner/lootdrop/minor/beret_or_rabbitears,
+/obj/structure/curtain/obscuring/grey{
+	open = 0
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/airlock/ship/maintenance{
-	dir = 4;
-	name = "Munitions Control";
-	req_one_access_txt = "69"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+/obj/structure/table/wood,
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/starboard/fore)
 "vsn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
 /turf/open/floor/monotile,
 /area/engine/atmos)
-"vsK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "vtl" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -50616,12 +50701,6 @@
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
-"vxy" = (
-/obj/machinery/advanced_airlock_controller{
-	pixel_y = 24
-	},
-/turf/open/floor/plating,
-/area/engine/engineering/hangar)
 "vzs" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -50712,6 +50791,22 @@
 	},
 /turf/open/floor/plasteel/grid/steel,
 /area/engine/engineering/reactor_core)
+"vLt" = (
+/obj/machinery/computer/security/console{
+	dir = 5;
+	icon_screen = null;
+	icon_state = "computer_end"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4;
+	icon_state = "door_open"
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/dark,
+/area/bridge{
+	name = "CIC"
+	})
 "vMN" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
@@ -50773,6 +50868,18 @@
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/space/nearstation)
+"vST" = (
+/obj/structure/window/reinforced/spawner,
+/obj/machinery/computer/atmos_control/tank/nitrogen_tank{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "vUD" = (
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
@@ -50823,6 +50930,12 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
+"vYP" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/curtain/obscuring/grey,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/plating,
+/area/chapel/main)
 "vZc" = (
 /obj/machinery/light{
 	dir = 8
@@ -50882,6 +50995,17 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
+"whd" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/glowstick,
+/obj/structure/table,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "wiv" = (
 /obj/effect/turf_decal/pool{
 	dir = 4
@@ -50894,6 +51018,18 @@
 	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
+"wiG" = (
+/obj/machinery/computer/ship/dradis/minor/console{
+	dir = 1;
+	icon_state = "computer"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile,
+/area/bridge{
+	name = "CIC"
+	})
 "wiW" = (
 /obj/machinery/light{
 	dir = 8
@@ -51066,6 +51202,24 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering/reactor_core)
+"wyB" = (
+/obj/machinery/modular_computer/console/preset/command{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile,
+/area/bridge{
+	name = "CIC"
+	})
 "wyO" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
@@ -51171,6 +51325,12 @@
 /obj/machinery/computer/ship/munitions_computer/west,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
+"wLq" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "wLz" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -51180,6 +51340,23 @@
 	},
 /turf/open/floor/monotile,
 /area/security/brig)
+"wMJ" = (
+/obj/structure/chair/office,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	pixel_x = 32;
+	pixel_y = -32
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile,
+/area/bridge{
+	name = "CIC"
+	})
 "wPl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -51289,6 +51466,37 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"wYE" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"wZk" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
+	},
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/machinery/computer/ship/viewscreen,
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4;
+	icon_state = "door_open"
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/dark,
+/area/bridge{
+	name = "CIC"
+	})
 "wZp" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -51304,6 +51512,29 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/hangar)
+"xbG" = (
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Bar";
+	req_one_access_txt = "25"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile,
+/area/crew_quarters/cafeteria{
+	name = "Mess hall"
+	})
+"xbZ" = (
+/obj/machinery/meter/atmos/distro_loop,
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "xdR" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -51318,16 +51549,6 @@
 "xdT" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"xfd" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "xgv" = (
@@ -51397,6 +51618,18 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet,
 /area/library)
+"xpB" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "xpP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -51496,6 +51729,19 @@
 /obj/machinery/light,
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
+"xvg" = (
+/obj/machinery/computer/ship/tactical/console,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/dark,
+/area/bridge{
+	name = "CIC"
+	})
 "xxg" = (
 /obj/structure/sign/barsign,
 /turf/closed/wall/ship,
@@ -51506,6 +51752,16 @@
 /obj/effect/spawner/lootdrop/gloves,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"xAD" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "xAS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -51580,6 +51836,14 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"xIH" = (
+/obj/machinery/atmospherics/pipe/simple/dark/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "xMG" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -51662,6 +51926,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/hangar)
+"xTP" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/storage/box/lights/mixed,
+/turf/open/floor/plasteel/techmaint,
+/area/maintenance/starboard)
 "xWe" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -51806,10 +52080,6 @@
 /obj/structure/lattice,
 /turf/open/space,
 /area/engine/atmos)
-"yfo" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "ygv" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
@@ -68440,7 +68710,7 @@ aaa
 aCJ
 aaD
 aLC
-aLL
+hqj
 aLN
 aNw
 aCJ
@@ -68458,7 +68728,7 @@ vYs
 rHk
 wss
 oun
-qLh
+mCu
 mrY
 aaa
 aaa
@@ -75611,7 +75881,7 @@ bhf
 afw
 aXN
 agX
-agP
+afw
 aZb
 aZc
 aTL
@@ -75868,7 +76138,7 @@ aUx
 afw
 aXN
 oBT
-agP
+afw
 agW
 aki
 akg
@@ -76125,10 +76395,10 @@ aUy
 afw
 aYp
 afw
+afw
 agP
-afV
-bcp
-afV
+gJJ
+agP
 afV
 afV
 akS
@@ -77193,7 +77463,7 @@ bri
 bry
 brH
 brR
-brX
+tbz
 bre
 vIy
 bsx
@@ -77394,7 +77664,7 @@ abY
 anh
 ahB
 aov
-aUY
+eCP
 baQ
 aAI
 bvC
@@ -77407,7 +77677,7 @@ bbc
 bCl
 baQ
 baQ
-uUz
+qoc
 aZg
 aZT
 bhg
@@ -77448,8 +77718,8 @@ aOS
 aeb
 brj
 brz
-brI
-aLX
+wYE
+mcA
 bre
 bre
 bss
@@ -77651,7 +77921,7 @@ bGO
 aUV
 aWq
 baz
-bvz
+eLS
 bvA
 bvB
 bCk
@@ -77664,7 +77934,7 @@ aPE
 bCm
 bvA
 bvA
-dqx
+lca
 aZi
 aZX
 ahc
@@ -77963,7 +78233,7 @@ laZ
 brl
 bre
 bre
-mIj
+lJd
 bDQ
 bsl
 brZ
@@ -78221,9 +78491,9 @@ cFg
 sFd
 mIj
 mIj
-brY
-czo
-xdT
+dno
+ffH
+wLq
 laZ
 afL
 adh
@@ -78471,14 +78741,14 @@ bpg
 afE
 aWd
 laZ
-yfo
+gWm
 aZh
-jVR
-brn
-jVR
+oES
+mNq
+oES
 brJ
 jVR
-brZ
+lpe
 laZ
 laZ
 laZ
@@ -78729,9 +78999,9 @@ afD
 bpL
 laZ
 wCS
-cFg
-bnn
-psk
+mMv
+riN
+sqw
 sFd
 cFg
 mIj
@@ -78986,7 +79256,7 @@ agR
 bil
 laZ
 mIj
-cFg
+xAD
 laZ
 laZ
 laZ
@@ -78994,13 +79264,13 @@ brK
 laZ
 laZ
 laZ
-adK
+rsM
 adh
-afO
+shm
 adh
 adh
 adh
-byd
+eiX
 adh
 bIJ
 aaa
@@ -79243,7 +79513,7 @@ agS
 bpM
 laZ
 isj
-cFg
+dDu
 laZ
 act
 acD
@@ -79500,7 +79770,7 @@ bpB
 bpN
 laZ
 sxM
-bsS
+kqi
 laZ
 acu
 acE
@@ -79757,7 +80027,7 @@ laZ
 laZ
 laZ
 mIj
-cFg
+lgg
 laZ
 acv
 bcZ
@@ -80001,20 +80271,20 @@ bwq
 bEa
 xMG
 laZ
-yfo
-yfo
+nWr
+nWr
+psk
 laZ
 iNZ
 qxg
-mIj
-mIj
+bVc
 mIj
 bpm
 mIj
+qBl
+nxI
 mIj
-sYU
-mIj
-cFg
+whd
 laZ
 abF
 abF
@@ -80258,10 +80528,10 @@ acx
 bDp
 bmQ
 laZ
-kSX
-jVR
-bnY
-jVR
+pzR
+lKg
+lKg
+grp
 jVR
 jVR
 jVR
@@ -80269,9 +80539,9 @@ jVR
 bsJ
 jVR
 jVR
-qRw
+xpB
 jVR
-brZ
+cUs
 laZ
 acP
 bJk
@@ -80515,8 +80785,8 @@ afS
 bDp
 bmQ
 laZ
-mMv
-bnH
+asF
+thO
 laZ
 boq
 boq
@@ -80772,8 +81042,8 @@ aPg
 bEd
 btC
 laZ
-xfd
-keR
+xTP
+jBs
 boq
 aaa
 aaa
@@ -81029,8 +81299,8 @@ aeT
 bEe
 bmU
 laZ
-ecN
-iNZ
+asF
+kdN
 boq
 aaa
 aaa
@@ -81286,8 +81556,8 @@ bFH
 bEf
 bmU
 laZ
-cFg
-kOA
+asF
+kvZ
 boq
 aaa
 aaa
@@ -81521,7 +81791,7 @@ bBu
 bBu
 bBu
 bBu
-vpE
+rix
 bBu
 ahz
 bbr
@@ -81543,7 +81813,7 @@ bIw
 bEe
 bmU
 laZ
-bLj
+iPA
 laZ
 jmS
 aaa
@@ -81563,11 +81833,11 @@ abF
 abF
 abF
 abF
-bxM
-adC
-afJ
-afJ
-afJ
+uKm
+csW
+vYP
+vYP
+vYP
 adh
 adh
 adh
@@ -82317,7 +82587,7 @@ aSh
 bLl
 ohf
 abU
-aOG
+lxM
 adA
 aaa
 aaa
@@ -82327,7 +82597,7 @@ aaa
 aaa
 aaa
 kSO
-pcI
+sxT
 vHB
 uYD
 gWy
@@ -82344,7 +82614,7 @@ dIP
 aNX
 aNZ
 aOd
-aOf
+ezQ
 esn
 aaa
 aaa
@@ -82858,7 +83128,7 @@ aNs
 tfI
 aNZ
 aOd
-aOf
+svU
 esn
 aaa
 aaa
@@ -83576,7 +83846,7 @@ ago
 mTR
 mTR
 bBr
-bKE
+pHv
 bLO
 bKK
 aeT
@@ -84113,10 +84383,10 @@ bwt
 bEi
 bmU
 aad
-bLs
+ecX
 ohf
 abU
-aOG
+kez
 adA
 aaa
 aaa
@@ -84126,7 +84396,7 @@ aaa
 aaa
 aaa
 kSO
-hSg
+uha
 wqk
 hSP
 gFM
@@ -84354,24 +84624,24 @@ aeT
 bcq
 aMv
 abG
-acJ
-bko
-bqt
+kCd
+jYY
+dhL
 abG
 bxG
 bAC
 bBI
 abG
-byy
-bLe
-bLf
+wZk
+ilH
+jnA
 abG
 bnZ
 bDE
 bDG
 aSh
 bLr
-oyf
+abT
 aOe
 aOe
 aOe
@@ -84400,7 +84670,7 @@ bsc
 tfI
 aNZ
 aOd
-aOf
+ezQ
 esn
 aOi
 aaa
@@ -84884,7 +85154,7 @@ bgf
 bEe
 bmU
 aad
-bLt
+cjB
 bnJ
 aOe
 aOg
@@ -84914,7 +85184,7 @@ bsc
 tfI
 aNZ
 aOd
-aOf
+svU
 esn
 aaa
 aaa
@@ -85117,8 +85387,8 @@ sfW
 abV
 dDv
 twd
-aTs
-bYG
+iDf
+jLy
 eQi
 bXF
 biK
@@ -85127,13 +85397,13 @@ aMv
 abG
 biQ
 bzN
-bYO
-bZG
+wyB
+tqh
 bZR
 bmE
 car
-cav
-caC
+tbX
+itk
 caR
 bmE
 abG
@@ -85372,7 +85642,7 @@ lfL
 lfL
 khU
 aSz
-bXJ
+nPc
 bYs
 aTt
 bhW
@@ -85384,20 +85654,20 @@ aMv
 abG
 biT
 bBU
-bYP
-bZH
+cNT
+muV
 bmE
 bmE
 bmE
-caw
-caD
+rCv
+bTi
 caT
 gHw
 abG
 bmr
 bFh
 bLa
-bLg
+twU
 bLv
 bLw
 bLx
@@ -85629,7 +85899,7 @@ bBd
 bHu
 bXB
 aSD
-bYl
+dtG
 bku
 aTi
 bJe
@@ -85641,13 +85911,13 @@ bLK
 abI
 biZ
 bBU
-bBV
-bLV
+sOm
+wiG
 bmE
 biJ
 biI
-bLW
-bLX
+oIf
+lge
 caT
 bLJ
 abI
@@ -85898,13 +86168,13 @@ aMv
 abG
 bji
 bBU
-rxN
-bZJ
+wMJ
+nDn
 bmE
 bmE
 bmE
-cay
-caD
+xvg
+bTi
 caT
 bmE
 abG
@@ -85917,9 +86187,9 @@ bnM
 bnM
 aci
 aci
-bxI
+fpL
 adg
-bcA
+tNt
 tWK
 aci
 ake
@@ -86155,13 +86425,13 @@ aMv
 abG
 bjQ
 bTR
-bYR
-bZK
+lyW
+eCs
 bZS
 bmE
 cat
-caz
-caF
+gDl
+vLt
 caV
 bmE
 abG
@@ -88461,11 +88731,11 @@ efA
 efA
 efA
 efA
-cbX
+hxW
 aeT
 bcq
 aMv
-abf
+pZe
 acm
 acl
 acl
@@ -88477,7 +88747,7 @@ bvj
 bFY
 bKM
 bKU
-bLb
+eNN
 bBS
 bHd
 bmU
@@ -88718,11 +88988,11 @@ aTr
 aTr
 aTr
 aTr
-aQa
+prp
 aeT
 bcq
 aMv
-abf
+pZe
 acl
 acl
 acl
@@ -88979,7 +89249,7 @@ agm
 ahz
 bcq
 aMv
-abi
+fHb
 acI
 aAk
 aSI
@@ -90305,8 +90575,8 @@ aaa
 aaa
 aaa
 aij
-lQE
-pRQ
+ekv
+foY
 aij
 aij
 aij
@@ -90480,7 +90750,7 @@ aaa
 aaa
 aaa
 aaa
-iyL
+moR
 enx
 tux
 auB
@@ -90737,7 +91007,7 @@ aaa
 aaa
 bAe
 aaa
-iyL
+moR
 fvp
 tux
 auz
@@ -90994,7 +91264,7 @@ aaa
 aaa
 aaa
 aaa
-iyL
+moR
 aup
 tux
 emm
@@ -91836,7 +92106,7 @@ qEO
 bqD
 bcn
 bsG
-bxL
+asN
 bFZ
 bFZ
 bJv
@@ -92022,7 +92292,7 @@ aaa
 aaa
 aaa
 aaa
-iyL
+moR
 iLl
 gUD
 auJ
@@ -92059,7 +92329,7 @@ ath
 ato
 aVa
 aVe
-amF
+xbG
 asZ
 aOR
 aOR
@@ -92279,7 +92549,7 @@ aaa
 aaa
 aaa
 aaa
-iyL
+moR
 iLl
 ljk
 auJ
@@ -92536,14 +92806,14 @@ aaa
 aaa
 aaa
 aaa
-iyL
+moR
 iLl
 gUD
 auJ
 auJ
 mAn
 mHC
-abm
+htk
 bfr
 atz
 bhD
@@ -92559,9 +92829,9 @@ aqQ
 ami
 ami
 ami
-avj
+dTk
 aZI
-btO
+giC
 ami
 ami
 amm
@@ -92793,14 +93063,14 @@ aaa
 aaa
 aaa
 aaa
-iyL
+moR
 iLl
 jld
 auJ
 auL
 nQO
 aqI
-amr
+dDO
 bzD
 atz
 qvd
@@ -92808,12 +93078,12 @@ xEa
 aqy
 mXe
 ahe
-avu
+eot
 aiJ
 aln
 aln
 aln
-avu
+eot
 ayG
 azW
 aGr
@@ -92865,7 +93135,7 @@ brT
 eFj
 vjc
 iuA
-axG
+cpD
 qEO
 aBh
 aBh
@@ -93050,14 +93320,14 @@ aaa
 aaa
 aaa
 aaa
-iyL
+moR
 iLl
 auV
 bFP
 bFP
 bMb
 bMc
-aqB
+hFc
 afT
 aLS
 asw
@@ -93065,12 +93335,12 @@ ahl
 auR
 bAN
 aLZ
-aMk
+jZR
 afT
 afT
 aMB
 afT
-aMW
+fTr
 aZo
 aZw
 bhF
@@ -93085,7 +93355,7 @@ bkj
 acR
 afc
 alX
-atJ
+bNC
 acS
 aVk
 bga
@@ -93314,7 +93584,7 @@ paV
 hdp
 nLB
 fex
-abm
+htk
 bIx
 pwx
 aqy
@@ -93882,7 +94152,7 @@ abr
 ruX
 ail
 ail
-bGi
+gKB
 ail
 ail
 ail
@@ -94124,7 +94394,7 @@ ark
 aVP
 bbQ
 bfB
-bgU
+pOt
 bjo
 buc
 buj
@@ -94132,7 +94402,7 @@ buC
 arb
 abr
 abr
-avv
+qlU
 abr
 abr
 abr
@@ -94388,7 +94658,7 @@ bzC
 aqT
 arc
 iuA
-qEO
+dmM
 blp
 bkZ
 bkZ
@@ -94404,8 +94674,8 @@ apV
 apV
 apV
 apV
-oyi
-vsK
+apV
+hGU
 iuA
 iuA
 aPw
@@ -94646,8 +94916,8 @@ iuA
 iuA
 iuA
 qEO
-oyi
-oyi
+apV
+apV
 apV
 apV
 apV
@@ -94661,7 +94931,7 @@ aWb
 aWb
 aWb
 aWb
-oyi
+apV
 glh
 iuA
 qEO
@@ -94902,8 +95172,8 @@ aVJ
 iuA
 uDe
 iuA
-qEO
-oyi
+aiK
+apV
 bFj
 azC
 azP
@@ -94918,7 +95188,7 @@ apV
 apV
 apV
 aWa
-oyi
+apV
 glh
 iuA
 aAa
@@ -95160,7 +95430,7 @@ blz
 nUJ
 iuA
 qEO
-oyi
+apV
 aWb
 azO
 azR
@@ -95175,7 +95445,7 @@ aDU
 aVY
 aVZ
 aWb
-oyi
+apV
 bqH
 iuA
 iuA
@@ -95417,7 +95687,7 @@ air
 blL
 ais
 qEO
-oyi
+apV
 aWb
 azO
 azS
@@ -95432,7 +95702,7 @@ apV
 apV
 apV
 aWa
-oyi
+apV
 glh
 bHw
 qEO
@@ -95674,7 +95944,7 @@ iuA
 for
 iuA
 iuA
-oyi
+apV
 xXX
 azO
 azT
@@ -95689,7 +95959,7 @@ aWb
 aWb
 aWb
 aWb
-oyi
+apV
 glh
 iuA
 wXi
@@ -95929,24 +96199,24 @@ iuA
 blo
 iuA
 for
-ait
-aix
-oyi
-oyi
-oyi
-oyi
-oyi
+pLb
+rew
+apV
+apV
+apV
+apV
+apV
 aiE
-oyi
-oyi
-mwO
-oyi
-oyi
-oyi
-oyi
-oyi
-oyi
-oyi
+apV
+apV
+oMQ
+apV
+apV
+apV
+apV
+apV
+apV
+apV
 glh
 oyi
 oyi
@@ -96188,14 +96458,14 @@ nUJ
 for
 qEO
 qEO
-ckc
+hwO
 qEO
 qEO
 clm
 wYw
 mlC
 qjd
-qjd
+xIH
 rso
 qjd
 qjd
@@ -96438,14 +96708,14 @@ aBJ
 iuA
 eFj
 aiW
-ail
+gRe
 blk
 blq
 blA
 blM
 bjI
 bjI
-fdU
+gYf
 bjI
 bna
 hsX
@@ -96456,12 +96726,12 @@ aml
 aml
 aml
 aml
-jhH
+epQ
 qEO
-qEO
+bUn
 oyi
-eFj
-qEO
+tLT
+vse
 oyi
 aaa
 aaa
@@ -96699,17 +96969,17 @@ oyi
 oyi
 blr
 oyi
-aml
-aml
-aml
+oyi
+qEO
+qEO
 aml
 aml
 aml
 aml
 aml
 npw
-jdl
-fub
+tsS
+kgr
 stP
 nqT
 aml
@@ -96957,8 +97227,8 @@ arq
 blw
 axH
 jpj
-aAc
-bmd
+aml
+aml
 jpj
 rhe
 rhe
@@ -97199,14 +97469,14 @@ aPB
 bte
 bys
 bys
-bAx
+kTY
 bys
 bAz
 bAA
 bAB
 aEc
 oOl
-aoN
+lLt
 apb
 apv
 xQF
@@ -97215,7 +97485,7 @@ apv
 qqT
 fAz
 atZ
-uJx
+sIU
 uTH
 rhe
 vfz
@@ -97425,7 +97695,7 @@ arT
 apq
 apq
 iQX
-agO
+tzp
 rxn
 aIc
 bny
@@ -97474,7 +97744,7 @@ aml
 asG
 asG
 aml
-cjU
+ska
 vfz
 vfz
 aml
@@ -97734,13 +98004,13 @@ rhe
 rhe
 vfz
 vfz
-oLa
+dXK
 vfz
 vfz
 vfz
 vfz
 vfz
-mQp
+vST
 rwL
 apG
 asG
@@ -98192,7 +98462,7 @@ aaa
 aaa
 aaa
 arT
-aCV
+hRE
 aHJ
 aHT
 aHU
@@ -98242,7 +98512,7 @@ edN
 aQd
 aml
 aml
-qce
+qHG
 vfz
 vfz
 vfz
@@ -98449,7 +98719,7 @@ aaa
 aaa
 aaa
 arT
-aCV
+hRE
 aqw
 aHU
 aIx
@@ -98706,7 +98976,7 @@ aaa
 aaa
 aaa
 arT
-aCV
+hRE
 aHJ
 aHV
 aHU
@@ -98754,7 +99024,7 @@ rhe
 rhe
 rhe
 pDN
-sff
+hus
 rhe
 rhe
 vfz
@@ -99249,12 +99519,12 @@ aAP
 amu
 afI
 anX
-aCq
+hZH
 aCW
-aDl
+gjO
 aDY
 aWh
-aRd
+koR
 amu
 aqn
 aNS
@@ -99522,8 +99792,8 @@ enS
 enS
 qwl
 nVs
-syz
-sHp
+tdT
+hvW
 vfz
 pOO
 eKA
@@ -99779,7 +100049,7 @@ aoW
 aoW
 aoW
 tPM
-ciA
+xbZ
 nvK
 vfz
 hpZ
@@ -100036,8 +100306,8 @@ arG
 aqp
 aoW
 vIp
-mvU
-mwK
+loN
+tZE
 rtT
 iiq
 iiq
@@ -100552,13 +100822,13 @@ aoW
 apJ
 aqg
 hRh
-fPW
+hqs
 edO
 aqg
 kpf
 uaW
 awe
-peo
+lLZ
 svT
 ewO
 fBs
@@ -100567,7 +100837,7 @@ dlD
 aqg
 eso
 aqg
-peo
+lLZ
 aqg
 azL
 aml
@@ -105398,7 +105668,7 @@ anK
 luW
 smz
 rti
-vxy
+epE
 anj
 anj
 azk

--- a/_maps/map_files/Tycoon/Tycoon2.dmm
+++ b/_maps/map_files/Tycoon/Tycoon2.dmm
@@ -49,15 +49,15 @@
 /turf/open/floor/monotile,
 /area/security/execution/transfer)
 "aaj" = (
-/obj/machinery/door/airlock/glass_large/ship{
-	name = "Briefing Room"
-	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/effect/landmark/zebra_interlock_point,
 /obj/effect/turf_decal/ship/delivery/yellow,
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "CIC Hallway"
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
 "aak" = (
@@ -354,14 +354,6 @@
 "abd" = (
 /turf/closed/wall/ship,
 /area/crew_quarters/bar)
-"abe" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/monotile/dark,
-/area/hallway/nsv/deck2/frame1/central)
 "abf" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/ship{
@@ -536,15 +528,15 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/nsv/hanger/deck2)
 "abE" = (
-/obj/machinery/door/airlock/glass_large/ship{
-	name = "Pilot Ready Room";
-	req_access_txt = "69"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Pilot Ready Room";
+	req_access_txt = "69"
+	},
 /turf/open/floor/monotile,
 /area/nsv/hanger/deck2)
 "abF" = (
@@ -685,7 +677,7 @@
 	width = 7
 	},
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "abX" = (
 /obj/structure/rack,
 /obj/item/storage/box/teargas,
@@ -794,6 +786,7 @@
 /area/hallway/nsv/deck2/frame1/central)
 "aco" = (
 /obj/machinery/door/airlock/ship/security/glass{
+	dir = 4;
 	req_one_access_txt = "2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -995,6 +988,10 @@
 /obj/machinery/door/morgue{
 	name = "Relic Closet";
 	req_access_txt = "22"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/chapel/office)
@@ -1287,6 +1284,10 @@
 /obj/machinery/conveyor{
 	id = "packageExternal"
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "adw" = (
@@ -1344,6 +1345,7 @@
 /area/engine/engineering)
 "adC" = (
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "Chapel"
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -1418,6 +1420,12 @@
 /obj/machinery/door/morgue{
 	name = "Confession Booth (Chaplain)";
 	req_access_txt = "22"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
@@ -1524,7 +1532,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/motion{
-	c_tag = "Armoury"
+	c_tag = "Armory"
 	},
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/security/armory)
@@ -1612,6 +1620,11 @@
 	id = "chem_privacy";
 	name = "privacy shutters"
 	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile,
 /area/medical/chemistry)
 "aee" = (
@@ -1620,6 +1633,11 @@
 	id = "chem_privacy";
 	name = "privacy shutters"
 	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/medical/chemistry)
 "aef" = (
@@ -1822,6 +1840,10 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Pilot Ready Room";
+	req_access_txt = "69"
+	},
 /turf/open/floor/monotile,
 /area/nsv/hanger/deck2)
 "aeE" = (
@@ -1890,6 +1912,7 @@
 /area/nsv/weapons/fore)
 "aeQ" = (
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "Virology";
 	req_one_access_txt = "39"
 	},
@@ -2080,6 +2103,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "afk" = (
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "Engineering lobby"
 	},
 /obj/structure/disposalpipe/segment{
@@ -2333,6 +2357,12 @@
 "afO" = (
 /obj/machinery/door/morgue{
 	name = "Confession Booth"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
@@ -2590,7 +2620,7 @@
 	dir = 4
 	},
 /turf/open/space/basic,
-/area/space)
+/area/engine/engine_room)
 "agx" = (
 /obj/machinery/space_heater,
 /obj/machinery/firealarm{
@@ -2613,6 +2643,7 @@
 /area/medical/virology)
 "agA" = (
 /obj/machinery/door/airlock/ship/public{
+	dir = 4;
 	name = "Bunk 1-A"
 	},
 /obj/structure/cable{
@@ -2890,6 +2921,7 @@
 /area/medical/genetics)
 "ahd" = (
 /obj/machinery/door/airlock/ship/maintenance{
+	dir = 4;
 	name = "Hangar rescue"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -3154,6 +3186,7 @@
 /area/medical/medbay/central)
 "ahK" = (
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "Patient Room A"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -3267,6 +3300,7 @@
 /area/chapel/main)
 "ahY" = (
 /obj/machinery/door/airlock/ship/maintenance{
+	dir = 4;
 	name = "Crematorium";
 	req_one_access_txt = "22;27"
 	},
@@ -3320,6 +3354,7 @@
 /area/medical/morgue)
 "aid" = (
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "Morgue"
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -3521,8 +3556,9 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/ship/maintenance{
+	dir = 4;
 	name = "Incinerator";
-	req_access_txt = "12"
+	req_access_txt = "24"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4024,8 +4060,6 @@
 /turf/open/floor/monotile,
 /area/hydroponics)
 "ajS" = (
-/obj/item/gun/ballistic/shotgun/doublebarrel,
-/obj/structure/closet/secure_closet/bar,
 /turf/open/floor/monotile,
 /area/crew_quarters/bar)
 "ajT" = (
@@ -4297,6 +4331,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile,
 /area/hydroponics)
 "akw" = (
@@ -4465,9 +4500,6 @@
 /turf/open/floor/monotile/dark,
 /area/medical/virology)
 "akP" = (
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
@@ -4478,6 +4510,7 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "Cloning Lab";
 	req_access_txt = "5; 68"
 	},
@@ -4485,6 +4518,9 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -4512,6 +4548,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "Cryogenics Freezer";
 	req_one_access_txt = "5"
 	},
@@ -4519,6 +4556,12 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
@@ -4738,6 +4781,7 @@
 /area/medical/medbay/central)
 "alr" = (
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "Medbay Lobby";
 	req_one_access_txt = "5"
 	},
@@ -4829,6 +4873,7 @@
 /area/medical/virology)
 "alA" = (
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "Virology";
 	req_one_access_txt = "39"
 	},
@@ -5066,6 +5111,7 @@
 /area/science/nanite)
 "ama" = (
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "Medbay Lobby";
 	req_one_access_txt = "5"
 	},
@@ -5183,12 +5229,12 @@
 /turf/closed/wall/ship,
 /area/lawoffice)
 "amr" = (
-/obj/machinery/door/airlock/glass_large/ship{
-	name = "Gym"
-	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
+	},
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Gym"
 	},
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/fitness/recreation)
@@ -5259,6 +5305,10 @@
 	name = "Bar";
 	req_one_access_txt = "25"
 	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/monotile,
 /area/crew_quarters/cafeteria{
 	name = "Mess hall"
@@ -5327,6 +5377,7 @@
 /area/medical/surgery)
 "amO" = (
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "Surgery";
 	req_one_access_txt = "5"
 	},
@@ -5760,6 +5811,7 @@
 /area/crew_quarters/heads/chief)
 "anV" = (
 /obj/machinery/door/airlock/ship/command{
+	dir = 4;
 	name = "Chief Engineer";
 	req_one_access_txt = "56"
 	},
@@ -6234,6 +6286,7 @@
 /area/maintenance/department/engine)
 "apa" = (
 /obj/machinery/door/airlock/ship/maintenance{
+	dir = 4;
 	name = "Virology maintenance"
 	},
 /obj/structure/cable{
@@ -6744,6 +6797,11 @@
 "aqv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/machinery/airalarm/directional/east,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/structure/table/reinforced,
+/obj/item/multitool,
 /turf/open/floor/monotile,
 /area/engine/gravity_generator)
 "aqw" = (
@@ -6791,6 +6849,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
+	},
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Gym"
 	},
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/fitness/recreation)
@@ -6854,6 +6915,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile,
 /area/hydroponics)
 "aqL" = (
@@ -7073,6 +7135,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/cafeteria{
 	name = "Mess hall"
@@ -7425,11 +7488,12 @@
 /turf/open/floor/carpet/blue,
 /area/lawoffice)
 "asd" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/turf/open/floor/monotile,
-/area/engine/gravity_generator)
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "ase" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -7479,6 +7543,7 @@
 /area/engine/engineering)
 "asp" = (
 /obj/machinery/door/airlock/ship/engineering/glass{
+	dir = 4;
 	name = "Reactor control Room";
 	req_one_access_txt = "10; 24"
 	},
@@ -7898,6 +7963,10 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/wood,
 /area/hydroponics)
 "atC" = (
@@ -8076,13 +8145,6 @@
 /turf/open/floor/carpet,
 /area/library)
 "aum" = (
-/obj/machinery/door/airlock/glass_large/ship{
-	bound_height = 64;
-	bound_width = 32;
-	dir = 4;
-	name = "Library";
-	pixel_x = -32
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -8091,6 +8153,10 @@
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
+	},
+/obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
+	name = "Library"
 	},
 /turf/open/floor/carpet/ship,
 /area/library)
@@ -8436,6 +8502,7 @@
 /area/crew_quarters/dorms)
 "avg" = (
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "Crew Lounge"
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -8470,6 +8537,7 @@
 /area/hallway/nsv/deck2/frame1/central)
 "avj" = (
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "Crew Lounge"
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -8488,7 +8556,7 @@
 "avl" = (
 /obj/structure/lattice,
 /obj/machinery/camera/motion{
-	c_tag = "Armoury";
+	c_tag = "Armory";
 	dir = 1
 	},
 /turf/open/space/basic,
@@ -8508,7 +8576,7 @@
 "avo" = (
 /obj/machinery/atmospherics/components/binary/valve/digital{
 	dir = 8;
-	icon_state = "dvalve_map-2"
+	name = "Incinerator valve"
 	},
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/starboard/fore)
@@ -8547,8 +8615,9 @@
 /area/crew_quarters/dorms)
 "avv" = (
 /obj/machinery/door/airlock/ship/maintenance{
+	dir = 4;
 	name = "Kitchen maintenance";
-	req_access_txt = "12"
+	req_access_txt = "12;28"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8572,6 +8641,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/highsecurity/ship{
+	dir = 4;
 	name = "Naval Artillery";
 	req_one_access_txt = "69"
 	},
@@ -9210,13 +9280,10 @@
 /turf/open/floor/plating/airless,
 /area/engine/atmos)
 "ayv" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
 /obj/structure/cable{
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
-/turf/open/floor/monotile,
+/turf/closed/wall/r_wall/ship,
 /area/engine/gravity_generator)
 "ayz" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
@@ -9843,6 +9910,7 @@
 /area/maintenance/starboard/fore)
 "azY" = (
 /obj/machinery/door/airlock/ship/external/glass{
+	dir = 4;
 	req_one_access_txt = "24"
 	},
 /turf/open/floor/plating,
@@ -9999,7 +10067,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
+	dir = 4
+	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
@@ -10175,6 +10245,7 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "Virology Decontamination";
 	req_one_access_txt = "39"
 	},
@@ -10562,6 +10633,7 @@
 /area/tcommsat/server)
 "aBE" = (
 /obj/machinery/door/airlock/ship/engineering/glass{
+	dir = 4;
 	name = "Reactor core access";
 	req_one_access_txt = "10; 24"
 	},
@@ -10757,7 +10829,7 @@
 "aCl" = (
 /obj/structure/lattice,
 /obj/machinery/camera/motion{
-	c_tag = "Armoury";
+	c_tag = "Armory";
 	dir = 8
 	},
 /turf/open/space/basic,
@@ -10788,6 +10860,7 @@
 /area/medical/virology)
 "aCp" = (
 /obj/machinery/door/airlock/ship/hatch{
+	dir = 4;
 	name = "Network Administration";
 	req_one_access_txt = "61;65"
 	},
@@ -11251,7 +11324,7 @@
 /obj/structure/closet/l3closet/security,
 /obj/effect/turf_decal/bot,
 /obj/machinery/camera/motion{
-	c_tag = "Armoury"
+	c_tag = "Armory"
 	},
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/security/armory)
@@ -11403,7 +11476,7 @@
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/engineering/reactor_core)
 "aDT" = (
 /obj/machinery/telecomms/processor/preset_four,
 /turf/open/floor/circuit/telecomms/server,
@@ -11433,6 +11506,7 @@
 /area/tcommsat/server)
 "aDX" = (
 /obj/machinery/door/airlock/ship/hatch{
+	dir = 4;
 	name = "Network Administration";
 	req_one_access_txt = "61;65"
 	},
@@ -11488,6 +11562,7 @@
 /area/tcommsat/computer)
 "aEb" = (
 /obj/machinery/door/airlock/ship/hatch{
+	dir = 4;
 	name = "Network Administration";
 	req_one_access_txt = "61;65"
 	},
@@ -11568,6 +11643,7 @@
 /area/ai_monitored/security/armory)
 "aEk" = (
 /obj/machinery/door/airlock/ship/security/glass{
+	dir = 4;
 	name = "Evidence lockup";
 	req_one_access_txt = "3"
 	},
@@ -11587,7 +11663,6 @@
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
-/obj/effect/landmark/nuclear_waste_spawner,
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile,
 /area/security/brig)
@@ -11887,10 +11962,11 @@
 /turf/open/floor/monotile,
 /area/security/brig)
 "aET" = (
-/obj/effect/landmark/nuclear_waste_spawner,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/turf/open/floor/monotile,
-/area/security/brig)
+/obj/structure/sign/ship/nosmoking,
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/starboard/secondary{
+	name = "Munitions Projects"
+	})
 "aEU" = (
 /obj/machinery/flasher{
 	id = "pw_2";
@@ -11941,6 +12017,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/monotile,
 /area/security/brig)
 "aFc" = (
@@ -11950,6 +12030,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/monotile,
 /area/security/brig)
 "aFd" = (
@@ -11959,6 +12043,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/monotile,
 /area/security/brig)
 "aFe" = (
@@ -11980,6 +12068,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/monotile,
 /area/security/brig)
 "aFg" = (
@@ -12607,6 +12699,7 @@
 /area/gateway)
 "aGv" = (
 /obj/machinery/door/airlock/ship{
+	dir = 4;
 	name = "Gateway";
 	req_one_access_txt = "62"
 	},
@@ -12824,6 +12917,7 @@
 /area/security/execution/transfer)
 "aGS" = (
 /obj/machinery/door/airlock/ship/external/glass{
+	dir = 4;
 	req_one_access_txt = "2"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -12916,6 +13010,7 @@
 /area/security/detectives_office)
 "aHe" = (
 /obj/machinery/door/airlock/ship/security{
+	dir = 4;
 	name = "Head of Security";
 	req_one_access_txt = "58"
 	},
@@ -13206,51 +13301,33 @@
 /area/engine/gravity_generator)
 "aHK" = (
 /obj/machinery/power/apc/auto_name/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
+	icon_state = "0-2"
 	},
 /turf/open/floor/monotile,
 /area/engine/gravity_generator)
 "aHL" = (
-/obj/machinery/door/airlock/ship/command{
-	name = "Gravity Generator";
-	req_one_access_txt = "56"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/floor/monotile,
 /area/engine/gravity_generator)
 "aHM" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
+/obj/machinery/power/smes{
+	charge = 5e+006
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
 /turf/open/floor/monotile,
 /area/engine/gravity_generator)
@@ -13276,6 +13353,7 @@
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
 	},
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "aHQ" = (
@@ -13403,11 +13481,13 @@
 /obj/item/clothing/gloves/color/latex,
 /obj/item/clothing/mask/surgical,
 /obj/structure/window/reinforced,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/monotile/light,
 /area/security/detectives_office)
 "aIh" = (
 /obj/machinery/door/window,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/monotile/light,
 /area/security/detectives_office)
 "aIi" = (
@@ -13441,6 +13521,7 @@
 /obj/machinery/computer/operating{
 	dir = 8
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/monotile/light,
 /area/security/detectives_office)
 "aIm" = (
@@ -13532,12 +13613,20 @@
 /turf/open/floor/monotile/dark,
 /area/engine/gravity_generator)
 "aIy" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
+/obj/machinery/power/terminal{
+	dir = 1
 	},
-/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/monotile,
 /area/engine/gravity_generator)
@@ -13545,7 +13634,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/closed/wall/r_wall/ship,
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
 /area/maintenance/department/engine)
 "aIA" = (
 /obj/machinery/camera/autoname,
@@ -13631,17 +13724,17 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/virology{
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/ship/medical{
 	autoclose = 0;
 	frequency = 1449;
 	id_tag = "virology_airlock_interior";
 	name = "Virology Interior Airlock";
 	req_access_txt = "39"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/monotile/dark,
 /area/medical/virology)
 "aIM" = (
@@ -13784,6 +13877,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "Gateway Chamber";
 	req_one_access_txt = "62"
 	},
@@ -13842,12 +13936,10 @@
 /turf/open/floor/mineral/plastitanium/airless,
 /area/science/test_area)
 "aJo" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
 /obj/machinery/camera/autoname,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/gravity_generator)
@@ -13881,6 +13973,7 @@
 /area/maintenance/department/engine)
 "aJs" = (
 /obj/machinery/door/airlock/ship/maintenance{
+	dir = 4;
 	name = "Engineering wing maintenance";
 	req_one_access_txt = "10"
 	},
@@ -14029,9 +14122,12 @@
 /turf/open/floor/mineral/plastitanium/airless,
 /area/science/test_area)
 "aJJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/gravity_generator)
@@ -14051,6 +14147,7 @@
 /area/science/test_area)
 "aJN" = (
 /obj/machinery/door/airlock/ship/public{
+	dir = 4;
 	name = "Quiet Room"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -14121,6 +14218,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/monotile/dark,
 /area/science/robotics)
 "aJV" = (
@@ -14136,6 +14234,7 @@
 /area/science/research)
 "aJW" = (
 /obj/machinery/door/airlock/ship{
+	dir = 4;
 	name = "Robotics Lab";
 	req_one_access_txt = "29"
 	},
@@ -14262,6 +14361,10 @@
 /obj/machinery/door/airlock/ship{
 	name = "Munitions Briefing Room";
 	req_access_txt = "69"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/nsv/weapons/fore)
@@ -14514,6 +14617,7 @@
 /obj/item/clothing/gloves/color/latex,
 /obj/item/surgical_drapes,
 /obj/item/clothing/mask/surgical,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/monotile/dark,
 /area/science/robotics)
 "aKK" = (
@@ -15043,6 +15147,10 @@
 	req_one_access_txt = "30"
 	},
 /obj/machinery/atmospherics/pipe/simple,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/monotile/dark,
 /area/science/server)
 "aLM" = (
@@ -15198,6 +15306,11 @@
 	req_access_txt = "55"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/science/xenobiology)
 "aMe" = (
@@ -15318,10 +15431,10 @@
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/heads/hor)
 "aMr" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 26
-	},
 /obj/machinery/suit_storage_unit/rd,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/science/mixing{
 	name = "Prototype munitions bay"
@@ -15441,6 +15554,10 @@
 /obj/item/ship_weapon/parts/missile/warhead/torpedo,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/item/ship_weapon/parts/missile/iff_card,
+/obj/item/ship_weapon/parts/missile/iff_card,
+/obj/item/ship_weapon/parts/missile/iff_card,
+/obj/item/ship_weapon/parts/missile/propulsion_system,
 /turf/open/floor/carpet/red,
 /area/nsv/weapons/fore)
 "aMF" = (
@@ -15683,6 +15800,7 @@
 	})
 "aNd" = (
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "Engineering lobby"
 	},
 /obj/structure/disposalpipe/segment{
@@ -16237,7 +16355,7 @@
 	width = 29
 	},
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "aOj" = (
 /obj/structure/table/reinforced,
 /obj/item/cartridge/quartermaster{
@@ -16715,6 +16833,7 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "Aft Primary Hallway"
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -16786,6 +16905,7 @@
 /area/engine/break_room)
 "aPm" = (
 /obj/machinery/door/airlock/ship/command{
+	dir = 4;
 	name = "Decontamination Shower";
 	req_one_access_txt = "56"
 	},
@@ -16989,6 +17109,10 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Medical Central";
+	req_one_access_txt = "5"
+	},
 /turf/open/floor/monotile,
 /area/medical/medbay/central)
 "aPH" = (
@@ -17164,12 +17288,18 @@
 	dir = 4;
 	req_one_access_txt = "10"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
 "aQo" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	dir = 4;
 	req_one_access_txt = "10"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
@@ -17202,6 +17332,7 @@
 /area/engine/engineering/hangar)
 "aQu" = (
 /obj/machinery/door/airlock/ship/engineering/glass{
+	dir = 4;
 	name = "Reactor control Room";
 	req_one_access_txt = "10; 24"
 	},
@@ -17299,6 +17430,7 @@
 /area/engine/engine_smes)
 "aQC" = (
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "Medical Storage";
 	req_one_access_txt = "5"
 	},
@@ -17323,11 +17455,31 @@
 /turf/open/floor/monotile,
 /area/medical/medbay/central)
 "aQD" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space)
+/obj/machinery/door/airlock/ship/command{
+	dir = 4;
+	name = "Gravity Generator";
+	req_one_access_txt = "56"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/monotile,
+/area/engine/gravity_generator)
 "aQE" = (
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "FTL navigation";
 	req_access_txt = "10"
 	},
@@ -17644,6 +17796,7 @@
 /area/crew_quarters/dorms/nsv/dorms_1)
 "aRn" = (
 /obj/machinery/door/airlock/ship/public{
+	dir = 4;
 	id_tag = "erp1";
 	name = "Showers"
 	},
@@ -17724,6 +17877,7 @@
 /area/crew_quarters/dorms/nsv/dorms_2)
 "aRA" = (
 /obj/machinery/door/airlock/ship/public{
+	dir = 4;
 	id_tag = "erp2";
 	name = "Showers"
 	},
@@ -18347,7 +18501,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/carpet/blue,
 /area/hallway/nsv/deck2/frame1/central)
 "aSP" = (
@@ -18545,10 +18698,17 @@
 /area/nsv/weapons/fore)
 "aTs" = (
 /obj/machinery/door/airlock/highsecurity/ship{
+	dir = 4;
 	name = "Gauss rounds";
 	req_one_access_txt = "69"
 	},
 /obj/structure/lattice/catwalk/over/ship,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/nsv/weapons/gauss)
 "aTt" = (
@@ -18716,7 +18876,7 @@
 	dir = 4;
 	name = "Suit Storage";
 	pixel_x = -32;
-	req_one_access_txt = "10"
+	req_one_access_txt = "10;24"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18732,20 +18892,13 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/storage_shared)
-"aTS" = (
-/obj/machinery/door/airlock/glass_large/ship{
-	name = "Infirmary"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/monotile/light,
-/area/medical/medbay/lobby)
 "aTT" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
+	},
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Medbay Lobby Access"
 	},
 /turf/open/floor/monotile/light,
 /area/medical/medbay/lobby)
@@ -18771,6 +18924,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/plasteel/ship,
 /area/engine/break_room)
 "aTX" = (
@@ -18841,6 +18995,7 @@
 /area/medical/morgue)
 "aUg" = (
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "Paramedic Station";
 	req_one_access_txt = "5"
 	},
@@ -19234,10 +19389,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "aUY" = (
-/obj/machinery/door/airlock/glass_large/ship{
-	name = "Virology Access";
-	req_one_access_txt = "5"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -19245,6 +19396,10 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Virology";
+	req_one_access_txt = "5"
+	},
 /turf/open/floor/monotile/dark,
 /area/medical/virology)
 "aUZ" = (
@@ -19331,8 +19486,8 @@
 	})
 "aVh" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	name = "Morale Office";
-	req_one_access_txt = "46"
+	dir = 4;
+	name = "Morale Office"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -19426,6 +19581,7 @@
 	name = "intra ship intercom";
 	pixel_y = 26
 	},
+/obj/structure/table/wood,
 /turf/open/floor/monotile,
 /area/crew_quarters/theatre)
 "aVq" = (
@@ -19497,6 +19653,7 @@
 	})
 "aVx" = (
 /obj/machinery/door/airlock/ship/hatch{
+	dir = 4;
 	name = "Network Administration";
 	req_one_access_txt = "61;65"
 	},
@@ -19521,6 +19678,9 @@
 "aVz" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
+	},
+/obj/structure/chair/sofa/corner{
+	dir = 8
 	},
 /turf/open/floor/monotile,
 /area/crew_quarters/theatre)
@@ -19637,6 +19797,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/cafeteria{
 	name = "Mess hall"
@@ -19671,6 +19832,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/cafeteria{
 	name = "Mess hall"
@@ -20297,6 +20459,11 @@
 	id = "xb_containment";
 	name = "Xenobiology Containment Shutter"
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/science/xenobiology)
 "aXf" = (
@@ -20334,6 +20501,10 @@
 	dir = 8;
 	id = "packageExternal"
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "aXk" = (
@@ -20814,10 +20985,6 @@
 /turf/open/floor/carpet/red,
 /area/security/detectives_office)
 "aYp" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	name = "Medbay maintenance";
-	req_one_access_txt = "5"
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -20829,6 +20996,9 @@
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
+	},
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
@@ -20995,10 +21165,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "aYO" = (
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -21055,6 +21221,7 @@
 /area/maintenance/port)
 "aYU" = (
 /obj/machinery/door/airlock/ship/maintenance{
+	dir = 4;
 	name = "Virology maintenance"
 	},
 /obj/structure/cable{
@@ -21256,6 +21423,10 @@
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
+	},
+/obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
+	name = "Library"
 	},
 /turf/open/floor/carpet/ship,
 /area/library)
@@ -21532,7 +21703,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
+	dir = 4
+	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
@@ -21697,6 +21870,7 @@
 /area/nsv/weapons/fore)
 "bah" = (
 /obj/machinery/door/airlock/highsecurity/ship{
+	dir = 4;
 	name = "Missile Bay";
 	req_one_access_txt = "69"
 	},
@@ -21817,6 +21991,10 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/item/ship_weapon/parts/missile/iff_card,
+/obj/item/ship_weapon/parts/missile/iff_card,
+/obj/item/ship_weapon/parts/missile/iff_card,
+/obj/item/ship_weapon/parts/missile/propulsion_system,
 /turf/open/floor/carpet/red,
 /area/nsv/weapons/fore)
 "bas" = (
@@ -21963,6 +22141,7 @@
 /area/maintenance/department/medical)
 "baF" = (
 /obj/machinery/door/airlock/ship/maintenance{
+	dir = 4;
 	name = "Medbay maintenance";
 	req_one_access_txt = "5"
 	},
@@ -22006,10 +22185,8 @@
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
 "baI" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
+/obj/structure/closet/secure_closet/bar,
+/obj/item/gun/ballistic/shotgun/doublebarrel,
 /turf/open/floor/monotile,
 /area/crew_quarters/bar)
 "baJ" = (
@@ -22026,7 +22203,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
 /turf/open/floor/monotile,
@@ -22081,7 +22259,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
+	dir = 4
+	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
@@ -22097,10 +22277,6 @@
 /turf/open/floor/monotile/dark,
 /area/medical/medbay/central)
 "baR" = (
-/obj/machinery/door/airlock/glass_large/ship{
-	name = "Surgery Access";
-	req_one_access_txt = "5"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -22108,10 +22284,15 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Medical Central";
+	req_one_access_txt = "5"
+	},
 /turf/open/floor/monotile/dark,
 /area/medical/medbay/central)
 "baS" = (
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "Patient rooms"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -22200,6 +22381,7 @@
 /area/medical/morgue)
 "bbb" = (
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "Morgue"
 	},
 /obj/structure/cable{
@@ -22250,6 +22432,11 @@
 "bbf" = (
 /obj/structure/table/reinforced,
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/monotile,
 /area/crew_quarters/cafeteria{
 	name = "Mess hall"
@@ -22373,8 +22560,7 @@
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
 "bbv" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
+/turf/template_noop,
 /area/maintenance/department/science)
 "bbw" = (
 /obj/structure/closet/crate,
@@ -22394,6 +22580,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/monotile,
 /area/crew_quarters/cafeteria{
 	name = "Mess hall"
@@ -22405,10 +22596,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/monotile,
 /area/crew_quarters/cafeteria{
 	name = "Mess hall"
@@ -22881,6 +23072,7 @@
 /area/medical/medbay/central)
 "bcp" = (
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "Examination Room"
 	},
 /obj/structure/cable{
@@ -23011,6 +23203,7 @@
 /area/hallway/secondary/exit)
 "bcA" = (
 /obj/machinery/door/airlock/ship/station/mining{
+	dir = 4;
 	name = "Cargo Bay";
 	req_one_access_txt = "31; 48"
 	},
@@ -23848,6 +24041,10 @@
 	name = "Hangar Bay";
 	req_access_txt = "69"
 	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
 "bdV" = (
@@ -23858,6 +24055,7 @@
 /area/science/robotics)
 "bdW" = (
 /obj/machinery/door/airlock/ship{
+	dir = 4;
 	name = "Robotics Lab";
 	req_one_access_txt = "29"
 	},
@@ -23966,6 +24164,7 @@
 /area/security/warden)
 "beg" = (
 /obj/machinery/door/airlock/ship/security/glass{
+	dir = 4;
 	name = "Forensics";
 	req_one_access_txt = "4"
 	},
@@ -24400,6 +24599,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess{
+	dir = 4;
 	name = "Munitions Projects"
 	},
 /turf/open/floor/monotile/dark,
@@ -24753,8 +24953,8 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/ship/public/glass{
-	name = "Morale Office";
-	req_one_access_txt = "46"
+	dir = 4;
+	name = "Morale Office"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -24985,6 +25185,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bgc" = (
 /obj/machinery/door/airlock/ship/external{
+	dir = 4;
 	name = "Mining Shuttle Airlock";
 	req_one_access_txt = "31;48"
 	},
@@ -25116,6 +25317,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/chair/sofa/right{
+	dir = 1
+	},
 /turf/open/floor/monotile,
 /area/crew_quarters/theatre)
 "bgp" = (
@@ -25211,6 +25415,7 @@
 /area/hallway/nsv/deck2/frame1/port)
 "bgz" = (
 /obj/machinery/door/airlock/highsecurity/ship{
+	dir = 4;
 	name = "Missile Bay";
 	req_one_access_txt = "69"
 	},
@@ -25414,7 +25619,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
+	dir = 4
+	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
@@ -25897,6 +26104,7 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/ship/security/glass{
+	dir = 4;
 	name = "Detective's Office";
 	req_one_access_txt = "4"
 	},
@@ -26127,19 +26335,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/lattice/catwalk/over/ship,
-/turf/open/floor/monotile/dark,
-/area/hallway/nsv/deck2/frame1/central)
-"bix" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/airlock/glass_large/ship{
-	name = "Briefing Room"
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "CIC Hallway"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
 "biy" = (
@@ -26441,6 +26639,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
 	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bje" = (
@@ -26569,6 +26771,7 @@
 /area/crew_quarters/kitchen)
 "bjp" = (
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "Service Break Room";
 	req_one_access_txt = "28;35;25;46;26"
 	},
@@ -27033,6 +27236,10 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
+	},
+/obj/structure/chair/sofa/right{
+	dir = 8;
+	icon_state = "sofaend_right"
 	},
 /turf/open/floor/monotile,
 /area/crew_quarters/theatre)
@@ -27680,6 +27887,7 @@
 /area/maintenance/starboard/fore)
 "blr" = (
 /obj/machinery/door/airlock/ship/maintenance{
+	dir = 4;
 	name = "Atmospherics maintenance";
 	req_one_access_txt = "24"
 	},
@@ -27698,7 +27906,10 @@
 /turf/open/floor/monotile,
 /area/maintenance/starboard/fore)
 "bls" = (
-/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "blt" = (
@@ -28059,6 +28270,7 @@
 /area/hallway/nsv/deck2/frame1/port)
 "bmn" = (
 /obj/machinery/door/airlock/ship/security/glass{
+	dir = 4;
 	req_one_access_txt = "2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -29028,7 +29240,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/landmark/nuclear_waste_spawner,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
@@ -29209,6 +29420,7 @@
 /area/quartermaster/storage)
 "boD" = (
 /obj/machinery/door/airlock/ship/station/mining{
+	dir = 4;
 	name = "Warehouse";
 	req_one_access_txt = "31;48"
 	},
@@ -29535,6 +29747,7 @@
 /area/janitor)
 "bpl" = (
 /obj/machinery/door/airlock/ship/public{
+	dir = 4;
 	name = "Janitorial Storage";
 	req_one_access_txt = "26"
 	},
@@ -29669,9 +29882,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "bpx" = (
@@ -29682,7 +29892,7 @@
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 6
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
@@ -29898,6 +30108,7 @@
 /area/quartermaster/storage)
 "bpQ" = (
 /obj/machinery/door/airlock/ship/station/mining{
+	dir = 4;
 	name = "Quartermaster's Office";
 	req_one_access_txt = "41"
 	},
@@ -30133,6 +30344,7 @@
 /area/quartermaster/qm)
 "bqj" = (
 /obj/machinery/door/airlock/ship{
+	dir = 4;
 	name = "Experimental munitions";
 	req_one_access_txt = "8"
 	},
@@ -30552,9 +30764,11 @@
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/heads/hor)
 "bqX" = (
-/obj/effect/landmark/nuclear_waste_spawner,
-/turf/open/floor/monotile/light,
-/area/medical/genetics)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/turf/open/floor/monotile,
+/area/engine/gravity_generator)
 "bqY" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -30690,6 +30904,7 @@
 /area/maintenance/disposal)
 "brl" = (
 /obj/machinery/door/airlock/ship/maintenance{
+	dir = 4;
 	name = "Disposals"
 	},
 /obj/structure/cable{
@@ -30794,7 +31009,7 @@
 	dir = 8;
 	sortType = 11
 	},
-/turf/open/floor/plating,
+/turf/template_noop,
 /area/maintenance/department/science)
 "bru" = (
 /obj/structure/cable{
@@ -30806,7 +31021,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/turf/open/floor/plating,
+/turf/template_noop,
 /area/maintenance/department/science)
 "brv" = (
 /obj/machinery/conveyor{
@@ -30855,7 +31070,8 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "brB" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance/eight,
+/obj/structure/closet/cardboard,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary{
 	name = "Munitions Projects"
@@ -30947,6 +31163,7 @@
 /area/maintenance/starboard)
 "brK" = (
 /obj/machinery/door/airlock/ship/maintenance{
+	dir = 4;
 	name = "Crematorium";
 	req_one_access_txt = "22;27"
 	},
@@ -31233,6 +31450,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/ship/maintenance{
+	dir = 4;
 	name = "Trash compactor"
 	},
 /obj/structure/disposalpipe/segment{
@@ -31291,6 +31509,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/ship/maintenance{
+	dir = 4;
 	name = "Trash compactor"
 	},
 /obj/structure/disposalpipe/segment{
@@ -31905,6 +32124,7 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "Aft Primary Hallway"
 	},
 /obj/structure/disposalpipe/segment{
@@ -32047,6 +32267,7 @@
 /area/crew_quarters/dorms)
 "btO" = (
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "Crew Lounge"
 	},
 /obj/structure/disposalpipe/segment{
@@ -32153,6 +32374,7 @@
 /area/crew_quarters/dorms/nsv/dorms_2)
 "btW" = (
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "Crew Lounge"
 	},
 /obj/structure/disposalpipe/segment{
@@ -32306,6 +32528,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/monotile,
 /area/crew_quarters/cafeteria{
 	name = "Mess hall"
@@ -32573,10 +32800,15 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/fans/tiny,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/kitchen/coldroom)
 "buI" = (
 /obj/machinery/door/airlock/ship/security/glass{
+	dir = 4;
 	name = "Long Term Confinement";
 	req_one_access_txt = "2"
 	},
@@ -32661,6 +32893,7 @@
 /area/security/brig)
 "buN" = (
 /obj/machinery/door/airlock/ship/security/glass{
+	dir = 4;
 	req_one_access_txt = "2"
 	},
 /obj/structure/cable{
@@ -32685,6 +32918,7 @@
 /area/security/brig)
 "buO" = (
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "Engineering section"
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -32755,7 +32989,6 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
-/obj/effect/landmark/nuclear_waste_spawner,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/dark,
 /area/security/brig)
@@ -32782,6 +33015,7 @@
 /area/hallway/nsv/deck2/frame1/central)
 "buW" = (
 /obj/machinery/door/airlock/highsecurity/ship{
+	dir = 4;
 	name = "CIC";
 	req_one_access_txt = "19"
 	},
@@ -32845,6 +33079,7 @@
 /area/nsv/hanger/deck2)
 "bvc" = (
 /obj/machinery/door/airlock/highsecurity/ship{
+	dir = 4;
 	name = "CIC";
 	req_one_access_txt = "19"
 	},
@@ -32983,21 +33218,12 @@
 /turf/open/floor/monotile,
 /area/medical/medbay/lobby)
 "bvo" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/effect/landmark/nuclear_waste_spawner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/turf/open/floor/monotile,
-/area/medical/medbay/lobby)
+/turf/open/floor/plating,
+/area/maintenance/port)
 "bvp" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -33015,6 +33241,7 @@
 /area/medical/medbay/lobby)
 "bvq" = (
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "Medical Storage";
 	req_one_access_txt = "5"
 	},
@@ -33130,6 +33357,10 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Virology";
+	req_one_access_txt = "5"
+	},
 /turf/open/floor/monotile,
 /area/medical/virology)
 "bvA" = (
@@ -33228,6 +33459,7 @@
 /area/medical/virology)
 "bvJ" = (
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "Surgery";
 	req_one_access_txt = "5"
 	},
@@ -33581,13 +33813,13 @@
 /turf/open/floor/monotile,
 /area/medical/medbay/lobby)
 "bwp" = (
-/obj/machinery/door/airlock/glass_large/ship{
-	name = "Infirmary"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
+	},
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Medbay Lobby Access"
 	},
 /turf/open/floor/monotile/light,
 /area/medical/medbay/lobby)
@@ -34309,6 +34541,7 @@
 /area/hallway/secondary/exit)
 "bxI" = (
 /obj/machinery/door/airlock/ship/station/mining{
+	dir = 4;
 	name = "Cargo Bay";
 	req_one_access_txt = "31; 48"
 	},
@@ -34371,6 +34604,7 @@
 /area/maintenance/department/cargo)
 "bxM" = (
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "Chapel"
 	},
 /obj/structure/cable{
@@ -34531,7 +34765,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
 	},
-/obj/effect/landmark/nuclear_waste_spawner,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/tech/grid,
 /area/chapel/main)
@@ -34556,6 +34789,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/ship/hatch{
+	dir = 4;
 	name = "Funeral Parlour"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -34613,6 +34847,7 @@
 /area/chapel/main)
 "byj" = (
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "Engineering section"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -34847,6 +35082,7 @@
 /area/security/brig)
 "byI" = (
 /obj/machinery/door/airlock/ship/maintenance{
+	dir = 4;
 	name = "Deck 1 access maintenance"
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -34859,6 +35095,7 @@
 /area/hallway/nsv/deck2/frame1/central)
 "byJ" = (
 /obj/machinery/door/airlock/ship/security/glass{
+	dir = 4;
 	name = "Security Equipment";
 	req_one_access_txt = "1;4"
 	},
@@ -35338,21 +35575,25 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/landmark/nuclear_waste_spawner,
 /obj/machinery/newscaster{
 	pixel_x = 32
 	},
 /turf/open/floor/monotile/light,
 /area/crew_quarters/kitchen)
 "bzD" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/landmark/nuclear_waste_spawner,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "bzE" = (
-/obj/effect/landmark/nuclear_waste_spawner,
-/turf/closed/wall/r_wall/ship,
-/area/engine/atmospherics_engine)
+/obj/machinery/door/airlock/ship/external/glass{
+	dir = 4;
+	req_one_access_txt = "10"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/engineering/hangar)
 "bzF" = (
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess,
@@ -35361,9 +35602,12 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "bzG" = (
-/obj/effect/landmark/nuclear_waste_spawner,
-/turf/closed/wall/ship,
-/area/maintenance/starboard/fore)
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/effect/spawner/lootdrop/maintenance/five,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "bzH" = (
 /obj/machinery/newscaster{
 	pixel_y = -32
@@ -35374,10 +35618,9 @@
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
 "bzI" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/effect/landmark/nuclear_waste_spawner,
-/turf/open/floor/plating,
-/area/hydroponics)
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/department/engine)
 "bzJ" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/donut_box,
@@ -35390,14 +35633,24 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/cafeteria{
 	name = "Mess hall"
 	})
 "bzL" = (
-/obj/effect/landmark/nuclear_waste_spawner,
-/turf/open/floor/monotile/light,
-/area/crew_quarters/heads/cmo)
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer3{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/engine/engineering/reactor_core)
 "bzM" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -35420,6 +35673,7 @@
 	})
 "bzO" = (
 /obj/machinery/door/airlock/highsecurity/ship{
+	dir = 8;
 	name = "CIC";
 	req_one_access_txt = "19"
 	},
@@ -35441,6 +35695,7 @@
 	})
 "bzP" = (
 /obj/machinery/door/airlock/highsecurity/ship{
+	dir = 4;
 	name = "CIC";
 	req_one_access_txt = "19"
 	},
@@ -35496,7 +35751,6 @@
 "bzT" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/holopad,
-/obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/heads/hor)
 "bzU" = (
@@ -35505,12 +35759,9 @@
 /turf/open/floor/monotile,
 /area/science/nanite)
 "bzV" = (
-/obj/effect/landmark/nuclear_waste_spawner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/turf/open/floor/monotile,
-/area/science/xenobiology)
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/engine/engineering/reactor_core)
 "bzW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -35523,8 +35774,8 @@
 /area/science/xenobiology)
 "bzX" = (
 /obj/effect/landmark/nuclear_waste_spawner,
-/turf/closed/wall/r_wall/ship,
-/area/maintenance/department/science)
+/turf/open/floor/monotile,
+/area/medical/surgery)
 "bzY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -35532,9 +35783,11 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
 "bzZ" = (
-/obj/effect/landmark/nuclear_waste_spawner,
-/turf/closed/wall/ship,
-/area/maintenance/starboard)
+/obj/structure/sign/ship/nosmoking{
+	dir = 8
+	},
+/turf/closed/wall/r_wall/ship,
+/area/nsv/weapons/fore)
 "bAa" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
@@ -35574,7 +35827,7 @@
 	dir = 6
 	},
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/engineering/reactor_core)
 "bAm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/armour_plating_nanorepair_pump/forward_port{
@@ -35615,6 +35868,7 @@
 /area/engine/engineering)
 "bAs" = (
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "Engineering Hangar Bay"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -35835,6 +36089,7 @@
 /area/crew_quarters/dorms)
 "bAM" = (
 /obj/machinery/door/airlock/ship/public{
+	dir = 4;
 	name = "Bunk 1-B"
 	},
 /obj/structure/cable{
@@ -35935,7 +36190,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12;35"
+	req_access_txt = "12;35"
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -36132,6 +36387,7 @@
 "bBr" = (
 /obj/structure/lattice/catwalk/over/ship,
 /obj/machinery/door/airlock/highsecurity/ship{
+	dir = 4;
 	name = "Munitions Control Room";
 	req_one_access_txt = "69"
 	},
@@ -36222,6 +36478,7 @@
 /area/nsv/hanger/deck2)
 "bBz" = (
 /obj/machinery/door/airlock/ship{
+	dir = 4;
 	name = "Munitions Briefing Room";
 	req_access_txt = "69"
 	},
@@ -36340,6 +36597,9 @@
 	dir = 1
 	},
 /obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "CIC Hallway"
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
 "bBL" = (
@@ -36367,7 +36627,6 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/effect/landmark/nuclear_waste_spawner,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
@@ -36696,7 +36955,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/landmark/nuclear_waste_spawner,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
@@ -36887,6 +37145,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/extinguisher_cabinet/west,
 /turf/open/floor/monotile/dark,
 /area/science/mixing{
 	name = "Prototype munitions bay"
@@ -37171,6 +37430,7 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/ship/station/mining{
+	dir = 4;
 	name = "Warehouse";
 	req_one_access_txt = "31;48"
 	},
@@ -38182,7 +38442,7 @@
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/space,
-/area/space/nearstation)
+/area/engine/atmos)
 "bEW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -38196,7 +38456,7 @@
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/space,
-/area/space/nearstation)
+/area/engine/atmos)
 "bEY" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -38259,6 +38519,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/ship/security/glass{
+	dir = 4;
 	req_one_access_txt = "2"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -38322,7 +38583,7 @@
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/space,
-/area/space/nearstation)
+/area/engine/atmos)
 "bFj" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on,
 /obj/structure/lattice/catwalk,
@@ -38402,6 +38663,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/ship/security/glass{
+	dir = 4;
 	req_one_access_txt = "2"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -38451,21 +38713,21 @@
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/space,
-/area/space/nearstation)
+/area/engine/atmos)
 "bFw" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 9
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/engine/atmos)
 "bFx" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space/nearstation)
+/area/engine/atmos)
 "bFy" = (
 /obj/structure/chair{
 	dir = 8
@@ -38514,27 +38776,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
-/obj/machinery/power/deck_relay,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /turf/closed/wall/ship,
 /area/maintenance/central)
 "bFE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bFF" = (
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
@@ -38582,7 +38834,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space/nearstation)
+/area/engine/atmos)
 "bFK" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/monotile,
@@ -38625,6 +38877,9 @@
 "bFQ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/monotile,
 /area/maintenance/starboard/secondary{
@@ -38681,11 +38936,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bFW" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -22
 	},
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "bFX" = (
@@ -39122,13 +39377,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/obj/machinery/door/airlock/virology{
-	autoclose = 0;
-	frequency = 1449;
-	id_tag = "virology_airlock_exterior";
-	name = "Virology Exterior Airlock";
-	req_access_txt = "39"
-	},
 /obj/machinery/doorButtons/access_button{
 	idDoor = "virology_airlock_exterior";
 	idSelf = "virology_airlock_control";
@@ -39141,6 +39389,13 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
+	},
+/obj/machinery/door/airlock/ship/medical{
+	autoclose = 0;
+	frequency = 1449;
+	id_tag = "virology_airlock_exterior";
+	name = "Virology Exterior Airlock";
+	req_access_txt = "39"
 	},
 /turf/open/floor/monotile/dark,
 /area/medical/virology)
@@ -39345,7 +39600,7 @@
 	pixel_y = -8
 	},
 /turf/closed/wall/ship,
-/area/hallway/nsv/deck2/frame1/port)
+/area/maintenance/department/medical)
 "bHk" = (
 /obj/structure/sign/poster/official/report_crimes{
 	pixel_y = -8
@@ -39401,7 +39656,7 @@
 /area/hallway/nsv/deck2/frame1/central)
 "bHt" = (
 /obj/machinery/door/airlock/ship{
-	dir = 1;
+	dir = 4;
 	name = "Deck 1 access"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -39514,31 +39769,29 @@
 	name = "Intensive care unit"
 	})
 "bHF" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
 	},
 /turf/open/floor/monotile,
 /area/engine/gravity_generator)
 "bHG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
+/obj/effect/landmark/nuclear_waste_spawner,
 /turf/closed/wall/r_wall/ship,
-/area/engine/gravity_generator)
+/area/engine/engineering)
 "bHH" = (
 /obj/machinery/door/airlock/ship/command{
 	name = "Gravity Generator";
 	req_one_access_txt = "56"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile,
 /area/maintenance/department/engine)
 "bHI" = (
@@ -39654,7 +39907,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/motion{
-	c_tag = "Armoury";
+	c_tag = "Armory";
 	dir = 1
 	},
 /obj/machinery/flasher/portable,
@@ -39725,6 +39978,7 @@
 /area/medical/virology)
 "bIe" = (
 /obj/machinery/door/airlock/ship/external/glass{
+	dir = 4;
 	name = "Auxiliary Shuttle Dock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -39740,6 +39994,7 @@
 /area/hallway/secondary/exit)
 "bIf" = (
 /obj/machinery/door/airlock/ship/external/glass{
+	dir = 4;
 	name = "Auxiliary Shuttle Dock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -39780,11 +40035,18 @@
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/space,
-/area/space/nearstation)
+/area/engine/atmos)
 "bIk" = (
-/obj/structure/fans/tiny/invisible,
-/turf/open/space/basic,
-/area/maintenance/department/cargo)
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/landmark/nuclear_waste_spawner,
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck2/frame1/central)
 "bIl" = (
 /obj/structure/closet/radiation,
 /turf/open/floor/plating,
@@ -39951,8 +40213,12 @@
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/disposal)
 "bIH" = (
-/turf/closed/wall/r_wall/ship,
-/area/medical/chemistry)
+/obj/structure/lattice,
+/obj/machinery/camera{
+	c_tag = "Armory"
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "bII" = (
 /turf/closed/wall/r_wall/ship,
 /area/chapel/office)
@@ -39981,6 +40247,7 @@
 /obj/structure/window/reinforced,
 /obj/structure/closet/secure_closet/brig_phys,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/monotile/light,
 /area/security/prison)
 "bIO" = (
@@ -39989,6 +40256,7 @@
 	pixel_x = 27
 	},
 /obj/machinery/stasis,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/monotile/light,
 /area/security/prison)
 "bIP" = (
@@ -40146,7 +40414,7 @@
 	width = 5
 	},
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "bJh" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -40496,7 +40764,7 @@
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/space,
-/area/space/nearstation)
+/area/engine/atmos)
 "bJS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable{
@@ -40758,6 +41026,7 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess{
+	dir = 4;
 	name = "Munitions Projects"
 	},
 /turf/open/floor/plating,
@@ -41055,14 +41324,14 @@
 /turf/closed/wall/ship,
 /area/hallway/nsv/deck2/frame1/central)
 "bKZ" = (
-/obj/machinery/door/airlock/glass_large/ship{
-	name = "Briefing Room"
-	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "CIC Hallway"
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
 "bLa" = (
@@ -41154,7 +41423,6 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
 "bLh" = (
@@ -41186,6 +41454,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/ship/public{
+	dir = 4;
 	name = "Arrivals Emergency Storage"
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -41338,6 +41607,7 @@
 /area/hallway/secondary/exit)
 "bLt" = (
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "Arrivals"
 	},
 /obj/structure/cable{
@@ -41496,7 +41766,15 @@
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
 "bLG" = (
-/obj/machinery/door/airlock/ship/public/glass/turbolift,
+/obj/machinery/door/airlock/ship/public/glass/turbolift{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/monotile,
 /area/shuttle/turbolift/secondary)
 "bLH" = (
@@ -41553,19 +41831,22 @@
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
 "bLN" = (
-/obj/structure/fans/tiny/invisible,
-/turf/open/space/basic,
-/area/engine/engineering/hangar)
-"bLO" = (
-/obj/docking_port/stationary{
-	dwidth = 1;
-	height = 4;
-	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
-	width = 3
+/obj/structure/sign/ship/nosmoking{
+	dir = 4
 	},
-/obj/structure/fans/tiny/invisible,
-/turf/open/space/basic,
-/area/engine/engineering/hangar)
+/obj/structure/sign/ship/nosmoking{
+	dir = 8
+	},
+/turf/closed/wall/ship,
+/area/nsv/weapons/fore)
+"bLO" = (
+/obj/structure/sign/ship/nosmoking{
+	dir = 8
+	},
+/turf/closed/wall/ship,
+/area/nsv/hanger/storage{
+	name = "Munitions Control Room"
+	})
 "bLP" = (
 /obj/structure/fans/tiny/invisible,
 /turf/open/floor/monotile,
@@ -41587,7 +41868,7 @@
 	},
 /obj/structure/fans/tiny/invisible,
 /turf/open/space/basic,
-/area/maintenance/department/cargo)
+/area/space/nearstation)
 "bLS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/effect/landmark/zebra_interlock_point,
@@ -41601,6 +41882,10 @@
 	req_one_access_txt = "69"
 	},
 /obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/gauss)
 "bLU" = (
@@ -41710,7 +41995,7 @@
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/space,
-/area/space/nearstation)
+/area/engine/atmos)
 "bMo" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -41904,6 +42189,10 @@
 /obj/machinery/door/airlock/highsecurity/ship{
 	name = "Weapons Bay";
 	req_one_access_txt = "69"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/nsv/weapons/gauss)
@@ -42207,6 +42496,10 @@
 	name = "Hangar Bay";
 	req_access_txt = "69"
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/monotile,
 /area/nsv/weapons/fore)
 "bYW" = (
@@ -42276,13 +42569,12 @@
 /area/medical/medbay/lobby)
 "bZG" = (
 /obj/structure/table/reinforced,
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 8
-	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
+	},
+/obj/structure/railing{
+	dir = 10
 	},
 /turf/open/floor/monotile,
 /area/bridge{
@@ -42312,15 +42604,14 @@
 	})
 "bZK" = (
 /obj/structure/table/reinforced,
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4;
 	icon_state = "door_open"
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/structure/railing{
+	dir = 6
+	},
 /turf/open/floor/monotile,
 /area/bridge{
 	name = "CIC"
@@ -42957,6 +43248,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"cjd" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/ship/maintenance{
+	name = "Arrivals maintenance"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "ckc" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -43032,6 +43337,25 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering/hangar)
+"cqJ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/maintenance{
+	dir = 4;
+	name = "Trash compactor"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "cri" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -43525,6 +43849,7 @@
 /area/engine/engine_room)
 "dRf" = (
 /obj/machinery/door/airlock/highsecurity/ship{
+	dir = 4;
 	name = "Naval Artillery";
 	req_one_access_txt = "69"
 	},
@@ -43540,6 +43865,7 @@
 /area/nsv/weapons/fore)
 "dSD" = (
 /obj/machinery/door/airlock/ship/external/glass{
+	dir = 4;
 	req_one_access_txt = "2"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -43556,7 +43882,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/engineering/reactor_core)
 "dUS" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -43579,6 +43905,7 @@
 /area/engine/engineering/reactor_core)
 "dXv" = (
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "Patient Room B"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -43945,6 +44272,7 @@
 /area/crew_quarters/fitness/recreation)
 "eEA" = (
 /obj/machinery/door/airlock/ship/external/glass{
+	dir = 4;
 	req_one_access_txt = "13"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -44028,15 +44356,14 @@
 /turf/open/floor/monotile/light,
 /area/medical/virology)
 "eQi" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/structure/sign/ship/nosmoking{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/science)
+/turf/closed/wall/ship,
+/area/nsv/weapons/gauss)
 "eQZ" = (
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "Diplomatic Reception Area"
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -44092,13 +44419,9 @@
 /turf/closed/wall/r_wall/ship,
 /area/shuttle/turbolift/shaft)
 "fcO" = (
-/obj/structure/cable,
-/obj/machinery/power/solar{
-	id = "portsolar";
-	name = "Port Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/space)
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/monotile/light,
+/area/security/prison)
 "fdU" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -44119,6 +44442,7 @@
 /area/crew_quarters/fitness/recreation)
 "fjB" = (
 /obj/machinery/door/airlock/ship{
+	dir = 4;
 	name = "Exothermic Chamber";
 	req_one_access_txt = "8"
 	},
@@ -44233,7 +44557,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/engineering/reactor_core)
 "fEj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/closed/wall/r_wall/ship,
@@ -44334,7 +44658,7 @@
 	dir = 4
 	},
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/engineering/reactor_core)
 "fVu" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_y = -30
@@ -44700,6 +45024,7 @@
 /area/security/brig)
 "gZZ" = (
 /obj/machinery/door/airlock/highsecurity/ship{
+	dir = 4;
 	name = "Ordnance Production";
 	req_one_access_txt = "69"
 	},
@@ -44799,9 +45124,10 @@
 /turf/open/floor/monotile/dark,
 /area/security/prison)
 "hmf" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/maintenance/department/science)
+/obj/structure/disposalpipe/segment,
+/obj/structure/table/wood,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/theatre)
 "hnv" = (
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 26
@@ -44893,6 +45219,11 @@
 	},
 /turf/open/floor/plating,
 /area/nsv/weapons/fore)
+"hzP" = (
+/obj/structure/table/glass,
+/obj/effect/landmark/nuclear_waste_spawner,
+/turf/open/floor/carpet/blue,
+/area/hallway/secondary/exit)
 "hAu" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -44943,12 +45274,18 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "hER" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/turf/open/space/basic,
-/area/space)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/chair/sofa{
+	dir = 8;
+	icon_state = "sofamiddle"
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/theatre)
 "hHa" = (
 /obj/effect/turf_decal/pool/corner{
 	dir = 1
@@ -45299,7 +45636,7 @@
 	dir = 9
 	},
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/engineering/reactor_core)
 "iLi" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
@@ -45487,7 +45824,9 @@
 /turf/open/floor/plasteel/techmaint,
 /area/engine/engine_room)
 "jbU" = (
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
+	dir = 4
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -45675,6 +46014,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"jyj" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/template_noop,
+/area/maintenance/department/science)
 "jAE" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -45707,6 +46053,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
+/obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "jKR" = (
@@ -46656,11 +47003,8 @@
 /turf/open/floor/monotile/dark,
 /area/science/xenobiology)
 "lTI" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
+/obj/effect/spawner/room/fivexfour,
+/turf/template_noop,
 /area/maintenance/department/science)
 "lVx" = (
 /obj/effect/turf_decal/stripes/line{
@@ -46788,7 +47132,7 @@
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/space,
-/area/space/nearstation)
+/area/engine/atmos)
 "mmu" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 6
@@ -47016,6 +47360,12 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/monotile,
 /area/engine/engineering/hangar)
+"mRi" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/template_noop,
+/area/maintenance/department/science)
 "mSg" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -47118,7 +47468,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "neD" = (
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
+	dir = 4
+	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
@@ -47154,6 +47506,15 @@
 	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_control)
+"nlR" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/template_noop,
+/area/maintenance/department/science)
 "noR" = (
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/computer/ship/munitions_computer/west,
@@ -47418,6 +47779,12 @@
 	name = "Private Study";
 	req_access_txt = "37"
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/library)
 "obX" = (
@@ -47479,6 +47846,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/ship/engineering/glass{
+	dir = 4;
 	name = "Turbine Hall Access";
 	req_one_access_txt = "10; 24"
 	},
@@ -47578,7 +47946,7 @@
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/engineering/reactor_core)
 "owl" = (
 /obj/machinery/shower{
 	name = "emergency shower"
@@ -47594,7 +47962,7 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
-/area/space)
+/area/space/nearstation)
 "oyf" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -47653,6 +48021,10 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/ship/maintenance{
+	name = "Arrivals maintenance"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
@@ -47815,6 +48187,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
+/obj/effect/landmark/nuclear_waste_spawner/strong,
 /turf/open/floor/monotile,
 /area/engine/engineering/reactor_core)
 "pgF" = (
@@ -48067,7 +48440,9 @@
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "pPw" = (
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
+	dir = 4
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -48160,9 +48535,12 @@
 /turf/open/floor/monotile/dark,
 /area/medical/morgue)
 "qeW" = (
-/obj/effect/landmark/nuclear_waste_spawner,
-/turf/open/floor/wood,
-/area/library)
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/engine/atmos)
 "qio" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -48277,6 +48655,7 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/ship/engineering/glass{
+	dir = 4;
 	name = "Turbine Hall Access";
 	req_one_access_txt = "10; 24"
 	},
@@ -48826,6 +49205,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile,
 /area/crew_quarters/bar)
 "rHg" = (
@@ -48863,6 +49243,7 @@
 /area/nsv/weapons/fore)
 "rJv" = (
 /obj/machinery/door/airlock/ship/engineering/glass{
+	dir = 4;
 	name = "Reactor core access";
 	req_one_access_txt = "10; 24"
 	},
@@ -48888,9 +49269,12 @@
 /turf/open/floor/monotile,
 /area/engine/engineering/reactor_core)
 "rLi" = (
-/obj/structure/sign/warning/vacuum/external,
-/turf/closed/wall/r_wall/ship,
-/area/maintenance/starboard/fore)
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 9
+	},
+/turf/open/space/basic,
+/area/engine/atmos)
 "rLj" = (
 /obj/machinery/computer/fiftycal,
 /obj/effect/turf_decal/ship/delivery/yellow,
@@ -49342,6 +49726,7 @@
 /area/medical/genetics)
 "tjC" = (
 /obj/machinery/door/airlock/ship/external/glass{
+	dir = 4;
 	req_one_access_txt = "13"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -49387,6 +49772,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
 	name = "Prison Sleepers"
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -49783,6 +50169,7 @@
 /area/maintenance/starboard/fore)
 "uDu" = (
 /obj/machinery/door/airlock/ship/external{
+	dir = 4;
 	name = "Mining Shuttle Airlock";
 	req_one_access_txt = "31;48"
 	},
@@ -50103,7 +50490,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "vwu" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -50175,6 +50562,7 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/ship/maintenance{
+	dir = 4;
 	name = "Munitions Control";
 	req_one_access_txt = "69"
 	},
@@ -50484,7 +50872,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
+	dir = 4
+	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
@@ -50600,6 +50990,10 @@
 	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
+"wCS" = (
+/obj/effect/landmark/nuclear_waste_spawner,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "wDH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/structure/lattice/catwalk,
@@ -50764,8 +51158,9 @@
 /turf/open/floor/plating,
 /area/nsv/weapons/fore)
 "xhI" = (
-/turf/closed/wall/r_wall/ship,
-/area/science/nanite)
+/obj/effect/spawner/lootdrop/maintenance/six,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "xhM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -50912,19 +51307,9 @@
 	name = "Mess hall"
 	})
 "xyX" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer3{
-	dir = 4
-	},
-/obj/machinery/meter,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/spawner/lootdrop/gloves,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "xDn" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -51073,8 +51458,7 @@
 /area/nsv/weapons/fore)
 "xXX" = (
 /obj/effect/landmark/nuclear_waste_spawner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/closed/wall/r_wall/ship,
+/turf/open/space/basic,
 /area/engine/atmospherics_engine)
 "xXY" = (
 /obj/structure/cable{
@@ -51160,6 +51544,10 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering/reactor_core)
+"yeQ" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/engine/atmos)
 "yfo" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -65706,7 +66094,7 @@ apq
 aFA
 bIK
 bIM
-bIM
+fcO
 bIQ
 bIR
 amE
@@ -66735,7 +67123,7 @@ bdy
 bmj
 aBf
 aFR
-aET
+aFa
 aFb
 aFg
 aEX
@@ -70117,7 +70505,7 @@ bxf
 aKS
 aLQ
 aLR
-bzV
+poV
 riT
 aeI
 aMd
@@ -71140,7 +71528,7 @@ aKs
 aKs
 aKs
 aKs
-xhI
+aXi
 bdu
 aLA
 aLT
@@ -71397,7 +71785,7 @@ bpv
 bik
 aMl
 alZ
-xhI
+aXi
 bdv
 aeI
 aLU
@@ -71654,7 +72042,7 @@ bqo
 aLm
 aWB
 alZ
-xhI
+aXi
 aJA
 aLE
 bCI
@@ -71866,7 +72254,7 @@ aEh
 aEn
 aEC
 aac
-apq
+bIH
 apq
 apq
 apq
@@ -71911,7 +72299,7 @@ bwL
 aKz
 aXm
 rMN
-xhI
+aXi
 aXi
 aXi
 aXi
@@ -72168,7 +72556,7 @@ bwM
 bzU
 aXn
 bgD
-xhI
+aXi
 aJB
 aJB
 aJB
@@ -72425,7 +72813,7 @@ bzx
 bwR
 aXm
 cPU
-xhI
+aXi
 aJD
 aJB
 aJB
@@ -72682,7 +73070,7 @@ bwN
 bwE
 aXo
 alZ
-xhI
+aXi
 aJB
 aLF
 aJB
@@ -72939,7 +73327,7 @@ bwO
 aKv
 aMl
 uMm
-xhI
+aXi
 aXi
 aXi
 aXi
@@ -73196,7 +73584,7 @@ bwP
 aKs
 acr
 acr
-xhI
+aXi
 aJB
 aJB
 aJB
@@ -73453,7 +73841,7 @@ bwQ
 bqN
 brd
 bli
-xhI
+aXi
 aJD
 aLG
 aJB
@@ -73710,7 +74098,7 @@ aKu
 aLp
 aah
 bkw
-xhI
+aXi
 aJB
 aLF
 aJB
@@ -73966,13 +74354,13 @@ aah
 aah
 aah
 aah
-bkw
-bIF
-bIF
-bIF
-bIF
-bIF
-bIF
+cqJ
+aXi
+aXi
+aXi
+aXi
+aXi
+aXi
 bsD
 bIv
 aMc
@@ -74217,19 +74605,19 @@ bcO
 bcO
 bcO
 bpw
-bls
-bls
+acs
+acs
 bls
 bFW
-eQi
-bls
+aah
+mRi
 brt
 bbv
 lTI
-hmf
-bbv
+aah
+acs
 mPw
-bIF
+aXi
 aMc
 bHP
 aXi
@@ -74474,23 +74862,23 @@ acs
 acs
 acs
 bpx
-bcO
-bcO
-bcO
-bcO
+bgE
+bgE
+bgE
+bgE
 oCE
-bcO
+nlR
 bru
-bgE
-bgE
-bgE
+jyj
+jyj
+cjd
 bgE
 bli
-bIF
+aXi
 blu
 blC
 aXi
-aQD
+arT
 aaa
 aaa
 aaa
@@ -74735,19 +75123,19 @@ aah
 aah
 aah
 aah
-bIF
-bIF
-bIF
-bIF
-bIF
-bIF
-bIF
+aah
+bbv
+bbv
+bbv
+bbv
+aah
+acs
 bkw
-bzX
+aXi
 blv
 blD
 aXi
-aQD
+arT
 aaa
 aaa
 aaa
@@ -74972,7 +75360,7 @@ all
 akl
 alG
 acF
-agX
+xhI
 bHj
 acx
 bCS
@@ -74992,19 +75380,19 @@ kJA
 bjr
 aOS
 aOS
-bIH
-aaJ
-aaJ
-aaJ
-aaJ
-aaJ
-bIF
+aeb
+bbv
+bbv
+bbv
+bbv
+aah
+acs
 bkw
 bIF
 bIF
 bIF
 bIF
-aQD
+arT
 aaa
 aaa
 aaa
@@ -75229,8 +75617,8 @@ alt
 alF
 alH
 acF
-agX
-abL
+xyX
+afw
 bws
 bCz
 aOP
@@ -75249,19 +75637,19 @@ bwz
 aTH
 aTH
 aOS
-bIH
-aaJ
-aaJ
-aaJ
-aaJ
-aaJ
-bIF
+aeb
+bbv
+bbv
+bbv
+bbv
+aah
+acs
 kuF
 chs
 gqO
 uNi
 hwV
-aQD
+arT
 aaa
 aaa
 aaa
@@ -75506,13 +75894,13 @@ aTH
 aTH
 aTH
 aOS
-bIH
-bIG
-bIG
-bIG
-bIG
-bIG
-bIG
+aeb
+aah
+aah
+aah
+aah
+aah
+bre
 bsp
 bIF
 bIF
@@ -76254,7 +76642,7 @@ bhK
 ahf
 aiR
 blc
-bzL
+akj
 als
 txH
 bfk
@@ -77313,7 +77701,7 @@ mIj
 bDQ
 bsl
 brZ
-bzZ
+laZ
 laZ
 adh
 blJ
@@ -78074,7 +78462,7 @@ bph
 afD
 bpL
 laZ
-mIj
+wCS
 cFg
 bnn
 psk
@@ -78314,7 +78702,7 @@ bvm
 amd
 aMR
 ahf
-aTS
+aTT
 bws
 bCz
 bmQ
@@ -78819,12 +79207,12 @@ aUj
 ahc
 ajb
 ajY
-bqX
+ajY
 ajY
 ajY
 ahc
 bZs
-bvo
+bvn
 bdh
 aTM
 ahf
@@ -79055,7 +79443,7 @@ apY
 bnm
 bne
 akC
-amM
+bzX
 amM
 amW
 bhi
@@ -81863,7 +82251,7 @@ aal
 aal
 aal
 aal
-aal
+aET
 aTD
 ahD
 ahD
@@ -82434,7 +82822,7 @@ aad
 bLo
 abT
 aez
-aez
+hzP
 aOg
 aaa
 aaa
@@ -82923,7 +83311,7 @@ mTR
 mTR
 bBr
 bKE
-mTR
+bLO
 bKK
 aeT
 bcf
@@ -83665,7 +84053,7 @@ bIl
 bnm
 gXS
 bne
-bhm
+bvo
 aZO
 fbx
 bip
@@ -84465,7 +84853,7 @@ dDv
 twd
 aTs
 bYG
-dDv
+eQi
 bXF
 biK
 bcw
@@ -85478,7 +85866,7 @@ aTc
 aav
 afd
 bBw
-ago
+abz
 aMJ
 bJX
 meb
@@ -86258,7 +86646,7 @@ ago
 aTk
 ago
 dRf
-ago
+bLN
 ago
 ago
 ago
@@ -86526,7 +86914,7 @@ agm
 biO
 bcN
 blZ
-bix
+bBK
 bkv
 bmW
 buV
@@ -86538,7 +86926,7 @@ bxt
 bkv
 bmW
 bkv
-bix
+bBK
 bBM
 bHd
 bmU
@@ -86783,7 +87171,7 @@ agm
 jZc
 bcq
 aMv
-abe
+bKZ
 abu
 atx
 aSG
@@ -86795,7 +87183,7 @@ bvh
 bFz
 atx
 abu
-abe
+bKZ
 bmr
 bFI
 bmU
@@ -88100,14 +88488,14 @@ bqe
 bqc
 lzn
 bIC
-aaJ
+aaa
 bID
 bDL
 aOC
 bID
-aaJ
-aaJ
-aaJ
+aaa
+aaa
+aaa
 aij
 wsH
 aih
@@ -88307,7 +88695,7 @@ boj
 bBF
 agg
 agm
-agm
+bzZ
 agm
 agm
 agm
@@ -88357,14 +88745,14 @@ bqe
 bqc
 bqT
 bIC
-aaJ
+aaa
 bID
 bjB
 bDM
 bID
-aaJ
-aaJ
-aaJ
+aaa
+aaa
+aaa
 aij
 bJH
 aim
@@ -88568,14 +88956,14 @@ amk
 bgX
 bAP
 aKC
-bgX
+bIk
 bKe
 aAf
 agm
 agm
 agm
 agm
-agm
+bzZ
 agm
 agm
 bHm
@@ -88614,14 +89002,14 @@ bqe
 bqc
 bqU
 bIC
-aaJ
+aaa
 bID
 bID
 uDu
 bID
-aaJ
-aaJ
-aaJ
+aaa
+aaa
+aaa
 aij
 bJH
 aim
@@ -88871,14 +89259,14 @@ brb
 bnO
 bqV
 bIC
-aaJ
-aaJ
-aaJ
+aaa
+aaa
+aaa
 bMo
-aaJ
-aaJ
-aaJ
-aaJ
+aaa
+aaa
+aaa
+aaa
 aij
 bJH
 bjF
@@ -89128,14 +89516,14 @@ bqh
 pxy
 aEf
 bIC
-aaJ
-aaJ
-aaJ
-aaJ
-aaJ
-aaJ
-aaJ
-aaJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aij
 bJH
 aim
@@ -89384,15 +89772,15 @@ bDi
 bqi
 bqC
 aEf
-aaJ
-aaJ
-aaJ
-aaJ
-aaJ
-aaJ
-aaJ
-aaJ
-aaJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aij
 bJH
 aim
@@ -89641,21 +90029,21 @@ bxy
 aka
 bHN
 aEf
-aaJ
-aaJ
-aaJ
-aaJ
-aaJ
-aaJ
-aaJ
-aaJ
-aaJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aij
 lQE
 pRQ
 aij
-bKQ
-bKQ
+aij
+aij
 aaa
 aaa
 aaa
@@ -89898,21 +90286,21 @@ bGD
 aka
 eJW
 aEf
-aaJ
-aaJ
-aaJ
-aaJ
-aaJ
-aaJ
-aaJ
-aaJ
-aaJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aij
 bJH
 aim
-bIk
-aaa
-aaa
+anb
+aaJ
+aaJ
 aaa
 aaa
 aaa
@@ -90155,21 +90543,21 @@ aOj
 aOr
 phM
 aEf
-aaJ
-aaJ
-aaJ
-aaJ
-aaJ
-aaJ
-aaJ
-aaJ
-aaJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aij
 bJH
 byx
 bLR
-aaa
-aaa
+aaJ
+aaJ
 aaa
 aaa
 aaa
@@ -90386,7 +90774,7 @@ aOR
 aOR
 aOR
 atD
-bzI
+aeM
 bdj
 but
 apZ
@@ -90412,11 +90800,11 @@ aMt
 aka
 aka
 aEf
-aaJ
-aaJ
-aaJ
-aaJ
-aaJ
+aaa
+aaa
+aaa
+aaa
+aaa
 aij
 aij
 aij
@@ -90424,9 +90812,9 @@ aij
 aij
 bJH
 bCd
-bIk
-aaa
-aaa
+anb
+aaJ
+aaJ
 aaa
 aaa
 aaa
@@ -90682,8 +91070,8 @@ aih
 bJH
 aim
 aij
-bKQ
-bKQ
+aij
+aij
 aaa
 aaa
 aaa
@@ -92147,7 +92535,7 @@ auL
 nQO
 aqI
 amr
-aqy
+bzD
 atz
 qvd
 xEa
@@ -93170,7 +93558,7 @@ asL
 asL
 aHP
 aYN
-aYM
+asd
 haf
 aJL
 hvH
@@ -93691,7 +94079,7 @@ hvH
 iNo
 hvH
 cIa
-qeW
+hvH
 aMI
 auD
 hvH
@@ -93736,26 +94124,26 @@ arc
 iuA
 qEO
 blp
-bzD
+bkZ
 bkZ
 bng
 bnB
 mIw
 fEj
-xXX
+fEj
 jku
 apV
 apV
 apV
 apV
-bzE
+apV
 apV
 oyi
 vsK
 iuA
 iuA
 aPw
-bzG
+iuA
 oyi
 oyi
 oyi
@@ -94494,7 +94882,7 @@ bcl
 bcR
 bdp
 bzB
-bdp
+hmf
 bgo
 hLd
 bjG
@@ -94751,7 +95139,7 @@ aeL
 amJ
 aVv
 bkg
-aVv
+hER
 aVz
 hLd
 amP
@@ -95021,7 +95409,7 @@ for
 iuA
 iuA
 oyi
-aWb
+xXX
 azO
 azT
 aBc
@@ -96045,10 +96433,10 @@ oyi
 oyi
 blr
 oyi
-oyi
-oyi
-oyi
-oyi
+aml
+aml
+aml
+aml
 oyi
 oyi
 oyi
@@ -96252,8 +96640,8 @@ aaa
 aaa
 aaa
 aaa
-aQD
-aQD
+arT
+arT
 apq
 asL
 aYN
@@ -96261,7 +96649,7 @@ aYK
 aYK
 aYK
 aYM
-aHP
+bzG
 asL
 anG
 aqd
@@ -96305,7 +96693,7 @@ axH
 jpj
 aAc
 bmd
-rLi
+jpj
 vFe
 vFe
 vFe
@@ -96510,7 +96898,7 @@ aaa
 aaa
 aaa
 aaa
-aQD
+arT
 apq
 asL
 asL
@@ -96766,8 +97154,8 @@ aaa
 aaa
 aaa
 aaa
-aQD
-aQD
+arT
+arT
 apq
 apq
 iQX
@@ -97023,7 +97411,7 @@ aaa
 aaa
 aaa
 aaa
-aQD
+arT
 amx
 amx
 amx
@@ -97090,7 +97478,7 @@ apz
 apz
 apG
 asG
-bCt
+yeQ
 asH
 aCB
 aCN
@@ -97280,7 +97668,7 @@ aaa
 aaa
 bAe
 aaa
-aQD
+arT
 amx
 aHJ
 aHJ
@@ -97537,7 +97925,7 @@ aaa
 aaa
 aaa
 aaa
-aQD
+arT
 aCV
 aHJ
 aHT
@@ -97604,7 +97992,7 @@ aym
 ayA
 apG
 asG
-bCt
+yeQ
 aqk
 aqk
 aqk
@@ -97794,7 +98182,7 @@ aaa
 aaa
 aaa
 aaa
-aQD
+arT
 aCV
 aqw
 aHU
@@ -97804,7 +98192,7 @@ aSw
 asL
 bFR
 aoZ
-asL
+bzI
 anT
 anU
 aSr
@@ -98051,9 +98439,9 @@ aaa
 aaa
 aaa
 aaa
-aQD
+arT
 aCV
-asd
+aHJ
 aHV
 aHU
 aSu
@@ -98073,7 +98461,7 @@ aQH
 bhy
 avc
 aCd
-aey
+bHG
 aQW
 aAK
 aOQ
@@ -98118,7 +98506,7 @@ cSo
 ayC
 apG
 asG
-bCt
+yeQ
 asH
 aCE
 aCQ
@@ -98303,16 +98691,16 @@ aaa
 aaa
 aaa
 aaa
-aQD
-aQD
-aQD
+arT
+arT
+arT
 agw
-aQD
-aQD
+arT
+arT
 amx
 aHK
-aHJ
-aHJ
+aHL
+bqX
 aHJ
 aHJ
 asL
@@ -98560,15 +98948,15 @@ aaa
 aaa
 aaa
 aaa
-aQD
+arT
 anJ
 anJ
 dOU
 anJ
 anJ
 amx
-aHL
 amx
+aQD
 amx
 asL
 asL
@@ -98632,7 +99020,7 @@ ayr
 ayE
 apG
 asG
-bCt
+yeQ
 aqk
 aqk
 aqk
@@ -98817,7 +99205,7 @@ aaa
 aaa
 aaa
 aaa
-aQD
+arT
 anJ
 axF
 pBW
@@ -99074,7 +99462,7 @@ aaa
 aaa
 aaa
 aaa
-aQD
+arT
 anJ
 axV
 jHA
@@ -99083,7 +99471,7 @@ anJ
 amx
 aJo
 aJJ
-bHG
+amx
 asL
 aYO
 aSo
@@ -99146,7 +99534,7 @@ cWp
 apz
 apG
 asG
-bCt
+yeQ
 asH
 aCH
 aDA
@@ -99330,7 +99718,7 @@ aaa
 aaa
 aaa
 aaa
-aQD
+arT
 anJ
 anJ
 aPT
@@ -99587,7 +99975,7 @@ aaa
 aaa
 aaa
 aaa
-aQD
+arT
 anJ
 asJ
 aPU
@@ -99660,7 +100048,7 @@ asE
 ayA
 apG
 aml
-bCt
+yeQ
 aqk
 aqk
 aqk
@@ -99844,7 +100232,7 @@ aaa
 aaa
 aaa
 aaa
-aQD
+arT
 anJ
 atN
 aPW
@@ -100101,7 +100489,7 @@ aaa
 aaa
 aaa
 aaa
-aQD
+arT
 anJ
 avO
 aPW
@@ -100358,7 +100746,7 @@ aaa
 aaa
 aaa
 aaa
-aQD
+arT
 anJ
 atN
 aPW
@@ -100405,9 +100793,9 @@ amz
 aaJ
 aaJ
 apq
-bAl
-aDR
-aDR
+awD
+axA
+axA
 mlW
 mlW
 mlW
@@ -100420,13 +100808,13 @@ bFv
 bEX
 bFw
 bFx
-bCt
+yeQ
 bFJ
-bCt
+yeQ
 bFx
-bCt
+yeQ
 bFJ
-bCt
+yeQ
 bCt
 apz
 apz
@@ -100615,7 +101003,7 @@ aaa
 aaa
 aaa
 aaa
-aQD
+arT
 anJ
 awg
 aPW
@@ -100662,7 +101050,7 @@ amz
 aaJ
 aaJ
 apq
-fUk
+qeW
 apq
 apq
 apq
@@ -100872,7 +101260,7 @@ aaa
 aaa
 aaa
 aaa
-aQD
+arT
 anJ
 awK
 aPW
@@ -100919,7 +101307,7 @@ amz
 aaJ
 aaJ
 apq
-fUk
+qeW
 apq
 arT
 arT
@@ -101129,7 +101517,7 @@ aaa
 aaa
 aaa
 aaa
-aQD
+arT
 anJ
 awS
 aPW
@@ -101176,7 +101564,7 @@ amz
 aaJ
 aaJ
 apq
-fUk
+qeW
 apq
 arT
 aaJ
@@ -101386,7 +101774,7 @@ aaa
 aaa
 aaa
 aaa
-aQD
+arT
 anJ
 axb
 aPW
@@ -101433,7 +101821,7 @@ amz
 aaJ
 aaJ
 apq
-fUk
+qeW
 apq
 arT
 bCt
@@ -101643,7 +102031,7 @@ aaa
 aaa
 aaa
 aaa
-aQD
+arT
 anJ
 anJ
 anJ
@@ -101690,7 +102078,7 @@ amz
 aaJ
 aaJ
 apq
-fUk
+qeW
 apq
 arT
 aaJ
@@ -101908,9 +102296,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-bLN
+aaJ
+aaJ
+anb
 bLP
 anM
 apX
@@ -101947,7 +102335,7 @@ amz
 apq
 apq
 apq
-fUk
+qeW
 apq
 arT
 bCt
@@ -102165,9 +102553,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-bLO
+aaJ
+aaJ
+aoV
 bLQ
 aoL
 mKt
@@ -102204,7 +102592,7 @@ amz
 aaJ
 aaJ
 aaJ
-fUk
+qeW
 apq
 arT
 aBX
@@ -102422,9 +102810,9 @@ bAe
 aaa
 aaa
 aaa
-aaa
-aaa
-bLN
+aaJ
+aaJ
+anb
 bLP
 aoX
 aQl
@@ -102461,7 +102849,7 @@ arT
 arT
 arT
 arT
-fUk
+qeW
 apq
 arT
 aBX
@@ -102678,9 +103066,9 @@ aaa
 aaa
 aaa
 aaa
-bKQ
-ano
-ano
+anj
+anj
+anj
 anj
 bYb
 anm
@@ -102708,17 +103096,17 @@ inx
 tmq
 azk
 bAl
-aDR
-aDR
-aDR
-aDR
-aDR
-aDR
-aDR
-aDR
-aDR
-aDR
-iJw
+axA
+axA
+axA
+axA
+axA
+axA
+axA
+axA
+axA
+axA
+rLi
 arT
 arT
 aBX
@@ -102936,8 +103324,8 @@ aaa
 aaa
 aaa
 aaa
-hER
-fcO
+icy
+vRI
 aaZ
 bhs
 anx
@@ -103243,7 +103631,7 @@ nRp
 fYc
 fYc
 fYc
-aQD
+arT
 aaa
 aaa
 aaa
@@ -103498,9 +103886,9 @@ atK
 nRp
 fYc
 fYc
-aQD
-aQD
-aQD
+arT
+arT
+arT
 aaa
 aaa
 aaa
@@ -103755,7 +104143,7 @@ atK
 nRp
 nRp
 fYc
-aQD
+arT
 aaa
 aaa
 aaa
@@ -104012,7 +104400,7 @@ atK
 nRp
 fYc
 fYc
-aQD
+arT
 aaa
 aaa
 aaa
@@ -104269,7 +104657,7 @@ atK
 nRp
 nRp
 fYc
-aQD
+arT
 aaa
 aaa
 aaa
@@ -104526,7 +104914,7 @@ atK
 nRp
 fYc
 fYc
-aQD
+arT
 aaa
 aaa
 aaa
@@ -104783,7 +105171,7 @@ atK
 nRp
 nRp
 fYc
-aQD
+arT
 aaa
 aaa
 aaa
@@ -104997,11 +105385,11 @@ vRI
 anj
 ajn
 anj
-aQo
-aQo
-aQo
-aQo
-aQo
+bzE
+bzE
+bzE
+bzE
+bzE
 anj
 arT
 azk
@@ -105040,7 +105428,7 @@ atK
 nRp
 fYc
 fYc
-aQD
+arT
 aaa
 aaa
 aaa
@@ -105297,7 +105685,7 @@ atK
 nRp
 nRp
 fYc
-aQD
+arT
 aaa
 aaa
 aaa
@@ -105506,7 +105894,7 @@ aaa
 aaa
 aaa
 aaa
-aQD
+arT
 arT
 bMp
 rCH
@@ -105554,7 +105942,7 @@ atK
 nRp
 fYc
 fYc
-aQD
+arT
 aaa
 aaa
 aaa
@@ -105811,7 +106199,7 @@ atK
 nRp
 nRp
 fYc
-aQD
+arT
 aaa
 aaa
 aaa
@@ -106068,7 +106456,7 @@ mLQ
 nRp
 fYc
 fYc
-aQD
+arT
 aaa
 aaa
 aaa
@@ -106325,7 +106713,7 @@ nRp
 nRp
 nRp
 fYc
-aQD
+arT
 aaa
 aaa
 aaa
@@ -106582,7 +106970,7 @@ fYc
 nRp
 fYc
 fYc
-aQD
+arT
 aaa
 aaa
 aaa
@@ -106838,8 +107226,8 @@ fYc
 fYc
 fYc
 fYc
-aQD
-aQD
+arT
+arT
 aaa
 aaa
 aaa
@@ -107081,21 +107469,21 @@ atK
 nRp
 nRp
 fYc
-aQD
-aQD
-aQD
-aQD
-aQD
-aQD
-aQD
-aQD
-aQD
-aQD
-aQD
-aQD
-aQD
-aQD
-aQD
+arT
+arT
+arT
+arT
+arT
+arT
+arT
+arT
+arT
+arT
+arT
+arT
+arT
+arT
+arT
 aaa
 aaa
 aaa
@@ -107338,7 +107726,7 @@ atK
 nRp
 lrx
 oZe
-aQD
+arT
 aaa
 aaa
 aaa
@@ -107578,15 +107966,15 @@ nRp
 aaJ
 aaJ
 atK
-npS
+bzL
 fCZ
-apq
-apq
-apq
-apq
-apq
-apq
-apq
+bzV
+bzV
+bzV
+bzV
+bzV
+bzV
+bzV
 tzE
 nUo
 atK
@@ -107595,7 +107983,7 @@ atK
 nRp
 nRp
 lmX
-aQD
+arT
 aaa
 aaa
 aaa
@@ -107835,15 +108223,15 @@ nRp
 aaJ
 aaJ
 atK
-npS
-xyX
-apq
-apq
-apq
-apq
-apq
-apq
-apq
+bzL
+ygv
+bzV
+bzV
+bzV
+bzV
+bzV
+bzV
+bzV
 tzE
 oHb
 atK
@@ -107852,7 +108240,7 @@ atK
 nRp
 lrx
 pWk
-aQD
+arT
 aaa
 aaa
 aaa
@@ -108109,7 +108497,7 @@ atK
 nRp
 nRp
 lmX
-aQD
+arT
 aaa
 aaa
 aaa
@@ -108342,7 +108730,7 @@ aaa
 aaa
 aaa
 aaa
-aQD
+arT
 nSs
 vRI
 nRp
@@ -108366,7 +108754,7 @@ atK
 nRp
 lrx
 pWk
-aQD
+arT
 aaa
 aaa
 aaa
@@ -108599,7 +108987,7 @@ aaa
 aaa
 aaa
 aaa
-aQD
+arT
 lmX
 nRp
 nRp
@@ -108623,7 +109011,7 @@ atK
 nRp
 nRp
 lmX
-aQD
+arT
 aaa
 aaa
 aaa
@@ -108856,7 +109244,7 @@ aaa
 aaa
 aaa
 aaa
-aQD
+arT
 nSs
 vRI
 nRp
@@ -108880,7 +109268,7 @@ atK
 nRp
 lrx
 pWk
-aQD
+arT
 aaa
 aaa
 aaa
@@ -109113,7 +109501,7 @@ aaa
 aaa
 aaa
 aaa
-aQD
+arT
 lmX
 nRp
 nRp
@@ -109137,7 +109525,7 @@ atK
 nRp
 nRp
 lmX
-aQD
+arT
 aaa
 aaa
 aaa
@@ -109370,7 +109758,7 @@ aaa
 aaa
 aaa
 aaa
-aQD
+arT
 nSs
 vRI
 nRp
@@ -109394,7 +109782,7 @@ nRp
 nRp
 lrx
 pWk
-aQD
+arT
 aaa
 aaa
 aaa
@@ -109627,7 +110015,7 @@ aaa
 aaa
 aaa
 aaa
-aQD
+arT
 nSs
 oZe
 nRp
@@ -109651,7 +110039,7 @@ uYj
 nRp
 nRp
 lmX
-aQD
+arT
 aaa
 aaa
 aaa
@@ -109884,7 +110272,7 @@ aaa
 aaa
 aaa
 aaa
-aQD
+arT
 owu
 fNY
 kKu
@@ -109908,7 +110296,7 @@ efv
 kKu
 kKu
 vzs
-aQD
+arT
 aaa
 aaa
 aaa
@@ -110141,31 +110529,31 @@ aaa
 aaa
 aaa
 aaa
-aQD
-aQD
-aQD
-aQD
-aQD
-aQD
-aQD
-aQD
-aQD
-aQD
-aQD
-aQD
-aQD
-aQD
-aQD
-aQD
-aQD
-aQD
-aQD
-aQD
-aQD
-aQD
-aQD
-aQD
-aQD
+arT
+arT
+arT
+arT
+arT
+arT
+arT
+arT
+arT
+arT
+arT
+arT
+arT
+arT
+arT
+arT
+arT
+arT
+arT
+arT
+arT
+arT
+arT
+arT
+arT
 aaa
 aaa
 aaa

--- a/_maps/map_files/Tycoon/Tycoon2.dmm
+++ b/_maps/map_files/Tycoon/Tycoon2.dmm
@@ -5168,6 +5168,12 @@
 /area/medical/medbay/lobby)
 "amf" = (
 /obj/machinery/smartfridge,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/monotile,
 /area/hydroponics)
 "amg" = (
@@ -18253,14 +18259,6 @@
 "aSq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
-	},
-/obj/structure/rack,
-/obj/item/powder_bag{
-	pixel_y = -10
-	},
-/obj/item/powder_bag,
-/obj/item/powder_bag{
-	pixel_y = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary{
@@ -31768,6 +31766,11 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/door/airlock/ship{
+	dir = 4;
+	name = "Hangar Bay";
+	req_access_txt = "69"
 	},
 /turf/open/floor/monotile,
 /area/maintenance/port)
@@ -49505,6 +49508,24 @@
 /obj/machinery/status_display/evac,
 /turf/closed/wall/ship,
 /area/medical/medbay/lobby)
+"ssX" = (
+/obj/machinery/door/window{
+	name = "Gunpowder Storage";
+	req_access_txt = "69"
+	},
+/obj/item/powder_bag{
+	pixel_y = -10
+	},
+/obj/item/powder_bag,
+/obj/item/powder_bag{
+	pixel_y = 8
+	},
+/obj/structure/rack,
+/obj/structure/window/reinforced/spawner/west,
+/turf/open/floor/monotile,
+/area/maintenance/starboard/secondary{
+	name = "Munitions Projects"
+	})
 "stk" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/machinery/meter,
@@ -51195,6 +51216,20 @@
 	},
 /turf/open/floor/monotile,
 /area/engine/engineering/reactor_core)
+"xlE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship{
+	dir = 4;
+	name = "Hangar Bay";
+	req_access_txt = "69"
+	},
+/turf/open/floor/monotile,
+/area/maintenance/port)
 "xmt" = (
 /obj/machinery/newscaster{
 	pixel_x = -28
@@ -81234,8 +81269,8 @@ bKp
 akw
 bBn
 akw
-akw
-akc
+aal
+xlE
 bsT
 bHp
 bHp
@@ -82251,7 +82286,7 @@ aal
 aal
 aal
 aal
-aET
+aal
 aTD
 ahD
 ahD
@@ -82508,7 +82543,7 @@ adF
 adF
 adF
 adF
-aal
+aET
 aSq
 ahD
 ahD
@@ -82766,7 +82801,7 @@ aal
 aal
 adF
 aal
-ahD
+ssX
 ahD
 ahD
 bFQ

--- a/_maps/map_files/Tycoon/Tycoon2.dmm
+++ b/_maps/map_files/Tycoon/Tycoon2.dmm
@@ -184,7 +184,9 @@
 /area/science/xenobiology)
 "aaD" = (
 /obj/machinery/rnd/server,
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -277,7 +279,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -440,7 +444,9 @@
 /area/nsv/weapons/fore)
 "abp" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -873,15 +879,6 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/medical/medbay/central)
-"acz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "acA" = (
 /obj/structure/chair,
 /obj/machinery/camera/autoname,
@@ -1004,7 +1001,9 @@
 /turf/open/floor/monotile,
 /area/hallway/secondary/exit)
 "acP" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -1161,7 +1160,9 @@
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/warehouse)
 "adj" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -1273,23 +1274,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/monotile,
 /area/hallway/secondary/exit)
-"adv" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
-	},
-/obj/machinery/conveyor{
-	id = "packageExternal"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/plating,
-/area/quartermaster/storage)
 "adw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1463,7 +1447,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -1491,7 +1477,9 @@
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/security/armory)
 "adS" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -1765,7 +1753,9 @@
 /obj/structure/chair/comfy/black{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -1864,18 +1854,6 @@
 	},
 /turf/open/floor/monotile,
 /area/hallway/secondary/exit)
-"aeH" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "aeI" = (
 /turf/open/floor/monotile/dark,
 /area/science/xenobiology)
@@ -2187,7 +2165,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -2305,7 +2285,9 @@
 /area/hallway/nsv/deck2/frame1/port)
 "afI" = (
 /obj/machinery/modular_computer/console/preset/command,
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -2336,7 +2318,9 @@
 /turf/open/floor/plasteel/cult,
 /area/chapel/main)
 "afM" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -2410,7 +2394,9 @@
 /obj/structure/chair/sofa/left{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -2716,24 +2702,6 @@
 /obj/structure/sign/ship/radiation,
 /turf/closed/wall/r_wall/ship,
 /area/engine/engineering/reactor_core)
-"agH" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/closet/secure_closet/chemical{
-	pixel_x = -3
-	},
-/obj/machinery/requests_console{
-	department = "Chemistry";
-	departmentType = 2;
-	pixel_x = -30;
-	receive_ore_updates = 1
-	},
-/turf/open/floor/monotile,
-/area/medical/chemistry)
 "agI" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -2812,8 +2780,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/advanced_airlock_controller{
-	pixel_x = 26;
-	pixel_y = 2
+	pixel_y = 24
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
@@ -3266,7 +3233,9 @@
 	})
 "ahV" = (
 /obj/machinery/computer/crew,
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -3442,7 +3411,9 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aip" = (
@@ -3676,7 +3647,9 @@
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
 "aiT" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -3823,7 +3796,7 @@
 	dir = 8
 	},
 /obj/machinery/advanced_airlock_controller{
-	pixel_y = 26
+	pixel_y = 24
 	},
 /obj/machinery/light/small,
 /obj/structure/cable/yellow{
@@ -3855,10 +3828,6 @@
 "ajs" = (
 /turf/closed/wall/ship,
 /area/quartermaster/qm)
-"ajt" = (
-/obj/structure/fans/tiny/invisible,
-/turf/open/space/basic,
-/area/security/execution/transfer)
 "aju" = (
 /turf/open/floor/monotile/light,
 /area/medical/virology)
@@ -3991,7 +3960,9 @@
 "ajK" = (
 /obj/structure/closet/crate/wooden/toy,
 /obj/effect/turf_decal/tile/neutral,
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -4005,31 +3976,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/dark,
 /area/medical/surgery)
-"ajM" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Intensive Care Access"
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/monotile,
-/area/medical/medbay/central)
-"ajN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/monotile,
-/area/maintenance/port)
 "ajO" = (
 /obj/structure/sign/solgov_flag,
 /turf/open/floor/carpet/ship,
@@ -4069,7 +4015,9 @@
 "ajU" = (
 /obj/machinery/chem_dispenser/drinks/beer,
 /obj/structure/table/reinforced,
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -4124,15 +4072,6 @@
 	dir = 6
 	},
 /turf/open/floor/plating,
-/area/maintenance/port)
-"akc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/turf/open/floor/monotile,
 /area/maintenance/port)
 "akd" = (
 /obj/machinery/computer/cargo{
@@ -5097,7 +5036,9 @@
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/nsv/observation)
 "alY" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
 	},
@@ -5262,12 +5203,6 @@
 	},
 /turf/open/floor/plasteel/grid/lino,
 /area/engine/engineering/reactor_control)
-"amw" = (
-/obj/structure/shuttle/engine/huge{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space)
 "amx" = (
 /turf/closed/wall/r_wall/ship,
 /area/engine/gravity_generator)
@@ -5375,7 +5310,9 @@
 /turf/open/floor/monotile,
 /area/medical/surgery)
 "amN" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -5480,23 +5417,6 @@
 /obj/structure/table,
 /turf/open/floor/monotile,
 /area/hallway/secondary/service)
-"amZ" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "Biohazard";
-	name = "biohazard containment door"
-	},
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	id = "sci_shared_desk";
-	name = "desk shutters"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/monotile,
-/area/science/research)
 "ana" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/reactor/stats,
@@ -5654,7 +5574,9 @@
 /area/engine/engineering/hangar)
 "any" = (
 /obj/machinery/photocopier,
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -5673,7 +5595,9 @@
 /turf/open/floor/monotile/dark,
 /area/lawoffice)
 "anB" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -5768,13 +5692,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
-"anP" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "anQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -5799,7 +5716,9 @@
 /area/crew_quarters/heads/chief)
 "anT" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -6248,7 +6167,9 @@
 /turf/open/floor/plasteel/freezer,
 /area/medical/virology)
 "aoS" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -6349,7 +6270,9 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "apg" = (
@@ -6522,7 +6445,9 @@
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
 "apF" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -6704,8 +6629,7 @@
 /area/crew_quarters/heads/chief)
 "aqf" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10;
-	icon_state = "pipe11-2"
+	dir = 10
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -6839,7 +6763,9 @@
 	pixel_y = 26
 	},
 /obj/machinery/vending/dinnerware,
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -7065,7 +6991,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -7348,7 +7276,9 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/service)
 "arA" = (
@@ -7418,8 +7348,7 @@
 /area/engine/storage)
 "arP" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 6;
-	icon_state = "pipe11-2"
+	dir = 6
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -7428,16 +7357,14 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 8;
-	icon_state = "pipe11-2"
+	dir = 8
 	},
 /turf/open/space/basic,
 /area/engine/atmos)
 "arR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/layer_manifold/visible{
-	dir = 4;
-	icon_state = "manifoldlayer"
+	dir = 4
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -7591,7 +7518,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -7674,7 +7603,9 @@
 /area/engine/atmos)
 "asJ" = (
 /obj/effect/turf_decal/stripes/corner,
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -7704,8 +7635,7 @@
 /area/engine/atmos)
 "asU" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
-	dir = 8;
-	icon_state = "manifold-2"
+	dir = 8
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -7756,7 +7686,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -8819,14 +8751,6 @@
 	},
 /turf/open/floor/monotile/light,
 /area/medical/virology)
-"aww" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/atmos)
 "awC" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/structure/lattice/catwalk,
@@ -8856,8 +8780,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 6;
-	icon_state = "pipe11-1"
+	dir = 6
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -8951,16 +8874,13 @@
 /area/engine/atmos)
 "axg" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
-	dir = 4;
-	icon_state = "manifold-2"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 4;
-	icon_state = "pipe11-1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/violet/visible/layer3{
-	dir = 8;
-	icon_state = "pipe11-3"
+	dir = 8
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -8968,12 +8888,10 @@
 "axh" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 9;
-	icon_state = "pipe11-1"
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/violet/visible/layer3{
-	dir = 9;
-	icon_state = "pipe11-3"
+	dir = 9
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -9018,8 +8936,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1,
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/violet/visible/layer3{
-	dir = 6;
-	icon_state = "pipe11-3"
+	dir = 6
 	},
 /turf/open/space/basic,
 /area/engine/atmos)
@@ -9039,8 +8956,7 @@
 /area/engine/atmos)
 "axB" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
-	dir = 10;
-	icon_state = "pipe11-3"
+	dir = 10
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -9146,28 +9062,24 @@
 /area/engine/atmos)
 "ayb" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 8;
-	icon_state = "pipe11-2"
+	dir = 8
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/engine/atmos)
 "ayc" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
-	dir = 1;
-	icon_state = "manifold-2"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/violet/visible/layer3{
-	dir = 5;
-	icon_state = "pipe11-3"
+	dir = 5
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/engine/atmos)
 "ayd" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
-	dir = 1;
-	icon_state = "manifold-2"
+	dir = 1
 	},
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/components/binary/pump/layer3{
@@ -9178,12 +9090,10 @@
 /area/engine/atmos)
 "aye" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
-	dir = 1;
-	icon_state = "manifold-2"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/violet/visible/layer3{
-	dir = 8;
-	icon_state = "pipe11-3"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3,
 /obj/structure/lattice/catwalk,
@@ -9191,17 +9101,14 @@
 /area/engine/atmos)
 "ayf" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
-	dir = 1;
-	icon_state = "manifold-2"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/violet/visible/layer3{
-	dir = 8;
-	icon_state = "pipe11-3"
+	dir = 8
 	},
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 5;
-	icon_state = "pipe11-1"
+	dir = 5
 	},
 /turf/open/space/basic,
 /area/engine/atmos)
@@ -9213,32 +9120,27 @@
 	},
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
-	dir = 6;
-	icon_state = "pipe11-3"
+	dir = 6
 	},
 /turf/open/space/basic,
 /area/engine/atmos)
 "aym" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 6;
-	icon_state = "pipe11-2"
+	dir = 6
 	},
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
-	dir = 8;
-	icon_state = "pipe11-3"
+	dir = 8
 	},
 /turf/open/space/basic,
 /area/engine/atmos)
 "ayn" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4;
-	icon_state = "pipe11-2"
+	dir = 4
 	},
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
-	dir = 8;
-	icon_state = "pipe11-3"
+	dir = 8
 	},
 /turf/open/space/basic,
 /area/engine/atmos)
@@ -9250,8 +9152,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
-	dir = 8;
-	icon_state = "pipe11-3"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3,
 /turf/open/space/basic,
@@ -9280,8 +9181,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
-	dir = 8;
-	icon_state = "pipe11-3"
+	dir = 8
 	},
 /turf/open/floor/plating/airless,
 /area/engine/atmos)
@@ -9293,8 +9193,7 @@
 /area/engine/gravity_generator)
 "ayz" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8;
-	icon_state = "manifold-2"
+	dir = 8
 	},
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3,
@@ -9309,16 +9208,14 @@
 /area/engine/atmos)
 "ayB" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/visible{
-	dir = 4;
-	icon_state = "manifoldlayer"
+	dir = 4
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/engine/atmos)
 "ayC" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1{
-	dir = 4;
-	icon_state = "pipe11-1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped/inverse{
 	dir = 8;
@@ -9330,12 +9227,10 @@
 "ayD" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1{
-	dir = 10;
-	icon_state = "pipe11-1"
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 8;
-	icon_state = "pipe11-2"
+	dir = 8
 	},
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3,
@@ -9343,8 +9238,7 @@
 /area/engine/atmos)
 "ayE" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 8;
-	icon_state = "pipe11-2"
+	dir = 8
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -9523,7 +9417,9 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/machinery/computer/reactor/pump/rbmk_moderator,
 /turf/open/floor/plasteel/grid/lino,
 /area/engine/engineering/reactor_control)
@@ -9620,24 +9516,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/monotile,
 /area/engine/engineering/hangar)
-"azh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/monotile/dark,
-/area/engine/engineering)
 "azi" = (
 /obj/structure/closet/secure_closet/detective,
 /obj/structure/sign/nanotrasen{
@@ -9713,8 +9591,7 @@
 /area/engine/atmos)
 "azu" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 6;
-	icon_state = "pipe11-2"
+	dir = 6
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -9734,8 +9611,7 @@
 /area/maintenance/starboard/fore)
 "azA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 6;
-	icon_state = "pipe11-2"
+	dir = 6
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -10149,23 +10025,6 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
-"aAF" = (
-/obj/machinery/door/airlock/glass_large/ship{
-	bound_height = 64;
-	bound_width = 32;
-	dir = 4;
-	name = "Engineering Storage";
-	pixel_x = -32;
-	req_one_access_txt = "10"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/monotile/dark,
-/area/engine/engineering)
 "aAG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -10221,21 +10080,6 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/monotile/dark,
-/area/engine/storage_shared)
-"aAM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
@@ -10339,21 +10183,6 @@
 "aAV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile,
-/area/engine/engineering)
-"aAW" = (
-/obj/machinery/door/airlock/glass_large/ship{
-	name = "Engineering Wing";
-	req_one_access_txt = "10; 24"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/monotile/dark,
 /area/engine/engineering)
 "aAX" = (
 /obj/structure/chair{
@@ -10534,7 +10363,9 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/structure/closet/secure_closet/engineering_personal,
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/item/clothing/suit/radiation,
 /obj/item/clothing/head/radiation,
 /obj/structure/cable{
@@ -11380,14 +11211,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/security/armory)
-"aDG" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plating,
-/area/maintenance/port)
 "aDH" = (
 /obj/structure/rack,
 /obj/item/storage/box/flashbangs,
@@ -11462,7 +11285,9 @@
 /area/ai_monitored/security/armory)
 "aDP" = (
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -12198,7 +12023,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -12247,7 +12074,9 @@
 /turf/open/floor/monotile,
 /area/security/brig)
 "aFu" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -12393,7 +12222,9 @@
 /area/crew_quarters/heads/hos)
 "aFG" = (
 /obj/machinery/suit_storage_unit/hos,
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -12411,9 +12242,6 @@
 /obj/item/pen,
 /turf/open/floor/plasteel/ship,
 /area/security/prison)
-"aFJ" = (
-/turf/open/space/basic,
-/area/security/execution/transfer)
 "aFK" = (
 /obj/structure/rack,
 /obj/item/ship_weapon/ammunition/gauss{
@@ -12433,18 +12261,6 @@
 /area/maintenance/starboard/secondary{
 	name = "Munitions Projects"
 	})
-"aFL" = (
-/obj/machinery/door/airlock/ship/external/glass{
-	req_one_access_txt = "13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "aFM" = (
 /turf/open/floor/plating,
 /area/security/execution/transfer)
@@ -12740,16 +12556,6 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
-/area/security/execution/transfer)
-"aGy" = (
-/obj/docking_port/stationary{
-	dwidth = 1;
-	height = 4;
-	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
-	width = 3
-	},
-/obj/structure/fans/tiny/invisible,
-/turf/open/space/basic,
 /area/security/execution/transfer)
 "aGz" = (
 /obj/machinery/camera/autoname{
@@ -13306,7 +13112,9 @@
 /turf/open/floor/monotile,
 /area/engine/gravity_generator)
 "aHK" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -13640,7 +13448,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -13814,9 +13624,6 @@
 /obj/structure/sign/poster/contraband/shamblers_juice,
 /turf/closed/wall/r_wall/ship,
 /area/science/test_area)
-"aIX" = (
-/turf/open/floor/mineral/titanium/airless,
-/area/space)
 "aIY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -13836,7 +13643,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -14114,7 +13923,9 @@
 /turf/open/floor/mineral/plastitanium/airless,
 /area/science/test_area)
 "aJH" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -14375,7 +14186,9 @@
 /turf/open/floor/monotile,
 /area/nsv/weapons/fore)
 "aKj" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -14478,22 +14291,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/nanite)
-"aKt" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Aft Primary Hallway"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/monotile,
-/area/hallway/nsv/deck2/frame1/port)
 "aKu" = (
 /obj/machinery/nanite_chamber,
 /obj/machinery/light{
@@ -14585,7 +14382,9 @@
 "aKF" = (
 /obj/machinery/mecha_part_fabricator,
 /obj/effect/turf_decal/delivery,
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -14596,7 +14395,9 @@
 /turf/open/floor/monotile,
 /area/science/research)
 "aKI" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -14943,19 +14744,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/techmaint,
 /area/medical/chemistry)
-"aLr" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Chemistry Access"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/monotile/dark,
-/area/hallway/nsv/deck2/frame1/port)
 "aLs" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -15713,7 +15501,9 @@
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "aMU" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -15897,7 +15687,9 @@
 /turf/open/floor/plating,
 /area/chapel/main)
 "aNl" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -16308,7 +16100,7 @@
 	dir = 8
 	},
 /obj/machinery/advanced_airlock_controller{
-	pixel_y = -26
+	pixel_y = 24
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
@@ -16336,8 +16128,7 @@
 "aOf" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/advanced_airlock_controller{
-	pixel_x = 26;
-	pixel_y = 2
+	pixel_y = 24
 	},
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -16490,18 +16281,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/monotile/dark,
 /area/hydroponics)
-"aOw" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/monotile/dark,
-/area/engine/engineering)
 "aOx" = (
 /obj/item/ship_weapon/ammunition/naval_artillery/cannonball,
 /turf/open/floor/monotile,
@@ -16535,12 +16314,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
-"aOC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/layer3{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/quartermaster/miningdock)
 "aOD" = (
 /obj/machinery/light{
 	dir = 8
@@ -16572,8 +16345,7 @@
 	dir = 4
 	},
 /obj/machinery/advanced_airlock_controller{
-	pixel_x = -26;
-	pixel_y = 2
+	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1,
@@ -16695,7 +16467,9 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -17019,7 +16793,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -17030,7 +16806,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -17107,20 +16885,6 @@
 	name = "telecomms server floor"
 	},
 /area/tcommsat/server)
-"aPG" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Medical Central";
-	req_one_access_txt = "5"
-	},
-/turf/open/floor/monotile,
-/area/medical/medbay/central)
 "aPH" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -17309,10 +17073,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
-"aQp" = (
-/obj/effect/spawner/lootdrop/maintenance/two,
-/turf/open/floor/plating,
-/area/maintenance/port)
 "aQq" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 5
@@ -17373,7 +17133,9 @@
 /obj/item/bedsheet/black{
 	layer = 2.85
 	},
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -17607,7 +17369,9 @@
 /area/medical/medbay/central)
 "aQS" = (
 /obj/effect/turf_decal/stripes/corner,
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -17759,7 +17523,9 @@
 /area/tcommsat/server)
 "aRj" = (
 /obj/machinery/telecomms/broadcaster/preset_left,
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/structure/cable,
 /turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
@@ -18179,26 +17945,6 @@
 /obj/machinery/vending/wardrobe/law_wardrobe,
 /turf/open/floor/monotile/dark,
 /area/lawoffice)
-"aSg" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Chemistry";
-	req_one_access_txt = "33"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/monotile,
-/area/hallway/nsv/deck2/frame1/port)
 "aSh" = (
 /obj/structure/sign/directions/engineering{
 	dir = 4
@@ -18297,7 +18043,9 @@
 /obj/item/bedsheet/black{
 	layer = 2.85
 	},
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -18399,11 +18147,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/nsv/weapons/fore)
-"aSF" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard/secondary{
-	name = "Munitions Projects"
-	})
 "aSG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
@@ -18456,25 +18199,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame2/port)
-"aSL" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	name = "Briefing room maintenance";
-	req_one_access_txt = "19"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/hallway/nsv/deck2/frame1/central)
 "aSM" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -18587,7 +18311,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
@@ -18776,10 +18502,6 @@
 /area/maintenance/starboard/secondary{
 	name = "Munitions Projects"
 	})
-"aTE" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/techmaint,
-/area/medical/chemistry)
 "aTF" = (
 /obj/item/pipe_dispenser/plumbing,
 /obj/structure/table/reinforced,
@@ -18787,7 +18509,9 @@
 /turf/open/floor/plasteel/techmaint,
 /area/medical/chemistry)
 "aTG" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -18867,39 +18591,6 @@
 /obj/item/reagent_containers/food/drinks/solgovcup,
 /turf/open/floor/monotile/light,
 /area/medical/medbay/lobby)
-"aTR" = (
-/obj/machinery/door/airlock/glass_large/ship{
-	bound_height = 64;
-	bound_width = 32;
-	dir = 4;
-	name = "Suit Storage";
-	pixel_x = -32;
-	req_one_access_txt = "10;24"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/monotile/dark,
-/area/engine/storage_shared)
-"aTT" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Medbay Lobby Access"
-	},
-/turf/open/floor/monotile/light,
-/area/medical/medbay/lobby)
 "aTU" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -18933,7 +18624,9 @@
 /area/medical/medbay/central)
 "aTZ" = (
 /obj/structure/table/glass,
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -19511,27 +19204,6 @@
 "aVk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/crew_quarters/cafeteria{
-	name = "Mess hall"
-	})
-"aVl" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/monotile,
 /area/crew_quarters/cafeteria{
 	name = "Mess hall"
 	})
@@ -20486,25 +20158,6 @@
 "aXi" = (
 /turf/closed/wall/r_wall/ship,
 /area/science/xenobiology)
-"aXj" = (
-/obj/structure/window/reinforced,
-/obj/machinery/door/window/eastleft{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Deliveries";
-	req_access_txt = "50"
-	},
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "packageExternal"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/plasteel/grid/steel,
-/area/quartermaster/storage)
 "aXk" = (
 /obj/structure/plasticflaps/opaque,
 /obj/structure/window/reinforced,
@@ -20642,15 +20295,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"aXx" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/monotile,
-/area/security/brig)
 "aXy" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/landmark/secequipment,
@@ -21147,7 +20791,9 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/gauss)
 "aYM" = (
@@ -21209,14 +20855,6 @@
 /area/maintenance/starboard/secondary{
 	name = "Munitions Projects"
 	})
-"aYT" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/effect/turf_decal/loading_area{
-	dir = 8
-	},
-/turf/open/floor/monotile,
-/area/maintenance/port)
 "aYU" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	dir = 4;
@@ -21303,7 +20941,9 @@
 /area/maintenance/department/medical)
 "aZb" = (
 /obj/structure/closet/secure_closet/personal/patient,
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -21521,7 +21161,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -21691,51 +21333,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/medical/medbay/central)
-"aZO" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
-"aZP" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
-"aZQ" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plating,
-/area/maintenance/port)
-"aZR" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/maintenance/port)
 "aZS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21768,15 +21365,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/medical/medbay/central)
-"aZU" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "aZV" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -21899,12 +21487,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
-"baj" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/carpet/ship,
-/area/nsv/crew_quarters/heads/maa)
 "bak" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -22274,20 +21856,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/medical/medbay/central)
-"baR" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Medical Central";
-	req_one_access_txt = "5"
-	},
-/turf/open/floor/monotile/dark,
-/area/medical/medbay/central)
 "baS" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	dir = 4;
@@ -22418,7 +21986,9 @@
 /area/nsv/weapons/fore)
 "bbe" = (
 /obj/structure/closet/wardrobe/white,
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -22700,25 +22270,6 @@
 	},
 /turf/open/floor/monotile/light,
 /area/medical/medbay/central)
-"bbI" = (
-/obj/machinery/door/airlock/glass_large/ship{
-	bound_height = 64;
-	bound_width = 32;
-	dir = 4;
-	name = "Mess Hall";
-	pixel_x = -32
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/monotile,
-/area/crew_quarters/cafeteria{
-	name = "Mess hall"
-	})
 "bbJ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -22891,7 +22442,9 @@
 /area/medical/medbay/central)
 "bbX" = (
 /obj/structure/kitchenspike,
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -22938,7 +22491,9 @@
 /area/hallway/nsv/deck2/frame1/central)
 "bcc" = (
 /obj/machinery/smartfridge/drying_rack,
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -23729,7 +23284,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -24432,7 +23989,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -24500,7 +24059,9 @@
 /turf/open/floor/carpet/red,
 /area/security/warden)
 "beK" = (
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
 /obj/structure/cable,
 /obj/machinery/computer/secure_data{
 	dir = 1
@@ -24515,7 +24076,9 @@
 /area/quartermaster/warehouse)
 "beM" = (
 /obj/machinery/computer/security/qm,
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -24586,22 +24149,6 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/quartermaster/qm)
-"beU" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
-	dir = 4;
-	name = "Munitions Projects"
-	},
-/turf/open/floor/monotile/dark,
-/area/maintenance/port)
 "beV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -24674,7 +24221,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -25727,12 +25276,6 @@
 /obj/item/paint/anycolor,
 /turf/open/floor/monotile,
 /area/nsv/hanger/deck2)
-"bhm" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "bhn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -26066,12 +25609,6 @@
 	},
 /turf/open/floor/engine,
 /area/medical/medbay/lobby)
-"bhV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/turf/closed/wall/ship,
-/area/maintenance/central)
 "bhW" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -26423,8 +25960,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4;
-	icon_state = "pipe11-1"
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
@@ -26524,7 +26060,9 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/lattice/catwalk/over/ship,
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -26640,7 +26178,9 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bje" = (
@@ -26837,18 +26377,6 @@
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/janitor)
-"bjv" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Medbay Lobby Access"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/monotile,
-/area/medical/medbay/lobby)
 "bjw" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -26914,15 +26442,6 @@
 /obj/machinery/light,
 /turf/open/floor/monotile,
 /area/hallway/secondary/exit)
-"bjB" = (
-/obj/machinery/computer/shuttle/mining{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/quartermaster/miningdock)
 "bjC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -26943,8 +26462,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bjE" = (
 /obj/machinery/advanced_airlock_controller{
-	pixel_x = -26;
-	pixel_y = 2
+	pixel_y = 24
 	},
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -27377,12 +26895,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/engine_smes)
-"bks" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "bkt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -27427,7 +26939,9 @@
 /turf/open/floor/monotile,
 /area/ai_monitored/security/armory)
 "bky" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -27662,17 +27176,6 @@
 	},
 /turf/open/floor/monotile/light,
 /area/medical/medbay/lobby)
-"bkT" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Medbay Lobby Access"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/monotile,
-/area/medical/medbay/lobby)
 "bkU" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -27850,10 +27353,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile,
 /area/security/warden)
-"blm" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/closed/wall/ship,
-/area/maintenance/central)
 "bln" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -28169,7 +27668,9 @@
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
 "bmd" = (
-/obj/machinery/advanced_airlock_controller/directional/west,
+/obj/machinery/advanced_airlock_controller/directional/west{
+	pixel_y = 24
+	},
 /turf/open/floor/plating,
 /area/engine/atmos)
 "bme" = (
@@ -28448,7 +27949,9 @@
 	})
 "bmD" = (
 /obj/structure/table/reinforced,
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /turf/open/floor/mineral/plastitanium/red/airless,
 /area/science/test_area)
 "bmE" = (
@@ -28484,13 +27987,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
-"bmH" = (
-/obj/structure/disposalpipe/trunk/multiz{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/multiz,
-/turf/closed/wall/ship,
-/area/maintenance/central)
 "bmI" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -28762,19 +28258,6 @@
 /obj/machinery/vending/wardrobe/science_wardrobe,
 /turf/open/floor/monotile/dark,
 /area/science)
-"bnk" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Aft Primary Hallway"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/monotile,
-/area/hallway/nsv/deck2/frame1/port)
 "bnl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -28886,7 +28369,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "bnx" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -29371,10 +28856,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/medical/chemistry)
-"boy" = (
-/obj/machinery/disposal/bin,
-/turf/open/floor/monotile,
-/area/janitor)
 "boz" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -30487,7 +29968,9 @@
 	name = "CIC"
 	})
 "bqu" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -30529,13 +30012,6 @@
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"bqy" = (
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "bqz" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -30683,11 +30159,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
 /area/science/nanite)
-"bqO" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/port)
 "bqP" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -31067,13 +30538,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"brB" = (
-/obj/effect/spawner/lootdrop/maintenance/eight,
-/obj/structure/closet/cardboard,
-/turf/open/floor/plating,
-/area/maintenance/starboard/secondary{
-	name = "Munitions Projects"
-	})
 "brC" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -31143,7 +30607,9 @@
 /area/maintenance/disposal)
 "brI" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "brJ" = (
@@ -31760,20 +31226,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"bsT" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/ship{
-	dir = 4;
-	name = "Hangar Bay";
-	req_access_txt = "69"
-	},
-/turf/open/floor/monotile,
-/area/maintenance/port)
 "bsU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -31919,19 +31371,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/monotile/dark,
-/area/engine/engineering)
-"btk" = (
-/obj/machinery/door/airlock/glass_large/ship{
-	name = "Engineering Wing";
-	req_one_access_txt = "10; 24"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
 "btl" = (
@@ -33031,8 +32470,7 @@
 	},
 /obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4;
-	icon_state = "pipe11-1"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -33095,8 +32533,7 @@
 	},
 /obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4;
-	icon_state = "pipe11-1"
+	dir = 4
 	},
 /obj/structure/lattice/catwalk/over/ship,
 /turf/open/floor/monotile,
@@ -33220,13 +32657,6 @@
 	},
 /turf/open/floor/monotile,
 /area/medical/medbay/lobby)
-"bvo" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/landmark/nuclear_waste_spawner,
-/turf/open/floor/plating,
-/area/maintenance/port)
 "bvp" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -33280,23 +32710,6 @@
 /area/medical/medbay/zone2{
 	name = "Intensive care unit"
 	})
-"bvt" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Intensive Care Access"
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/monotile,
-/area/medical/medbay/zone2{
-	name = "Intensive care unit"
-	})
 "bvu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -33304,21 +32717,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile,
-/area/medical/medbay/central)
-"bvv" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Intensive Care Access"
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/monotile/dark,
 /area/medical/medbay/central)
 "bvw" = (
 /obj/structure/cable{
@@ -33592,23 +32990,6 @@
 	},
 /turf/open/floor/plating,
 /area/medical/morgue)
-"bvW" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Medbay Central";
-	req_one_access_txt = "5"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/monotile/dark,
-/area/medical/medbay/lobby)
 "bvX" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -33616,23 +32997,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/monotile/dark,
-/area/medical/medbay/lobby)
-"bvY" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Cryogenics";
-	req_one_access_txt = "5"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/monotile/dark,
 /area/medical/medbay/lobby)
 "bvZ" = (
@@ -33815,17 +33179,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/monotile,
 /area/medical/medbay/lobby)
-"bwp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Medbay Lobby Access"
-	},
-/turf/open/floor/monotile/light,
-/area/medical/medbay/lobby)
 "bwq" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -33936,33 +33289,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile,
 /area/science)
-"bwD" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/southright{
-	name = "Science Desk";
-	req_one_access_txt = "7;29"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Biohazard";
-	name = "biohazard containment door"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/item/folder/white{
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/obj/item/pen,
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	id = "sci_shared_desk";
-	name = "desk shutters"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/monotile,
-/area/science/research)
 "bwE" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -34513,8 +33839,7 @@
 /area/hallway/secondary/exit)
 "bxG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4;
-	icon_state = "pipe11-1"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -34902,8 +34227,7 @@
 /area/hallway/nsv/deck2/frame2/port)
 "byo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4;
-	icon_state = "pipe11-1"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -35049,8 +34373,7 @@
 /area/security/warden)
 "byF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4;
-	icon_state = "pipe11-1"
+	dir = 4
 	},
 /obj/structure/lattice/catwalk/over/ship,
 /turf/open/floor/monotile/dark,
@@ -35083,19 +34406,6 @@
 	},
 /turf/open/floor/monotile,
 /area/security/brig)
-"byI" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	dir = 4;
-	name = "Deck 1 access maintenance"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/monotile,
-/area/hallway/nsv/deck2/frame1/central)
 "byJ" = (
 /obj/machinery/door/airlock/ship/security/glass{
 	dir = 4;
@@ -35813,7 +35123,9 @@
 /turf/open/space/basic,
 /area/space)
 "bAf" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/machinery/camera/autoname,
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -35975,8 +35287,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8;
-	icon_state = "manifold-3"
+	dir = 8
 	},
 /turf/open/floor/plasteel/ship,
 /area/engine/break_room)
@@ -36263,8 +35574,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8;
-	icon_state = "manifold-3"
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
@@ -36338,18 +35648,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/monotile,
 /area/nsv/hanger/deck2)
-"bBl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/monotile,
-/area/maintenance/port)
 "bBm" = (
 /obj/machinery/lazylift/master,
 /turf/open/floor/monotile/dark,
@@ -36563,8 +35861,7 @@
 /area/security/brig)
 "bBH" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8;
-	icon_state = "manifold-3"
+	dir = 8
 	},
 /obj/structure/lattice/catwalk/over/ship,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -36731,8 +36028,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4;
-	icon_state = "pipe11-1"
+	dir = 4
 	},
 /obj/machinery/conveyor/slow{
 	id = "torp"
@@ -36752,8 +36048,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4;
-	icon_state = "pipe11-1"
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -36898,7 +36193,9 @@
 /turf/open/floor/monotile,
 /area/medical/medbay/central)
 "bCq" = (
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
 /obj/structure/cable,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo)
@@ -37242,29 +36539,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
-	},
-/turf/open/floor/monotile,
-/area/security/brig)
-"bCW" = (
-/obj/machinery/door/airlock/glass_large/ship{
-	bound_height = 64;
-	bound_width = 32;
-	dir = 4;
-	name = "Security Light Armoury";
-	pixel_x = -32;
-	req_one_access_txt = "2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
 	},
 /turf/open/floor/monotile,
 /area/security/brig)
@@ -37665,12 +36939,6 @@
 /obj/effect/turf_decal/ship/delivery/yellow,
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
-"bDH" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "bDI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37685,30 +36953,6 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck2)
-"bDL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/advanced_airlock_controller{
-	pixel_y = 29
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/quartermaster/miningdock)
-"bDM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/layer1{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/quartermaster/miningdock)
 "bDN" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -38752,13 +37996,6 @@
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
-"bFA" = (
-/obj/structure/disposalpipe/trunk/multiz{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/closed/wall/ship,
-/area/maintenance/central)
 "bFB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38774,12 +38011,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
-/area/maintenance/central)
-"bFD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
-/turf/closed/wall/ship,
 /area/maintenance/central)
 "bFE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -38932,12 +38163,6 @@
 	},
 /turf/open/floor/monotile/light,
 /area/medical/medbay/lobby)
-"bFV" = (
-/obj/machinery/airalarm{
-	pixel_y = 26
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "bFW" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -39411,15 +38636,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/medical/virology)
-"bGQ" = (
-/turf/open/space/basic,
-/area/maintenance/port)
-"bGR" = (
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/maintenance/starboard/secondary{
-	name = "Munitions Projects"
-	})
 "bGS" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -40050,47 +39266,6 @@
 /obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
-"bIl" = (
-/obj/structure/closet/radiation,
-/turf/open/floor/plating,
-/area/maintenance/port)
-"bIm" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/port)
-"bIn" = (
-/obj/structure/closet/radiation,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
-"bIo" = (
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
-	name = "Damage control closet"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
-"bIp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/turf/closed/wall/r_wall/ship,
-/area/maintenance/starboard/secondary{
-	name = "Munitions Projects"
-	})
-"bIq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/closed/wall/r_wall/ship,
-/area/maintenance/starboard/secondary{
-	name = "Munitions Projects"
-	})
 "bIr" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -40399,8 +39574,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8;
-	icon_state = "manifold-3"
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -40510,7 +39684,9 @@
 /area/quartermaster/miningdock)
 "bJs" = (
 /obj/structure/closet/secure_closet/miner,
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -40727,18 +39903,6 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/closed/wall/r_wall/ship,
 /area/medical/virology)
-"bJL" = (
-/obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/secondary{
-	name = "Munitions Projects"
-	})
 "bJM" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
@@ -40794,17 +39958,6 @@
 	},
 /turf/open/floor/monotile/light,
 /area/medical/virology)
-"bJV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/closed/wall/ship,
-/area/maintenance/starboard/secondary{
-	name = "Munitions Projects"
-	})
 "bJW" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -40864,23 +40017,6 @@
 /area/maintenance/starboard/secondary{
 	name = "Munitions Projects"
 	})
-"bKc" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/plating,
-/area/maintenance/starboard/secondary{
-	name = "Munitions Projects"
-	})
-"bKd" = (
-/obj/item/cigbutt,
-/obj/item/clothing/head/cone,
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/plating,
-/area/maintenance/starboard/secondary{
-	name = "Munitions Projects"
-	})
 "bKe" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -40891,7 +40027,9 @@
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
 "bKf" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -40948,30 +40086,6 @@
 /area/maintenance/starboard/secondary{
 	name = "Munitions Projects"
 	})
-"bKk" = (
-/obj/structure/ladder,
-/turf/open/floor/plating,
-/area/maintenance/starboard/secondary{
-	name = "Munitions Projects"
-	})
-"bKl" = (
-/obj/machinery/atmospherics/pipe/simple/multiz,
-/turf/open/floor/plating,
-/area/maintenance/starboard/secondary{
-	name = "Munitions Projects"
-	})
-"bKn" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/turf_decal/ship/shutoff,
-/obj/machinery/power/deck_relay,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/starboard/secondary{
-	name = "Munitions Projects"
-	})
 "bKo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -40992,47 +40106,6 @@
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
-/area/maintenance/starboard/secondary{
-	name = "Munitions Projects"
-	})
-"bKq" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/plating,
-/area/maintenance/starboard/secondary{
-	name = "Munitions Projects"
-	})
-"bKr" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/secondary{
-	name = "Munitions Projects"
-	})
-"bKs" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/plating,
-/area/maintenance/starboard/secondary{
-	name = "Munitions Projects"
-	})
-"bKt" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
-	dir = 4;
-	name = "Munitions Projects"
-	},
-/turf/open/floor/plating,
 /area/maintenance/starboard/secondary{
 	name = "Munitions Projects"
 	})
@@ -41081,70 +40154,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
-"bKy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/turf/closed/wall/r_wall/ship,
-/area/maintenance/starboard/secondary{
-	name = "Munitions Projects"
-	})
-"bKz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
-	name = "Flight Deck Access"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/secondary{
-	name = "Munitions Projects"
-	})
-"bKA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/monotile,
-/area/maintenance/port)
-"bKB" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/turf/open/floor/monotile,
-/area/maintenance/port)
-"bKC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light,
-/obj/effect/turf_decal/loading_area{
-	dir = 8
-	},
-/turf/open/floor/monotile,
-/area/maintenance/port)
-"bKD" = (
-/obj/machinery/camera/autoname{
-	dir = 1;
-	icon_state = "camera"
-	},
-/turf/open/floor/monotile,
-/area/maintenance/port)
 "bKE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -41241,11 +40250,6 @@
 	},
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/monotile/dark,
-/area/hallway/nsv/deck2/frame1/central)
-"bKO" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance/three,
-/turf/open/floor/plating,
 /area/hallway/nsv/deck2/frame1/central)
 "bKP" = (
 /obj/structure/stairs{
@@ -42016,16 +41020,6 @@
 /obj/structure/ladder,
 /turf/open/space/basic,
 /area/space/nearstation)
-"bMq" = (
-/obj/structure/lattice,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/structure/disposaloutlet{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "bMr" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1
@@ -42064,14 +41058,19 @@
 "bNa" = (
 /turf/closed/wall/r_wall/ship,
 /area/library)
-"bNd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
+"bOr" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/closed/wall/ship,
-/area/maintenance/starboard/secondary{
-	name = "Munitions Projects"
-	})
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
 "bOT" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/structure/lattice/catwalk,
@@ -42089,13 +41088,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"bQx" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/maintenance/port)
 "bRy" = (
 /obj/item/beacon,
 /turf/open/floor/engine,
@@ -42103,8 +41095,7 @@
 "bTs" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 4;
-	icon_state = "pipe11-1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 10
@@ -42351,8 +41342,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8;
-	icon_state = "manifold-3"
+	dir = 8
 	},
 /turf/open/floor/monotile,
 /area/nsv/weapons/gauss)
@@ -43280,7 +42270,7 @@
 	dir = 4
 	},
 /obj/machinery/advanced_airlock_controller{
-	pixel_y = -26
+	pixel_y = 24
 	},
 /obj/machinery/light{
 	dir = 1
@@ -43436,6 +42426,25 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/dark,
 /area/medical/virology)
+"cAo" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
+"cAJ" = (
+/obj/structure/disposalpipe/trunk/multiz{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/multiz,
+/turf/closed/wall/ship,
+/area/medical/medbay/lobby)
 "cBD" = (
 /obj/structure/sign/ship/shock{
 	dir = 1
@@ -43474,8 +42483,7 @@
 /area/quartermaster/miningdock)
 "cED" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 4;
-	icon_state = "pipe11-1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 8
@@ -43528,6 +42536,20 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
+"cKq" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/monotile,
+/area/maintenance/starboard/secondary{
+	name = "Munitions Projects"
+	})
 "cOu" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -43535,6 +42557,9 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
+"cOK" = (
+/turf/closed/wall/ship,
+/area/maintenance/nsv/hangar)
 "cPU" = (
 /obj/item/radio/intercom{
 	name = "intra ship intercom";
@@ -43551,13 +42576,11 @@
 	})
 "cSo" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10;
-	icon_state = "pipe11-2"
+	dir = 10
 	},
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
-	dir = 8;
-	icon_state = "pipe11-3"
+	dir = 8
 	},
 /turf/open/space/basic,
 /area/engine/atmos)
@@ -43597,6 +42620,27 @@
 	},
 /turf/open/floor/monotile,
 /area/crew_quarters/fitness/recreation)
+"cUM" = (
+/obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
+	name = "Chemistry";
+	req_one_access_txt = "33"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck2/frame1/port)
 "cWp" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -43608,6 +42652,22 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet,
 /area/library)
+"cWE" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
+	dir = 4;
+	name = "Munitions Projects"
+	},
+/turf/open/floor/monotile/dark,
+/area/maintenance/nsv/hangar)
 "cWG" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -43673,6 +42733,12 @@
 /obj/item/book/manual/wiki/rbmk,
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
+"ddh" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/quartermaster/miningdock)
 "ddD" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "shellOne";
@@ -43683,6 +42749,9 @@
 	},
 /turf/open/floor/monotile,
 /area/nsv/weapons/fore)
+"ddW" = (
+/turf/open/floor/plating,
+/area/maintenance/nsv/weapons)
 "dgt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -43698,6 +42767,10 @@
 /obj/item/fuel_rod,
 /turf/open/indestructible/sound/pool/spentfuel/wall,
 /area/engine/engineering/reactor_core)
+"dlA" = (
+/obj/structure/ladder,
+/turf/open/floor/plating,
+/area/maintenance/nsv/weapons)
 "dmA" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
@@ -43719,11 +42792,27 @@
 "dqq" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 8;
-	icon_state = "pipe11-2"
+	dir = 8
 	},
 /turf/open/space/basic,
 /area/engine/atmos)
+"dqx" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Medical Central";
+	req_one_access_txt = "5"
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/turf/open/floor/monotile,
+/area/medical/medbay/central)
 "dqy" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -43763,6 +42852,13 @@
 	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
+"dCz" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
 "dDv" = (
 /turf/closed/wall/ship,
 /area/nsv/weapons/gauss)
@@ -43775,6 +42871,17 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
+"dFO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/monotile,
+/area/maintenance/starboard/secondary{
+	name = "Munitions Projects"
+	})
 "dHB" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 26
@@ -43792,18 +42899,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/grid/steel,
-/area/engine/engineering/reactor_core)
-"dIi" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction,
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer1,
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer3,
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	id = "agcnr_hellburn";
-	name = "Hellburn Shutters"
-	},
-/turf/open/floor/monotile,
 /area/engine/engineering/reactor_core)
 "dIo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -43844,6 +42939,10 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/monotile,
 /area/security/brig)
+"dNn" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/maintenance/nsv/weapons)
 "dOU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -43906,6 +43005,20 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/monotile,
 /area/engine/engineering/reactor_core)
+"dXo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/ship/engineering/glass{
+	req_one_access_txt = "10;24"
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/engineering)
 "dXv" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	dir = 4;
@@ -43950,19 +43063,6 @@
 /obj/item/clothing/mask/breath,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"edc" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plating,
-/area/maintenance/port)
 "edN" = (
 /obj/machinery/suit_storage_unit/atmos,
 /obj/effect/turf_decal/stripes/line{
@@ -44019,11 +43119,19 @@
 /area/nsv/hanger/storage{
 	name = "Munitions Control Room"
 	})
-"eix" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/machinery/door/firedoor/border_only{
+"elG" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer3{
+	dir = 1
+	},
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /obj/machinery/door/poddoor/shutters/ship/preopen{
 	id = "agcnr_hellburn";
@@ -44094,6 +43202,15 @@
 /obj/structure/table,
 /turf/open/floor/monotile,
 /area/crew_quarters/fitness/recreation)
+"enE" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/structure/disposaloutlet{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "eoU" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -44293,16 +43410,12 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"eFX" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	id = "agcnr_hellburn";
-	name = "Hellburn Shutters"
+"eHi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/monotile,
-/area/engine/engineering/reactor_core)
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/nsv/weapons)
 "eHZ" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -44408,6 +43521,25 @@
 "eVQ" = (
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
+"eVR" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
+"eWa" = (
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Intensive Care Access"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/dark,
+/area/medical/medbay/central)
 "eXm" = (
 /obj/machinery/light/small,
 /obj/structure/bed,
@@ -44418,6 +43550,24 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/security/prison)
+"eZJ" = (
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "Biohazard";
+	name = "biohazard containment door"
+	},
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "sci_shared_desk";
+	name = "desk shutters"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile,
+/area/science/research)
 "fbx" = (
 /turf/closed/wall/r_wall/ship,
 /area/shuttle/turbolift/shaft)
@@ -44538,6 +43688,26 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/engine/atmos)
+"fBC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/engineering/glass{
+	dir = 4;
+	name = "Engineering Equipment";
+	req_one_access_txt = "11;24"
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/storage_shared)
 "fBV" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -44555,8 +43725,7 @@
 /area/medical/virology)
 "fCZ" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/visible{
-	dir = 4;
-	icon_state = "manifoldlayer"
+	dir = 4
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -44595,8 +43764,16 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
-"fMP" = (
-/obj/machinery/portable_atmospherics/canister/air,
+"fJZ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "fNY" = (
@@ -44612,6 +43789,12 @@
 /obj/item/beacon,
 /turf/open/floor/monotile,
 /area/hallway/secondary/exit)
+"fPU" = (
+/obj/structure/shuttle/engine/huge{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "fPZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -44628,33 +43811,6 @@
 	},
 /turf/open/floor/monotile,
 /area/engine/engineering/hangar)
-"fQN" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer3{
-	dir = 1
-	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	id = "agcnr_hellburn";
-	name = "Hellburn Shutters"
-	},
-/turf/open/floor/monotile,
-/area/engine/engineering/reactor_core)
-"fSB" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/port)
 "fUk" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
@@ -44739,6 +43895,12 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
+"giV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/nsv/weapons)
 "gjw" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -44784,6 +43946,12 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
+"gqw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/turf/closed/wall/ship,
+/area/medical/medbay/lobby)
 "gqO" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	req_one_access_txt = "13"
@@ -44793,6 +43961,21 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"gtM" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
 "gvw" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/monotile,
@@ -44809,12 +43992,30 @@
 /obj/machinery/meter,
 /turf/open/space/basic,
 /area/engine/atmos)
+"gzY" = (
+/obj/effect/spawner/lootdrop/maintenance/eight,
+/obj/structure/closet/cardboard,
+/turf/open/floor/plating,
+/area/maintenance/nsv/weapons)
 "gAS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
+"gCz" = (
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Medbay Lobby Access"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile,
+/area/medical/medbay/lobby)
 "gCM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8;
@@ -44865,6 +44066,21 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/engine,
 /area/engine/engine_room)
+"gGP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light,
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/turf/open/floor/monotile,
+/area/maintenance/starboard/secondary{
+	name = "Munitions Projects"
+	})
 "gGU" = (
 /obj/structure/lattice/catwalk/over/ship,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -44941,10 +44157,29 @@
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/wood,
 /area/library)
+"gOn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/turf/closed/wall/ship,
+/area/maintenance/nsv/weapons)
 "gOD" = (
 /obj/machinery/status_display/evac,
 /turf/closed/wall/ship,
 /area/security/brig)
+"gPJ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
+"gSH" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
 "gUy" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -45011,16 +44246,16 @@
 	},
 /turf/open/floor/monotile,
 /area/hallway/secondary/exit)
-"gXS" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/maintenance/port)
 "gZm" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
+"gZK" = (
+/obj/structure/closet/radiation,
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
 "gZS" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/monotile/dark,
@@ -45056,6 +44291,10 @@
 	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
+"hdo" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
 "hdp" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -45106,6 +44345,13 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/monotile,
 /area/crew_quarters/heads/chief)
+"hiP" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/monotile,
+/area/janitor)
 "hjP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/ship/preopen{
@@ -45204,6 +44450,21 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"hxF" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/ship/engineering/glass{
+	req_one_access_txt = "10;24"
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/engineering)
 "hyv" = (
 /obj/machinery/ship_weapon/vls,
 /obj/effect/turf_decal/stripes/line{
@@ -45322,18 +44583,20 @@
 "hLd" = (
 /turf/closed/wall/ship,
 /area/hallway/secondary/service)
-"hMm" = (
+"hLX" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/door/poddoor/shutters/ship/preopen{
 	id = "agcnr_hellburn";
 	name = "Hellburn Shutters"
 	},
 /turf/open/floor/monotile,
 /area/engine/engineering/reactor_core)
+"hNp" = (
+/obj/structure/table/reinforced,
+/obj/item/wrench/medical,
+/turf/open/floor/plasteel/techmaint,
+/area/medical/chemistry)
 "hNP" = (
 /obj/machinery/vending/wardrobe/curator_wardrobe,
 /turf/open/floor/wood,
@@ -45393,13 +44656,21 @@
 	id = "spentfuel2"
 	},
 /area/engine/engineering/reactor_core)
+"hRO" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "agcnr_hellburn";
+	name = "Hellburn Shutters"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/open/floor/monotile,
+/area/engine/engineering/reactor_core)
 "hSg" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /obj/machinery/advanced_airlock_controller{
-	pixel_x = 26;
-	pixel_y = 2
+	pixel_y = 24
 	},
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1{
 	dir = 1
@@ -45414,12 +44685,35 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile,
 /area/hallway/secondary/exit)
+"hWb" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/security/glass{
+	dir = 4;
+	name = "Security Equipment";
+	req_one_access_txt = "2"
+	},
+/turf/open/floor/monotile,
+/area/security/brig)
 "hWt" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/closed/wall/r_wall/ship,
 /area/engine/engine_smes)
+"hYm" = (
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/weapons)
 "icy" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -45437,21 +44731,19 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"ijO" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction,
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer1,
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer3,
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+"ife" = (
+/obj/machinery/light/small,
+/obj/machinery/advanced_airlock_controller{
+	pixel_y = 24
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	id = "agcnr_hellburn";
-	name = "Hellburn Shutters"
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1{
+	dir = 8
 	},
-/turf/open/floor/monotile,
-/area/engine/engineering/reactor_core)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
 "ilc" = (
 /turf/open/floor/monotile,
 /area/engine/engineering/reactor_core)
@@ -45605,6 +44897,13 @@
 	},
 /turf/open/floor/monotile,
 /area/nsv/hanger/deck2)
+"iDH" = (
+/obj/structure/closet/radiation,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
 "iDJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/newscaster{
@@ -45633,6 +44932,20 @@
 	},
 /turf/open/floor/monotile,
 /area/security/execution/transfer)
+"iIr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship{
+	dir = 4;
+	name = "Hangar Bay";
+	req_access_txt = "69"
+	},
+/turf/open/floor/monotile,
+/area/nsv/hanger/deck2)
 "iJw" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
@@ -45675,6 +44988,13 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
+"iLE" = (
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/weapons)
 "iMe" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -45743,8 +45063,7 @@
 /area/space/nearstation)
 "iSm" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 4;
-	icon_state = "pipe11-1"
+	dir = 4
 	},
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/supply/visible{
@@ -45766,6 +45085,13 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/monotile/dark,
 /area/gateway)
+"iSP" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/plating,
+/area/maintenance/nsv/weapons)
 "iVI" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
@@ -45841,6 +45167,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"jcy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/closed/wall/ship,
+/area/maintenance/nsv/weapons)
 "jeX" = (
 /obj/structure/cable,
 /obj/structure/cable{
@@ -45921,6 +45256,31 @@
 "jmS" = (
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/starboard)
+"jnx" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
+	name = "Mess Hall"
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/cafeteria{
+	name = "Mess hall"
+	})
 "jou" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -45997,6 +45357,17 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
+"juI" = (
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Intensive Care Access"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile,
+/area/medical/medbay/central)
 "jvI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -46038,6 +45409,12 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/break_room)
+"jHw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/nsv/weapons)
 "jHA" = (
 /obj/machinery/atmospherics/components/binary/stormdrive_reactor{
 	base_power = 47500;
@@ -46059,6 +45436,20 @@
 /obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/engine,
 /area/engine/engine_room)
+"jHU" = (
+/obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
+	name = "Chemistry Access"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck2/frame1/port)
 "jKR" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
@@ -46199,6 +45590,22 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/techmaint,
 /area/engine/engine_room)
+"kcr" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
+	dir = 4;
+	name = "Munitions Projects"
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/weapons)
 "kdb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -46211,6 +45618,22 @@
 	},
 /turf/open/floor/monotile,
 /area/gateway)
+"kdX" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
+"keI" = (
+/obj/machinery/camera/autoname{
+	dir = 1;
+	icon_state = "camera"
+	},
+/turf/open/floor/monotile,
+/area/maintenance/starboard/secondary{
+	name = "Munitions Projects"
+	})
+"keO" = (
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
 "keR" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -46225,7 +45648,9 @@
 /area/nsv/weapons/fore)
 "khE" = (
 /obj/structure/punching_bag,
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -46333,34 +45758,10 @@
 "koN" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 6;
-	icon_state = "pipe11-2"
+	dir = 6
 	},
 /turf/open/space/basic,
 /area/engine/atmos)
-"kpX" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer3{
-	dir = 1
-	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	id = "agcnr_hellburn";
-	name = "Hellburn Shutters"
-	},
-/turf/open/floor/monotile,
-/area/engine/engineering/reactor_core)
 "kqI" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -46411,6 +45812,13 @@
 /obj/machinery/light/small,
 /turf/open/floor/engine/vacuum,
 /area/engine/engineering/reactor_core)
+"kuw" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/landmark/nuclear_waste_spawner,
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
 "kuF" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -46444,7 +45852,7 @@
 	dir = 4
 	},
 /obj/machinery/advanced_airlock_controller{
-	pixel_y = -26
+	pixel_y = 24
 	},
 /turf/open/floor/plasteel/ship,
 /area/engine/engineering/reactor_core)
@@ -46465,6 +45873,28 @@
 	},
 /turf/open/floor/monotile,
 /area/engine/engineering/reactor_core)
+"kze" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
+"kzF" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
+	name = "Mess Hall"
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/cafeteria{
+	name = "Mess hall"
+	})
 "kAJ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/computer/turbine_computer{
@@ -46475,7 +45905,9 @@
 /area/engine/engineering/reactor_core)
 "kBg" = (
 /obj/structure/closet/wardrobe/science_white,
-/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -46625,8 +46057,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 4;
-	icon_state = "pipe11-1"
+	dir = 4
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/ship/preopen{
@@ -46752,8 +46183,7 @@
 /area/nsv/crew_quarters/heads/maa)
 "liF" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 4;
-	icon_state = "pipe11-1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/monotile,
@@ -46828,6 +46258,10 @@
 /obj/machinery/status_display/ai,
 /turf/closed/wall/ship,
 /area/engine/break_room)
+"luJ" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
 "luW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/layer3,
 /turf/open/floor/plating,
@@ -46903,6 +46337,15 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/closed/wall/r_wall/ship,
 /area/science/xenobiology)
+"lEm" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/visible,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "agcnr_hellburn";
+	name = "Hellburn Shutters"
+	},
+/turf/open/floor/monotile,
+/area/engine/engineering/reactor_core)
 "lEy" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -46921,6 +46364,25 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/atmos)
+"lJZ" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	name = "Briefing room maintenance";
+	req_one_access_txt = "19"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
 "lKI" = (
 /obj/structure/bookcase{
 	name = "Forbidden Knowledge"
@@ -46997,6 +46459,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"lQU" = (
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
 "lRd" = (
 /obj/structure/sink{
 	dir = 8;
@@ -47009,6 +46475,18 @@
 /obj/effect/spawner/room/fivexfour,
 /turf/template_noop,
 /area/maintenance/department/science)
+"lUM" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/ship/engineering/glass{
+	req_one_access_txt = "10;24"
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/engineering)
 "lVx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -47131,6 +46609,17 @@
 /obj/structure/lattice/catwalk/over/ship,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
+"mjx" = (
+/obj/structure/disposalpipe/trunk/multiz{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/closed/wall/ship,
+/area/medical/medbay/lobby)
+"mlM" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
 "mlW" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
@@ -47145,6 +46634,19 @@
 	},
 /turf/open/floor/monotile,
 /area/engine/engineering/reactor_core)
+"moE" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
+	},
+/obj/machinery/conveyor{
+	id = "packageExternal"
+	},
+/turf/open/floor/plating,
+/area/quartermaster/storage)
 "mpS" = (
 /obj/effect/turf_decal/pool/corner,
 /obj/effect/turf_decal/stripes/line{
@@ -47171,18 +46673,6 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"msk" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	id = "agcnr_hellburn";
-	name = "Hellburn Shutters"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/monotile,
-/area/engine/engineering/reactor_core)
 "mte" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -47193,6 +46683,34 @@
 /obj/structure/closet/l3closet/scientist,
 /turf/open/floor/monotile/dark,
 /area/science)
+"mvj" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/southright{
+	name = "Science Desk";
+	req_one_access_txt = "7;29"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "Biohazard";
+	name = "biohazard containment door"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/item/folder/white{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/item/pen,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "sci_shared_desk";
+	name = "desk shutters"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile,
+/area/science/research)
 "mwO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -47257,6 +46775,12 @@
 	},
 /turf/open/floor/plasteel/grid/steel,
 /area/engine/engineering/reactor_core)
+"mGt" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
 "mGu" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 1;
@@ -47265,6 +46789,20 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/engine/atmos)
+"mGT" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer1,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer3,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "agcnr_hellburn";
+	name = "Hellburn Shutters"
+	},
+/turf/open/floor/monotile,
+/area/engine/engineering/reactor_core)
 "mHC" = (
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -47317,6 +46855,21 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
+"mOC" = (
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/eastleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Deliveries";
+	req_access_txt = "50"
+	},
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "packageExternal"
+	},
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
 "mON" = (
 /obj/machinery/pool_filter,
 /obj/item/fuel_rod,
@@ -47466,7 +47019,7 @@
 	dir = 4
 	},
 /obj/machinery/advanced_airlock_controller{
-	pixel_y = 26
+	pixel_y = 24
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
@@ -47559,6 +47112,10 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
+"nsk" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
 "ntS" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/ship,
@@ -47587,6 +47144,15 @@
 	},
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
+"nwR" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/weapons)
 "nCw" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -47599,6 +47165,21 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
+"nDD" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/advanced_airlock_controller{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/quartermaster/miningdock)
 "nEa" = (
 /turf/open/floor/carpet/red,
 /area/nsv/weapons/fore)
@@ -47633,6 +47214,13 @@
 /obj/machinery/ship_weapon/torpedo_launcher/west,
 /turf/open/floor/plating,
 /area/nsv/weapons/fore)
+"nIX" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
 "nJo" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -47648,6 +47236,18 @@
 /obj/structure/bookcase/random/adult,
 /turf/open/floor/wood,
 /area/library)
+"nKT" = (
+/obj/machinery/door/airlock/ship/external/glass{
+	req_one_access_txt = "13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
 "nLp" = (
 /obj/machinery/light{
 	dir = 8
@@ -47767,16 +47367,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"nVy" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/advanced_airlock_controller{
-	pixel_x = -26;
-	pixel_y = 2
-	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/monotile/dark,
-/area/hallway/secondary/exit)
 "nYT" = (
 /obj/machinery/door/morgue{
 	name = "Private Study";
@@ -47790,6 +47380,13 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"obU" = (
+/obj/structure/sign/ship/securearea{
+	dir = 4;
+	icon_state = "securearea"
+	},
+/turf/closed/wall/r_wall/ship,
+/area/nsv/weapons/fore)
 "obX" = (
 /obj/machinery/light,
 /turf/open/indestructible/sound/pool/spentfuel{
@@ -48035,7 +47632,9 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
 	},
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -48099,6 +47698,33 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/engine/break_room)
+"oPR" = (
+/obj/structure/grille,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/weapons)
+"oQy" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer3{
+	dir = 1
+	},
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "agcnr_hellburn";
+	name = "Hellburn Shutters"
+	},
+/turf/open/floor/monotile,
+/area/engine/engineering/reactor_core)
 "oSC" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -48175,11 +47801,30 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/advanced_airlock_controller{
-	pixel_x = -26;
-	pixel_y = 2
+	pixel_y = 24
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
+"pdT" = (
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Cryogenics";
+	req_one_access_txt = "5"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/turf/open/floor/monotile/dark,
+/area/medical/medbay/lobby)
 "peN" = (
 /obj/machinery/atmospherics/components/trinary/nuclear_reactor/preset{
 	dir = 1
@@ -48224,6 +47869,33 @@
 	},
 /turf/open/floor/plasteel/grid/lino,
 /area/engine/engine_room)
+"pkP" = (
+/obj/machinery/airalarm{
+	pixel_y = 26
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
+"pla" = (
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
+	name = "Damage control closet"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
+"plm" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
 "pmq" = (
 /obj/structure/closet/radiation,
 /obj/item/geiger_counter,
@@ -48293,8 +47965,7 @@
 /area/medical/virology)
 "psH" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 4;
-	icon_state = "pipe11-1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -48308,6 +47979,17 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms)
+"pxx" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/advanced_airlock_controller/directional/east{
+	pixel_y = 24
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "pxy" = (
 /obj/machinery/newscaster,
 /turf/closed/wall/ship,
@@ -48442,21 +48124,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
-"pPw" = (
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "pRQ" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -48474,6 +48141,14 @@
 /obj/machinery/newscaster,
 /turf/closed/wall/ship,
 /area/medical/genetics)
+"pTD" = (
+/obj/machinery/door/airlock/ship/security/glass{
+	dir = 4;
+	name = "Security Equipment";
+	req_one_access_txt = "2"
+	},
+/turf/open/floor/monotile/dark,
+/area/security/brig)
 "pVi" = (
 /obj/machinery/airalarm{
 	pixel_y = 26
@@ -48494,6 +48169,12 @@
 	},
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
+"pXO" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
 "pZr" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
@@ -48585,8 +48266,7 @@
 "qqk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8;
-	icon_state = "manifold-3"
+	dir = 8
 	},
 /turf/open/floor/monotile,
 /area/engine/atmos)
@@ -48646,13 +48326,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
-"qBc" = (
-/obj/structure/sign/ship/securearea{
-	dir = 4;
-	icon_state = "securearea"
-	},
-/turf/closed/wall/r_wall/ship,
-/area/maintenance/port)
 "qBT" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 1
@@ -48717,6 +48390,16 @@
 /obj/machinery/status_display/ai,
 /turf/closed/wall/ship,
 /area/security/brig)
+"qIe" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/turf/closed/wall/ship,
+/area/medical/medbay/lobby)
+"qIN" = (
+/obj/machinery/atmospherics/pipe/simple/multiz,
+/turf/open/floor/plating,
+/area/maintenance/nsv/weapons)
 "qJv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -48745,8 +48428,7 @@
 	dir = 4
 	},
 /obj/machinery/advanced_airlock_controller{
-	pixel_x = 26;
-	pixel_y = 2
+	pixel_y = 24
 	},
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -48767,6 +48449,19 @@
 	},
 /turf/open/floor/plasteel/grid/lino,
 /area/engine/engine_room)
+"qMf" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
 "qNS" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -48806,21 +48501,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/dark,
 /area/engine/break_room)
-"qOI" = (
-/obj/machinery/door/airlock/ship/external/glass{
-	req_one_access_txt = "13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "qOP" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -48913,6 +48593,12 @@
 	},
 /turf/closed/wall/r_wall/ship,
 /area/engine/engineering/reactor_core)
+"rdp" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
 "rel" = (
 /obj/structure/punching_bag,
 /obj/machinery/computer/ship/viewscreen,
@@ -49114,6 +48800,16 @@
 /area/bridge{
 	name = "CIC"
 	})
+"ryW" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/ship/shutoff,
+/obj/machinery/power/deck_relay,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/nsv/weapons)
 "rzw" = (
 /obj/item/fuel_rod,
 /turf/open/indestructible/sound/pool/spentfuel,
@@ -49149,31 +48845,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"rBo" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/advanced_airlock_controller{
-	pixel_x = 26;
-	pixel_y = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1,
-/turf/open/floor/plating,
-/area/hallway/secondary/exit)
-"rCB" = (
-/obj/machinery/light/small,
-/obj/machinery/advanced_airlock_controller{
-	pixel_y = 26
-	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "rCH" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -49200,6 +48871,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/engine,
 /area/engine/engine_room)
+"rEt" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/monotile,
+/area/maintenance/starboard/secondary{
+	name = "Munitions Projects"
+	})
 "rFe" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/border_only{
@@ -49211,6 +48890,20 @@
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile,
 /area/crew_quarters/bar)
+"rGX" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/engineering/glass{
+	dir = 4;
+	name = "Engineering Storage";
+	req_one_access_txt = "11;24"
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/engineering)
 "rHg" = (
 /obj/machinery/gateway,
 /obj/structure/cable{
@@ -49309,6 +49002,15 @@
 	id = "spentfuel2"
 	},
 /area/engine/engineering/reactor_core)
+"rSa" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
 "rST" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -49362,10 +49064,28 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"saO" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
 "sbl" = (
 /obj/structure/bookcase/random/reference,
 /turf/open/floor/wood,
 /area/library)
+"scS" = (
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Intensive Care Access"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/monotile,
+/area/medical/medbay/zone2{
+	name = "Intensive care unit"
+	})
 "sdw" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
@@ -49462,6 +49182,19 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
+"snt" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	dir = 4;
+	name = "Deck 1 access maintenance"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/monotile,
+/area/maintenance/central)
 "snV" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -49558,7 +49291,9 @@
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
 "sxM" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -49622,16 +49357,6 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/monotile/dark,
 /area/security/prison)
-"sKP" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	id = "agcnr_hellburn";
-	name = "Hellburn Shutters"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/monotile,
-/area/engine/engineering/reactor_core)
 "sMC" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -49705,15 +49430,10 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
-"teQ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/spawner/lootdrop/maintenance/two,
-/turf/open/floor/plating,
-/area/maintenance/port)
 "tfj" = (
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/library)
@@ -49727,6 +49447,17 @@
 	},
 /turf/open/floor/monotile,
 /area/hallway/secondary/exit)
+"tfG" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer1,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer3,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "agcnr_hellburn";
+	name = "Hellburn Shutters"
+	},
+/turf/open/floor/monotile,
+/area/engine/engineering/reactor_core)
 "tfI" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -49788,6 +49519,20 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/break_room)
+"tnq" = (
+/obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
+	name = "Aft Primary Hallway"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck2/frame1/port)
 "tow" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -49812,14 +49557,43 @@
 	},
 /turf/open/floor/monotile,
 /area/engine/engineering/reactor_core)
+"tqp" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/chemical{
+	pixel_x = -3
+	},
+/obj/machinery/requests_console{
+	department = "Chemistry";
+	departmentType = 2;
+	pixel_x = -30;
+	receive_ore_updates = 1
+	},
+/obj/item/storage/bag/chemistry,
+/turf/open/floor/monotile,
+/area/medical/chemistry)
 "trQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5;
-	icon_state = "pipe11-2"
+	dir = 5
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/engine/atmos)
+"tsM" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Medbay Lobby Access"
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/light,
+/area/medical/medbay/lobby)
 "tup" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/barricade/wooden,
@@ -49849,6 +49623,16 @@
 	},
 /turf/closed/wall/ship,
 /area/nsv/weapons/gauss)
+"twB" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/turf/open/floor/monotile,
+/area/maintenance/starboard/secondary{
+	name = "Munitions Projects"
+	})
 "txH" = (
 /obj/machinery/holopad,
 /turf/open/floor/carpet/blue,
@@ -49895,6 +49679,23 @@
 /obj/machinery/deck_turret/powder_gate,
 /turf/open/floor/plating,
 /area/nsv/weapons/fore)
+"tCu" = (
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/nsv/hangar)
+"tCW" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship{
+	dir = 4;
+	name = "Hangar Bay";
+	req_access_txt = "69"
+	},
+/turf/open/floor/monotile,
+/area/nsv/hanger/deck2)
 "tDf" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -49946,6 +49747,21 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/fitness/recreation)
+"tMg" = (
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
 "tNz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -49985,14 +49801,40 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
+"tRF" = (
+/obj/structure/barricade/wooden/crude,
+/obj/machinery/door/airlock/ship/engineering{
+	dir = 4;
+	name = "Abandoned Reactor Control Chamber";
+	req_one_access_txt = "10;24"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/monotile,
+/area/engine/engine_room)
+"tRQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Medbay Lobby Access"
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/light,
+/area/medical/medbay/lobby)
 "tSL" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
-	dir = 9;
-	icon_state = "pipe11-3"
+	dir = 9
 	},
 /turf/open/floor/plating/airless,
 /area/engine/atmos)
@@ -50015,8 +49857,7 @@
 "tWf" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/layer_manifold/visible{
-	dir = 4;
-	icon_state = "manifoldlayer"
+	dir = 4
 	},
 /turf/open/space/basic,
 /area/engine/atmos)
@@ -50058,6 +49899,10 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
+"uct" = (
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/closed/wall/ship,
+/area/medical/medbay/lobby)
 "udH" = (
 /obj/machinery/gateway/centerstation,
 /turf/open/floor/monotile/dark,
@@ -50076,6 +49921,44 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
+"udN" = (
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Medbay Central";
+	req_one_access_txt = "5"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/mapping_helpers/airlock/unres,
+/turf/open/floor/monotile/dark,
+/area/medical/medbay/lobby)
+"udX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/engineering/glass{
+	dir = 4;
+	name = "Engineering Equipment";
+	req_one_access_txt = "11;24"
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/storage_shared)
 "uee" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -50105,17 +49988,37 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"uir" = (
+/obj/machinery/computer/shuttle/mining{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/quartermaster/miningdock)
 "uiz" = (
 /obj/machinery/newscaster{
 	pixel_y = -32
 	},
 /turf/open/floor/carpet,
 /area/library)
+"uln" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
 "ulr" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/space/basic,
 /area/space/nearstation)
+"uoW" = (
+/turf/closed/wall/ship,
+/area/maintenance/nsv/weapons)
 "uqx" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -50196,8 +50099,23 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
+"uGJ" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Master at Arms";
+	departmentType = 5;
+	name = "Master at Arms RC";
+	pixel_x = -32
+	},
+/turf/open/floor/carpet/ship,
+/area/nsv/crew_quarters/heads/maa)
 "uIA" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -50207,10 +50125,17 @@
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/monotile/dark,
 /area/engine/atmospherics_engine)
+"uJx" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer1,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "uKU" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/visible{
-	dir = 4;
-	icon_state = "manifoldlayer"
+	dir = 4
 	},
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/door/poddoor/shutters/ship/preopen{
@@ -50226,18 +50151,18 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/science/nanite)
-"uNi" = (
-/obj/machinery/light/small{
-	dir = 8
+"uOk" = (
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Medbay Lobby Access"
 	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1,
-/obj/machinery/advanced_airlock_controller{
-	pixel_x = 26;
-	pixel_y = 2
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plating,
-/area/maintenance/department/science)
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile,
+/area/medical/medbay/lobby)
 "uOY" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -50259,12 +50184,28 @@
 /area/engine/engineering)
 "uUs" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 4;
-	icon_state = "pipe11-1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/monotile,
 /area/engine/engineering/reactor_core)
+"uUz" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Medical Central";
+	req_one_access_txt = "5"
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/turf/open/floor/monotile/dark,
+/area/medical/medbay/central)
 "uVV" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/violet/visible,
@@ -50305,8 +50246,7 @@
 /area/hallway/secondary/exit)
 "vaj" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 4;
-	icon_state = "pipe11-1"
+	dir = 4
 	},
 /turf/open/floor/monotile,
 /area/engine/engineering/reactor_core)
@@ -50423,6 +50363,22 @@
 	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
+"vlk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
+	name = "Flight Deck Access"
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/weapons)
 "vly" = (
 /obj/machinery/computer/ship/munitions_computer/east,
 /obj/effect/turf_decal/ship/delivery/yellow,
@@ -50454,11 +50410,28 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9;
-	icon_state = "pipe11-1"
+	dir = 9
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"vpE" = (
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/maintenance{
+	dir = 4;
+	name = "Munitions Control";
+	req_one_access_txt = "69"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
 "vsn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -50527,7 +50500,7 @@
 /area/hallway/nsv/deck2/frame1/central)
 "vxy" = (
 /obj/machinery/advanced_airlock_controller{
-	pixel_y = -26
+	pixel_y = 24
 	},
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
@@ -50555,45 +50528,11 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /turf/open/space/basic,
 /area/engine/atmos)
-"vCU" = (
-/obj/structure/barricade/wooden/crude,
-/obj/machinery/door/airlock/ship/engineering{
-	name = "Abandoned Reactor Control Chamber";
-	req_one_access_txt = "10;24"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/monotile,
-/area/engine/engine_room)
 "vFe" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/engine/atmos)
-"vHd" = (
-/obj/effect/landmark/zebra_interlock_point,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/airlock/ship/maintenance{
-	dir = 4;
-	name = "Munitions Control";
-	req_one_access_txt = "69"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/nsv/hanger/storage{
-	name = "Munitions Control Room"
-	})
 "vHB" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -50710,6 +50649,9 @@
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/space/nearstation)
+"vUD" = (
+/turf/open/floor/plating,
+/area/quartermaster/miningdock)
 "vVm" = (
 /obj/item/beacon,
 /turf/open/floor/mineral/plastitanium/red/airless,
@@ -50736,6 +50678,20 @@
 	},
 /turf/open/floor/plasteel/grid/steel,
 /area/engine/engineering/reactor_core)
+"vXM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/monotile,
+/area/maintenance/starboard/secondary{
+	name = "Munitions Projects"
+	})
 "vYs" = (
 /obj/machinery/camera/autoname,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
@@ -50754,8 +50710,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 4;
-	icon_state = "pipe11-1"
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -50809,6 +50764,13 @@
 	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
+"wiW" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/plating,
+/area/maintenance/nsv/weapons)
 "wjv" = (
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 4
@@ -51048,6 +51010,23 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit)
+"wHH" = (
+/obj/machinery/door/airlock/ship/public/glass{
+	dir = 4;
+	name = "Aft Primary Hallway"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck2/frame1/port)
 "wId" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
@@ -51089,6 +51068,29 @@
 	},
 /turf/open/floor/monotile,
 /area/engine/engineering/reactor_core)
+"wQk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/engineering/glass{
+	dir = 4;
+	name = "Engineering Storage";
+	req_one_access_txt = "11;24"
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/engineering)
 "wQJ" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -51130,22 +51132,44 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/shuttle/turbolift/shaft)
+"wWN" = (
+/obj/item/cigbutt,
+/obj/item/clothing/head/cone,
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/plating,
+/area/maintenance/nsv/weapons)
 "wXi" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"wZc" = (
-/obj/structure/cable{
-	icon_state = "2-4"
+"wYf" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/structure/closet/wardrobe/chemistry_white,
+/turf/open/floor/monotile,
+/area/medical/chemistry)
+"wYv" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/central)
 "wZp" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/nsv/observation)
+"xbj" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
 "xdR" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -51211,25 +51235,10 @@
 "xlf" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8;
-	icon_state = "manifold-2"
+	dir = 8
 	},
 /turf/open/floor/monotile,
 /area/engine/engineering/reactor_core)
-"xlE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/door/airlock/ship{
-	dir = 4;
-	name = "Hangar Bay";
-	req_access_txt = "69"
-	},
-/turf/open/floor/monotile,
-/area/maintenance/port)
 "xmt" = (
 /obj/machinery/newscaster{
 	pixel_x = -28
@@ -51279,8 +51288,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/layer_manifold/visible{
-	dir = 4;
-	icon_state = "manifoldlayer"
+	dir = 4
 	},
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -51314,6 +51322,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/monotile,
 /area/engine/engine_room)
+"xsc" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
 "xsw" = (
 /obj/machinery/vending/wardrobe/viro_wardrobe,
 /turf/open/floor/monotile/light,
@@ -51335,6 +51349,9 @@
 /obj/machinery/atmospherics/pipe/manifold/green/visible,
 /turf/open/floor/monotile,
 /area/engine/engineering/reactor_core)
+"xuS" = (
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/nsv/weapons)
 "xxg" = (
 /obj/structure/sign/barsign,
 /turf/closed/wall/ship,
@@ -51345,6 +51362,20 @@
 /obj/effect/spawner/lootdrop/gloves,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"xAS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/monotile,
+/area/maintenance/starboard/secondary{
+	name = "Munitions Projects"
+	})
 "xDn" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -51473,6 +51504,20 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/engine/plasma,
 /area/engine/atmos)
+"xSZ" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
+"xTj" = (
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
 "xWe" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -51491,6 +51536,41 @@
 	},
 /turf/open/floor/plating,
 /area/nsv/weapons/fore)
+"xWy" = (
+/obj/machinery/door/airlock/ship/external/glass{
+	req_one_access_txt = "13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
+"xWZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/security/glass{
+	dir = 4;
+	name = "Security Equipment";
+	req_one_access_txt = "2"
+	},
+/turf/open/floor/monotile,
+/area/security/brig)
 "xXX" = (
 /obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/space/basic,
@@ -51565,8 +51645,7 @@
 /area/engine/atmos)
 "yet" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 4;
-	icon_state = "pipe11-1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -51601,16 +51680,13 @@
 /obj/machinery/meter,
 /turf/open/space/basic,
 /area/engine/engineering/reactor_core)
-"ylf" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	id = "agcnr_hellburn";
-	name = "Hellburn Shutters"
+"yiR" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
 	},
-/turf/open/floor/monotile,
-/area/engine/engineering/reactor_core)
+/turf/open/floor/plating,
+/area/maintenance/nsv/hangar)
 
 (1,1,1) = {"
 aaa
@@ -61766,12 +61842,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-amw
-aaa
-aaa
-amw
+aaJ
+aaJ
+fPU
+aaJ
+aaJ
+fPU
 aaa
 aaa
 aaa
@@ -62023,12 +62099,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaJ
+aaJ
+aaJ
+aaJ
+aaJ
+aaJ
 aaa
 aaa
 aaa
@@ -62280,12 +62356,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaJ
+aaJ
+aaJ
+aaJ
+aaJ
+aaJ
 aaa
 apq
 apq
@@ -62786,9 +62862,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-amw
+aaJ
+aaJ
+fPU
 aaa
 aXR
 aXR
@@ -63043,9 +63119,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+aaJ
+aaJ
+aaJ
 aXR
 aXR
 aHW
@@ -63300,9 +63376,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+aaJ
+aaJ
+aaJ
 wBI
 aXS
 aHW
@@ -63552,7 +63628,7 @@ aaa
 aaa
 aaa
 aaa
-aaJ
+aaa
 bdq
 bdq
 bdq
@@ -63647,17 +63723,17 @@ aaa
 aaa
 aaa
 aaa
-aIX
-aIX
-aIX
-aIX
-aIX
-aIX
-aIX
-aIX
-aIX
-aIX
-aIX
+aGX
+aGX
+aGX
+aGX
+aGX
+aGX
+aGX
+aGX
+aGX
+aGX
+aGX
 aaa
 aaa
 aaa
@@ -63809,10 +63885,10 @@ aaa
 aaa
 aaa
 aaa
-aFJ
-aFJ
-aFJ
-ajt
+aaJ
+aaJ
+aaJ
+anb
 aFM
 aGM
 bdq
@@ -63904,7 +63980,7 @@ aaa
 aaa
 aaa
 aaa
-aIX
+aGX
 aGW
 aHD
 aGW
@@ -63914,7 +63990,7 @@ aIF
 aGW
 aHD
 aGW
-aIX
+aGX
 aaa
 aaa
 aaa
@@ -64066,10 +64142,10 @@ aaa
 aaa
 aaa
 aaa
-aFJ
-aFJ
-aFJ
-aGy
+aaJ
+aaJ
+aaJ
+aoV
 aFN
 aGP
 aGU
@@ -64161,7 +64237,7 @@ aaa
 aaa
 aaa
 aaa
-aIX
+aGX
 aGW
 aJM
 aGW
@@ -64171,7 +64247,7 @@ aIG
 aGW
 aJM
 aGW
-aIX
+aGX
 aaa
 aaa
 aaa
@@ -64323,10 +64399,10 @@ aaa
 aaa
 aaa
 aaa
-aFJ
-aFJ
-aFJ
-ajt
+aaJ
+aaJ
+aaJ
+anb
 aGx
 aGR
 bdq
@@ -64414,11 +64490,11 @@ aaa
 aaa
 aaa
 aaa
-aIX
-aIX
-aIX
-aIX
-aIX
+aGX
+aGX
+aGX
+aGX
+aGX
 aGW
 aGY
 aGW
@@ -64428,11 +64504,11 @@ aIG
 aGW
 aGY
 aGW
-aIX
-aIX
-aIX
-aIX
-aIX
+aGX
+aGX
+aGX
+aGX
+aGX
 aaa
 aaa
 aaa
@@ -64612,20 +64688,17 @@ apq
 aaa
 aaa
 aaa
+aaJ
+aaJ
+fPU
 aaa
+aaJ
+aaJ
+fPU
 aaa
-amw
-aaa
-aaa
-aaa
-amw
-aaa
-aaa
-aaa
-amw
-aaa
-aaa
-aaa
+aaJ
+aaJ
+fPU
 aaa
 aaa
 aaa
@@ -64671,7 +64744,10 @@ aaa
 aaa
 aaa
 aaa
-aIX
+aaa
+aaa
+aaa
+aGX
 aGW
 aGW
 aGW
@@ -64689,7 +64765,7 @@ aGW
 aGW
 aGW
 aGW
-aIX
+aGX
 aaa
 aaa
 aaa
@@ -64869,17 +64945,17 @@ apq
 aaa
 aaa
 aaa
+aaJ
+aaJ
+aaJ
 aaa
+aaJ
+aaJ
+aaJ
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaJ
+aaJ
+aaJ
 aaa
 ufF
 ufF
@@ -64928,7 +65004,7 @@ aaa
 aaa
 aaa
 aaa
-aIX
+aGX
 aGW
 aGY
 aJb
@@ -64946,7 +65022,7 @@ aGY
 aJt
 aGY
 aGW
-aIX
+aGX
 aaa
 aaa
 aaa
@@ -65126,17 +65202,17 @@ apq
 aaa
 aaa
 aaa
+aaJ
+aaJ
+aaJ
 aaa
+aaJ
+aaJ
+aaJ
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaJ
+aaJ
+aaJ
 aaa
 ufF
 fxX
@@ -65185,7 +65261,7 @@ aaa
 aaa
 aaa
 aaa
-aIX
+aGX
 aGW
 aGY
 aHG
@@ -65203,7 +65279,7 @@ aHG
 aHG
 aGY
 aGW
-aIX
+aGX
 aaa
 aaa
 aaa
@@ -65442,7 +65518,7 @@ aaa
 aaa
 aaa
 aaa
-aIX
+aGX
 aGW
 aGY
 aHG
@@ -65460,7 +65536,7 @@ aHG
 aHG
 aGY
 aGW
-aIX
+aGX
 aaa
 aaa
 aaa
@@ -65699,7 +65775,7 @@ aaa
 aaa
 aaa
 aaa
-aIX
+aGX
 aGW
 aGY
 aGY
@@ -65717,7 +65793,7 @@ aGY
 aGY
 aGY
 aGW
-aIX
+aGX
 aaa
 aaa
 aaa
@@ -65956,7 +66032,7 @@ aaa
 aaa
 aaa
 aaa
-aIX
+aGX
 aGW
 aGW
 aGW
@@ -65974,7 +66050,7 @@ aGW
 aGW
 aGW
 aGW
-aIX
+aGX
 aaa
 aaa
 aaa
@@ -66213,7 +66289,7 @@ aaa
 aaa
 aaa
 aaa
-aIX
+aGX
 aGW
 aHB
 aHB
@@ -66231,7 +66307,7 @@ aHB
 aHB
 aHB
 aGW
-aIX
+aGX
 aaa
 aaa
 aaa
@@ -66470,7 +66546,7 @@ aaa
 aaa
 aaa
 aaa
-aIX
+aGX
 aIS
 aGY
 aGY
@@ -66488,7 +66564,7 @@ aGY
 aGY
 aGY
 aGW
-aIX
+aGX
 aaa
 aaa
 aaa
@@ -66727,7 +66803,7 @@ aaa
 aaa
 aaa
 aaa
-aIX
+aGX
 aGW
 aHB
 aHB
@@ -66745,7 +66821,7 @@ aHB
 aHB
 aHB
 aGW
-aIX
+aGX
 aaa
 aaa
 aaa
@@ -66984,7 +67060,7 @@ aaa
 aaa
 aaa
 aaa
-aIX
+aGX
 aIW
 aGY
 aGY
@@ -67002,7 +67078,7 @@ aGY
 aGY
 aGY
 aGW
-aIX
+aGX
 aaa
 aaa
 aaa
@@ -67241,7 +67317,7 @@ aaa
 aaa
 aaa
 aaa
-aIX
+aGX
 aGW
 aHB
 aHB
@@ -67259,7 +67335,7 @@ aHB
 aHB
 aHB
 aGW
-aIX
+aGX
 aaa
 aaa
 aaa
@@ -67498,7 +67574,7 @@ aaa
 aaa
 aaa
 aaa
-aIX
+aGX
 aGW
 aGY
 aGY
@@ -67516,7 +67592,7 @@ aGY
 aGY
 aGY
 aGW
-aIX
+aGX
 aaa
 aaa
 aaa
@@ -67755,7 +67831,7 @@ aaa
 aaa
 aaa
 aaa
-aIX
+aGX
 aGW
 aHB
 aHB
@@ -67773,7 +67849,7 @@ aHB
 aHB
 aHB
 aGW
-aIX
+aGX
 aaa
 aaa
 aaa
@@ -68012,7 +68088,7 @@ aaa
 aaa
 aaa
 aaa
-aIX
+aGX
 aGW
 aGW
 aGW
@@ -68030,7 +68106,7 @@ aGW
 aGW
 aGW
 aGW
-aIX
+aGX
 aaa
 aaa
 aaa
@@ -68269,7 +68345,7 @@ aaa
 aaa
 aaa
 aaa
-aIX
+aGX
 aGX
 aGX
 aGX
@@ -68287,7 +68363,7 @@ aGW
 aGX
 aGX
 aGX
-aIX
+aGX
 aaa
 aaa
 aaa
@@ -68527,7 +68603,7 @@ aaa
 aaa
 aaa
 aaa
-aIX
+aGX
 aGW
 aGW
 aJi
@@ -68543,7 +68619,7 @@ aGY
 aGW
 aGW
 aGW
-aIX
+aGX
 aaa
 aaa
 aaa
@@ -68800,7 +68876,7 @@ aGY
 aIV
 aGX
 aHC
-aIX
+aGX
 aaa
 aaa
 aaa
@@ -69041,7 +69117,7 @@ aaa
 aaa
 aaa
 aaa
-aIX
+aGX
 aGW
 aGW
 aJi
@@ -69057,7 +69133,7 @@ aGY
 aGW
 aGW
 aGW
-aIX
+aGX
 aaa
 aaa
 aaa
@@ -69263,7 +69339,7 @@ bJO
 bJO
 bJO
 bJQ
-bMq
+enE
 aaa
 aaa
 aaa
@@ -69298,7 +69374,7 @@ aaa
 aaa
 aaa
 aaa
-aIX
+aGX
 aGX
 aGX
 aGW
@@ -69314,7 +69390,7 @@ aGY
 aGW
 aGX
 aGX
-aIX
+aGX
 aaa
 aaa
 aaa
@@ -69555,7 +69631,7 @@ aaa
 aaa
 aaa
 aaa
-aIX
+aGX
 aGW
 aGW
 aGW
@@ -69571,7 +69647,7 @@ aGW
 aGW
 aGW
 aGW
-aIX
+aGX
 aaa
 aaa
 aaa
@@ -69812,7 +69888,7 @@ aaa
 aaa
 aaa
 aaa
-aIX
+aGX
 aGW
 aGY
 aGY
@@ -69828,7 +69904,7 @@ aGY
 aGY
 aGY
 aGW
-aIX
+aGX
 aaa
 aaa
 aaa
@@ -70069,7 +70145,7 @@ aaa
 aaa
 aaa
 aaa
-aIX
+aGX
 aGW
 aGY
 aJb
@@ -70085,7 +70161,7 @@ aGY
 aJt
 aGY
 aGW
-aIX
+aGX
 aaa
 aaa
 aaa
@@ -70326,7 +70402,7 @@ aaa
 aaa
 aaa
 aaa
-aIX
+aGX
 aHD
 aGY
 aJM
@@ -70342,7 +70418,7 @@ aJP
 aJM
 aGY
 aHD
-aIX
+aGX
 aaa
 aaa
 aaa
@@ -70583,7 +70659,7 @@ aaa
 aaa
 aaa
 aaa
-aIX
+aGX
 aHD
 aGY
 aJM
@@ -70599,7 +70675,7 @@ aJP
 aJM
 aGY
 aHD
-aIX
+aGX
 aaa
 aaa
 aaa
@@ -70840,7 +70916,7 @@ aaa
 aaa
 aaa
 aaa
-aIX
+aGX
 aGW
 aGY
 aJM
@@ -70856,7 +70932,7 @@ aJP
 aJM
 aGY
 aGW
-aIX
+aGX
 aaa
 aaa
 aaa
@@ -71097,7 +71173,7 @@ aaa
 aaa
 aaa
 aaa
-aIX
+aGX
 aGW
 aGY
 aGY
@@ -71113,7 +71189,7 @@ aGY
 aGY
 aGY
 aGW
-aIX
+aGX
 aaa
 aaa
 aaa
@@ -71354,7 +71430,7 @@ aaa
 aaa
 aaa
 aaa
-aIX
+aGX
 aGW
 aGW
 aGW
@@ -71370,7 +71446,7 @@ aGW
 aGW
 aGW
 aGW
-aIX
+aGX
 aaa
 aaa
 aaa
@@ -71611,7 +71687,7 @@ aaa
 aaa
 aaa
 aaa
-aIX
+aGX
 aGW
 aGY
 aGY
@@ -71627,7 +71703,7 @@ aGY
 aGY
 aGY
 aGW
-aIX
+aGX
 aaa
 aaa
 aaa
@@ -71868,7 +71944,7 @@ aaa
 aaa
 aaa
 aaa
-aIX
+aGX
 aHD
 aGY
 aJM
@@ -71884,7 +71960,7 @@ aGY
 aJM
 aGY
 aHD
-aIX
+aGX
 aaa
 aaa
 aaa
@@ -72049,7 +72125,7 @@ aHv
 aHX
 aFP
 bdr
-aFP
+pTD
 bCU
 bKL
 bHQ
@@ -72125,7 +72201,7 @@ aaa
 aaa
 aaa
 aaa
-aIX
+aGX
 aHD
 aGY
 aJP
@@ -72141,7 +72217,7 @@ aGY
 aJP
 aGY
 aHD
-aIX
+aGX
 aaa
 aaa
 aaa
@@ -72382,7 +72458,7 @@ aaa
 aaa
 aaa
 aaa
-aIX
+aGX
 aHD
 aGY
 aGY
@@ -72398,7 +72474,7 @@ aGY
 aGY
 aGY
 aHD
-aIX
+aGX
 aaa
 aaa
 aaa
@@ -72563,8 +72639,8 @@ acX
 aaV
 aEZ
 aEZ
-aXx
-bCW
+hWb
+xWZ
 aEZ
 aEZ
 aaV
@@ -72639,7 +72715,7 @@ aaa
 aaa
 aaa
 aaa
-aIX
+aGX
 aGW
 aHD
 aHD
@@ -72655,7 +72731,7 @@ aHD
 aHD
 aHD
 aGW
-aIX
+aGX
 aaa
 aaa
 aaa
@@ -72792,9 +72868,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-amw
+aaJ
+aaJ
+fPU
 aaa
 apq
 aac
@@ -72896,23 +72972,23 @@ aaa
 aaa
 aaa
 aaa
-aIX
-aIX
-aIX
-aIX
-aIX
-aIX
+aGX
+aGX
+aGX
+aGX
+aGX
+aGX
 aGW
 aIR
 aGW
 aIR
 aGW
-aIX
-aIX
-aIX
-aIX
-aIX
-aIX
+aGX
+aGX
+aGX
+aGX
+aGX
+aGX
 aaa
 aaa
 aaa
@@ -73049,9 +73125,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+aaJ
+aaJ
+aaJ
 aaa
 apq
 aac
@@ -73158,13 +73234,13 @@ aaa
 aaa
 aaa
 aaa
-aIX
+aGX
 aHD
 aGY
 aJn
 aGY
 aHD
-aIX
+aGX
 aaa
 aaa
 aaa
@@ -73306,9 +73382,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+aaJ
+aaJ
+aaJ
 aaa
 apq
 apq
@@ -73415,13 +73491,13 @@ aaa
 aaa
 aaa
 aaa
-aIX
+aGX
 aHD
 aJm
 aJm
 aJm
 aHD
-aIX
+aGX
 aaa
 aaa
 aaa
@@ -73672,13 +73748,13 @@ aaa
 aaa
 aaa
 aaa
-aIX
+aGX
 aGW
 aHD
 aHD
 aHD
 aGW
-aIX
+aGX
 aaa
 aaa
 aaa
@@ -73815,7 +73891,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aaJ
 aaJ
 aaJ
 anb
@@ -73865,7 +73941,7 @@ aKp
 bzR
 bwC
 aKB
-bwD
+mvj
 aKw
 bwF
 bwH
@@ -73929,13 +74005,13 @@ aaa
 aaa
 aaa
 aaa
-aIX
-aIX
-aIX
-aIX
-aIX
-aIX
-aIX
+aGX
+aGX
+aGX
+aGX
+aGX
+aGX
+aGX
 aaa
 aaa
 aaa
@@ -74057,22 +74133,22 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-amw
-aaa
-aaa
-amw
-aaa
-aaa
-amw
-aaa
-aaa
-amw
-aaa
-aaa
-amw
-aaa
+aaJ
+aaJ
+fPU
+aaJ
+aaJ
+fPU
+aaJ
+aaJ
+fPU
+aaJ
+aaJ
+fPU
+aaJ
+aaJ
+fPU
+aaJ
 aaJ
 aaJ
 aoV
@@ -74122,7 +74198,7 @@ bgi
 bwG
 aWu
 aWv
-amZ
+eZJ
 aKy
 xhY
 bfd
@@ -74314,22 +74390,22 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaJ
+aaJ
+aaJ
+aaJ
+aaJ
+aaJ
+aaJ
+aaJ
+aaJ
+aaJ
+aaJ
+aaJ
+aaJ
+aaJ
+aaJ
+aaJ
 aaJ
 aaJ
 anb
@@ -74369,14 +74445,14 @@ aZa
 aZa
 aZa
 afw
-aKt
+wHH
 bBJ
-bnk
+tnq
 abL
 abL
 abL
 abL
-aLr
+jHU
 abL
 aah
 aah
@@ -74571,21 +74647,21 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaJ
+aaJ
+aaJ
+aaJ
+aaJ
+aaJ
+aaJ
+aaJ
+aaJ
+aaJ
+aaJ
+aaJ
+aaJ
+aaJ
+aaJ
 aaa
 bKQ
 bKQ
@@ -75147,7 +75223,7 @@ abL
 abL
 abL
 abL
-aSg
+cUM
 abL
 aah
 aah
@@ -75357,9 +75433,9 @@ fCB
 fCB
 bjX
 aUO
-aaJ
+aaa
 apq
-aaJ
+aaa
 apq
 aZa
 akL
@@ -75406,7 +75482,7 @@ aft
 bjK
 bow
 bGS
-agH
+tqp
 agI
 aeb
 bHZ
@@ -75614,9 +75690,9 @@ abY
 abY
 abY
 abY
-aaJ
+aaa
 apq
-aaJ
+aaa
 apq
 aZa
 akL
@@ -75682,7 +75758,7 @@ acs
 kuF
 chs
 gqO
-uNi
+pxx
 hwV
 arT
 aaa
@@ -75873,7 +75949,7 @@ bjY
 aUO
 apq
 apq
-aaJ
+aaa
 apq
 aZa
 baD
@@ -75921,7 +75997,7 @@ bnX
 bol
 box
 afv
-agJ
+wYf
 aeb
 aTG
 bfb
@@ -76128,7 +76204,7 @@ aow
 ahh
 aoU
 aUO
-aaJ
+aaa
 apq
 apq
 aZa
@@ -76180,7 +76256,7 @@ box
 afv
 agL
 aeb
-aTE
+hNp
 aTH
 aTH
 aTH
@@ -76385,9 +76461,9 @@ abY
 abY
 abY
 abY
-aaJ
+aaa
 apq
-aaJ
+aaa
 aZa
 qZd
 akL
@@ -76409,10 +76485,10 @@ ahO
 aYZ
 aZM
 bfg
-bvW
+udN
 beb
 bvX
-bvY
+pdT
 akU
 amc
 aMs
@@ -76642,9 +76718,9 @@ aox
 bGL
 aUJ
 abY
-aaJ
+aaa
 apq
-aaJ
+aaa
 aZa
 qbw
 akL
@@ -77176,7 +77252,7 @@ bbc
 bCl
 baQ
 baQ
-baR
+uUz
 aZg
 aZT
 bhg
@@ -77433,7 +77509,7 @@ aPE
 bCm
 bvA
 bvA
-aPG
+dqx
 aZi
 aZX
 ahc
@@ -77975,7 +78051,7 @@ afn
 qOb
 agQ
 afP
-boy
+hiP
 aaB
 afU
 aWe
@@ -78737,7 +78813,7 @@ bvm
 amd
 aMR
 ahf
-aTT
+tsM
 bws
 bCz
 bmQ
@@ -78955,10 +79031,10 @@ abY
 abY
 abY
 abY
-bGQ
-bGQ
-bGQ
-bGQ
+aaa
+aaa
+aaa
+aaa
 bHp
 brm
 bnm
@@ -78994,7 +79070,7 @@ bvn
 ame
 aTM
 ahf
-aTT
+tsM
 acx
 bDn
 bmR
@@ -79462,13 +79538,13 @@ afa
 afa
 afa
 aal
-aal
-aal
-bGR
-bGR
-bGR
-aal
-aal
+xuS
+xuS
+dNn
+dNn
+dNn
+xuS
+xuS
 bsW
 bsX
 bBE
@@ -79719,13 +79795,13 @@ adF
 adF
 adF
 adF
-aal
-aSF
-aSF
-aSF
-bKk
-aSF
-aal
+xuS
+ddW
+ddW
+ddW
+dlA
+hYm
+xuS
 bsW
 bBm
 bCf
@@ -79765,7 +79841,7 @@ bvp
 bwn
 bwo
 bvl
-bwp
+tRQ
 bwq
 bEa
 xMG
@@ -79976,13 +80052,13 @@ adF
 aal
 aal
 aal
-aal
-aSF
-bIp
-bKc
-bKl
-bKq
-bKy
+xuS
+ddW
+jHw
+wiW
+qIN
+iLE
+giV
 bsW
 bsW
 bLG
@@ -80003,10 +80079,10 @@ aUp
 bHD
 aUr
 bvs
-bvt
+scS
 bvu
 bvZ
-bvv
+eWa
 bBj
 alq
 bHB
@@ -80016,13 +80092,13 @@ amg
 apT
 amg
 amg
-bjv
+gCz
 bvk
 bwm
 bBi
 aTN
 ahf
-aTT
+tsM
 acx
 bDp
 bmQ
@@ -80233,18 +80309,18 @@ aal
 aal
 aAs
 aYR
-aal
-aal
-bIq
-aSF
-bKn
-bKr
-bKz
+xuS
+xuS
+eHi
+ddW
+ryW
+nwR
+vlk
 ceq
 ceq
-bBl
-bKA
-bne
+vXM
+rEt
+bsV
 brm
 sSl
 bne
@@ -80263,7 +80339,7 @@ aUq
 ahr
 aTX
 aTX
-ajM
+juI
 bbW
 aLj
 bHC
@@ -80273,7 +80349,7 @@ bgG
 azf
 azf
 azf
-bkT
+uOk
 iDJ
 uWe
 lVV
@@ -80490,18 +80566,18 @@ aOM
 auQ
 aAu
 aYS
-aal
-brB
-bJL
-bKd
-bKl
-bKs
-bNd
+xuS
+gzY
+oPR
+wWN
+qIN
+iSP
+gOn
 ahD
 ahD
-akc
-bKD
-bne
+dFO
+keI
+bsV
 aAt
 bne
 bne
@@ -80530,13 +80606,13 @@ aae
 aae
 aae
 aae
-aae
-bhV
-blm
-bmH
-bFA
-bFD
-aae
+afV
+gqw
+uct
+cAJ
+mjx
+qIe
+afV
 aPg
 bEd
 btC
@@ -80747,17 +80823,17 @@ aux
 azE
 aux
 aYX
-aal
-bsV
-bJV
-bsV
-bsV
-bKt
-bsV
+xuS
+uoW
+jcy
+uoW
+uoW
+kcr
+uoW
 ces
 cev
-bKB
-ajN
+cKq
+xAS
 anu
 aqU
 akb
@@ -80793,7 +80869,7 @@ asv
 bsm
 bFB
 bFE
-aae
+aad
 aeT
 bEe
 bmU
@@ -81013,16 +81089,16 @@ bKw
 cbY
 cet
 bBa
-aYT
-bKC
-bne
+twB
+gGP
+bsV
 baB
 asK
 cer
 krf
 cer
 cer
-cer
+fJZ
 cer
 krf
 cer
@@ -81270,27 +81346,27 @@ akw
 bBn
 akw
 aal
-xlE
-bsT
-bHp
-bHp
-bHp
-bHp
-bHp
-bHp
-bHp
-bHp
-qBc
-bHp
-bHp
-bHp
-bHp
-bHp
+iIr
+tCW
+aam
+aam
+aam
+agm
+agm
+agm
+agm
+agm
+obU
+agm
+agm
+agm
+agm
+agm
 bBu
 bBu
 bBu
 bBu
-vHd
+vpE
 bBu
 ahz
 bbr
@@ -81299,14 +81375,14 @@ aad
 aad
 aad
 aad
-aSL
+lJZ
 aad
 aad
 aad
 aad
-byI
+snt
 aad
-bKO
+wYv
 aad
 bIw
 bEe
@@ -81780,7 +81856,7 @@ ahD
 bKa
 lhC
 aan
-baj
+uGJ
 aaO
 agV
 ain
@@ -82627,7 +82703,7 @@ aNs
 tfI
 aNZ
 aOd
-nVy
+aOf
 esn
 aaa
 aaa
@@ -83055,13 +83131,13 @@ aaa
 aaa
 aaa
 aaa
-bHp
-bHp
-bHp
-bHp
-bHp
-bHp
-beU
+tCu
+tCu
+tCu
+tCu
+tCu
+tCu
+cWE
 fbx
 bip
 bip
@@ -83312,13 +83388,13 @@ aaa
 aaa
 aaa
 aaa
-bHp
-jtt
-bnm
-jtt
-bne
-sSl
-aZO
+tCu
+mlM
+keO
+mlM
+cOK
+kdX
+xsc
 fbx
 bip
 bip
@@ -83569,13 +83645,13 @@ aaa
 aaa
 aaa
 aaa
-bHp
-bhm
-bnm
-bnm
-bIo
-bnm
-aZO
+tCu
+eVR
+keO
+keO
+pla
+keO
+xsc
 fbx
 bip
 bip
@@ -83826,13 +83902,13 @@ aaa
 aaa
 aaa
 aaa
-bHp
-bIm
-bnm
-bnm
-bne
-bnm
-aZO
+tCu
+luJ
+keO
+keO
+cOK
+keO
+xsc
 fbx
 bip
 bip
@@ -83885,7 +83961,7 @@ aad
 bLs
 ohf
 abU
-rBo
+aOG
 adA
 aaa
 aaa
@@ -84083,13 +84159,13 @@ aaa
 aaa
 aaa
 aaa
-bHp
-bIl
-bnm
-gXS
-bne
-bvo
-aZO
+tCu
+gZK
+keO
+saO
+cOK
+kuw
+xsc
 fbx
 bip
 bip
@@ -84340,13 +84416,13 @@ aaa
 aaa
 aaa
 aaa
-bHp
-bIl
-bnm
-fMP
-bne
-bnm
-aZO
+tCu
+gZK
+keO
+nsk
+cOK
+keO
+xsc
 fbx
 bip
 bip
@@ -84597,13 +84673,13 @@ aaa
 aaa
 aaa
 aaa
-bHp
-bIn
-bnm
-fMP
-bne
-bFV
-aZO
+tCu
+iDH
+keO
+nsk
+cOK
+pkP
+xsc
 fbx
 qcm
 bip
@@ -84683,7 +84759,7 @@ bsc
 tfI
 aNZ
 aOd
-nVy
+aOf
 esn
 aaa
 aaa
@@ -84854,13 +84930,13 @@ aaa
 aaa
 aaa
 aaa
-bHp
-bIl
-bnm
-fMP
-bne
-aQp
-aZO
+tCu
+gZK
+keO
+nsk
+cOK
+lQU
+xsc
 fbx
 bip
 bip
@@ -85111,13 +85187,13 @@ aaa
 aaa
 aaa
 aaa
-bHp
-bIl
-bnm
-bnm
-bne
-bnm
-aZO
+tCu
+gZK
+keO
+keO
+cOK
+keO
+xsc
 fbx
 bip
 bip
@@ -85368,13 +85444,13 @@ aaa
 aaa
 aaa
 aaa
-bHp
-bIm
-bnm
-bnm
-bne
-bnm
-aZO
+tCu
+luJ
+keO
+keO
+cOK
+keO
+xsc
 fbx
 bip
 bip
@@ -85625,13 +85701,13 @@ aaa
 aaa
 aaa
 aaa
-bHp
-bhm
-bnm
-bnm
-bIo
-bnm
-aZO
+tCu
+eVR
+keO
+keO
+pla
+keO
+xsc
 fbx
 bip
 bip
@@ -85882,13 +85958,13 @@ aaa
 aaa
 aaa
 aaa
-bHp
-gXS
-gXS
-jtt
-bne
-bhm
-aZO
+tCu
+saO
+saO
+mlM
+cOK
+eVR
+xsc
 fbx
 bip
 bip
@@ -86139,13 +86215,13 @@ aaa
 aaa
 aaa
 aaa
-bHp
-bHp
-bHp
-bHp
-bHp
-bPM
-aZO
+tCu
+tCu
+tCu
+tCu
+tCu
+hdo
+xsc
 fbx
 bip
 bip
@@ -86400,9 +86476,9 @@ aaa
 aaa
 aaa
 aaa
-bHp
-bIm
-aZO
+tCu
+luJ
+xsc
 fbx
 fbx
 fbx
@@ -86657,11 +86733,11 @@ aaa
 aaa
 aaa
 aaa
-bHp
-bHp
-bDH
-bQx
-bHp
+tCu
+tCu
+kze
+dCz
+aam
 aas
 bgQ
 aaz
@@ -86915,10 +86991,10 @@ aaa
 aaa
 aaa
 arT
-bHp
-bnm
-aZO
-bHp
+tCu
+keO
+xsc
+aam
 fjX
 aat
 aat
@@ -87172,10 +87248,10 @@ aaa
 aaa
 aaa
 arT
-bHp
-bnm
-aZO
-bHp
+tCu
+keO
+xsc
+aam
 aaE
 aav
 bBC
@@ -87429,10 +87505,10 @@ aaa
 aaa
 aaa
 arT
-bHp
-bnm
-aZO
-bHp
+tCu
+keO
+xsc
+aam
 bBo
 aaz
 aaz
@@ -87686,10 +87762,10 @@ aaa
 aaa
 aaa
 arT
-bHp
-bhm
-aZO
-bHp
+tCu
+eVR
+xsc
+aam
 aam
 aam
 aam
@@ -87943,10 +88019,10 @@ aaa
 aaa
 aaa
 arT
-bHp
-bnm
-aZO
-bHp
+tCu
+keO
+xsc
+aam
 lOu
 pED
 jqz
@@ -88200,10 +88276,10 @@ aaa
 aaa
 aaa
 arT
-bHp
-bnm
-teQ
-bHp
+tCu
+keO
+gPJ
+aam
 aby
 aaF
 aaF
@@ -88455,12 +88531,12 @@ aaa
 aaa
 aaa
 aaa
-bHp
-aFL
-bHp
-bqy
-aZU
-bHp
+tCu
+nKT
+tCu
+xTj
+xbj
+aam
 abD
 aaF
 bBD
@@ -88525,8 +88601,8 @@ lzn
 bIC
 aaa
 bID
-bDL
-aOC
+nDD
+vUD
 bID
 aaa
 aaa
@@ -88712,12 +88788,12 @@ aaa
 aaa
 aaa
 aaa
-bHp
-rCB
-bHp
-cuG
-aZO
-bHp
+tCu
+ife
+tCu
+pXO
+xsc
+aam
 bIy
 aaG
 aaG
@@ -88782,8 +88858,8 @@ bqT
 bIC
 aaa
 bID
-bjB
-bDM
+uir
+ddh
 bID
 aaa
 aaa
@@ -88968,13 +89044,13 @@ aaa
 aaa
 aaa
 aaa
-bHp
-bHp
-qOI
-bHp
-bne
-aZP
-bHp
+tCu
+tCu
+xWy
+tCu
+cOK
+gtM
+aam
 aam
 aam
 aam
@@ -89022,7 +89098,7 @@ aRQ
 bEj
 bhv
 aci
-aXj
+mOC
 bxC
 bsw
 aes
@@ -89222,21 +89298,21 @@ aaa
 aaa
 aaa
 aaa
-bHp
-bHp
-bHp
-bHp
-anP
-acz
-fSB
-jtt
-aZO
-bne
-bqO
-bks
-bnm
-bqO
-bne
+tCu
+tCu
+tCu
+tCu
+yiR
+rSa
+nIX
+mlM
+xsc
+cOK
+xSZ
+rdp
+keO
+xSZ
+cOK
 acg
 acg
 vwu
@@ -89278,7 +89354,7 @@ bhw
 bmF
 bIu
 bmZ
-adv
+moE
 aXk
 bnT
 bxB
@@ -89479,21 +89555,21 @@ aaa
 aaa
 aaa
 aaa
-bHp
-wZc
-cer
-cer
-cer
-aeH
-aDG
-aDG
-aZQ
-aZR
-aDG
-aDG
-aDG
-aDG
-edc
+tCu
+mGt
+gSH
+gSH
+gSH
+cAo
+uln
+uln
+plm
+bOr
+uln
+uln
+uln
+uln
+qMf
 aak
 aak
 aaT
@@ -89736,21 +89812,21 @@ aaa
 aaa
 aaa
 ksH
-ksH
-pPw
-ksH
-ksH
-anN
-anN
-anN
-bne
-bne
-bne
-bne
-bne
-bne
-bne
-bne
+tCu
+tMg
+tCu
+tCu
+cOK
+cOK
+cOK
+cOK
+cOK
+cOK
+cOK
+cOK
+cOK
+cOK
+cOK
 aay
 acn
 wfy
@@ -90033,8 +90109,8 @@ abZ
 abZ
 abZ
 bde
-aVl
-bbI
+jnx
+kzF
 bde
 sJI
 abZ
@@ -90336,7 +90412,7 @@ aim
 anb
 aaJ
 aaJ
-aaa
+aaJ
 aaa
 aaa
 aaa
@@ -90593,7 +90669,7 @@ byx
 bLR
 aaJ
 aaJ
-aaa
+aaJ
 aaa
 aaa
 aaa
@@ -90850,7 +90926,7 @@ bCd
 anb
 aaJ
 aaJ
-aaa
+aaJ
 aaa
 aaa
 aaa
@@ -95646,7 +95722,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aaJ
 aaJ
 aaJ
 anb
@@ -95903,7 +95979,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aaJ
 aaJ
 aaJ
 aoV
@@ -96160,7 +96236,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aaJ
 aaJ
 aaJ
 anb
@@ -96984,7 +97060,7 @@ apv
 qqT
 erj
 atZ
-aww
+uJx
 pqF
 rhe
 apz
@@ -97470,8 +97546,8 @@ aQx
 aQB
 aey
 aey
-azh
-aAF
+wQk
+rGX
 aey
 aey
 asu
@@ -97982,12 +98058,12 @@ aph
 ayW
 azo
 iRB
-aAW
+dXo
 aIB
 azp
 aNV
 btj
-btk
+lUM
 btl
 btm
 btm
@@ -98239,12 +98315,12 @@ aQP
 aRb
 aTU
 aTU
-aOw
+hxF
 aXb
 aXp
 aOl
 aNu
-aOw
+hxF
 aOX
 aPq
 aPq
@@ -98755,8 +98831,8 @@ bym
 amC
 amC
 gHK
-aAM
-aTR
+udX
+fBC
 amC
 amu
 amu
@@ -101047,7 +101123,7 @@ aPW
 vIX
 anJ
 hJc
-vCU
+tRF
 anJ
 aJu
 bkm
@@ -102330,7 +102406,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aaJ
 aaJ
 aaJ
 anb
@@ -102587,7 +102663,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aaJ
 aaJ
 aaJ
 aoV
@@ -102844,7 +102920,7 @@ aaa
 bAe
 aaa
 aaa
-aaa
+aaJ
 aaJ
 aaJ
 anb
@@ -105687,11 +105763,11 @@ arT
 azk
 eVQ
 jKR
-kpX
+elG
 fpo
 wat
 kGv
-ijO
+mGT
 iLi
 eVQ
 azk
@@ -106201,11 +106277,11 @@ vRI
 azk
 hwT
 gHJ
-eix
+hLX
 nus
 liF
 wCL
-ylf
+hLX
 vNE
 hwT
 azk
@@ -106458,11 +106534,11 @@ vRI
 avJ
 eVQ
 eCn
-hMm
+lEm
 qrD
 iSm
 hcC
-eFX
+lEm
 jtu
 eVQ
 cBD
@@ -106715,11 +106791,11 @@ vRI
 azk
 dKL
 kmX
-msk
+hRO
 kvh
 psH
 csF
-sKP
+hRO
 wwd
 urB
 azk
@@ -107229,11 +107305,11 @@ vRI
 azk
 eVQ
 qnR
-fQN
+oQy
 dAh
 cED
 rNN
-dIi
+tfG
 pOG
 eVQ
 azk
@@ -107741,8 +107817,8 @@ apq
 szX
 vRI
 nRp
-aaJ
-aaJ
+aaa
+aaa
 atK
 ygv
 qKe
@@ -107998,8 +108074,8 @@ apq
 lmX
 nRp
 nRp
-aaJ
-aaJ
+aaa
+aaa
 atK
 bzL
 fCZ
@@ -108255,8 +108331,8 @@ apq
 nSs
 vRI
 nRp
-aaJ
-aaJ
+aaa
+aaa
 atK
 bzL
 ygv

--- a/_maps/map_files/Tycoon/Tycoon2.dmm
+++ b/_maps/map_files/Tycoon/Tycoon2.dmm
@@ -3567,21 +3567,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"aiI" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "aiJ" = (
 /obj/machinery/camera/autoname,
 /obj/structure/disposalpipe/segment,
@@ -3589,12 +3574,6 @@
 /area/crew_quarters/dorms)
 "aiK" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"aiL" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aiM" = (
@@ -5188,12 +5167,6 @@
 "ams" = (
 /turf/closed/wall/ship,
 /area/crew_quarters/dorms/nsv/dorms_1)
-"amt" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/closed/wall/r_wall/ship,
-/area/maintenance/starboard/fore)
 "amu" = (
 /turf/closed/wall/r_wall/ship,
 /area/tcommsat/computer)
@@ -5503,9 +5476,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/monotile,
 /area/engine/engineering/hangar)
-"ano" = (
-/turf/closed/wall/r_wall/ship,
-/area/space/nearstation)
 "anp" = (
 /turf/closed/wall/r_wall/ship,
 /area/crew_quarters/heads/chief)
@@ -6238,14 +6208,6 @@
 	},
 /turf/open/floor/monotile,
 /area/engine/atmos)
-"apc" = (
-/obj/machinery/atmospherics/components/trinary/mixer/layer3{
-	dir = 1;
-	name = "Shutdown Moderator Mixer"
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/atmos)
 "apd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/tile/yellow,
@@ -6400,33 +6362,6 @@
 /obj/effect/spawner/lootdrop/techstorage/rnd,
 /turf/open/floor/plating,
 /area/engine/storage)
-"apz" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/engine/atmos)
-"apA" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/engine/atmos)
-"apB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 5
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/atmos)
-"apC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	name = "Waste To Pure";
-	target_pressure = 4500
-	},
-/turf/open/space/basic,
-/area/engine/atmos)
 "apD" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -6459,15 +6394,6 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/engine/atmos)
-"apH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
 /area/engine/atmos)
 "apJ" = (
 /obj/structure/lattice/catwalk,
@@ -6502,13 +6428,6 @@
 	dir = 1
 	},
 /turf/open/floor/monotile/dark,
-/area/engine/atmos)
-"apO" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/space/basic,
 /area/engine/atmos)
 "apP" = (
 /obj/machinery/computer/ship/viewscreen,
@@ -6555,13 +6474,6 @@
 "apV" = (
 /turf/closed/wall/r_wall/ship,
 /area/engine/atmospherics_engine)
-"apW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/atmos)
 "apX" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
@@ -6599,15 +6511,6 @@
 	},
 /turf/open/floor/monotile,
 /area/engine/engineering)
-"aqc" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8;
-	name = "Air To Distro";
-	target_pressure = 4500
-	},
-/turf/open/space/basic,
-/area/engine/atmos)
 "aqd" = (
 /obj/machinery/computer/apc_control{
 	dir = 4
@@ -6627,13 +6530,6 @@
 "aqe" = (
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/chief)
-"aqf" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/atmos)
 "aqg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/structure/lattice/catwalk,
@@ -6704,12 +6600,6 @@
 "aqq" = (
 /turf/open/floor/monotile/light,
 /area/crew_quarters/kitchen)
-"aqr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall/ship,
-/area/engine/storage)
 "aqt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
@@ -7292,23 +7182,6 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/monotile,
 /area/crew_quarters/dorms)
-"arC" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/monotile/dark,
-/area/engine/engineering)
 "arE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -7346,36 +7219,6 @@
 /obj/effect/spawner/lootdrop/techstorage/security,
 /turf/open/floor/plating,
 /area/engine/storage)
-"arP" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 6
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/atmos)
-"arQ" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/engine/atmos)
-"arR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/layer_manifold/visible{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/atmos)
-"arS" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 4
-	},
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/engine/atmos)
 "arT" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -7388,14 +7231,6 @@
 "arW" = (
 /turf/closed/wall/ship,
 /area/engine/break_room)
-"arX" = (
-/obj/machinery/meter,
-/obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
 "arY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/mix_output{
 	dir = 8
@@ -7427,13 +7262,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"ase" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/machinery/shower,
-/turf/open/floor/plasteel/ship,
-/area/engine/engineering)
 "asf" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/box,
@@ -7579,16 +7407,6 @@
 	},
 /turf/open/floor/carpet/green,
 /area/engine/engineering/reactor_control)
-"asD" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/atmos)
-"asE" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/atmos)
 "asG" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
 /turf/open/floor/plating,
@@ -7632,13 +7450,6 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/engine/atmos)
-"asU" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
-	dir = 8
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
 /area/engine/atmos)
 "asV" = (
 /obj/structure/cable{
@@ -7775,16 +7586,6 @@
 /mob/living/simple_animal/pet/cat/Runtime,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo)
-"atk" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	icon_state = "pump_map-2";
-	name = "Mix Tank Input"
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/atmos)
 "atl" = (
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/monotile,
@@ -8013,21 +7814,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
-"aua" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/atmos)
-"aub" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/atmos)
-"auc" = (
-/obj/machinery/portable_atmospherics/canister/water_vapor,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/atmos)
 "aug" = (
 /obj/structure/closet/masks,
 /turf/open/floor/monotile,
@@ -8125,23 +7911,6 @@
 /area/maintenance/starboard/secondary{
 	name = "Munitions Projects"
 	})
-"auu" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	icon_state = "pump_map-2";
-	name = "N2O to Mix"
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/atmos)
-"auw" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/engine/atmos)
 "aux" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/monotile,
@@ -8511,13 +8280,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/lawoffice)
-"avo" = (
-/obj/machinery/atmospherics/components/binary/valve/digital{
-	dir = 8;
-	name = "Incinerator valve"
-	},
-/turf/closed/wall/r_wall/ship,
-/area/maintenance/starboard/fore)
 "avp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -8604,14 +8366,6 @@
 /obj/structure/sign/ship/shock,
 /turf/closed/wall/r_wall/ship,
 /area/engine/engineering/reactor_core)
-"avK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/atmos)
 "avL" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light/runway/delay4,
@@ -8699,43 +8453,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/engine_smes)
-"awk" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/atmos)
-"awm" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	dir = 1
-	},
-/turf/open/space/basic,
-/area/engine/atmos)
-"awq" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/atmos)
-"awr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/atmos)
-"awt" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/engine/atmos)
 "awu" = (
 /turf/open/indestructible/sound/pool/spentfuel/wall,
 /area/engine/engineering/reactor_core)
@@ -8751,38 +8468,11 @@
 	},
 /turf/open/floor/monotile/light,
 /area/medical/virology)
-"awC" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/structure/lattice/catwalk,
-/obj/machinery/meter,
-/turf/open/space/basic,
-/area/engine/atmos)
 "awD" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 6
 	},
-/turf/open/space/basic,
-/area/engine/atmos)
-"awE" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/manifold/purple/visible{
-	dir = 4
-	},
-/obj/machinery/meter,
-/turf/open/space/basic,
-/area/engine/atmos)
-"awG" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	icon_state = "pump_map-2";
-	name = "Plasma to Mix"
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 6
-	},
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/engine/atmos)
 "awI" = (
@@ -8801,24 +8491,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/engine_room)
-"awN" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/trinary/mixer/on{
-	dir = 1;
-	name = "Reactor Fuel Flavouriser";
-	node1_concentration = 0.8;
-	node2_concentration = 0.2;
-	target_pressure = 4500
-	},
-/turf/open/space/basic,
-/area/engine/atmos)
-"awP" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1,
-/obj/machinery/atmospherics/pipe/simple/violet/visible/layer3,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/atmos)
 "awQ" = (
 /obj/machinery/air_sensor/atmos/toxin_tank,
 /turf/open/floor/engine/plasma,
@@ -8843,12 +8515,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"awX" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
-/obj/machinery/meter,
-/turf/open/space/basic,
-/area/engine/atmos)
 "axa" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxin_input{
 	dir = 8
@@ -8867,35 +8533,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck2)
-"axe" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/atmos)
-"axg" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/violet/visible/layer3{
-	dir = 8
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/atmos)
-"axh" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/violet/visible/layer3{
-	dir = 9
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/atmos)
 "axi" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -8906,40 +8543,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile,
 /area/crew_quarters/dorms)
-"axn" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/visible,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/atmos)
-"axo" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 5
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/atmos)
-"axp" = (
-/obj/machinery/atmospherics/pipe/manifold/purple/visible{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk,
-/obj/machinery/meter,
-/turf/open/space/basic,
-/area/engine/atmos)
-"axr" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	icon_state = "pump_map-2";
-	name = "CO2 to Mix"
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1,
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/violet/visible/layer3{
-	dir = 6
-	},
-/turf/open/space/basic,
-/area/engine/atmos)
 "axs" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/carbon_output{
 	dir = 8
@@ -8952,13 +8555,6 @@
 "axA" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
-/turf/open/space/basic,
-/area/engine/atmos)
-"axB" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
-	dir = 10
-	},
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/engine/atmos)
 "axD" = (
@@ -8995,23 +8591,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/monotile/dark,
-/area/engine/atmos)
-"axQ" = (
-/obj/machinery/atmospherics/components/binary/pump/layer3{
-	dir = 1;
-	name = "Nitrogen to Shutdown Mixer"
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/atmos)
-"axR" = (
-/obj/machinery/atmospherics/components/binary/pump/layer1{
-	dir = 1;
-	icon_state = "pump_map-1";
-	name = "Plasma to Constrictors"
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
 /area/engine/atmos)
 "axU" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/carbon_input{
@@ -9060,103 +8639,6 @@
 "axY" = (
 /turf/open/floor/monotile,
 /area/engine/atmos)
-"ayb" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 8
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/atmos)
-"ayc" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/violet/visible/layer3{
-	dir = 5
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/atmos)
-"ayd" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
-	dir = 1
-	},
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/binary/pump/layer3{
-	dir = 1;
-	name = "Oxygen To Fuel Mixer"
-	},
-/turf/open/space/basic,
-/area/engine/atmos)
-"aye" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/violet/visible/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/atmos)
-"ayf" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/violet/visible/layer3{
-	dir = 8
-	},
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 5
-	},
-/turf/open/space/basic,
-/area/engine/atmos)
-"ayl" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	icon_state = "pump_map-2";
-	name = "Nitrogen to Mix"
-	},
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
-	dir = 6
-	},
-/turf/open/space/basic,
-/area/engine/atmos)
-"aym" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 6
-	},
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/engine/atmos)
-"ayn" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/engine/atmos)
-"ayo" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	icon_state = "pump_map-2";
-	name = "Oxygen to Mix"
-	},
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3,
-/turf/open/space/basic,
-/area/engine/atmos)
 "ayp" = (
 /obj/structure/rack,
 /obj/item/airlock_painter,
@@ -9176,73 +8658,12 @@
 	},
 /turf/open/floor/plating,
 /area/engine/storage)
-"ayr" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/engine/atmos)
 "ayv" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/closed/wall/r_wall/ship,
 /area/engine/gravity_generator)
-"ayz" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8
-	},
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3,
-/turf/open/space/basic,
-/area/engine/atmos)
-"ayA" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 9
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/atmos)
-"ayB" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/visible{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/atmos)
-"ayC" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped/inverse{
-	dir = 8;
-	icon_state = "mixer_on_f"
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/atmos)
-"ayD" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 8
-	},
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3,
-/turf/open/space/basic,
-/area/engine/atmos)
-"ayE" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 8
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/atmos)
 "ayF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -9367,10 +8788,6 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/engine/engine_smes)
-"ayP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/engine/storage)
 "ayQ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -9540,16 +8957,6 @@
 /obj/effect/spawner/lootdrop/techstorage/tcomms,
 /turf/open/floor/plating,
 /area/engine/storage)
-"azn" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/monotile/dark,
-/area/engine/storage_shared)
 "azo" = (
 /obj/machinery/light{
 	dir = 8
@@ -9588,13 +8995,6 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/monotile/dark,
-/area/engine/atmos)
-"azu" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 6
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
 /area/engine/atmos)
 "azx" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
@@ -9668,32 +9068,12 @@
 	},
 /turf/open/space/basic,
 /area/engine/atmos)
-"azH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold/visible,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/atmos)
 "azI" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2{
 	dir = 4;
 	icon_state = "filter_on_f"
 	},
 /obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/atmos)
-"azK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/camera/autoname{
-	c_tag = "Atmos - South #1";
-	dir = 1
-	},
 /turf/open/space/basic,
 /area/engine/atmos)
 "azL" = (
@@ -9723,13 +9103,6 @@
 /obj/structure/closet/radiation,
 /turf/open/floor/monotile/dark,
 /area/engine/atmospherics_engine)
-"azQ" = (
-/obj/structure/closet/cardboard,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "azR" = (
 /obj/machinery/power/smes{
 	capacity = 9e+006;
@@ -10562,16 +9935,6 @@
 /obj/effect/spawner/structure/window/reinforced/ship,
 /turf/open/floor/plating,
 /area/engine/atmos)
-"aBQ" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/engine/atmos)
-"aBR" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/effect/spawner/structure/window/reinforced/ship,
-/turf/open/floor/plating,
-/area/engine/atmos)
 "aBS" = (
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_control)
@@ -11283,17 +10646,6 @@
 /obj/machinery/suit_storage_unit/security,
 /turf/open/floor/monotile,
 /area/ai_monitored/security/armory)
-"aDP" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/power/apc/auto_name/north{
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/monotile/dark,
-/area/engine/engineering)
 "aDQ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -16923,15 +16275,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /turf/open/floor/plasteel/ship,
 /area/engine/break_room)
-"aPL" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/electrical{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/engine/storage)
 "aPM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -17017,27 +16360,9 @@
 	},
 /turf/closed/wall/r_wall/ship,
 /area/engine/storage)
-"aQh" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/turf/closed/wall/r_wall/ship,
-/area/engine/storage)
 "aQi" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
-	},
-/turf/closed/wall/r_wall/ship,
-/area/engine/storage)
-"aQj" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/closed/wall/r_wall/ship,
-/area/engine/storage)
-"aQk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
 	},
 /turf/closed/wall/r_wall/ship,
 /area/engine/storage)
@@ -26855,20 +26180,6 @@
 /area/bridge{
 	name = "CIC"
 	})
-"bkp" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/holopad,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/monotile,
-/area/engine/engineering)
 "bkq" = (
 /obj/structure/closet/emcloset,
 /obj/item/storage/toolbox/emergency,
@@ -28581,16 +27892,6 @@
 /obj/structure/filingcabinet/filingcabinet,
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
-"bnU" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "bnW" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -29266,26 +28567,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/security/prison)
-"bpo" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"bpp" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "bpq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -31255,10 +30536,6 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plating,
-/area/engine/storage)
-"bsZ" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/engine/storage)
 "bta" = (
@@ -37682,14 +36959,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/security/prison)
-"bEV" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
-/turf/open/space,
-/area/engine/atmos)
 "bEW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -37955,12 +37224,6 @@
 /obj/effect/spawner/structure/window/reinforced/ship,
 /turf/open/floor/plating,
 /area/security/prison)
-"bFv" = (
-/obj/machinery/meter,
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
-/turf/open/space,
-/area/engine/atmos)
 "bFw" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
@@ -39358,14 +38621,6 @@
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame2/port)
-"bIA" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/atmos)
 "bIB" = (
 /obj/structure/tank_dispenser,
 /obj/effect/turf_decal/stripes/line{
@@ -41071,12 +40326,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/nsv/hangar)
-"bOT" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1,
-/turf/open/space/basic,
-/area/engine/atmos)
 "bPF" = (
 /obj/machinery/deck_turret/payload_gate,
 /obj/effect/turf_decal/loading_area{
@@ -41092,16 +40341,6 @@
 /obj/item/beacon,
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"bTs" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 10
-	},
-/turf/open/space/basic,
-/area/engine/atmos)
 "bTR" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -41119,6 +40358,12 @@
 /area/bridge{
 	name = "CIC"
 	})
+"bUM" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "bUY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
@@ -42228,6 +41473,23 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"ciA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/meter/atmos/distro_loop,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
+"ciB" = (
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "ciL" = (
 /obj/machinery/light{
 	dir = 4
@@ -42277,6 +41539,28 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
+"clm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"cmj" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/atmospherics/pipe/simple/orange/visible/layer1{
+	dir = 4
+	},
+/obj/machinery/computer/atmos_control/tank/nitrous_tank{
+	dir = 8
+	},
+/obj/structure/window/reinforced/spawner/east,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "cms" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -42313,14 +41597,30 @@
 /obj/item/wrench,
 /turf/open/floor/plasteel/grid/steel,
 /area/engine/engineering/reactor_core)
-"cof" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
+"cob" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/camera/autoname{
-	c_tag = "Atmos - West #2";
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 4
 	},
 /turf/open/space/basic,
+/area/engine/atmos)
+"coz" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/computer/atmos_control/tank/toxin_tank{
+	dir = 8
+	},
+/obj/structure/window/reinforced/spawner/east,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
+"cpp" = (
+/obj/machinery/atmospherics/pipe/manifold/orange/visible/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
 /area/engine/atmos)
 "cpz" = (
 /obj/effect/turf_decal/stripes/white/line,
@@ -42438,6 +41738,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/hangar)
+"cAw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "cAJ" = (
 /obj/structure/disposalpipe/trunk/multiz{
 	dir = 4
@@ -42550,6 +41860,15 @@
 /area/maintenance/starboard/secondary{
 	name = "Munitions Projects"
 	})
+"cMS" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plating,
+/area/engine/storage)
 "cOu" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -42574,16 +41893,6 @@
 /area/bridge{
 	name = "CIC"
 	})
-"cSo" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10
-	},
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/engine/atmos)
 "cSU" = (
 /obj/effect/turf_decal/stripes/red/line,
 /obj/effect/turf_decal/stripes/red/line{
@@ -42641,13 +41950,6 @@
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/port)
-"cWp" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister,
-/turf/open/floor/plating/airless,
-/area/engine/atmos)
 "cWr" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet,
@@ -42682,6 +41984,14 @@
 	},
 /turf/open/floor/monotile,
 /area/security/prison)
+"cWI" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 9
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "cXV" = (
 /obj/machinery/light/small,
 /obj/structure/bed,
@@ -42692,6 +42002,14 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/security/prison)
+"cYP" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1{
+	dir = 6
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "cYZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -42771,6 +42089,20 @@
 /obj/structure/ladder,
 /turf/open/floor/plating,
 /area/maintenance/nsv/weapons)
+"dlD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	icon_state = "pump_map-2";
+	name = "CO2 to Mix"
+	},
+/obj/machinery/atmospherics/components/binary/pump/layer1{
+	dir = 8;
+	name = "Plasma to Fuel Mix"
+	},
+/turf/open/space/basic,
+/area/engine/atmos)
 "dmA" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
@@ -42789,13 +42121,13 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/monotile,
 /area/gateway)
-"dqq" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/engine/atmos)
+"dnZ" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/glowstick,
+/obj/effect/spawner/lootdrop/maintenance/four,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "dqx" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -42813,12 +42145,13 @@
 	},
 /turf/open/floor/monotile,
 /area/medical/medbay/central)
-"dqy" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 6
+"drl" = (
+/obj/machinery/meter,
+/obj/structure/grille,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
 	},
-/turf/open/space/basic,
+/turf/closed/wall/r_wall,
 /area/engine/atmos)
 "dud" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -42836,6 +42169,15 @@
 	},
 /turf/closed/wall/r_wall/ship,
 /area/engine/atmospherics_engine)
+"dvN" = (
+/obj/structure/window/reinforced/spawner,
+/obj/machinery/computer/atmos_control/tank/nitrogen_tank{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "dyj" = (
 /obj/structure/bookcase/manuals/medical,
 /obj/machinery/camera/autoname{
@@ -42995,6 +42337,16 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
+"dUU" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/components/trinary/mixer/layer1{
+	dir = 4;
+	name = "CO2 Moderator Mixer"
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "dVC" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
@@ -43042,14 +42394,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"dZn" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/manifold/purple/visible/layer1{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/engine/atmos)
 "ecN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -43073,6 +42417,16 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/monotile/dark,
+/area/engine/atmos)
+"edO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	icon_state = "pump_map-2";
+	name = "Mix Tank Input"
+	},
+/turf/open/space/basic,
 /area/engine/atmos)
 "eev" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
@@ -43211,6 +42565,10 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"enS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plating,
+/area/engine/storage)
 "eoU" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -43227,15 +42585,6 @@
 /obj/item/clothing/mask/breath,
 /turf/open/floor/monotile/dark,
 /area/gateway)
-"erj" = (
-/obj/machinery/door/airlock/ship/external/glass{
-	name = "Auxiliary Shuttle Dock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plating,
-/area/engine/atmos)
 "esn" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -43289,6 +42638,11 @@
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/port)
+"evG" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "ewO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/structure/lattice/catwalk,
@@ -43410,6 +42764,15 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"eGI" = (
+/obj/machinery/atmospherics/components/trinary/mixer/layer1{
+	dir = 1;
+	name = "Fuel Mixer"
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "eHi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -43438,21 +42801,30 @@
 	},
 /turf/open/floor/monotile,
 /area/engine/engineering/reactor_core)
-"eJM" = (
-/obj/machinery/atmospherics/pipe/simple/violet/visible,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/atmos)
 "eJW" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -27
 	},
 /turf/open/floor/carpet/ship,
 /area/quartermaster/qm)
+"eKA" = (
+/obj/machinery/atmospherics/pipe/manifold4w/orange/visible/layer1,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "eLv" = (
 /obj/structure/bookcase,
 /turf/open/floor/wood,
 /area/library)
+"eNG" = (
+/obj/structure/closet/cardboard,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/maintenance/four,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "eOh" = (
 /obj/effect/turf_decal/stripes/red/line,
 /obj/effect/turf_decal/stripes/red/line{
@@ -43568,6 +42940,11 @@
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile,
 /area/science/research)
+"eZK" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "fbx" = (
 /turf/closed/wall/r_wall/ship,
 /area/shuttle/turbolift/shaft)
@@ -43575,6 +42952,23 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/monotile/light,
 /area/security/prison)
+"fdo" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/binary/pump/on/layer1{
+	dir = 1;
+	name = "Nitrogen to Air Mix";
+	target_pressure = 2000
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	icon_state = "pump_map-2";
+	name = "Nitrogen to Mix"
+	},
+/turf/open/space/basic,
+/area/engine/atmos)
 "fdU" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -43680,6 +43074,15 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
+"fAz" = (
+/obj/machinery/door/airlock/ship/external/glass{
+	name = "Atmospherics Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "fBs" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/plasma{
 	dir = 1;
@@ -43789,6 +43192,14 @@
 /obj/item/beacon,
 /turf/open/floor/monotile,
 /area/hallway/secondary/exit)
+"fOF" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "fPU" = (
 /obj/structure/shuttle/engine/huge{
 	dir = 8
@@ -43811,6 +43222,15 @@
 	},
 /turf/open/floor/monotile,
 /area/engine/engineering/hangar)
+"fQD" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/unary/outlet_injector{
+	name = "Purge Mixline"
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "fUk" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
@@ -43824,6 +43244,14 @@
 	},
 /turf/open/floor/monotile,
 /area/security/warden)
+"fWK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1,
+/turf/open/space/basic,
+/area/engine/atmos)
 "fXp" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -43940,6 +43368,27 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/heads/hor)
+"gom" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/obj/machinery/computer/atmos_control/tank/oxygen_tank{
+	dir = 1
+	},
+/obj/structure/window/reinforced/spawner,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
+"gpN" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "gqp" = (
 /obj/machinery/newscaster,
 /turf/closed/wall/ship,
@@ -43976,6 +43425,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/hangar)
+"guw" = (
+/obj/machinery/door/airlock/ship/external/glass{
+	dir = 4;
+	req_one_access_txt = "24"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/atmos)
 "gvw" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/monotile,
@@ -43986,12 +43442,6 @@
 	id = "spentfuel2"
 	},
 /area/engine/engineering/reactor_core)
-"gxK" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/violet/visible,
-/obj/machinery/meter,
-/turf/open/space/basic,
-/area/engine/atmos)
 "gzY" = (
 /obj/effect/spawner/lootdrop/maintenance/eight,
 /obj/structure/closet/cardboard,
@@ -44282,6 +43732,15 @@
 "haf" = (
 /turf/closed/wall/ship,
 /area/library)
+"hbD" = (
+/obj/machinery/door/airlock/ship/engineering/glass{
+	name = "Atmospherics Storage";
+	req_one_access_txt = "10; 24"
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "hcC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible,
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -44306,6 +43765,16 @@
 	},
 /turf/open/floor/monotile,
 /area/crew_quarters/fitness/recreation)
+"hfD" = (
+/obj/machinery/atmospherics/components/trinary/mixer/airmix{
+	dir = 4;
+	piping_layer = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "hfS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -44360,13 +43829,6 @@
 	},
 /turf/open/floor/plating,
 /area/medical/chemistry)
-"hjX" = (
-/obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/atmos)
 "hkB" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/bucket,
@@ -44403,16 +43865,28 @@
 	},
 /turf/open/floor/monotile,
 /area/crew_quarters/fitness/recreation)
-"hrq" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
+"hpZ" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/layer1{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
 /area/engine/atmos)
 "hrv" = (
 /obj/machinery/newscaster/security_unit,
 /turf/closed/wall/ship,
 /area/security/brig)
+"hsX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "htl" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -44428,6 +43902,12 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/break_room)
+"hua" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/machinery/meter,
+/turf/open/space/basic,
+/area/engine/engineering/reactor_core)
 "hvH" = (
 /turf/open/floor/wood,
 /area/library)
@@ -44563,6 +44043,14 @@
 	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
+"hHh" = (
+/obj/machinery/atmospherics/pipe/manifold/purple/visible/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "hJc" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
 /turf/open/floor/plasteel/techmaint,
@@ -44614,14 +44102,13 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
-"hPf" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/binary/pump/layer1{
-	dir = 8;
-	name = "Plasma Fuel Mixers"
+"hOw" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible/layer1{
+	dir = 4
 	},
-/turf/open/space/basic,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
 /area/engine/atmos)
 "hPh" = (
 /obj/structure/cable{
@@ -44647,6 +44134,15 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
+"hRh" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Mix Tank Outlet"
+	},
+/turf/open/space/basic,
+/area/engine/atmos)
 "hRK" = (
 /obj/machinery/pool_filter{
 	id = "spentfuel2"
@@ -44705,6 +44201,23 @@
 	},
 /turf/closed/wall/r_wall/ship,
 /area/engine/engine_smes)
+"hXQ" = (
+/obj/machinery/atmospherics/pipe/manifold4w/yellow/visible,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
+"hXU" = (
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "hYm" = (
 /obj/machinery/power/apc/auto_name/south{
 	pixel_y = -24
@@ -44744,6 +44257,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/hangar)
+"iiq" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "ilc" = (
 /turf/open/floor/monotile,
 /area/engine/engineering/reactor_core)
@@ -44801,13 +44320,6 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
-"iro" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/engine/atmos)
 "iry" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	dir = 4;
@@ -44946,6 +44458,16 @@
 	},
 /turf/open/floor/monotile,
 /area/nsv/hanger/deck2)
+"iJg" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1,
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "iJw" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
@@ -45101,6 +44623,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"iVY" = (
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/ship,
+/area/engine/engineering)
 "iXF" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/power/terminal,
@@ -45206,6 +44732,15 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"jhH" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "jiL" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -45409,6 +44944,17 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/break_room)
+"jEa" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible/layer1{
+	dir = 4
+	},
+/obj/machinery/meter{
+	target_layer = 1
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "jHw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
@@ -45581,6 +45127,14 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
+"kbI" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
+	dir = 5
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "kcn" = (
 /obj/item/circuitboard/computer/stormdrive_reactor_control,
 /obj/structure/frame/computer,
@@ -45622,6 +45176,16 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/nsv/hangar)
+"kes" = (
+/obj/machinery/atmospherics/components/binary/magnetic_constrictor{
+	dir = 1;
+	piping_layer = 1;
+	pixel_x = -5
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "keI" = (
 /obj/machinery/camera/autoname{
 	dir = 1;
@@ -45682,6 +45246,15 @@
 	},
 /turf/open/floor/monotile,
 /area/hallway/secondary/exit)
+"kiC" = (
+/obj/machinery/atmospherics/pipe/manifold/purple/visible/layer1,
+/obj/machinery/meter{
+	target_layer = 1
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "kjd" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -45706,6 +45279,15 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
+"kls" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
+	dir = 5
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "kmy" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -45755,13 +45337,22 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/security/execution/transfer)
-"koN" = (
+"kpf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 6
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	icon_state = "pump_map-2";
+	name = "N2O to Mix"
 	},
 /turf/open/space/basic,
 /area/engine/atmos)
+"kpT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "kqI" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -45967,6 +45558,20 @@
 	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
+"kHn" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1,
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
+"kHI" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating/airless,
+/area/engine/atmos)
 "kHR" = (
 /obj/machinery/washing_machine,
 /obj/effect/turf_decal/tile/blue{
@@ -45990,6 +45595,20 @@
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/medical/chemistry)
+"kKo" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/power/port_gen/pacman,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/machinery/light,
+/turf/open/floor/plasteel/ship,
+/area/engine/engineering)
 "kKu" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -46019,6 +45638,14 @@
 	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
+"kNu" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
+	dir = 10
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "kNI" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/structure/frame/computer,
@@ -46104,6 +45731,14 @@
 	},
 /turf/closed/wall/r_wall/ship,
 /area/engine/engineering/reactor_core)
+"kXj" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible/layer1{
+	dir = 6
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "kZu" = (
 /obj/machinery/portable_atmospherics/scrubber/huge,
 /obj/machinery/light{
@@ -46266,6 +45901,16 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/layer3,
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
+"lvt" = (
+/obj/machinery/door/airlock/ship/engineering/glass{
+	dir = 4;
+	name = "Atmospherics Storage";
+	req_one_access_txt = "10; 24"
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "lwA" = (
 /obj/machinery/ship_weapon/vls,
 /obj/effect/turf_decal/stripes/line,
@@ -46287,11 +45932,6 @@
 /obj/structure/munitions_trolley,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
-"lyo" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/atmos)
 "lzn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -46358,12 +45998,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
-"lJM" = (
-/obj/machinery/atmospherics/components/binary/magnetic_constrictor{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/engine/atmos)
 "lJZ" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	name = "Briefing room maintenance";
@@ -46428,6 +46062,14 @@
 /obj/item/ship_weapon/ammunition/missile,
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2)
+"lOx" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1{
+	dir = 10
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "lPz" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
@@ -46475,6 +46117,12 @@
 /obj/effect/spawner/room/fivexfour,
 /turf/template_noop,
 /area/maintenance/department/science)
+"lUk" = (
+/obj/machinery/atmospherics/pipe/manifold/purple/visible/layer1,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "lUM" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -46616,6 +46264,22 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/closed/wall/ship,
 /area/medical/medbay/lobby)
+"mlC" = (
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "mlM" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -46683,6 +46347,19 @@
 /obj/structure/closet/l3closet/scientist,
 /turf/open/floor/monotile/dark,
 /area/science)
+"mtF" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/storage_shared)
 "mvj" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/southright{
@@ -46711,12 +46388,35 @@
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile,
 /area/science/research)
+"mvU" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
+"mwK" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "mwO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/starboard/fore)
+"myk" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/heater,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "mzP" = (
 /obj/machinery/requests_console{
 	department = "Chapel";
@@ -46763,6 +46463,15 @@
 	},
 /turf/open/floor/monotile,
 /area/security/brig)
+"mEC" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "mGr" = (
 /obj/effect/turf_decal/pool{
 	dir = 1
@@ -46781,14 +46490,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/hangar)
-"mGu" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 1;
-	icon_state = "connector_map-2"
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/atmos)
 "mGT" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction,
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer1,
@@ -46818,6 +46519,20 @@
 	},
 /turf/closed/wall/r_wall/ship,
 /area/engine/atmospherics_engine)
+"mJh" = (
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall/ship,
+/area/engine/atmos)
+"mKh" = (
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "mKt" = (
 /turf/open/floor/monotile/dark,
 /area/engine/engineering/hangar)
@@ -46826,6 +46541,12 @@
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
+"mMg" = (
+/obj/machinery/atmospherics/components/binary/valve,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "mMv" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -46922,14 +46643,6 @@
 	},
 /turf/template_noop,
 /area/maintenance/department/science)
-"mSg" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Mix to distro"
-	},
-/turf/open/space/basic,
-/area/engine/atmos)
 "mSw" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/item/multitool,
@@ -46945,6 +46658,17 @@
 /area/nsv/hanger/storage{
 	name = "Munitions Control Room"
 	})
+"mUv" = (
+/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "mVt" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -47056,6 +46780,15 @@
 /obj/machinery/light/small,
 /turf/open/floor/engine/o2,
 /area/engine/atmos)
+"nkN" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 1;
+	icon_state = "connector_map-2"
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "nls" = (
 /obj/machinery/light{
 	dir = 4
@@ -47079,6 +46812,13 @@
 	},
 /turf/open/floor/monotile,
 /area/nsv/weapons/fore)
+"npw" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "npB" = (
 /obj/structure/table,
 /obj/machinery/computer/libraryconsole/bookmanagement,
@@ -47112,6 +46852,13 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
+"nqT" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "nsk" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -47137,6 +46884,15 @@
 	},
 /turf/open/floor/monotile/light,
 /area/security/prison)
+"nvK" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Mix to distro"
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "nwp" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank - N2O";
@@ -47153,6 +46909,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/weapons)
+"nBS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk,
+/obj/machinery/camera/autoname{
+	c_tag = "Atmos - South #1";
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Air to Distro";
+	target_pressure = 2000
+	},
+/turf/open/space/basic,
+/area/engine/atmos)
 "nCw" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -47214,6 +46986,12 @@
 /obj/machinery/ship_weapon/torpedo_launcher/west,
 /turf/open/floor/plating,
 /area/nsv/weapons/fore)
+"nII" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/machinery/meter,
+/turf/open/space,
+/area/engine/atmos)
 "nIX" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -47284,6 +47062,15 @@
 	},
 /turf/open/floor/monotile,
 /area/crew_quarters/fitness/recreation)
+"nNX" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "nOu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -47293,6 +47080,27 @@
 	},
 /turf/open/floor/plasteel/grid/lino,
 /area/engine/engineering/reactor_control)
+"nOz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/binary/pump/layer3{
+	dir = 1;
+	name = "Oxygen To Fuel Mixer"
+	},
+/obj/machinery/atmospherics/components/binary/pump/on/layer1{
+	dir = 1;
+	name = "Oxygen to Air Mix";
+	target_pressure = 2000
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	icon_state = "pump_map-2";
+	name = "Oxygen to Mix"
+	},
+/turf/open/space/basic,
+/area/engine/atmos)
 "nOT" = (
 /obj/machinery/ship_weapon/vls,
 /turf/open/floor/monotile/dark,
@@ -47367,6 +47175,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"nVs" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold/visible,
+/turf/open/space/basic,
+/area/engine/atmos)
 "nYT" = (
 /obj/machinery/door/morgue{
 	name = "Private Study";
@@ -47401,14 +47217,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
-"ocF" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Shutdown Moderator To Reactor"
-	},
-/turf/open/space/basic,
-/area/engine/atmos)
 "ocV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -47520,6 +47328,13 @@
 	},
 /turf/open/floor/plasteel/grid/lino,
 /area/engine/engineering/reactor_control)
+"otV" = (
+/obj/machinery/portable_atmospherics/canister/water_vapor,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "otW" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -47541,6 +47356,10 @@
 /area/science/mixing{
 	name = "Prototype munitions bay"
 	})
+"ouF" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/engine/atmos)
 "owg" = (
 /obj/effect/landmark/carpspawn,
 /obj/structure/lattice/catwalk,
@@ -47672,6 +47491,18 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/fitness/recreation)
+"oJQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/structure/lattice/catwalk,
+/obj/machinery/camera/autoname{
+	c_tag = "Atmos - East #1";
+	dir = 8
+	},
+/obj/machinery/computer/atmos_control/tank/mix_tank{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/engine/atmos)
 "oMj" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -47780,6 +47611,11 @@
 	},
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
+"paH" = (
+/obj/structure/grille,
+/obj/machinery/meter,
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "paV" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -47825,6 +47661,16 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/medical/medbay/lobby)
+"per" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/shower,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/ship,
+/area/engine/engineering)
 "peN" = (
 /obj/machinery/atmospherics/components/trinary/nuclear_reactor/preset{
 	dir = 1
@@ -47940,16 +47786,6 @@
 	},
 /turf/open/floor/monotile,
 /area/hallway/secondary/exit)
-"pqF" = (
-/obj/machinery/door/airlock/ship/external/glass{
-	name = "Auxiliary Shuttle Dock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/plating,
-/area/engine/atmos)
 "psk" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -48093,6 +47929,25 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"pIA" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/computer/atmos_control/tank/carbon_tank{
+	dir = 8
+	},
+/obj/structure/window/reinforced/spawner/east,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
+"pIO" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3,
+/obj/machinery/meter{
+	target_layer = 1
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "pJt" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 9
@@ -48112,6 +47967,14 @@
 /obj/machinery/suit_storage_unit/pilot,
 /turf/open/floor/plasteel/tech/grid,
 /area/nsv/weapons/fore)
+"pNz" = (
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "pOG" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
@@ -48124,6 +47987,14 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
+"pOO" = (
+/obj/machinery/atmospherics/pipe/manifold/orange/visible/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "pRQ" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -48204,6 +48075,12 @@
 /obj/machinery/lazylift/master/aircraft_elevator,
 /turf/open/floor/monotile/dark,
 /area/shuttle/turbolift/shaft)
+"qcy" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "qcD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -48225,6 +48102,14 @@
 	},
 /turf/open/space/basic,
 /area/engine/atmos)
+"qgo" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/camera/autoname{
+	c_tag = "Atmos - West #2";
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/engine/atmos)
 "qio" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -48237,6 +48122,13 @@
 	},
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
+"qjd" = (
+/obj/machinery/atmospherics/pipe/simple/dark/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "qmJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -48300,6 +48192,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/monotile,
 /area/engine/engineering/reactor_core)
+"qwl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/closed/wall/r_wall/ship,
+/area/engine/storage)
 "qxg" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -48593,6 +48489,13 @@
 	},
 /turf/closed/wall/r_wall/ship,
 /area/engine/engineering/reactor_core)
+"rbT" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/effect/turf_decal/bot_red,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "rdp" = (
 /obj/machinery/light{
 	dir = 8
@@ -48630,6 +48533,13 @@
 "rhe" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
+/area/engine/atmos)
+"rhj" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
 /area/engine/atmos)
 "riu" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -48724,6 +48634,15 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
+"rso" = (
+/obj/machinery/atmospherics/pipe/simple/dark/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "rsK" = (
 /obj/effect/turf_decal/stripes/red/line,
 /obj/effect/turf_decal/stripes/red/line{
@@ -48740,6 +48659,16 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
+"rtT" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Air to Distro";
+	target_pressure = 2000
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "rtU" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
@@ -48764,6 +48693,14 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
+"rwL" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "rxn" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	req_one_access_txt = "13"
@@ -49168,11 +49105,6 @@
 	},
 /turf/open/floor/monotile,
 /area/medical/chemistry)
-"sjq" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/space/basic,
-/area/engine/atmos)
 "smz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
@@ -49241,6 +49173,15 @@
 /obj/machinery/status_display/evac,
 /turf/closed/wall/ship,
 /area/medical/medbay/lobby)
+"ssU" = (
+/obj/machinery/atmospherics/components/trinary/mixer/flipped/layer1{
+	dir = 8;
+	name = "Custom Moderator Input"
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "ssX" = (
 /obj/machinery/door/window{
 	name = "Gunpowder Storage";
@@ -49267,6 +49208,13 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmospherics_engine)
+"stP" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "sul" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/layer_manifold/visible,
@@ -49278,6 +49226,20 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"svT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	icon_state = "pump_map-2";
+	name = "Plasma to Mix"
+	},
+/obj/machinery/atmospherics/components/binary/pump/layer1{
+	dir = 8;
+	name = "Plasma to Fuel Mix"
+	},
+/turf/open/space/basic,
+/area/engine/atmos)
 "svX" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -49299,6 +49261,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"syz" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
+"szH" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/atmospherics/pipe/layer_manifold/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "szX" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -49341,6 +49318,14 @@
 	id = "spentfuel2"
 	},
 /area/engine/engineering/reactor_core)
+"sHp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "sJI" = (
 /obj/machinery/status_display/evac,
 /turf/closed/wall/ship,
@@ -49411,6 +49396,14 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"tar" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 5
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "tcb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
@@ -49468,6 +49461,15 @@
 	},
 /turf/open/floor/monotile,
 /area/hallway/secondary/exit)
+"tgd" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "tiu" = (
 /obj/machinery/requests_console{
 	department = "Genetics";
@@ -49576,13 +49578,6 @@
 /obj/item/storage/bag/chemistry,
 /turf/open/floor/monotile,
 /area/medical/chemistry)
-"trQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/atmos)
 "tsM" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -49670,6 +49665,15 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"tBp" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Mix to Incinerator"
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "tBx" = (
 /obj/machinery/airalarm/directional/south,
 /obj/structure/bookcase/manuals/research_and_development,
@@ -49706,6 +49710,20 @@
 	},
 /turf/open/floor/monotile,
 /area/engine/engineering/hangar)
+"tDy" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/engineering)
 "tDB" = (
 /obj/machinery/sleeper{
 	dir = 4
@@ -49747,6 +49765,18 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/fitness/recreation)
+"tKK" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/obj/machinery/computer/atmos_control/tank/air_tank{
+	dir = 1
+	},
+/obj/structure/window/reinforced/spawner,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "tMg" = (
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess{
 	dir = 4
@@ -49792,6 +49822,15 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"tPM" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "Waste To Filters";
+	target_pressure = 4500
+	},
+/turf/open/space/basic,
+/area/engine/atmos)
 "tPU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
@@ -49828,16 +49867,6 @@
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/light,
 /area/medical/medbay/lobby)
-"tSL" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
-	dir = 9
-	},
-/turf/open/floor/plating/airless,
-/area/engine/atmos)
 "tUT" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -49854,13 +49883,6 @@
 	},
 /turf/open/floor/monotile,
 /area/medical/chemistry)
-"tWf" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/layer_manifold/visible{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/engine/atmos)
 "tWK" = (
 /obj/machinery/status_display/supply,
 /turf/closed/wall/ship,
@@ -49882,6 +49904,14 @@
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
+"uaW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/orange/visible/layer1{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/engine/atmos)
 "ucc" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
@@ -49975,6 +50005,17 @@
 "ufF" = (
 /turf/closed/wall/r_wall/ship,
 /area/science/mixing/chamber)
+"ufS" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
+"ugz" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "ugK" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -50003,6 +50044,12 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
+"uju" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/visible,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "uln" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -50049,19 +50096,6 @@
 	},
 /turf/open/floor/monotile,
 /area/engine/engineering)
-"urZ" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/turf/open/space/basic,
-/area/engine/atmos)
-"uts" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "uyI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -50099,6 +50133,14 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
+"uFW" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "uGJ" = (
 /obj/machinery/light{
 	dir = 8
@@ -50145,6 +50187,13 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering/reactor_core)
+"uLZ" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/engine/atmos)
 "uMm" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -50170,6 +50219,14 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"uRG" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "uTe" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -50182,6 +50239,16 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/engine/engineering)
+"uTH" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/door/airlock/ship/external/glass{
+	name = "Atmospherics Airlock"
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "uUs" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
 	dir = 4
@@ -50206,16 +50273,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/medical/medbay/central)
-"uVV" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/violet/visible,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8;
-	name = "Fuel To Fuel Mixer";
-	target_pressure = 4500
-	},
-/turf/open/space/basic,
-/area/engine/atmos)
 "uWe" = (
 /obj/structure/chair{
 	dir = 8
@@ -50295,6 +50352,11 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
+"vfz" = (
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "vgd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
@@ -50523,15 +50585,10 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"vBD" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
-/turf/open/space/basic,
-/area/engine/atmos)
-"vFe" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
+"vGG" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/atmospherics/pipe/layer_manifold/visible,
+/turf/open/floor/plating,
 /area/engine/atmos)
 "vHB" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -50555,6 +50612,14 @@
 	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_control)
+"vIp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
+/turf/open/space/basic,
+/area/engine/atmos)
 "vIy" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -50591,6 +50656,14 @@
 	},
 /turf/open/floor/plasteel/grid/steel,
 /area/engine/engineering/reactor_core)
+"vMN" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/engine/atmos)
 "vNA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -50636,11 +50709,6 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
-"vPP" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/manifold4w/orange/visible,
-/turf/open/space/basic,
-/area/engine/atmos)
 "vRI" = (
 /obj/structure/cable,
 /obj/machinery/power/solar{
@@ -50720,6 +50788,12 @@
 	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
+"wcq" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
+/obj/structure/lattice/catwalk,
+/obj/machinery/meter/atmos/atmos_waste_loop,
+/turf/open/space/basic,
+/area/engine/atmos)
 "weE" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/machinery/firealarm{
@@ -50870,14 +50944,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"wvI" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Custom Moderator Input"
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/atmos)
 "wvQ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/reactor/control_rods,
@@ -50913,6 +50979,20 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"wwN" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/engineering)
 "wxB" = (
 /obj/structure/chair/comfy/shuttle{
 	color = "#696969";
@@ -50977,15 +51057,6 @@
 /obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"wDH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/structure/lattice/catwalk,
-/obj/machinery/camera/autoname{
-	c_tag = "Atmos - East #1";
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/engine/atmos)
 "wEq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
@@ -51155,6 +51226,13 @@
 /obj/effect/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"wYw" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "wZp" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -51352,6 +51430,16 @@
 "xuS" = (
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/nsv/weapons)
+"xuZ" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/open/floor/monotile/dark,
+/area/engine/engineering)
 "xxg" = (
 /obj/structure/sign/barsign,
 /turf/closed/wall/ship,
@@ -51687,6 +51775,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/hangar)
+"yju" = (
+/obj/machinery/atmospherics/pipe/manifold/purple/visible/layer1{
+	dir = 1
+	},
+/obj/machinery/meter{
+	target_layer = 1
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 
 (1,1,1) = {"
 aaa
@@ -92200,7 +92299,7 @@ awc
 aAb
 aYx
 aYA
-aYA
+ugz
 oyi
 ndL
 aij
@@ -92714,7 +92813,7 @@ axG
 qEO
 aBh
 aBh
-aYA
+eZK
 oyi
 arT
 arT
@@ -93220,7 +93319,7 @@ iuA
 iuA
 qEO
 qEO
-brT
+cAw
 qEO
 vjc
 iuA
@@ -93473,7 +93572,7 @@ bob
 blz
 bkZ
 bkZ
-bkZ
+evG
 boW
 bkZ
 boW
@@ -93738,7 +93837,7 @@ hCE
 ail
 bqF
 avr
-azQ
+eNG
 aCh
 aBh
 aYB
@@ -93987,7 +94086,7 @@ bob
 blz
 bkZ
 boN
-bkZ
+dnZ
 boW
 ooh
 bkZ
@@ -96036,16 +96135,16 @@ qEO
 ckc
 qEO
 qEO
-qEO
-qEO
-aiI
-aiL
-aiL
-uts
-aiL
-aiL
-aiL
-bpo
+clm
+wYw
+mlC
+qjd
+qjd
+rso
+qjd
+qjd
+tgd
+kpT
 ljw
 pFX
 ljw
@@ -96261,7 +96360,7 @@ bET
 bET
 amo
 arj
-arC
+tDy
 aAB
 aAY
 bHk
@@ -96293,16 +96392,16 @@ bjI
 fdU
 bjI
 bna
-bjI
-bjI
-bnU
-bjI
-bjI
-bkG
-bkZ
-bkZ
-boN
-bpp
+hsX
+aml
+aml
+aml
+aml
+aml
+aml
+aml
+jhH
+qEO
 qEO
 oyi
 eFj
@@ -96517,7 +96616,7 @@ biR
 biR
 biR
 aey
-ase
+per
 ayR
 aAC
 aBg
@@ -96548,19 +96647,19 @@ aml
 aml
 aml
 aml
-oyi
-oyi
-oyi
-oyi
-oyi
-oyi
-oyi
-amt
-oyi
-oyi
-oyi
-avo
-oyi
+aml
+aml
+aml
+aml
+npw
+npw
+stP
+stP
+nqT
+aml
+mJh
+aml
+aml
 oyi
 oyi
 oyi
@@ -96805,18 +96904,18 @@ jpj
 aAc
 bmd
 jpj
-vFe
-vFe
-vFe
-vFe
-sjq
-sjq
-sjq
-sjq
-urZ
-urZ
-urZ
-urZ
+rhe
+rhe
+rhe
+hbD
+vfz
+vfz
+vfz
+vfz
+vfz
+hbD
+cob
+rhe
 aml
 bCt
 bCt
@@ -97034,7 +97133,7 @@ aey
 avb
 azd
 aBw
-aBo
+kKo
 aey
 bfR
 aBH
@@ -97058,25 +97157,25 @@ xQF
 qqk
 apv
 qqT
-erj
+fAz
 atZ
 uJx
-pqF
+uTH
 rhe
-apz
-apz
-apz
-apz
-apz
-apz
-apz
-apz
-apz
-apz
+vfz
+vfz
+kHI
+rbT
+rbT
+vfz
+otV
+otV
+kHI
+tBp
 azA
 aBO
 aBV
-aqk
+paH
 aqk
 aqk
 aqk
@@ -97320,16 +97419,16 @@ asG
 asG
 aml
 rhe
-apz
-apz
-apz
-apz
-apz
-apz
-apz
-apz
-apz
-apz
+vfz
+vfz
+aml
+kHI
+kHI
+lvt
+kHI
+kHI
+aml
+rwL
 azF
 aBP
 bIj
@@ -97573,20 +97672,20 @@ biV
 axY
 ucr
 asG
-lyo
-cof
-lyo
 rhe
-apz
-apz
-apz
-apz
-apz
-apz
-apz
-apz
-apz
-apz
+qgo
+rhe
+rhe
+vfz
+vfz
+vfz
+vfz
+vfz
+vfz
+vfz
+vfz
+dvN
+rwL
 apG
 asG
 yeQ
@@ -97802,7 +97901,7 @@ bty
 anQ
 anQ
 aey
-aDP
+wwN
 aNv
 aNU
 aQU
@@ -97830,22 +97929,22 @@ axY
 axY
 asM
 asG
-aua
-aua
-aua
 rhe
-apz
-apz
-apz
-apz
-apz
-apz
-apz
-arP
-ayl
-ayz
-azH
-aBQ
+vfz
+vfz
+vfz
+vfz
+vfz
+vfz
+vfz
+vfz
+vfz
+vfz
+vfz
+cYP
+gpN
+fdo
+vGG
 bJR
 aCv
 aCC
@@ -98087,20 +98186,20 @@ edN
 aQd
 aml
 aml
-aub
-aub
-aub
 rhe
-vBD
-iro
-mGu
-rhe
-rhe
-rhe
-rhe
-ayb
-aym
-ayA
+vfz
+vfz
+vfz
+vfz
+vfz
+vfz
+vfz
+vfz
+vfz
+vfz
+vfz
+fOF
+rwL
 apG
 asG
 yeQ
@@ -98344,20 +98443,20 @@ asG
 asG
 aml
 aml
-auc
-auc
-auc
 rhe
-vBD
-vPP
-mGu
-rhe
-rhe
-rhe
-rhe
-ayb
-ayn
-ayB
+vfz
+vfz
+vfz
+vfz
+vfz
+vfz
+vfz
+vfz
+vfz
+vfz
+vfz
+fOF
+rwL
 azI
 aBP
 bIj
@@ -98602,19 +98701,19 @@ pDN
 rhe
 rhe
 rhe
-apz
-apz
-dqy
-wvI
-hjX
-mGu
-rhe
-rhe
-rhe
-rhe
-ayb
-cSo
-ayC
+vfz
+vfz
+vfz
+vfz
+vfz
+vfz
+vfz
+vfz
+vfz
+vfz
+vfz
+fOF
+gom
 apG
 asG
 yeQ
@@ -98851,29 +98950,29 @@ asb
 asb
 asb
 asb
-aQh
-apA
-apz
-apz
-apz
-apz
-apz
-apz
-apz
-apz
-awm
-awC
-awN
-awX
-axe
-axe
-axA
-axn
-ayd
-ayo
-ayD
-azH
-aBQ
+aQg
+uLZ
+vfz
+vfz
+vfz
+vfz
+vfz
+vfz
+kXj
+eGI
+uju
+pIO
+ufS
+ufS
+ufS
+ufS
+ufS
+ufS
+ufS
+hfD
+kHn
+nOz
+vGG
 bJR
 aCv
 aCF
@@ -99109,26 +99208,26 @@ aDy
 arI
 bHf
 aQi
-apB
-apz
-apz
-apz
-apz
-apz
-apz
-apz
-apz
-awm
-ocF
-uVV
-eJM
-gxK
-axn
-apc
-axn
-ayc
-ayr
-ayE
+wcq
+vfz
+vfz
+vfz
+uFW
+uFW
+vfz
+hOw
+hHh
+kes
+kbI
+vfz
+vfz
+vfz
+vfz
+fQD
+tar
+vfz
+fOF
+rwL
 apG
 asG
 yeQ
@@ -99361,33 +99460,33 @@ amu
 aqo
 asm
 blB
-bsZ
-aPL
-ayP
-ayP
-aQj
-apC
-apO
-trQ
-apz
-apz
-apz
-apz
-apz
-apz
-awk
-apz
-tWf
-awD
-lJM
-axo
-axB
-axQ
-aye
-tSL
-aqf
-avK
-aBR
+enS
+cMS
+enS
+enS
+qwl
+nVs
+syz
+sHp
+vfz
+pOO
+eKA
+cpp
+ssU
+yju
+kes
+kiC
+vfz
+vfz
+vfz
+vfz
+myk
+hXQ
+nkN
+lOx
+mEC
+fWK
+vGG
 bMg
 aCw
 aCG
@@ -99598,7 +99697,7 @@ aHw
 aIi
 aQL
 aBw
-kmy
+xuZ
 amC
 aBs
 aLv
@@ -99622,27 +99721,27 @@ ayq
 aoW
 aoW
 aoW
-aqr
-apG
-apW
-mSg
-apz
-apz
-apz
-apz
-apz
-apz
-awk
-apz
-bTs
-awE
-lJM
-axp
-axn
-axR
-ayf
-cWp
-apz
+aoW
+tPM
+ciA
+nvK
+vfz
+hpZ
+uRG
+uRG
+jEa
+kNu
+kes
+lUk
+vfz
+vfz
+vfz
+vfz
+bUM
+hXQ
+nkN
+vfz
+tKK
 apG
 asG
 yeQ
@@ -99848,14 +99947,14 @@ asL
 asL
 asL
 anY
-bkp
+urL
 hCr
-aBw
+iVY
 aaN
 kjd
 aQO
 aBw
-aQV
+kmy
 amC
 aRa
 qWB
@@ -99879,29 +99978,29 @@ asb
 asb
 arG
 aqp
-aQk
-apH
-aqc
-dqq
-rhe
-koN
-asD
-asU
-asD
-asD
-bIA
-asU
-hPf
-asD
-asD
-asU
-asD
-asD
-axg
-cWp
-azu
-azK
-aBR
+aoW
+vIp
+mvU
+mwK
+rtT
+iiq
+iiq
+iiq
+dUU
+rhj
+rhj
+iJg
+rhj
+rhj
+rhj
+kls
+iiq
+nNX
+iiq
+iiq
+nNX
+nBS
+vGG
 bMg
 aCx
 aCI
@@ -100138,25 +100237,25 @@ arG
 aqp
 aoW
 apG
-aqf
-arQ
-asE
-atk
-asE
-auu
-asE
-asE
-awq
-awG
-dZn
-bOT
-hrq
-axr
-awP
-awP
-axh
-asE
-ayA
+vfz
+pNz
+mMg
+mKh
+qcy
+mKh
+cmj
+qcy
+qcy
+hXU
+coz
+qcy
+qcy
+mUv
+pIA
+ciB
+qcy
+qcy
+cWI
 apG
 aml
 yeQ
@@ -100396,19 +100495,19 @@ aoW
 aoW
 apJ
 aqg
-arR
-wDH
-arR
+hRh
+oJQ
+edO
 aqg
-arR
-aqg
+kpf
+uaW
 awe
-awr
-arR
+aqg
+svT
 ewO
 fBs
 aqg
-arR
+dlD
 aqg
 eso
 aqg
@@ -100629,7 +100728,7 @@ riu
 aBn
 amC
 ayY
-azn
+mtF
 aBB
 aAO
 aQZ
@@ -100652,20 +100751,20 @@ apq
 aml
 aml
 aml
-aml
-arS
+guw
+szH
+asG
+szH
+asG
+szH
+szH
+atr
+asG
+szH
 asG
 atr
 asG
-auw
-asG
-atr
-awt
-auw
-asG
-atr
-asG
-auw
+szH
 asG
 atr
 aml
@@ -100673,7 +100772,7 @@ aml
 aml
 azY
 aml
-apz
+apq
 nRp
 nRp
 nRp
@@ -100910,14 +101009,14 @@ axA
 mlW
 mlW
 mlW
-bEV
+vMN
 mlW
 bEX
-mlW
+nII
 bFi
-bFv
-bEX
 bFw
+bFJ
+ouF
 bFx
 yeQ
 bFJ
@@ -100927,10 +101026,10 @@ yeQ
 bFJ
 yeQ
 bCt
-apz
-apz
-apz
-apz
+apq
+apq
+apq
+apq
 nRp
 fYc
 nRp
@@ -101167,7 +101266,7 @@ apq
 apq
 bCt
 aqk
-arX
+drl
 asH
 atL
 aqk
@@ -104230,10 +104329,10 @@ vlb
 sNm
 azk
 arT
-ano
-ano
-ano
-ano
+azk
+azk
+azk
+azk
 fUk
 aBk
 hKS
@@ -107823,7 +107922,7 @@ atK
 ygv
 qKe
 sul
-aDR
+hua
 aDR
 aDR
 aDR


### PR DESCRIPTION
## About The Pull Request

I've right clicked every door on the Tycoon and everything is now (actually) monstermos compliant. Double doors are also all going to be purged, so that's a good thing.
Oh and don't smoke in munitions. 🚭

Fixes #1153
Fixes #1157 
Fixes #1156 

## Changelog
:cl:
fix: You can no longer get into the Tycoon hangar from maintenance without access.
fix: Fixes Tycoon service sector maint airlocks' access.
fix: Removes all double doors from the Tycoon.
balance: Moves ore silo on Tycoon from the Vault to Cargo.
tweak: Tycoon's comms relay is now in the teleporter.
tweak: Tycoon munitions has been given a new paintjob.
/:cl: