### PR TITLE
[s] Fixes Fighters being reloadable from inside

### DIFF
--- a/nsv13/code/modules/overmap/fighters/fighters2.dm
+++ b/nsv13/code/modules/overmap/fighters/fighters2.dm
@@ -481,7 +481,7 @@ Repair
 		obj_flags ^= EMAGGED
 
 /obj/structure/overmap/fighter/attackby(obj/item/W, mob/user, params)
-	if(LAZYFIND(mobs_in_ship, user))
+	if(operators && LAZYFIND(operators, user))
 		to_chat(user, "<span class='warning'>You can't reach [src]'s exterior from in here..</span>")
 		return FALSE
 	for(var/slot in loadout.equippable_slots)

--- a/nsv13/code/modules/overmap/fighters/fighters2.dm
+++ b/nsv13/code/modules/overmap/fighters/fighters2.dm
@@ -481,6 +481,9 @@ Repair
 		obj_flags ^= EMAGGED
 
 /obj/structure/overmap/fighter/attackby(obj/item/W, mob/user, params)
+	if(LAZYFIND(mobs_in_ship, user))
+		to_chat(user, "<span class='warning'>You can't reach [src]'s exterior from in here..</span>")
+		return FALSE
 	for(var/slot in loadout.equippable_slots)
 		var/obj/item/fighter_component/FC = loadout.get_slot(slot)
 		if(FC?.load(src, W))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. Added a check to see if the one trying to use an item on the fighter is inside it, and blocks the attempt if yes.
Because, y'know, Pilots being able to just carry ten mags and be able to instantly reload (or even repair) on the fly without RTBing isn't intended
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Most item-fighter interaction are now blocked if you are inside said Fighter.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
