### PR TITLE
Gives MaA locker a munifab board

### DIFF
--- a/nsv13/code/game/objects/structures/custom_closets.dm
+++ b/nsv13/code/game/objects/structures/custom_closets.dm
@@ -19,6 +19,7 @@
 	new /obj/item/pet_carrier(src)
 	new /obj/item/clothing/neck/petcollar(src)
 	new /obj/item/storage/box/spare_munitions_keys(src)
+	new /obj/item/circuitboard/machine/techfab/department/munitions(src)
 
 /obj/structure/closet/secure_closet/munitions_technician
 	name = "munitions technician's locker"


### PR DESCRIPTION
## About The Pull Request

yeah 

## Why It's Good For The Game

All other heads get a techfab board in their lockers, also a temp fix for aetherwhisp not having a munitions lathe.

## Changelog
:cl:
fix: The Master at Arms now has a munitions lathe board in their locker.
/:cl:
