### PR TITLE
Makes it impossible to pick up munitions ammo with an evidence bag and gives cannonballs a construction time

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -22,7 +22,7 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 	new/datum/stack_recipe("bar stool", /obj/structure/chair/stool/bar, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("chair", /obj/structure/chair, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("bed", /obj/structure/bed, 2, one_per_turf = TRUE, on_floor = TRUE), \
-	new/datum/stack_recipe("cannon ball", /obj/item/ship_weapon/ammunition/naval_artillery/cannonball, 20, one_per_turf = TRUE, on_floor = TRUE), \
+	new/datum/stack_recipe("cannon ball", /obj/item/ship_weapon/ammunition/naval_artillery/cannonball, 20,time = 40, one_per_turf = TRUE, on_floor = TRUE), \
 	null, \
 	new/datum/stack_recipe_list("office chairs", list( \
 		new/datum/stack_recipe("dark office chair", /obj/structure/chair/office, 5, one_per_turf = TRUE, on_floor = TRUE), \

--- a/nsv13/code/modules/munitions/ammunition/missiles/missile_types.dm
+++ b/nsv13/code/modules/munitions/ammunition/missiles/missile_types.dm
@@ -4,6 +4,9 @@
 	icon_state = "highvelocity"
 	desc = "A standard pattern Nanotrasen anti-fighter missile."
 	density = TRUE
+	climbable = TRUE //No shenanigans
+	climb_time = 20
+	climb_stun = 0 
 	move_resist = MOVE_FORCE_EXTREMELY_STRONG
 	projectile_type = /obj/item/projectile/guided_munition/missile //What torpedo type we fire
 	pixel_x = -17

--- a/nsv13/code/modules/munitions/ammunition/missiles/missile_types.dm
+++ b/nsv13/code/modules/munitions/ammunition/missiles/missile_types.dm
@@ -7,6 +7,7 @@
 	climbable = TRUE //No shenanigans
 	climb_time = 20
 	climb_stun = 0 
+	w_class = WEIGHT_CLASS_GIGANTIC
 	move_resist = MOVE_FORCE_EXTREMELY_STRONG
 	projectile_type = /obj/item/projectile/guided_munition/missile //What torpedo type we fire
 	pixel_x = -17

--- a/nsv13/code/modules/munitions/ammunition/torpedos/torpedo_types.dm
+++ b/nsv13/code/modules/munitions/ammunition/torpedos/torpedo_types.dm
@@ -7,6 +7,7 @@
 	climbable = TRUE //No shenanigans
 	climb_time = 40
 	climb_stun = 0 
+	w_class = WEIGHT_CLASS_GIGANTIC
 	move_resist = MOVE_FORCE_EXTREMELY_STRONG
 	interaction_flags_item = 0 // -INTERACT_ITEM_ATTACK_HAND_PICKUP
 	projectile_type = /obj/item/projectile/guided_munition/torpedo //What torpedo type we fire

--- a/nsv13/code/modules/munitions/ammunition/torpedos/torpedo_types.dm
+++ b/nsv13/code/modules/munitions/ammunition/torpedos/torpedo_types.dm
@@ -6,7 +6,7 @@
 	density = TRUE
 	climbable = TRUE //No shenanigans
 	climb_time = 40
-	climb_stun = 0 
+	climb_stun = 5
 	w_class = WEIGHT_CLASS_GIGANTIC
 	move_resist = MOVE_FORCE_EXTREMELY_STRONG
 	interaction_flags_item = 0 // -INTERACT_ITEM_ATTACK_HAND_PICKUP

--- a/nsv13/code/modules/munitions/ammunition/torpedos/torpedo_types.dm
+++ b/nsv13/code/modules/munitions/ammunition/torpedos/torpedo_types.dm
@@ -4,6 +4,9 @@
 	icon_state = "standard"
 	desc = "A fairly standard torpedo which is designed to cause massive structural damage to a target. It is fitted with a basic homing mechanism to ensure it always hits the mark."
 	density = TRUE
+	climbable = TRUE //No shenanigans
+	climb_time = 40
+	climb_stun = 0 
 	move_resist = MOVE_FORCE_EXTREMELY_STRONG
 	interaction_flags_item = 0 // -INTERACT_ITEM_ATTACK_HAND_PICKUP
 	projectile_type = /obj/item/projectile/guided_munition/torpedo //What torpedo type we fire

--- a/nsv13/code/modules/munitions/ship_weapons/_ship_weapon.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/_ship_weapon.dm
@@ -13,11 +13,64 @@
 	var/projectile_type = null //What does the projectile look like on the overmap?
 	var/volatility = 0 //Is this ammo likely to go up in flames when hit or burned?
 	var/explode_when_hit = FALSE //If the ammo's volatile, can it be detonated by damage? Or just burning it.
+	var/climb_time = 20 //Time it takes to climb
+	var/climb_stun = 20 //Time to be stunned for after climbing
+	var/climbable = FALSE //Can you climb on it?
+	var/mob/living/climber //Who is climbing on it
 
 /obj/item/ship_weapon/ammunition/Initialize()
 	. = ..()
 	if(volatility > 0)
 		AddComponent(/datum/component/volatile, volatility, explode_when_hit)
+
+/obj/item/ship_weapon/ammunition/MouseDrop_T(atom/movable/O, mob/user)
+	. = ..()
+	if(!climbable)
+		return
+	if(user == O && iscarbon(O))
+		var/mob/living/carbon/C = O
+		if(C.mobility_flags & MOBILITY_MOVE)
+			climb_torp(user)
+			return
+	if(!istype(O, /obj/item) || user.get_active_held_item() != O)
+		return
+	if(iscyborg(user))
+		return
+	if(!user.dropItemToGround(O))
+		return
+	if (O.loc != src.loc)
+		step(O, get_dir(O, src))
+
+/obj/item/ship_weapon/ammunition/proc/do_climb(atom/movable/A)
+	if(climbable)
+		density = FALSE
+		. = step(A,get_dir(A,src.loc))
+		density = TRUE
+
+/obj/item/ship_weapon/ammunition/proc/climb_torp(mob/living/user)
+	src.add_fingerprint(user)
+	user.visible_message("<span class='warning'>[user] starts climbing onto [src].</span>", \
+								"<span class='notice'>You start climbing onto [src]...</span>")
+	var/adjusted_climb_time = climb_time
+	if(user.restrained()) //climbing takes twice as long when restrained.
+		adjusted_climb_time *= 2
+	if(isalien(user))
+		adjusted_climb_time *= 0.25 //aliens are terrifyingly fast
+	if(HAS_TRAIT(user, TRAIT_FREERUNNING)) //do you have any idea how fast I am???
+		adjusted_climb_time *= 0.8
+	climber = user
+	if(do_mob(user, user, adjusted_climb_time))
+		if(src.loc) //Checking if structure has been destroyed
+			if(do_climb(user))
+				user.visible_message("<span class='warning'>[user] climbs onto [src].</span>", \
+									"<span class='notice'>You climb onto [src].</span>")
+				log_combat(user, src, "climbed onto")
+				if(climb_stun)
+					user.Stun(climb_stun)
+				. = 1
+			else
+				to_chat(user, "<span class='warning'>You fail to climb onto [src].</span>")
+	climber = null
 
 /**
  * Ship-to-ship weapons

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
@@ -221,6 +221,7 @@
 	icon = 'nsv13/icons/obj/munitions/deck_gun.dmi'
 	icon_state = "powder"
 	density = TRUE
+	w_class = WEIGHT_CLASS_HUGE // Bag is big
 	var/volatility = 1 //Gunpowder is volatile...
 	var/power = 0.5
 
@@ -242,7 +243,8 @@
 	icon_state = "torpedo"
 	desc = "A large shell designed to deliver a high-yield warhead upon high-speed impact with solid objects. You need to arm it with a multitool before firing."
 	anchored = FALSE
-	move_resist = MOVE_FORCE_EXTREMELY_STRONG
+	w_class = WEIGHT_CLASS_HUGE
+	move_resist = MOVE_FORCE_EXTREMELY_STRONG //Possible to pick up with two hands
 	density = TRUE
 	projectile_type = /obj/item/projectile/bullet/mac_round //What torpedo type we fire
 	obj_integrity = 300 //Beefy, relatively hard to use as a grief tool.
@@ -267,6 +269,7 @@
 	projectile_type = /obj/item/projectile/bullet/mac_round/cannonshot
 	obj_integrity = 100
 	max_integrity = 100
+	w_class = WEIGHT_CLASS_GIGANTIC
 	climbable = TRUE //No ballin'
 	climb_time = 30
 	climb_stun = 0 

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
@@ -271,8 +271,8 @@
 	max_integrity = 100
 	w_class = WEIGHT_CLASS_GIGANTIC
 	climbable = TRUE //No ballin'
-	climb_time = 30
-	climb_stun = 0 
+	climb_time = 25
+	climb_stun = 3
 	explosive = FALSE //Cannonshot is just iron
 	volatility = 0
 	explode_when_hit = FALSE //Literally just iron

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
@@ -267,6 +267,9 @@
 	projectile_type = /obj/item/projectile/bullet/mac_round/cannonshot
 	obj_integrity = 100
 	max_integrity = 100
+	climbable = TRUE //No ballin'
+	climb_time = 30
+	climb_stun = 0 
 	explosive = FALSE //Cannonshot is just iron
 	volatility = 0
 	explode_when_hit = FALSE //Literally just iron


### PR DESCRIPTION
## About The Pull Request

Makes it so munitions ammo (Torps, FTL funny, cannonballs, missiles) actually have a weight class so they can't be put into hilariously small spaces. Also makes constructing cannonballs out of iron take a while and gives you the ability to climb on torps, missiles and cannonballs to avoid people trapping themselves inbetween two torp tubes or four cannonballs. :bonklit:

## Why It's Good For The Game

Creative use of game mechanics:tm: bad.

## Changelog
:cl:
balance: Building Cannonballs is no longer instant.
fix: Gives Ship weapon ammunition a weight class.
/:cl:
