### PR TITLE
Adds guidance computer bolt driver to gladius missile factory

### DIFF
--- a/_maps/map_files/Gladius/Gladius1.dmm
+++ b/_maps/map_files/Gladius/Gladius1.dmm
@@ -8456,7 +8456,6 @@
 	dir = 4;
 	id = "torp"
 	},
-/obj/item/ship_weapon/ammunition/missile/missile_casing,
 /turf/open/floor/plasteel/ridged/steel,
 /area/nsv/weapons/starboard)
 "ejZ" = (
@@ -13305,6 +13304,11 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
+/obj/machinery/conveyor/slow{
+	dir = 4;
+	id = "torp"
+	},
+/obj/item/ship_weapon/ammunition/missile/missile_casing,
 /turf/open/floor/plasteel/ridged/steel,
 /area/nsv/weapons/starboard)
 "gxX" = (
@@ -21038,8 +21042,7 @@
 /area/medical/nsv/plumbing)
 "kiF" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
-/obj/item/ship_weapon/parts/missile/propulsion_system,
-/obj/machinery/missile_builder/assembler,
+/obj/machinery/missile_builder,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/starboard)
 "kiW" = (
@@ -21096,7 +21099,8 @@
 /area/crew_quarters/heads/captain/private)
 "kkl" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
-/obj/machinery/missile_builder,
+/obj/machinery/missile_builder/assembler,
+/obj/item/ship_weapon/parts/missile/guidance_system,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/starboard)
 "kkv" = (
@@ -21177,8 +21181,8 @@
 /area/security/brig)
 "klF" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
+/obj/item/ship_weapon/parts/missile/propulsion_system,
 /obj/machinery/missile_builder/assembler,
-/obj/item/ship_weapon/parts/missile/guidance_system,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/starboard)
 "klT" = (
@@ -84496,7 +84500,7 @@ ybF
 itg
 ybF
 ybF
-ybF
+klF
 gxV
 nmT
 cgF
@@ -85267,7 +85271,7 @@ kam
 fcZ
 hIw
 ybF
-klF
+krO
 aMh
 nmT
 vlK


### PR DESCRIPTION
## About The Pull Request

Adds a screwdriver machine to the missile factory one the Gladius.

## Why It's Good For The Game

fixes #1166 

## Changelog
:cl:
fix: Fixes the Gladius' missile factory not having a screwdriver machine after the guidance computer inserter,
/:cl:
