### PR TITLE
Gladius SMES & APC connections [Ready]

### DIFF
--- a/_maps/map_files/Gladius/Gladius1.dmm
+++ b/_maps/map_files/Gladius/Gladius1.dmm
@@ -6126,6 +6126,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/storage/satellite)
 "dcg" = (
@@ -7553,6 +7556,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile,
 /area/security/brig)
 "dLM" = (
@@ -8720,6 +8726,12 @@
 	},
 /turf/open/floor/monotile,
 /area/nsv/briefingroom)
+"epP" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/monotile/dark,
+/area/ai_monitored/turret_protected/ai)
 "epZ" = (
 /turf/open/floor/carpet/blue,
 /area/bridge)
@@ -9489,6 +9501,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/security/armory)
 "eFF" = (
@@ -9579,15 +9594,15 @@
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/captain)
 "eGY" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /obj/effect/turf_decal/ship/shutoff,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/monotile,
 /area/crew_quarters/nsv/officerquarters)
@@ -9862,6 +9877,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
+/obj/machinery/iv_drip,
 /turf/open/floor/monotile/light,
 /area/security/brig)
 "eMn" = (
@@ -11247,6 +11263,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/storage/satellite)
@@ -13732,6 +13751,17 @@
 /obj/item/ship_weapon/ammunition/torpedo/torpedo_casing,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/starboard)
+"gHa" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/nsv/officerquarters)
 "gHb" = (
 /obj/structure/lattice/catwalk/over/ship,
 /obj/effect/landmark/start/flight_leader,
@@ -13888,6 +13918,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/monotile,
 /area/crew_quarters/nsv/officerquarters)
@@ -15368,6 +15401,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/ai)
 "htM" = (
@@ -15460,6 +15496,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet/green,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -15561,6 +15600,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ai_monitored/turret_protected/aisat/foyer)
@@ -17416,6 +17458,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "iri" = (
@@ -19244,17 +19289,17 @@
 /obj/machinery/power/apc/auto_name/south{
 	pixel_y = -24
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/floor/monotile,
 /area/crew_quarters/nsv/officerquarters)
@@ -19275,13 +19320,13 @@
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/captain)
 "jjW" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
 /obj/effect/turf_decal/ship/shutoff,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ai_monitored/turret_protected/aisat/foyer)
@@ -22370,6 +22415,9 @@
 /area/security/brig)
 "kOA" = (
 /obj/machinery/status_display/evac/west,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/ai)
 "kOD" = (
@@ -22879,6 +22927,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "kZz" = (
@@ -22920,6 +22971,9 @@
 "lbY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
@@ -23113,6 +23167,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "lgf" = (
@@ -23209,6 +23266,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
@@ -23440,6 +23500,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "lnf" = (
@@ -23486,6 +23549,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/ai)
@@ -23547,6 +23613,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/security/armory)
@@ -24942,6 +25011,7 @@
 /obj/machinery/power/apc/auto_name/east{
 	pixel_x = 24
 	},
+/obj/structure/cable,
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/security/armory)
 "mcB" = (
@@ -25119,6 +25189,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile,
 /area/ai_monitored/security/armory)
 "mfE" = (
@@ -30933,6 +31006,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile,
 /area/crew_quarters/nsv/officerquarters)
 "oTn" = (
@@ -31103,6 +31179,7 @@
 	pixel_y = 28
 	},
 /obj/effect/turf_decal/ship/shutoff,
+/obj/structure/cable/yellow,
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/ai)
 "oVM" = (
@@ -31614,6 +31691,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "phQ" = (
@@ -31650,6 +31730,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/grid/lino,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -32162,6 +32245,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/grid/lino,
 /area/ai_monitored/turret_protected/aisat_interior)
 "psu" = (
@@ -32273,6 +32362,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
 /turf/open/floor/carpet/green,
 /area/ai_monitored/turret_protected/aisat_interior)
 "ptY" = (
@@ -35191,9 +35283,7 @@
 /obj/machinery/power/apc/auto_name/west{
 	pixel_x = -24
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
+/obj/structure/cable/yellow,
 /turf/open/floor/plasteel/grid/lino,
 /area/ai_monitored/turret_protected/aisat_interior)
 "qUC" = (
@@ -35662,9 +35752,6 @@
 /turf/open/floor/wood,
 /area/maintenance/nsv/deck1/port/aft)
 "rgd" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
@@ -35926,9 +36013,6 @@
 "rnV" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -44788,6 +44872,9 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/security/armory)
 "vCo" = (
@@ -47185,6 +47272,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile,
 /area/crew_quarters/nsv/officerquarters)
 "wLD" = (
@@ -47856,6 +47946,7 @@
 	dir = 8
 	},
 /obj/machinery/light,
+/obj/item/reagent_containers/blood/OMinus,
 /turf/open/floor/monotile/light,
 /area/security/brig)
 "xdw" = (
@@ -48130,6 +48221,9 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/security/armory)
@@ -87192,7 +87286,7 @@ fns
 fns
 dhv
 kOA
