### PR TITLE
Fixes a runtime that causes the CI to scream

### DIFF
--- a/nsv13/code/_HELPERS/overmap.dm
+++ b/nsv13/code/_HELPERS/overmap.dm
@@ -35,7 +35,7 @@ Helper method to get what ship an observer belongs to for stuff like parallax.
 */
 
 /mob/proc/find_overmap()
-	var/obj/structure/overmap/OM = loc.get_overmap() //Accounts for things like fighters
+	var/obj/structure/overmap/OM = loc?.get_overmap() //Accounts for things like fighters and for being in nullspace because having no loc is bad.
 	if(!OM) //We're on the overmap Z-level itself, thus we don't belong to any ship
 		if(last_overmap)
 			last_overmap.mobs_in_ship -= src


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. Find overmap runtimes if loc is null. This makes it not do that.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Runtimes bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The find_overmap proc should no longer runtime if used on things in nullspace / with no location.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
