### PR TITLE
(Probably) fixes Search & Destroy AI goals

### DIFF
--- a/nsv13/code/modules/overmap/ai-skynet2.dm
+++ b/nsv13/code/modules/overmap/ai-skynet2.dm
@@ -717,20 +717,28 @@ GLOBAL_LIST_EMPTY(ai_goals)
 	score = AI_SCORE_DEFAULT
 
 /datum/ai_goal/seek/check_score(obj/structure/overmap/OM)
+	message_admins("Running checks for search & destroy, for object [OM]")
 	if(!OM.fleet) //If this is a rogue / lone AI. This should be their only objective.
+		message_admins("returning [AI_SCORE_MAXIMUM] / AI_SCORE_MAXIMUM")
 		return AI_SCORE_MAXIMUM
 	if(!..()) //If it's not an overmap, or it's not linked to a fleet.
+		message_admins("returning 0")
 		return 0
 	if(!OM.last_target || QDELETED(OM.last_target))
+		message_admins("Seeking target")
 		OM.seek_new_target()
 	if(OM.last_target) //If we can't find a target, then don't bother hunter-killering.
+		message_admins("Returning [score] / score")
 		return score
 	else
+		message_admins("returning [AI_SCORE_VERY_LOW_PRIORITY] / AI_SCORE_VERY_LOW_PRIORITY")
 		return AI_SCORE_VERY_LOW_PRIORITY //Just so that there's a "default" behaviour to avoid issues.
 
 /datum/ai_goal/seek/action(obj/structure/overmap/OM)
 	..()
+	message_admins("Executing search and destroy for [OM]")
 	if(OM.last_target)
+		message_admins("Engaging target [OM.last_target]")
 		if(get_dist(OM, OM.last_target) <= 10)
 			OM.move_away_from(OM.last_target)
 		else
@@ -738,6 +746,7 @@ GLOBAL_LIST_EMPTY(ai_goals)
 	else
 		OM.send_sonar_pulse() //Send a pong when we're actively hunting.
 		OM.seek_new_target()
+		message_admins("No target, pinging. Target after ping; [OM.last_target]")
 		OM.move_toward(null) //Just fly around in a straight line, I guess.
 
 //Boarding! Boarders love to board your ships.
@@ -981,14 +990,6 @@ GLOBAL_LIST_EMPTY(ai_goals)
 			addtimer(CALLBACK(src, .proc/resupply), 30 SECONDS)
 			break
 //Method to allow a supply ship to resupply other AIs.
-
-/obj/structure/overmap/Destroy()
-	if(fleet)
-		for(var/list/L in fleet.taskforces) //Clean out the null refs.
-			for(var/obj/structure/overmap/OM in L)
-				if(OM == src)
-					L -= src
-	. = ..()
 
 /obj/structure/overmap/proc/resupply()
 	if(!resupply_target || get_dist(src, resupply_target) > resupply_range)

--- a/nsv13/code/modules/overmap/ai-skynet2.dm
+++ b/nsv13/code/modules/overmap/ai-skynet2.dm
@@ -791,11 +791,11 @@ GLOBAL_LIST_EMPTY(ai_goals)
 /datum/ai_goal/defend/check_score(obj/structure/overmap/OM)
 	if(!..() || !OM.fleet) //If it's not an overmap, or it's not linked to a fleet.
 		return score
+	if(!OM.fleet.taskforces["supply"]?.len)
+		return 0	//If there is nothing to defend, lets hunt the guys that destroyed our supply line instead.
 	if(OM.ai_trait == AI_TRAIT_BATTLESHIP)
 		var/list/L = OM.fleet.taskforces["supply"]
 		return (L.len ? AI_SCORE_CRITICAL : 0)
-	if(!OM.fleet.taskforces["supply"]?.len)
-		return 0	//If there is nothing to defend, lets hunt the guys that destroyed our supply line instead.
 	return score //If you've got nothing better to do, come group with the main fleet.
 
 //Goal used entirely for supply ships, signalling them to run away! Most ships use the "repair and re-arm" goal instead of this one.

--- a/nsv13/code/modules/overmap/ai-skynet2.dm
+++ b/nsv13/code/modules/overmap/ai-skynet2.dm
@@ -777,7 +777,8 @@ GLOBAL_LIST_EMPTY(ai_goals)
 /datum/ai_goal/defend/action(obj/structure/overmap/OM)
 	..()
 	if(!OM.defense_target || QDELETED(OM.defense_target))
-		OM.defense_target = OM.fleet.taskforces["supply"]?.len ? pick(OM.fleet.taskforces["supply"]) : OM
+		var/list/supplyline = OM.fleet.taskforces["supply"]
+		OM.defense_target = supplyline?.len ? pick(OM.fleet.taskforces["supply"]) : OM
 	OM.move_mode = NORTH
 	if(get_dist(OM, OM.defense_target) <= AI_PDC_RANGE)
 		OM.brakes = TRUE
@@ -791,11 +792,11 @@ GLOBAL_LIST_EMPTY(ai_goals)
 /datum/ai_goal/defend/check_score(obj/structure/overmap/OM)
 	if(!..() || !OM.fleet) //If it's not an overmap, or it's not linked to a fleet.
 		return score
-	if(!OM.fleet.taskforces["supply"]?.len)
+	var/list/supplyline = OM.fleet.taskforces["supply"]
+	if(!supplyline || !supplyline.len)
 		return 0	//If there is nothing to defend, lets hunt the guys that destroyed our supply line instead.
 	if(OM.ai_trait == AI_TRAIT_BATTLESHIP)
-		var/list/L = OM.fleet.taskforces["supply"]
-		return (L.len ? AI_SCORE_CRITICAL : 0)
+		return AI_SCORE_CRITICAL
 	return score //If you've got nothing better to do, come group with the main fleet.
 
 //Goal used entirely for supply ships, signalling them to run away! Most ships use the "repair and re-arm" goal instead of this one.

--- a/nsv13/code/modules/overmap/ai_interiors.dm
+++ b/nsv13/code/modules/overmap/ai_interiors.dm
@@ -69,26 +69,6 @@
 	cinematic_sound(sound('sound/effects/explosion_distant.ogg'))
 	special()
 
-
-/obj/structure/overmap/Destroy()
-	STOP_PROCESSING(SSphysics_processing, src)
-	GLOB.overmap_objects -= src
-	relay('nsv13/sound/effects/ship/damage/ship_explode.ogg')
-	relay_to_nearby('nsv13/sound/effects/ship/damage/disable.ogg') //Kaboom.
-	new /obj/effect/temp_visual/fading_overmap(get_turf(src), name, icon, icon_state)
-	for(var/obj/structure/overmap/OM in enemies) //If target's in enemies, return
-		var/sound = pick('nsv13/sound/effects/computer/alarm.ogg','nsv13/sound/effects/computer/alarm_2.ogg')
-		var/message = "<span class='warning'>ATTENTION: [src]'s reactor is going supercritical. Destruction imminent.</span>"
-		OM?.tactical?.relay_sound(sound, message)
-		OM.enemies -= src //Stops AI from spamming ships that are already dead
-	overmap_explode(linked_areas)
-	if(role == MAIN_OVERMAP)
-		priority_announce("WARNING: ([rand(10,100)]) Attempts to establish DRADIS uplink with [station_name()] have failed. Unable to ascertain operational status. Presumed status: TERMINATED","Central Intelligence Unit", 'nsv13/sound/effects/ship/reactor/explode.ogg')
-		Cinematic(CINEMATIC_NSV_SHIP_KABOOM,world)
-		SSticker.mode.check_finished(TRUE)
-		SSticker.force_ending = 1
-	. = ..()
-
 /proc/overmap_explode(list/areas)
 	for(var/area/AR in areas)
 		var/turf/T = pick(get_area_turfs(AR))

--- a/nsv13/code/modules/overmap/ai_interiors.dm
+++ b/nsv13/code/modules/overmap/ai_interiors.dm
@@ -70,6 +70,8 @@
 	special()
 
 /proc/overmap_explode(list/areas)
+	if(!areas)
+		return
 	for(var/area/AR in areas)
 		var/turf/T = pick(get_area_turfs(AR))
 		explosion(T,30,30,30)

--- a/nsv13/code/modules/overmap/overmap.dm
+++ b/nsv13/code/modules/overmap/overmap.dm
@@ -354,6 +354,7 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 	if(physics2d)
 		qdel(physics2d)
 		physics2d = null
+	START_PROCESSING(SSphysics_processing, src)
 	. = ..()
 
 /obj/structure/overmap/proc/find_area()

--- a/nsv13/code/modules/overmap/overmap.dm
+++ b/nsv13/code/modules/overmap/overmap.dm
@@ -346,6 +346,15 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 	. = ..()
 
 /obj/structure/overmap/Destroy()
+	if(fleet)
+		for(var/V in fleet.taskforces)	//Very cursed but it works!
+			var/list/L = fleet.taskforces["[V]"]
+			if(!L)
+				continue
+			for(var/obj/structure/overmap/OM in L)
+				if(OM == src)
+					L.Remove(src)
+
 	STOP_PROCESSING(SSphysics_processing, src)
 	GLOB.overmap_objects -= src
 	relay('nsv13/sound/effects/ship/damage/ship_explode.ogg')
@@ -370,12 +379,7 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 	if(physics2d)
 		qdel(physics2d)
 		physics2d = null
-	if(fleet)
-		for(var/list/L in fleet.taskforces) //Clean out the null refs.
-			for(var/obj/structure/overmap/OM in L)
-				if(OM == src)
-					L -= src
-	. = ..()
+	return ..()
 
 /obj/structure/overmap/proc/find_area()
 	if(role == MAIN_OVERMAP) //We're the hero ship, link us to every ss13 area.

--- a/nsv13/code/modules/overmap/overmap.dm
+++ b/nsv13/code/modules/overmap/overmap.dm
@@ -354,7 +354,7 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 	if(physics2d)
 		qdel(physics2d)
 		physics2d = null
-	START_PROCESSING(SSphysics_processing, src)
+	STOP_PROCESSING(SSphysics_processing, src)
 	. = ..()
 
 /obj/structure/overmap/proc/find_area()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Testmerge this first. It worked on local but might have overlooked something yadda yadda.

Anyway, the main things this PR does are
a) Actually removing ships from their fleet taskforce once they get destroyed, as that didn't work before due to byond things.
b) Making the 'Defend' aka stand around goal not runtime without targets.
c) Tweaking the Defend goal to also get priority 0 if all the supply ships got destroyed, so the ships go hunting down the guys that destroyed their supply line instead.

Additionally, it adds a small thing to the overmap_explode proc (just a early return in case there are no areas), aswell as compressing the Destroy() proc of overmap ships from THREE procs in THREE seperate files down into one in overmap.dm
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Search and destroy working as intended is probably a good thing.
The other stuff's just small changes that shouldn't be negative.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: overmap structures no longer have their Destroy() split into three seperate procs.
fix: Ships should now behave as intended in regards to their search & destroy AI goal.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
