### PR TITLE
AI ships that aiprocess in nullspace now stop their own processing

### DIFF
--- a/nsv13/code/modules/overmap/ai-skynet2.dm
+++ b/nsv13/code/modules/overmap/ai-skynet2.dm
@@ -1214,6 +1214,11 @@ Seek a ship thich we'll station ourselves around
 	SSstar_system.update_pos(src)
 	if(!ai_controlled)
 		return
+	if(!z)	//Lets only fully stop processing on AI ships that get to nullspace with their processing still running, to not accidentally fuck up stuff.
+		STOP_PROCESSING(SSphysics_processing, src)
+		if(physics2d)
+			STOP_PROCESSING(SSphysics_processing, physics2d)
+		return
 	choose_goal()
 	if(!pilot) //AI ships need a pilot so that they aren't hit by their own bullets. Projectiles.dm's can_hit needs a mob to be the firer, so here we are.
 		pilot = new /mob/living(get_turf(src))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Generally, everything that gets them out of nullspace restarts their processing and having them still process while in nullspace ain't really intended nor needed. So, this stops their processing if they AI_process() while in nullspace (aka, they have no z), if it didn't get stopped beforehand for some reason.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Ghost pings & late initialize race conditions bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: AI ships should no longer be processing / pinging after being created in a nonloaded systes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
