### PR TITLE
(Probably) fixes some problems with small-ship ftl-dragalong

### DIFF
--- a/nsv13/code/modules/overmap/ftl.dm
+++ b/nsv13/code/modules/overmap/ftl.dm
@@ -109,6 +109,7 @@
 			var/obj/structure/overmap/ship = X
 			if(ship != OM && ship.occupying_levels.len) //If there's somehow a player ship in the system that is somehow not in other_player_ships, emergency return.
 				message_admins("Somehow [ship] got by the initial checks for system exits. This probably shouldn't happen, yell at a coder and / or check ftl.dm")
+				ftl_pull_small_craft(OM)
 				return
 	ftl_pull_small_craft(OM, FALSE)
 	for(var/atom/movable/X in system_contents)

--- a/nsv13/code/modules/overmap/ftl.dm
+++ b/nsv13/code/modules/overmap/ftl.dm
@@ -94,22 +94,20 @@
 		OM.reserved_z = temp
 		OM.forceMove(locate(OM.x, OM.y, OM.reserved_z)) //Annnd actually kick them out of the current system.
 		system_contents -= OM
+		ftl_pull_small_craft(OM)
 		return //Early return here. This means that another player ship is already holding the system, and we really don't need to double-check for this.
 	else
 		message_admins("Successfully removed [OM] from [src]")
 		OM.forceMove(locate(OM.x, OM.y, OM.reserved_z)) //Annnd actually kick them out of the current system.
 		system_contents -= OM
-	for(var/atom/movable/X in system_contents)
+	for(var/atom/movable/X in system_contents)	//Do a last check for safety so we don't stasis a player ship that slid by our others checks somehow.
 		if(istype(X, /obj/structure/overmap))
 			var/obj/structure/overmap/ship = X
 			if(ship != OM && ship.occupying_levels.len) //If there's a player ship left to hold the system, early return and keep this Z loaded.
+				message_admins("Somehow [ship] got by the initial checks for system exits. This probably shouldn't happen, yell at a coder and / or check ftl.dm")
 				return
-			if(ship.operators.len && !ship.ai_controlled) //Alright, now we handle the small ships. If there is no longer a large ship to hold the system, we just get caught up its wake and travel along with it.
-				ship.relay("<span class='warning'>You're caught in [OM]'s bluespace wake!</span>")
-				SEND_SIGNAL(ship, COMSIG_FTL_STATE_CHANGE)
-				ship.forceMove(locate(ship.x, ship.y, OM.reserved_z))
-				system_contents -= ship
-				continue
+	ftl_pull_small_craft(OM, FALSE)
+	for(var/atom/movable/X in system_contents)
 		contents_positions[X] = list("x" = X.x, "y" = X.y) //Cache the ship's position so we can regenerate it later.
 		X.moveToNullspace() //Anything that's an NPC should be stored safely in nullspace until we return.
 		if(istype(X, /obj/structure/overmap))
@@ -119,10 +117,29 @@
 				STOP_PROCESSING(SSphysics_processing, foo.physics2d) //Despawn this ship's collider, to avoid wasting time figuring out if it's colliding with things or not.
 	occupying_z = 0 //Alright, no ships are holding it anymore. Stop holding the Z-level
 
+/datum/star_system/proc/ftl_pull_small_craft(var/obj/structure/overmap/jumping, var/same_faction_only = TRUE)
+	if(!jumping)
+		return	//No.
+
+	for(var/atom/movable/AM in system_contents)
+		if(!istype(AM, /obj/structure/overmap))
+			continue
+		var/obj/structure/overmap/OM = AM
+		if(!OM.operators.len || OM.ai_controlled)	//AI ships / ships without a pilot just get put in stasis.
+			continue
+		if(same_faction_only && jumping.faction != OM.faction)	//We don't pull all small craft in the system unless we were the last ship here.
+			continue
+		OM.relay("<span class='warning'>You're caught in [jumping]'s bluespace wake!</span>")
+		SEND_SIGNAL(OM, COMSIG_FTL_STATE_CHANGE)
+		OM.forceMove(locate(OM.x, OM.y, jumping.reserved_z))
+		system_contents -= OM
+
+
 /obj/structure/overmap/proc/begin_jump(datum/star_system/target_system)
 	relay(ftl_drive.ftl_start, channel=CHANNEL_IMPORTANT_SHIP_ALERT)
 	desired_angle = 90 //90 degrees AKA face EAST to match the FTL parallax.
 	addtimer(CALLBACK(src, .proc/jump, target_system, TRUE), ftl_drive.ftl_startup_time)
+
 
 /obj/structure/overmap/proc/force_parallax_update(ftl_start)
 	if(reserved_z) //Actual overmap parallax behaviour

--- a/nsv13/code/modules/overmap/ftl.dm
+++ b/nsv13/code/modules/overmap/ftl.dm
@@ -96,14 +96,18 @@
 		system_contents -= OM
 		ftl_pull_small_craft(OM)
 		return //Early return here. This means that another player ship is already holding the system, and we really don't need to double-check for this.
-	else
-		message_admins("Successfully removed [OM] from [src]")
-		OM.forceMove(locate(OM.x, OM.y, OM.reserved_z)) //Annnd actually kick them out of the current system.
-		system_contents -= OM
-	for(var/atom/movable/X in system_contents)	//Do a last check for safety so we don't stasis a player ship that slid by our others checks somehow.
+
+	message_admins("Successfully removed [OM] from [src]")
+	OM.forceMove(locate(OM.x, OM.y, OM.reserved_z)) //Annnd actually kick them out of the current system.
+	system_contents -= OM
+
+	if(other_player_ships.len)	//There's still other ships here, only pull ships of our own faction.
+		ftl_pull_small_craft(OM)
+		return
+	for(var/atom/movable/X in system_contents)	//Do a last check for safety so we don't stasis a player ship that slid by our other checks somehow.
 		if(istype(X, /obj/structure/overmap))
 			var/obj/structure/overmap/ship = X
-			if(ship != OM && ship.occupying_levels.len) //If there's a player ship left to hold the system, early return and keep this Z loaded.
+			if(ship != OM && ship.occupying_levels.len) //If there's somehow a player ship in the system that is somehow not in other_player_ships, emergency return.
 				message_admins("Somehow [ship] got by the initial checks for system exits. This probably shouldn't happen, yell at a coder and / or check ftl.dm")
 				return
 	ftl_pull_small_craft(OM, FALSE)

--- a/nsv13/code/modules/overmap/ftl.dm
+++ b/nsv13/code/modules/overmap/ftl.dm
@@ -101,6 +101,8 @@
 	OM.forceMove(locate(OM.x, OM.y, OM.reserved_z)) //Annnd actually kick them out of the current system.
 	system_contents -= OM
 
+	if(!OM.occupying_levels.len)	//If this isn't actually a big ship with its own interior, do not pull ships, as only those get their own reserved z.
+		return
 	if(other_player_ships.len)	//There's still other ships here, only pull ships of our own faction.
 		ftl_pull_small_craft(OM)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Testmerge this for some time before merging. Fully testing all cases for things involving the jumping around of multiple player-controlled ships and fighters is slightly difficult on local, but the code *should* do what it's supposed to.

This is an issue that came up sometime ago in a pvp-test and it'd probably be good to have fixed before the next one in a few days so I threw this together. The changes this PR does *should* prevent fighters being dragged along weirdly, by firstly outsourcing the dragging to another proc to prevent copypasta, and secondly (hopefully) covering all cases that could happen.
Additionally, now, unless there is only one non-small playership (reads: ship with actual interior z-levels) left in the system, ships jumping out will only drag ships of their own faction, to prevent some fun problems.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix man good, probably.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Big ships dragging along small ships via FTL should now work correctly in situations involving multiple big ships.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
