### PR TITLE
Bridge Headset Rearrangement

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -218,7 +218,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	name = "\proper the executive officer's headset"
 	desc = "The headset of the guy who will one day be captain."
 	icon_state = "com_headset"
-	keyslot = new /obj/item/encryptionkey/heads/xo
+	keyslot = new /obj/item/encryptionkey/heads/captain //NSV13 - inserted captain key for better communication facilitation
 
 /obj/item/radio/headset/headset_cargo
 	name = "supply radio headset"

--- a/nsv13/code/game/objects/items/bridge_items.dm
+++ b/nsv13/code/game/objects/items/bridge_items.dm
@@ -2,4 +2,9 @@
 	name = "bridge radio headset"
 	desc = "A headset used by those who think they have power, but don't."
 	icon_state = "com_headset"
-	keyslot = new /obj/item/encryptionkey/heads/xo
+	keyslot = new /obj/item/encryptionkey/bridge_staff
+
+/obj/item/encryptionkey/bridge_staff
+	name = "bridge staff encryption key"
+	icon_state = "xo_cypherkey"
+	channels = list(RADIO_CHANNEL_COMMAND = 1)

--- a/nsv13/code/game/objects/items/munitions_items.dm
+++ b/nsv13/code/game/objects/items/munitions_items.dm
@@ -42,7 +42,6 @@
 	icon = 'nsv13/icons/obj/custom_radio.dmi'
 	icon_state = "mun_cypherkey"
 	channels = list(RADIO_CHANNEL_MUNITIONS = 1, RADIO_CHANNEL_SUPPLY = 1)
-	independent = TRUE
 
 ///////RADIO HEADSETS//////
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR alters the encryption keys for both the XO and Bridge STAFF.
XO gets a captain key to better facilitate assisting the Captain.
Bridge Staff have had their superfluous channels removed.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Allows for better communication channels and removes non required channels/flags.
Fixes: #1210
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added Bridge Staff encryption key
balance: Altered XO headset to use Captain's encryption key
remove: Removed Independent from MT's encryption key
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
