### PR TITLE
Some breach fixing stuff

### DIFF
--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -119,7 +119,7 @@
 	STOP_PROCESSING(SSfastprocess, src)
 	if(metal)
 		var/turf/T = get_turf(src)
-		if(isspaceturf(T)) //Block up any exposed space
+		if(isspaceturf(T) || istype(T, /turf/open/openspace)) //Block up any exposed space
 			T.PlaceOnTop(/turf/open/floor/plating/foam, flags = CHANGETURF_INHERIT_AIR)
 		for(var/direction in GLOB.cardinals)
 			var/turf/cardinal_turf = get_step(T, direction)

--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -119,7 +119,7 @@
 	STOP_PROCESSING(SSfastprocess, src)
 	if(metal)
 		var/turf/T = get_turf(src)
-		if(isspaceturf(T) || istype(T, /turf/open/openspace)) //Block up any exposed space
+		if(isspaceturf(T) || istype(T, /turf/open/openspace)) //Block up any exposed space - NSV13 change: Also accounts for openspace.
 			T.PlaceOnTop(/turf/open/floor/plating/foam, flags = CHANGETURF_INHERIT_AIR)
 		for(var/direction in GLOB.cardinals)
 			var/turf/cardinal_turf = get_step(T, direction)

--- a/nsv13/code/modules/overmap/components.dm
+++ b/nsv13/code/modules/overmap/components.dm
@@ -420,6 +420,18 @@ GLOBAL_LIST_INIT(computer_beeps, list('nsv13/sound/effects/computer/beep.ogg','n
 	. = ..()
 	return INITIALIZE_HINT_LATELOAD
 
+/obj/structure/hull_plate/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
+	var/turf/T = get_turf(src)
+	if(!T)
+		return FALSE
+	return T.rcd_vals(user, the_rcd)
+
+/obj/structure/hull_plate/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)
+	var/turf/T = get_turf(src)
+	if(!T)
+		return FALSE
+	return T.rcd_act(user, the_rcd, passed_mode)
+
 /obj/structure/hull_plate/LateInitialize()
 	try_find_parent()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR does the following:
Firstly, it does a small QoL change allowing RCDs to be used on hull plating, which will instead target the turf below, in case there is a breach below hull plating and you don't want to have to alt-click the hull plating to be able to click the actual turf.

Secondly, this fixes smartfoam not fixing floor / 'ceiling' breaches inbetween z-levels, as it did only fix explicitly space tiles, not openspace.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix man good.
Some QoL is neat too, saving a few clicks / seconds isn't too needed, but it shouldn't cause issues either.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Using smartfoam grenades on breaches that cause open space (aka, on the top deck of a ship) works now.
tweak: Using a RCD on hull plating will now attempt to use it on the turf below instead.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
