### PR TITLE
Free mission points

### DIFF
--- a/nsv13/code/datums/missions.dm
+++ b/nsv13/code/datums/missions.dm
@@ -69,9 +69,9 @@ NOTE:
 
 /datum/nsv_mission/proc/payout()
   var/ownerFaction = owner.faction
-  for(var/datum/faction/NT in SSstar_system.factions)
-    if( ownerFaction == lowertext( NT.name ) )
-      NT.gain_influence(ticket_bounty)
+  for(var/datum/faction/F in SSstar_system.factions)
+    if( ownerFaction == lowertext( F.name ) )
+      F.gain_influence(ticket_bounty)
   var/obj/item/holochip/money = owner.send_supplypod(/obj/item/holochip)
   money.credits = payout
   if(LAZYLEN(rewards))

--- a/nsv13/code/datums/missions.dm
+++ b/nsv13/code/datums/missions.dm
@@ -18,6 +18,7 @@ NOTE:
   var/list/valid_factions = list("nanotrasen")
 
   var/payout = 4000
+  var/ticket_bounty = 100
   var/list/rewards // List of items to be offered as a reward
 
   var/obj/structure/overmap/owner // Which ship owns this mission
@@ -67,6 +68,10 @@ NOTE:
     return FALSE // If the mission is not active, it can not be completed
 
 /datum/nsv_mission/proc/payout()
+  var/ownerFaction = owner.faction
+  for(var/datum/faction/NT in SSstar_system.factions)
+    if( ownerFaction == lowertext( NT.name ) )
+      NT.gain_influence(ticket_bounty)
   var/obj/item/holochip/money = owner.send_supplypod(/obj/item/holochip)
   money.credits = payout
   if(LAZYLEN(rewards))
@@ -516,7 +521,7 @@ kill station
 /datum/nsv_mission/cargo/nuke/proc/third_warning()
   if(stage != MISSION_ACTIVE) // Only report the crate is suspect if the mission is ongoing
     return
-  owner.hail("The person who tampered with the job listing revealed they are a Syndicate agent after a breif 'talking' too. You need to destroy or dispose of that crate as they intended to have you destroy [delivery_target.name].", the_client.name)
+  owner.hail("The person who tampered with the job listing revealed they are a Syndicate agent after a brief 'talking' too. You need to destroy or dispose of that crate as they intended to have you destroy [delivery_target.name].", the_client.name)
 
 /datum/nsv_mission/cargo/nuke/payout()
   if(delivered_cargo)
@@ -585,4 +590,3 @@ kill station
 /datum/nsv_mission/custom/
   desc = "A mission missing the correct paperwork to define what is required. Contact NT if you see this!"
   var/admin_hints = "SET 'the_client' TO THE OVERMAP STATION! Set stage to different things to mark progress. -1 is failed. 0 is idle and 2 is complete."
-

--- a/nsv13/code/modules/overmap/traders.dm
+++ b/nsv13/code/modules/overmap/traders.dm
@@ -244,8 +244,9 @@
 	if(action == "mission")
 		var/list/currentMissions = list()
 		for ( var/datum/nsv_mission/M in SSstar_system.all_missions )
-			if ( M.stage != MISSION_COMPLETE )
-				currentMissions += M
+			if ( M.owner == user.get_overmap() )
+				if ( M.stage != MISSION_COMPLETE )
+					currentMissions += M
 		if ( currentMissions.len < 3 ) // Max number of missions
 			give_mission(usr)
 		else

--- a/nsv13/code/modules/overmap/traders.dm
+++ b/nsv13/code/modules/overmap/traders.dm
@@ -242,7 +242,18 @@
 			return
 		attempt_purchase(target, usr)
 	if(action == "mission")
-		give_mission(usr)
+		if ( SSstar_system.all_missions.len < 3 ) // Max number of missions
+			give_mission(usr)
+		else
+			to_chat(user, "<span class='boldnotice'>" + pick(
+				"Why don't you complete the mission we just gave you first.",
+				"Please complete the mission we gave you first, then come back and ask again.",
+				"Stop pressing the button.",
+				"*static*",
+				"We appreciate your enthusiasm, but we want to make sure this mission gets completed first.",
+				"What are the chances you'll actually get this mission done? Go complete it before we trust you with another one.",
+				"Our superiors have asked us to stop stacking critical missions on one courier.",
+			) + "</span>")
 
 /datum/trader/proc/give_mission(mob/living/user)
 	if(!isliving(user))

--- a/nsv13/code/modules/overmap/traders.dm
+++ b/nsv13/code/modules/overmap/traders.dm
@@ -242,7 +242,11 @@
 			return
 		attempt_purchase(target, usr)
 	if(action == "mission")
-		if ( SSstar_system.all_missions.len < 3 ) // Max number of missions
+		var/list/currentMissions = list()
+		for ( var/datum/nsv_mission/M in SSstar_system.all_missions )
+			if ( M.stage != MISSION_COMPLETE )
+				currentMissions += M
+		if ( currentMissions.len < 3 ) // Max number of missions
 			give_mission(usr)
 		else
 			to_chat(user, "<span class='boldnotice'>" + pick(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Completing missions now awards a small amount of faction points

## Why It's Good For The Game

Ties missions into patrols and encourages doing more missions for that sweet gameplay variety 

I was going to add more missions but cargo freight torpedoes stopped working a long time ago apparently and I didn't feel like also fixing torp collisions 

## Changelog
:cl:
add: Completing missions now awards 100 faction points, which count toward patrol completion 
tweak: Ships may only have 3 uncompleted missions at a time
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
