### PR TITLE
More bee fixes

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -18,13 +18,16 @@ SUBSYSTEM_DEF(job)
 
 	var/spare_id_safe_code = ""
 
+	//NSV13 - rearranged CoC, renamed HoP to XO, added MAA
+	// Cap > XO > HoS > MAA > CE > CMO > RD
 	var/list/chain_of_command = list(
 		"Captain" = 1,				//Not used yet but captain is first in chain_of_command
-		"Head of Personnel" = 2,
-		"Research Director" = 3,
-		"Chief Engineer" = 4,
-		"Chief Medical Officer" = 5,
-		"Head of Security" = 6)
+		"Executive Officer" = 2,	//NSV13 - renamed HoP to XO
+		"Head of Security" = 3,
+		"Master At Arms" = 4,
+		"Chief Engineer" = 5,
+		"Chief Medical Officer" = 6,
+		"Research Director" = 7)
 
 /datum/controller/subsystem/job/Initialize(timeofday)
 	SSmapping.HACK_LoadMapConfig()

--- a/code/controllers/subsystem/tgui.dm
+++ b/code/controllers/subsystem/tgui.dm
@@ -81,6 +81,8 @@ SUBSYSTEM_DEF(tgui)
 			window_found = TRUE
 			break
 	if(!window_found)
+		if(issilicon(user))
+			to_chat(user, "<span class='warning'>Warning: Processor limit reached. Close some windows before opening more.</span>") //NSV13 - tell silicons when they've got too many windows
 		log_tgui(user, "Error: Pool exhausted")
 		return null
 	return window

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -613,7 +613,7 @@
 
 /datum/reagent/medicine/perfluorodecalin
 	name = "Perfluorodecalin"
-	description = "Extremely rapidly restores oxygen deprivation, but causes minor toxin damage. Overdose causes significant damage to the lungs."
+	description = "Extremely rapidly restores oxygen deprivation, but causes minor toxin damage. Overdose causes significant damage to the heart." //NSV13 - fixed OD to say heart instead of lungs
 	reagent_state = LIQUID
 	color = "#FF6464"
 	overdose_threshold = 30

--- a/nsv13/code/modules/mining/asteroid.dm
+++ b/nsv13/code/modules/mining/asteroid.dm
@@ -189,6 +189,13 @@ GLOBAL_LIST_EMPTY(asteroid_spawn_markers)		//handles mining asteroids, kind of s
 			qdel(DU)
 			icon_state = "magnet-[tier]"
 
+
+/obj/machinery/computer/ship/mineral_magnet/attack_ai(mob/user)
+	attack_hand(user)
+
+/obj/machinery/computer/ship/mineral_magnet/attack_robot(mob/user)
+	attack_hand(user)
+
 /obj/machinery/computer/ship/mineral_magnet/attack_hand(mob/user)
 	if(!allowed(user))
 		var/sound = pick('nsv13/sound/effects/computer/error.ogg','nsv13/sound/effects/computer/error2.ogg','nsv13/sound/effects/computer/error3.ogg')


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Added notification to silicon players when they try to go over the maximum number of TGUI windows
- Updated chain of command
- Made AIs and borgs able to use the arrestor
- Fixed the description of perfluorodecalin to state that OD does heart damage, not lung

## Changelog
:cl:
add: Added message to silicons when they open too many TGUIs
tweak: Reordered Chain of Command to be more appropriate for military vessels
fix: AIs and borgs can now use the asteroid arrestor
fix: The XO and MAA are in the chain of command
fix: Perfluorodecalin description now correctly states that overdose damages the heart
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