-mON
+epP
 oVL
 qFy
 sBu
@@ -93116,7 +93210,7 @@ dJn
 gJR
 wLg
 oSX
-ojD
+gHa
 jjw
 qBa
 uIL

--- a/_maps/map_files/Gladius/Gladius2.dmm
+++ b/_maps/map_files/Gladius/Gladius2.dmm
@@ -285,7 +285,7 @@
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/atmos)
 "akZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -8929,6 +8929,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/gravity_generator)
 "fBv" = (
@@ -10615,7 +10618,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-8"
 	},
 /turf/open/floor/monotile,
@@ -16153,16 +16156,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"jKk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/turf/open/floor/monotile,
-/area/tcommsat/computer)
 "jKq" = (
 /obj/machinery/light_switch/east,
 /obj/machinery/light{
@@ -18312,6 +18305,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/monotile/dark,
 /area/nsv/engine/corridor)
 "lgm" = (
@@ -24044,7 +24040,7 @@
 "oqD" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/power/terminal,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-4"
 	},
 /turf/open/floor/monotile,
@@ -25891,7 +25887,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/monotile,
@@ -26732,6 +26728,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/gravity_generator)
 "pUz" = (
@@ -27788,11 +27787,11 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/monotile,
 /area/tcommsat/computer)
@@ -27923,6 +27922,10 @@
 	},
 /turf/open/floor/monotile,
 /area/quartermaster/storage)
+"qBE" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/engine/atmos)
 "qBF" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1;
@@ -28511,6 +28514,9 @@
 /obj/structure/cable,
 /turf/open/floor/monotile,
 /area/hallway/secondary/entry)
+"qSL" = (
+/turf/open/space/basic,
+/area/engine/atmos)
 "qSR" = (
 /obj/structure/chair/stool/bar,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -29210,6 +29216,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/gravity_generator)
 "rkM" = (
@@ -29376,6 +29385,9 @@
 "roD" = (
 /obj/machinery/power/terminal{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/gravity_generator)
@@ -29992,8 +30004,10 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/effect/turf_decal/ship/shutoff,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile,
 /area/tcommsat/computer)
 "rIj" = (
@@ -33073,6 +33087,11 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/monotile,
 /area/security/checkpoint/customs)
+"trU" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/open/space/basic,
+/area/engine/atmos)
 "tsd" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -39025,6 +39044,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/gravity_generator)
 "xgF" = (
@@ -40488,6 +40510,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/gravity_generator)
@@ -57696,7 +57721,7 @@ hfx
 glx
 hYu
 rHY
-jKk
+pvO
 pvO
 pvO
 qyg
@@ -63801,13 +63826,13 @@ ncg
 cCg
 ncg
 aaa
-uCi
-uCi
-uCi
-uCi
-uCi
+qBE
+qBE
+qBE
+qBE
+qBE
 wWJ
-sqr
+trU
 kGx
 mSN
 fbN
@@ -64058,7 +64083,7 @@ ncg
 cCg
 ncg
 aaa
-uCi
+qBE
 dQa
 dQa
 dQa
@@ -64315,13 +64340,13 @@ ncg
 cCg
 ncg
 cTt
-uCi
+qBE
 dQa
 dkl
 ikE
 pLY
 gHt
-sqr
+trU
 rnA
 iSG
 pNp
@@ -64572,13 +64597,13 @@ ncg
 ncg
 ncg
 aaa
-uCi
+qBE
 dQa
 eil
 dmF
 qmK
 aVm
-qAk
+mgs
 ecD
 enJ
 joJ
@@ -64829,7 +64854,7 @@ aaa
 uCi
 aaa
 aaa
-uCi
+qBE
 dQa
 eki
 ivp
@@ -65086,13 +65111,13 @@ ncg
 ncg
 ncg
 aaa
-uCi
+qBE
 dQa
 dQa
 dQa
 dQa
 dQa
-qAk
+mgs
 drp
 dRm
 eed
@@ -65343,13 +65368,13 @@ ncg
 cCg
 ncg
 cTt
-uCi
-uCi
-uCi
-uCi
-uCi
-uCi
-qAk
+qBE
+qBE
+qBE
+qBE
+qBE
+qBE
+mgs
 drp
 jlg
 tol
@@ -65600,13 +65625,13 @@ ncg
 cCg
 ncg
 aaa
-aaa
-aaa
-aaa
-uCi
-aaa
-aaa
-qAk
+qSL
+qSL
+qSL
+qBE
+qSL
+qSL
+mgs
 drp
 cWM
 qQE


### PR DESCRIPTION
## About The Pull Request

Connected the Gravity Generator, Comms and AI sat SMES's to the power grid. Connected the armory APC to the power grid.

## Why It's Good For The Game

People like gravity and comms, and they sometimes like the AI and having the armory function properly.

## Changelog
:cl:
add: Added atmos area around the GenMix tank in atmos.
fix: Connected the Comms, Gravity Gen and AI sat SMESes to the power grid.
/:cl:

