### PR TITLE
Rewards antags with torps even if they redtext, disables greentext torps

### DIFF
--- a/code/__DEFINES/metacoin.dm
+++ b/code/__DEFINES/metacoin.dm
@@ -12,3 +12,5 @@
 #define METACOIN_NOTSURVIVE_REWARD       10
 /// Rewarded when you are alive and active for 10 minutes
 #define METACOIN_TENMINUTELIVING_REWARD  4
+/// Rewarded for being a antagonist - NSV13
+#define METACOIN_ANTAGONIST_REWARD 200

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -90,6 +90,7 @@
 	var/list/team_ids = list()
 
 	var/list/greentexters = list()
+	var/list/antagonist_list = list() // NSV13 - List of antags for metacoins
 
 	for(var/datum/antagonist/A in GLOB.antagonists)
 		if(!A.owner)
@@ -123,17 +124,18 @@
 				antag_info["objectives"] += list(list("objective_type"=O.type,"text"=O.explanation_text,"result"=result))
 		SSblackbox.record_feedback("associative", "antagonists", 1, antag_info)
 
-		if (greentexted)
-			if (A.owner && A.owner.key)
-				if (A.type != /datum/antagonist/custom)
-					var/client/C = GLOB.directory[ckey(A.owner.key)]
-					if (C)
+		if (A.owner && A.owner.key)
+			if (A.type != /datum/antagonist/custom)
+				var/client/C = GLOB.directory[ckey(A.owner.key)]
+				if (C) // NSV13
+					if (greentexted)
 						greentexters |= C
-
+					antagonist_list |= C
 	for (var/client/C in greentexters)
 		C.process_greentext()
 
-
+	for (var/client/C in antagonist_list) // NSV13 - Awards all antags with metacoins
+		C.antag_metacoins()
 
 /datum/controller/subsystem/ticker/proc/record_nuke_disk_location()
 	var/obj/item/disk/nuclear/N = locate() in GLOB.poi_list

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -124,18 +124,18 @@
 				antag_info["objectives"] += list(list("objective_type"=O.type,"text"=O.explanation_text,"result"=result))
 		SSblackbox.record_feedback("associative", "antagonists", 1, antag_info)
 
-		if (A.owner && A.owner.key)
+		if (A.owner && A.owner.key) // NSV13 start
 			if (A.type != /datum/antagonist/custom)
 				var/client/C = GLOB.directory[ckey(A.owner.key)]
-				if (C) // NSV13
+				if (C)
 					if (greentexted)
 						greentexters |= C
-					antagonist_list |= C
+					antagonist_list |= C // NSV13 end
 	for (var/client/C in greentexters)
 		C.process_greentext()
 
 	for (var/client/C in antagonist_list) // NSV13 - Awards all antags with metacoins
-		C.antag_metacoins()
+		C.antag_metacoins() //NSV13
 
 /datum/controller/subsystem/ticker/proc/record_nuke_disk_location()
 	var/obj/item/disk/nuclear/N = locate() in GLOB.poi_list

--- a/code/modules/metacoin/metacoin.dm
+++ b/code/modules/metacoin/metacoin.dm
@@ -17,11 +17,14 @@
 			inc_metabalance(METACOIN_NOTSURVIVE_REWARD, reason="You tried.")
 
 /client/proc/process_greentext()
-	inc_metabalance(METACOIN_GREENTEXT_REWARD, reason="Greentext!")
+	// inc_metabalance(METACOIN_GREENTEXT_REWARD, reason="Greentext!") NSV13 - Disabled to let antags get the same amount of torps no matter if they greentext
 	SSmedals.UnlockMedal(MEDAL_COMPLETE_ALL_OBJECTIVES,src)
 
 /client/proc/process_ten_minute_living()
 	inc_metabalance(METACOIN_TENMINUTELIVING_REWARD, FALSE)
+
+/client/proc/antag_metacoins() // NSV13  - Gives antags free metacoins
+	inc_metabalance(METACOIN_ANTAGONIST_REWARD, reason="Being a antagonist!")
 
 /client/proc/get_metabalance()
 	var/datum/DBQuery/query_get_metacoins = SSdbcore.NewQuery(
@@ -39,7 +42,7 @@
 /client/proc/set_metacoin_count(mc_count, ann=TRUE)
 	var/datum/DBQuery/query_set_metacoins = SSdbcore.NewQuery(
 		"UPDATE [format_table_name("player")] SET metacoins = :mc_count WHERE ckey = :ckey",
-		list("mc_count" = mc_count, "ckey" = ckey)	
+		list("mc_count" = mc_count, "ckey" = ckey)
 	)
 	query_set_metacoins.warn_execute()
 	qdel(query_set_metacoins)
@@ -51,7 +54,7 @@
 		return
 	var/datum/DBQuery/query_inc_metacoins = SSdbcore.NewQuery(
 		"UPDATE [format_table_name("player")] SET metacoins = metacoins + :mc_count WHERE ckey = :ckey",
-		list("mc_count" = mc_count, "ckey" = ckey)	
+		list("mc_count" = mc_count, "ckey" = ckey)
 	)
 	query_inc_metacoins.warn_execute()
 	qdel(query_inc_metacoins)

--- a/code/modules/metacoin/metacoin.dm
+++ b/code/modules/metacoin/metacoin.dm
@@ -24,7 +24,7 @@
 	inc_metabalance(METACOIN_TENMINUTELIVING_REWARD, FALSE)
 
 /client/proc/antag_metacoins() // NSV13  - Gives antags free metacoins
-	inc_metabalance(METACOIN_ANTAGONIST_REWARD, reason="Being a antagonist!")
+	inc_metabalance(METACOIN_ANTAGONIST_REWARD, reason="Being a antagonist!") // NSV13
 
 /client/proc/get_metabalance()
 	var/datum/DBQuery/query_get_metacoins = SSdbcore.NewQuery(


### PR DESCRIPTION
## About The Pull Request

Makes it so antags get 200 torps on roundend. Disables them from getting torps for greentexting.

First time actually coding something for byond so it's probably shitcode.

## Why It's Good For The Game

Only giving torps for greentexting encourages rushing objectives and disencourages creativity. By disabling greentext torps you are more encouraged to do objectives in creative ways even if they lead to death.

## Changelog
:cl:
tweak: Replaced greentext torps with torps for being a antagonist that are awarded at roundend
/:cl:

