### PR TITLE
Replace Atlas munitions protolathe with techfab

### DIFF
--- a/_maps/map_files/Atlas/atlas.dmm
+++ b/_maps/map_files/Atlas/atlas.dmm
@@ -14049,7 +14049,7 @@
 	icon_state = "tube"
 	},
 /obj/machinery/light_switch/north,
-/obj/machinery/rnd/production/protolathe/department/munitions,
+/obj/machinery/rnd/production/techfab/department/munitions,
 /turf/open/floor/carpet/red,
 /area/nsv/weapons)
 "YM" = (


### PR DESCRIPTION
Tech Fabricators can make things protolathes cant, so a few munitions research designs were missing.

:cl:
fix: Atlas weapons tech fabricator can now make all munitions designs
/:cl: