### PR TITLE
Scram axe

### DIFF
--- a/nsv13.dme
+++ b/nsv13.dme
@@ -3218,6 +3218,7 @@
 #include "nsv13\code\game\objects\items\custom_materials.dm"
 #include "nsv13\code\game\objects\items\munitions_items.dm"
 #include "nsv13\code\game\objects\items\nsv_circuitboards.dm"
+#include "nsv13\code\game\objects\items\scramaxe.dm"
 #include "nsv13\code\game\objects\items\space_pirate_items.dm"
 #include "nsv13\code\game\objects\items\storage_items.dm"
 #include "nsv13\code\game\objects\structures\barricade.dm"

--- a/nsv13/code/game/objects/items/scramaxe.dm
+++ b/nsv13/code/game/objects/items/scramaxe.dm
@@ -1,6 +1,6 @@
 /obj/item/twohanded/fireaxe/scramaxe
 	name = "SCRAM Axe"
-	desc = "A artifact from the old days. Where we werent dependent on expensive computers to help with our nuclear reactors. Where all that was between you and certain death was 1 man. With a trusty axe. To cut the control rod rope"
+	desc = "A artifact from the old days. Where we weren't dependent on expensive computers to help with our nuclear reactors. Where all that was between you and certain death was 1 man. With a trusty axe. To cut the control rod rope"
 
 /obj/item/twohanded/fireaxe/scramaxe/afterattack(atom/A, mob/user, proximity)
 	. = ..()

--- a/nsv13/code/game/objects/items/scramaxe.dm
+++ b/nsv13/code/game/objects/items/scramaxe.dm
@@ -9,4 +9,8 @@
 			var/obj/machinery/atmospherics/components/binary/stormdrive_reactor/W = A
 			W.control_rod_percent = 100
 			W.update_icon()
-			to_chat(user,"<span class='danger'>Your not sure why. But hitting the reactor with the axe caused the control rods to drop!</span>")
+			to_chat(user,"<span class='danger'>Your not sure why. But hitting [W.name] with [src] caused the control rods to drop!</span>")
+		if(istype(A,/obj/machinery/atmospherics/components/trinary/nuclear_reactor))
+			var/obj/machinery/atmospherics/components/trinary/nuclear_reactor/W = A
+			A.desired_k = 0
+			to_chat(user,"<span class='danger'>Your not sure why. But hitting [W.name] with [src] caused the control rods to drop!</span>")

--- a/nsv13/code/game/objects/items/scramaxe.dm
+++ b/nsv13/code/game/objects/items/scramaxe.dm
@@ -9,8 +9,10 @@
 			var/obj/machinery/atmospherics/components/binary/stormdrive_reactor/W = A
 			W.control_rod_percent = 100
 			W.update_icon()
+			message_admins("[ADMIN_LOOKUPFLW(user)] SCRAMMED [W] with [src] at [AREACOORD(user)]")
 			to_chat(user,"<span class='danger'>Your not sure why. But hitting [W.name] with [src] caused the control rods to drop!</span>")
 		if(istype(A,/obj/machinery/atmospherics/components/trinary/nuclear_reactor))
 			var/obj/machinery/atmospherics/components/trinary/nuclear_reactor/W = A
 			W.desired_k = 0
+			message_admins("[ADMIN_LOOKUPFLW(user)] SCRAMMED [W] with [src] at [AREACOORD(user)]")
 			to_chat(user,"<span class='danger'>Your not sure why. But hitting [W.name] with [src] caused the control rods to drop!</span>")

--- a/nsv13/code/game/objects/items/scramaxe.dm
+++ b/nsv13/code/game/objects/items/scramaxe.dm
@@ -1,0 +1,11 @@
+/obj/item/twohanded/fireaxe/scramaxe
+	name = "SCRAM Axe"
+	desc = "A artifact from the old days. Where we werent dependent on expensive computers to help with our nuclear reactors. Where all that was between you and certain death was 1 man. With a trusty axe. To cut the control rod rope"
+
+/obj/item/twohanded/fireaxe/scramaxe/afterattack(atom/A, mob/user, proximity)
+	. = ..()
+	if(istype(A, /obj/machinery/atmospherics/components/binary/stormdrive_reactor))
+		var/obj/machinery/atmospherics/components/binary/stormdrive_reactor/W = A
+		W.control_rod_percent = 100
+		W.update_icon()
+		to_chat(user,"<span class='danger'>Your not sure why. But hitting the reactor with the axe caused the control rods to drop!</span>")

--- a/nsv13/code/game/objects/items/scramaxe.dm
+++ b/nsv13/code/game/objects/items/scramaxe.dm
@@ -12,5 +12,5 @@
 			to_chat(user,"<span class='danger'>Your not sure why. But hitting [W.name] with [src] caused the control rods to drop!</span>")
 		if(istype(A,/obj/machinery/atmospherics/components/trinary/nuclear_reactor))
 			var/obj/machinery/atmospherics/components/trinary/nuclear_reactor/W = A
-			A.desired_k = 0
+			W.desired_k = 0
 			to_chat(user,"<span class='danger'>Your not sure why. But hitting [W.name] with [src] caused the control rods to drop!</span>")

--- a/nsv13/code/game/objects/items/scramaxe.dm
+++ b/nsv13/code/game/objects/items/scramaxe.dm
@@ -4,8 +4,9 @@
 
 /obj/item/twohanded/fireaxe/scramaxe/afterattack(atom/A, mob/user, proximity)
 	. = ..()
-	if(istype(A, /obj/machinery/atmospherics/components/binary/stormdrive_reactor))
-		var/obj/machinery/atmospherics/components/binary/stormdrive_reactor/W = A
-		W.control_rod_percent = 100
-		W.update_icon()
-		to_chat(user,"<span class='danger'>Your not sure why. But hitting the reactor with the axe caused the control rods to drop!</span>")
+	if(SEND_SIGNAL(src, COMSIG_ITEM_IS_WIELDED) & COMPONENT_WIELDED)
+		if(istype(A, /obj/machinery/atmospherics/components/binary/stormdrive_reactor))
+			var/obj/machinery/atmospherics/components/binary/stormdrive_reactor/W = A
+			W.control_rod_percent = 100
+			W.update_icon()
+			to_chat(user,"<span class='danger'>Your not sure why. But hitting the reactor with the axe caused the control rods to drop!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the SCRAM axe to the CE's office on some maps. Fun novelty item that instantly drops the reactor rods in the SD(scramming it)

## Why It's Good For The Game

SCRAM stands for [safety control rod axe man](https://en.wikipedia.org/wiki/Scram)

Idea being you cut down a rope holding up the control rods to drop them into the reactor with gravity. Fun novelty to have

## Changelog
:cl:
add: Reliably old SCRAM axe is now in the CE office on some ships
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
