### PR TITLE
Even more fleet stuff

### DIFF
--- a/nsv13/code/controllers/subsystem/starsystem.dm
+++ b/nsv13/code/controllers/subsystem/starsystem.dm
@@ -352,6 +352,7 @@ Returns a faction datum by its name (case insensitive!)
 		var/datum/fleet/fleet = new fleet_type(src)
 		fleet.current_system = src
 		fleets += fleet
+		fleet.assemble(src)
 	if(preset_trader)
 		trader = new preset_trader
 		//We need to instantiate the trader's shop now and give it info, so unfortunately these'll always load in.
@@ -904,6 +905,7 @@ Welcome to the neutral zone! Non corporate sanctioned traders with better gear a
 			randyfleet.hide_movements = TRUE //Prevent the shot of spam this caused to R1497.
 			randy.fleets += randyfleet
 			randy.alignment = randyfleet.alignment
+			randyfleet.assemble(randy)
 
 
 

--- a/nsv13/code/modules/overmap/ai-skynet2.dm
+++ b/nsv13/code/modules/overmap/ai-skynet2.dm
@@ -232,6 +232,7 @@ GLOBAL_LIST_EMPTY(ai_goals)
 				target.enemies_in_system += OM
 			if(current_system.contents_positions[OM]) //If we were loaded, but the system was not.
 				current_system.contents_positions -= OM
+			OM.current_system = target
 	target.fleets += src
 	current_system = target
 	if(target.alignment != alignment)

--- a/nsv13/code/modules/overmap/ai-skynet2.dm
+++ b/nsv13/code/modules/overmap/ai-skynet2.dm
@@ -660,7 +660,7 @@ GLOBAL_LIST_EMPTY(ai_goals)
 				SS.add_ship(member)
 			else
 				LAZYADD(SS.system_contents, member)
-				SS.contents_positions[member] = list("x" = rand(15, 240), "y" = rand(15, 240)) //If the system isn't loaded, just give them ranomized positions.
+				SS.contents_positions[member] = list("x" = rand(15, 240), "y" = rand(15, 240)) //If the system isn't loaded, just give them randomized positions.
 				STOP_PROCESSING(SSphysics_processing, member)
 				if(member.physics2d)
 					STOP_PROCESSING(SSphysics_processing, member.physics2d)
@@ -680,7 +680,7 @@ GLOBAL_LIST_EMPTY(ai_goals)
 				SS.add_ship(member)
 			else
 				LAZYADD(SS.system_contents, member)
-				SS.contents_positions[member] = list("x" = rand(15, 240), "y" = rand(15, 240)) //If the system isn't loaded, just give them ranomized positions..
+				SS.contents_positions[member] = list("x" = rand(15, 240), "y" = rand(15, 240)) //If the system isn't loaded, just give them randomized positions..
 				STOP_PROCESSING(SSphysics_processing, member)
 				if(member.physics2d)
 					STOP_PROCESSING(SSphysics_processing, member.physics2d)
@@ -700,7 +700,7 @@ GLOBAL_LIST_EMPTY(ai_goals)
 				SS.add_ship(member)
 			else
 				LAZYADD(SS.system_contents, member)
-				SS.contents_positions[member] = list("x" = rand(15, 240), "y" = rand(15, 240)) //If the system isn't loaded, just give them ranomized positions..
+				SS.contents_positions[member] = list("x" = rand(15, 240), "y" = rand(15, 240)) //If the system isn't loaded, just give them randomized positions..
 				STOP_PROCESSING(SSphysics_processing, member)
 				if(member.physics2d)
 					STOP_PROCESSING(SSphysics_processing, member.physics2d)

--- a/nsv13/code/modules/overmap/ai-skynet2.dm
+++ b/nsv13/code/modules/overmap/ai-skynet2.dm
@@ -472,6 +472,7 @@ GLOBAL_LIST_EMPTY(ai_goals)
 	supply_types = null
 	alignment = "pirate"
 	faction_id = FACTION_ID_PIRATES
+	reward = 35
 
 /datum/fleet/pirate/scout
 	name = "Space pirate scout fleet"
@@ -494,6 +495,7 @@ GLOBAL_LIST_EMPTY(ai_goals)
 	taunts = list("These are our waters you are sailing, prepare to surrender!", "Bold of you to fly Nanotrasen colours in this system, your last mistake.")
 	size = FLEET_DIFFICULTY_VERY_HARD
 	fleet_trait = FLEET_TRAIT_DEFENSE
+	reward = 100	//Difficult pirate fleet, so default reward.
 
 //Boss battles.
 

--- a/nsv13/code/modules/overmap/ai-skynet2.dm
+++ b/nsv13/code/modules/overmap/ai-skynet2.dm
@@ -1297,7 +1297,14 @@ Seek a ship thich we'll station ourselves around
 		if(ai_fighter_type.len)
 			for(var/i = 0, i < rand(2,3), i++)
 				var/ai_fighter = pick(ai_fighter_type)
-				var/obj/structure/overmap/newFighter = new ai_fighter(get_turf(pick(orange(3, src))))
+				var/turf/launch_turf = get_turf(pick(orange(3, src)))
+				if(!launch_turf)
+					if(!i)
+						ai_can_launch_fighters = TRUE
+					else
+						addtimer(VARSET_CALLBACK(src, ai_can_launch_fighters, TRUE), (1 + i) MINUTES)
+					break
+				var/obj/structure/overmap/newFighter = new ai_fighter(launch_turf)
 				newFighter.last_target = last_target
 				if(current_system)
 					current_system.system_contents += newFighter

--- a/nsv13/code/modules/overmap/ai-skynet2.dm
+++ b/nsv13/code/modules/overmap/ai-skynet2.dm
@@ -219,9 +219,7 @@ GLOBAL_LIST_EMPTY(ai_goals)
 				else
 					target.contents_positions[OM] = list("x" = rand(15, 240), "y" = rand(15, 240))
 			else
-				var/turf/target_turf = locate(OM.x, OM.y, target.occupying_z)
-				if(target_turf)
-					OM.forceMove(target_turf)
+				target.add_ship(OM)
 			current_system.system_contents -= OM
 			target.system_contents += OM
 			if(alignment != "nanotrasen" && alignment != "solgov") //NT, SGC or whatever don't count as enemies that NT hire you to kill.

--- a/nsv13/code/modules/overmap/ai-skynet2.dm
+++ b/nsv13/code/modules/overmap/ai-skynet2.dm
@@ -211,6 +211,8 @@ GLOBAL_LIST_EMPTY(ai_goals)
 			target.system_contents += OM
 			if(!target.occupying_z)
 				STOP_PROCESSING(SSphysics_processing, OM)
+				if(OM.physics2d)
+					STOP_PROCESSING(SSphysics_processing, OM.physics2d)
 				var/backupx = OM.x
 				var/backupy = OM.y
 				OM.moveToNullspace()
@@ -219,9 +221,12 @@ GLOBAL_LIST_EMPTY(ai_goals)
 				else
 					target.contents_positions[OM] = list("x" = rand(15, 240), "y" = rand(15, 240))
 			else
+				if(!OM.z)
+					START_PROCESSING(SSphysics_processing, OM)
+					if(OM.physics2d)
+						START_PROCESSING(SSphysics_processing, OM.physics2d)
 				target.add_ship(OM)
 			current_system.system_contents -= OM
-			target.system_contents += OM
 			if(alignment != "nanotrasen" && alignment != "solgov") //NT, SGC or whatever don't count as enemies that NT hire you to kill.
 				current_system.enemies_in_system -= OM
 				target.enemies_in_system += OM

--- a/nsv13/code/modules/overmap/ai-skynet2.dm
+++ b/nsv13/code/modules/overmap/ai-skynet2.dm
@@ -647,7 +647,10 @@ GLOBAL_LIST_EMPTY(ai_goals)
 				SS.add_ship(member)
 			else
 				LAZYADD(SS.system_contents, member)
-				SS.contents_positions[member] = list("x" = rand(15, 240), "y" = rand(15, 240)) //If the system isn't loaded, just give them ranomized positions..
+				SS.contents_positions[member] = list("x" = rand(15, 240), "y" = rand(15, 240)) //If the system isn't loaded, just give them ranomized positions.
+				STOP_PROCESSING(SSphysics_processing, member)
+				if(member.physics2d)
+					STOP_PROCESSING(SSphysics_processing, member.physics2d)
 		}
 	if(battleship_types?.len)
 		for(var/I=0; I<max(round(difficulty/4), 1);I++){
@@ -665,6 +668,9 @@ GLOBAL_LIST_EMPTY(ai_goals)
 			else
 				LAZYADD(SS.system_contents, member)
 				SS.contents_positions[member] = list("x" = rand(15, 240), "y" = rand(15, 240)) //If the system isn't loaded, just give them ranomized positions..
+				STOP_PROCESSING(SSphysics_processing, member)
+				if(member.physics2d)
+					STOP_PROCESSING(SSphysics_processing, member.physics2d)
 		}
 	if(supply_types?.len)
 		for(var/I=0; I<max(round(difficulty/4), 1);I++){
@@ -682,6 +688,9 @@ GLOBAL_LIST_EMPTY(ai_goals)
 			else
 				LAZYADD(SS.system_contents, member)
 				SS.contents_positions[member] = list("x" = rand(15, 240), "y" = rand(15, 240)) //If the system isn't loaded, just give them ranomized positions..
+				STOP_PROCESSING(SSphysics_processing, member)
+				if(member.physics2d)
+					STOP_PROCESSING(SSphysics_processing, member.physics2d)
 		}
 	return TRUE
 

