### PR TITLE
Pipe autism unleashed

### DIFF
--- a/code/modules/atmospherics/machinery/components/trinary_devices/trinary_devices.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/trinary_devices.dm
@@ -5,7 +5,7 @@
 	use_power = IDLE_POWER_USE
 	device_type = TRINARY
 	layer = GAS_FILTER_LAYER
-	pipe_flags = PIPING_ONE_PER_TURF
+//	pipe_flags = PIPING_ONE_PER_TURF
 
 	var/flipped = FALSE
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/unary_devices.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/unary_devices.dm
@@ -3,7 +3,7 @@
 	dir = SOUTH
 	initialize_directions = SOUTH
 	device_type = UNARY
-	pipe_flags = PIPING_ONE_PER_TURF
+//	pipe_flags = PIPING_ONE_PER_TURF
 	construction_type = /obj/item/pipe/directional
 	var/uid
 	var/static/gl_uid = 1


### PR DESCRIPTION
## About The Pull Request

Comments out one-per-tile for some pipe components. This still leaves the ones intended for that intact, so no connector/machine funtimes.

## Why It's Good For The Game

Four **/** to make atmos compact.
Autistic atmos setup limits have been unleashed and increased by at least a factor of six. Also allows the building of compact one-tile airlocks.

## Changelog
:cl:
balance: Vents/scrubbers/passives/filters/mixers can now be built one-per-layer.
/:cl: