### PR TITLE
Throttles SSambience.

### DIFF
--- a/code/controllers/subsystem/ambience.dm
+++ b/code/controllers/subsystem/ambience.dm
@@ -1,8 +1,10 @@
-#define AMBIENT_EFFECT_COOLDOWN 600	// The minimum amount to wait between playing ambient effects (deciseconds)
+#define AMBIENT_EFFECT_COOLDOWN 2 MINUTES	// Nsv13 - This was really just pissing me off - The minimum amount to wait between playing ambient effects. In what does it bloody look like, MINUTES.
 
 #define AMBIENT_BUZZ_VOLUME 40
 #define AMBIENT_MUSIC_VOLUME 75
 #define AMBIENT_EFFECTS_VOLUME 45
+
+#define MUSIC_THROTTLE_DELAY 7 MINUTES //Nsv13- Look, beestation, I really like robocop.ogg, but I don't want to hear it EVERY BLOODY MINUTE
 
 // Ambient sounds: buzz, effects, music
 SUBSYSTEM_DEF(ambience)
@@ -63,7 +65,8 @@ SUBSYSTEM_DEF(ambience)
 /datum/controller/subsystem/ambience/proc/update_music(mob/M) // Background music, the more OOC ambience, like eerie space music
 	var/area/A = get_area(M)
 
-	if(A.ambient_music && (M.client?.prefs.toggles & SOUND_AMBIENCE) && prob(1.25) && !M.client?.channel_in_use(CHANNEL_AMBIENT_MUSIC)) // 1/80 chance to play every second, only play while another one is not playing
+	if(A.ambient_music && (world.time >= (M.client?.music_last_played + MUSIC_THROTTLE_DELAY)) && (M.client?.prefs.toggles & SOUND_AMBIENCE) && prob(1.25) && !M.client?.channel_in_use(CHANNEL_AMBIENT_MUSIC)) // 1/80 chance to play every second, only play while another one is not playing
+		M.client.music_last_played = world.time
 		SEND_SOUND(M, sound(pick(A.ambient_music), repeat = 0, wait = 0, volume = AMBIENT_MUSIC_VOLUME, channel = CHANNEL_AMBIENT_MUSIC))
 
 

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -48,6 +48,7 @@
 	var/ambient_buzz_playing = null // What buzz ambience is currently playing
 	var/ambient_buzz = null
 	var/ambient_effect_last_played = 0 // What was the last time we played an ambient effect noise?
+	var/music_last_played = 0 // Nsv13 - What was the last time we played an ambient music track?
 		////////////
 		//SECURITY//
 		////////////

--- a/code/modules/tgui_panel/audio.dm
+++ b/code/modules/tgui_panel/audio.dm
@@ -28,6 +28,7 @@
 	if(length(extra_data) > 0)
 		for(var/key in extra_data)
 			payload[key] = extra_data[key]
+	client?.music_last_played = world.time //Nsv13 - Fucks off SSambience's music spam for the sake of me bloody ears.
 	payload["url"] = url
 	window.send_message("audio/playMusic", payload)
 

--- a/code/modules/tgui_panel/audio.dm
+++ b/code/modules/tgui_panel/audio.dm
@@ -28,7 +28,9 @@
 	if(length(extra_data) > 0)
 		for(var/key in extra_data)
 			payload[key] = extra_data[key]
-	client?.music_last_played = world.time //Nsv13 - Fucks off SSambience's music spam for the sake of me bloody ears.
+	if(client) //Nsv13 - Dunno why bee didn't think of this one themselves...
+		client.music_last_played = world.time //Nsv13 - Fucks off SSambience's music spam for the sake of me bloody ears.
+		client.mob?.stop_sound_channel(CHANNEL_AMBIENT_MUSIC)
 	payload["url"] = url
 	window.send_message("audio/playMusic", payload)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

So bee changed ambience to use a subsystem, meaning you can be sitting around doing nothing as a ghost and suddenly get blasted with music. This throttles the music system to play music less frequently, and helps to avoid overlapping ambient music with combat music.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

I love robocop.ogg, but not this bloody often

## Changelog
:cl:
tweak: Ambient music and combat music no longer overlap. Ambient sounds have been reduced in frequency.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