--- a/nsv13/code/modules/overmap/ftl.dm
+++ b/nsv13/code/modules/overmap/ftl.dm
@@ -72,8 +72,8 @@
 		var/list/info = contents_positions[ship]
 		ship.forceMove(get_turf(locate(info["x"], info["y"], occupying_z))) //Let's unbox that ship. Nice.
 		if(istype(ship, /obj/structure/overmap))
-			START_PROCESSING(SSphysics_processing, ship) //And let's stop it from processing too.
 			var/obj/structure/overmap/OM = ship
+			START_PROCESSING(SSphysics_processing, OM) //And let's restart its processing too..
 			if(OM.physics2d)
 				START_PROCESSING(SSphysics_processing, OM.physics2d) //Respawn this ship's collider so it can start colliding once more
 	}

--- a/nsv13/code/modules/overmap/ftl.dm
+++ b/nsv13/code/modules/overmap/ftl.dm
@@ -4,7 +4,7 @@
 #define FTL_STATE_JUMPING 4
 
 /datum/star_system/proc/add_ship(obj/structure/overmap/OM)
-	if(!LAZYFIND(system_contents, OM))
+	if(!system_contents.Find(OM))
 		system_contents += OM	//Lets be safe while I cast some black magic.
 	if(!occupying_z && OM.z) //Does this system have a physical existence? if not, we'll set this now so that any inbound ships jump to the same Z-level that we're on.
 		occupying_z = OM.z

--- a/nsv13/code/modules/overmap/ftl.dm
+++ b/nsv13/code/modules/overmap/ftl.dm
@@ -4,7 +4,8 @@
 #define FTL_STATE_JUMPING 4
 
 /datum/star_system/proc/add_ship(obj/structure/overmap/OM)
-	system_contents += OM
+	if(!LAZYFIND(system_contents, OM))
+		system_contents += OM	//Lets be safe while I cast some black magic.
 	if(!occupying_z && OM.z) //Does this system have a physical existence? if not, we'll set this now so that any inbound ships jump to the same Z-level that we're on.
 		occupying_z = OM.z
 		if(OM.role == MAIN_OVERMAP) //As these events all happen to the main ship, let's check that it's not say, the nomi that's triggering this system load...
@@ -114,7 +115,7 @@
 		X.moveToNullspace() //Anything that's an NPC should be stored safely in nullspace until we return.
 		if(istype(X, /obj/structure/overmap))
 			var/obj/structure/overmap/foo = X
-			STOP_PROCESSING(SSphysics_processing, X) //And let's stop it from processing too.
+			STOP_PROCESSING(SSphysics_processing, foo) //And let's stop it from processing too.
 			if(foo.physics2d)
 				STOP_PROCESSING(SSphysics_processing, foo.physics2d) //Despawn this ship's collider, to avoid wasting time figuring out if it's colliding with things or not.
 	occupying_z = 0 //Alright, no ships are holding it anymore. Stop holding the Z-level

--- a/nsv13/code/modules/overmap/overmap.dm
+++ b/nsv13/code/modules/overmap/overmap.dm
@@ -374,6 +374,8 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 		current_system.system_contents.Remove(src)
 		if(faction != "nanotrasen" && faction != "solgov")
 			current_system.enemies_in_system.Remove(src)
+		if(current_system.contents_positions[src])	//If we got destroyed while not loaded, chances are we should kill off this reference.
+			current_system.contents_positions.Remove(src)
 
 	STOP_PROCESSING(SSphysics_processing, src)
 	GLOB.overmap_objects -= src


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Did you know that fleets right now quite literally get regenerated every time a player encounters them and leave their already existing ships in nullspace forever, yet in the fleet, so the fleet can't be defeated if it was encountered before?
Yeah, me neither.

This PR improves some more stuff for fleets, namely
Fleets now get assembled as soon as they have a valid system, creating their ships. Further assembles will merely attemps to 'unstuck' ships that are still in nullspace when assemble is called in a loaded system (since that usually happens after the main restore_contents proc / simillar are handled). They also now store / deploy their stored ships correctly (least on local), so things should be less jank.

Additionally, fleets now will only change faction influence if there is a player ship in the system, since why'd NT give you credit for kills you weren't even in the system for it (This is mostly in preperation for some *fun* stuff but for now it's just helpful)

Oh and I also fixed the security level being reduced back to GQ if you encounter an enemy while over GQ (Zebra, or Delta). Rejoice.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fleets should no longer sometimes be undefeatable due to ships stuck in nullspace.
fix: Encountering an enemy will no longer force your alert level down to general quarters if it is higher.
code: Somewhat changed how fleets assemble themselves aswell as how they move.
balance: Fleets that are defeated outside of systems with players in them no longer modify influence (aka patrol completion)
balance: Pirate fleets are now worth less influence due to them being very easy to defeat.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
