### PR TITLE
Ethereal Blood [Ready]

### DIFF
--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -711,7 +711,7 @@
 		var/mob/living/carbon/human/H = M
 		var/datum/species/ethereal/E = H.dna?.species
 		E.adjust_charge(5*REM)
-	else if(prob(90)) //scp13 optimization
+	else if(prob(3)) //scp13 optimization
 		M.electrocute_act(rand(1,3), "Liquid Electricity in their body", 1) //lmao at the newbs who eat energy bars
 		playsound(M, "sparks", 50, 1)
 	return ..()

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -711,8 +711,8 @@
 		var/mob/living/carbon/human/H = M
 		var/datum/species/ethereal/E = H.dna?.species
 		E.adjust_charge(5*REM)
-	else if(prob(10)) //scp13 optimization
-		M.electrocute_act(rand(10,15), "Liquid Electricity in their body", 1) //lmao at the newbs who eat energy bars
+	else if(prob(90)) //scp13 optimization
+		M.electrocute_act(rand(1,3), "Liquid Electricity in their body", 1) //lmao at the newbs who eat energy bars
 		playsound(M, "sparks", 50, 1)
 	return ..()
 

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -712,7 +712,7 @@
 		var/datum/species/ethereal/E = H.dna?.species
 		E.adjust_charge(5*REM)
 	else if(prob(3)) //scp13 optimization
-		M.electrocute_act(rand(1,3), "Liquid Electricity in their body", 1) //lmao at the newbs who eat energy bars
+		M.electrocute_act(rand(2,5), "Liquid Electricity in their body", 1) //lmao at the newbs who eat energy bars
 		playsound(M, "sparks", 50, 1)
 	return ..()
 

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -711,7 +711,7 @@
 		var/mob/living/carbon/human/H = M
 		var/datum/species/ethereal/E = H.dna?.species
 		E.adjust_charge(5*REM)
-	else if(prob(25)) //scp13 optimization
+	else if(prob(10)) //scp13 optimization
 		M.electrocute_act(rand(10,15), "Liquid Electricity in their body", 1) //lmao at the newbs who eat energy bars
 		playsound(M, "sparks", 50, 1)
 	return ..()

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -317,3 +317,11 @@
 	results = list(/datum/reagent/medicine/hepanephrodaxon = 5)
 	required_reagents = list(/datum/reagent/medicine/carthatoline = 2, /datum/reagent/carbon = 2, /datum/reagent/lithium = 1)
 	required_catalysts = list(/datum/reagent/toxin/plasma = 5)
+
+/datum/chemical_reaction/liquidelectricity
+	name = "Liquid Electricity"
+	id = /datum/reagent/consumable/liquidelectricity
+	results = list(/datum/reagent/consumable/liquidelectricity = 5)
+	required_reagents = list(/datum/reagent/consumable/ethanol = 3, /datum/reagent/silver = 1)
+	required_catalysts = list(/datum/reagent/toxin/plasma = 1)
+	

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -324,4 +324,4 @@
 	results = list(/datum/reagent/consumable/liquidelectricity = 5)
 	required_reagents = list(/datum/reagent/consumable/ethanol = 3, /datum/reagent/silver = 1)
 	required_catalysts = list(/datum/reagent/toxin/plasma = 1)
-	
+	mix_message = "The mixture sparks and then subsides."

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -321,7 +321,7 @@
 /datum/chemical_reaction/liquidelectricity
 	name = "Liquid Electricity"
 	id = /datum/reagent/consumable/liquidelectricity
-	results = list(/datum/reagent/consumable/liquidelectricity = 5)
-	required_reagents = list(/datum/reagent/consumable/ethanol = 3, /datum/reagent/silver = 1)
-	required_catalysts = list(/datum/reagent/toxin/plasma = 1)
+	results = list(/datum/reagent/consumable/liquidelectricity = 3)
+	required_reagents = list(/datum/reagent/consumable/ethanol = 3, /datum/reagent/consumable/liquidelectricity = 1, /datum/reagent/toxin/plasma = 1)
 	mix_message = "The mixture sparks and then subsides."
+	playsound(M, "sparks", 50, 1)

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -324,4 +324,3 @@
 	results = list(/datum/reagent/consumable/liquidelectricity = 3)
 	required_reagents = list(/datum/reagent/consumable/ethanol = 3, /datum/reagent/consumable/liquidelectricity = 1, /datum/reagent/toxin/plasma = 1)
 	mix_message = "The mixture sparks and then subsides."
-	playsound(M, "sparks", 50, 1)


### PR DESCRIPTION
## About The Pull Request

Added a chemical recipe for Liquid Electricity: 1 Ground Plasma, 1 Liquid Electricity, 3 Ethanol (creates 3 units)
Lowered Liquid Electricity shock probability and damage to prevent it from being used effectively as a weapon.

## Why It's Good For The Game

Ethereals (all 2 of them) can now be refilled on their blood analogue without 20 minutes of work by them and medical department personnel.

## Changelog
:cl:
add: Recipe for Liquid Electricity
tweak: Lowered Liquid electricity shock damage and probability
/:cl:
