### PR TITLE
fixed missile construction not finishing

### DIFF
--- a/nsv13/code/modules/munitions/ammunition/missiles/missile_construction.dm
+++ b/nsv13/code/modules/munitions/ammunition/missiles/missile_construction.dm
@@ -214,6 +214,7 @@
 			to_chat(user, "<span class='notice'>You start sealing the casing on [src]...</span>")
 			if(tool.use_tool(src, user, 40, amount=1, volume=100))
 				to_chat(user, "<span class='notice'You seal the casing on [src].</span>")
+				state = 11
 				check_completion()
 			return TRUE
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

fixes missile construction not finishing due to off by 1 errors

## Why It's Good For The Game

missiles are a major mechanic, and as such this is an urgent fix

## Changelog
:cl:
fix: missile construction should now work properly
/:cl: