### PR TITLE
Fixes fighter pilots suffocating in pressurized areas without a canopy

### DIFF
--- a/nsv13/code/modules/overmap/fighters/fighters2.dm
+++ b/nsv13/code/modules/overmap/fighters/fighters2.dm
@@ -1761,16 +1761,21 @@ Utility modules can be either one of these types, just ensure you set its slot t
 	// Leak air if the canopy is missing or broken
 	// and air is in the cabin
 	// and the fighter's environment isn't pressurized
-	if(( (!C || (C.obj_integrity <= 0)) && ( cabin_air && (cabin_air?.total_moles() > 0) && (cabin_air.return_pressure() > loc?.return_air()?.return_pressure()) ) ))
-		var/datum/gas_mixture/removed = cabin_air.remove(5)
-		qdel(removed)
+
+	if((!C || (C.obj_integrity <= 0)) && (cabin_air && (cabin_air?.total_moles() > 0)))
+		var/datum/gas_mixture/outside_air = loc?.return_air()
+		var/outside_pressure = outside_air ? outside_air.return_pressure() : 0
+		if(outside_pressure && (cabin_air.return_pressure() > outside_pressure))
+			var/datum/gas_mixture/removed = cabin_air.remove(min(cabin_air.total_moles(), 5))
+			qdel(removed)
 	update_icon()
 
 /obj/structure/overmap/fighter/return_air()
 	var/obj/item/fighter_component/canopy/C = loadout.get_slot(HARDPOINT_SLOT_CANOPY)
 	if(canopy_open || !C || (C.obj_integrity <= 0))
-		return loc.return_air()
-	return cabin_air
+		. = loc.return_air()
+	else
+		. = cabin_air
 
 /obj/structure/overmap/fighter/remove_air(amount)
 	return return_air()?.remove(amount)

--- a/nsv13/code/modules/overmap/fighters/fighters2.dm
+++ b/nsv13/code/modules/overmap/fighters/fighters2.dm
@@ -1778,7 +1778,8 @@ Utility modules can be either one of these types, just ensure you set its slot t
 		. = cabin_air
 
 /obj/structure/overmap/fighter/remove_air(amount)
-	return return_air()?.remove(amount)
+	var/datum/gas_mixture/air
+	. = air?.remove(amount)
 
 /obj/structure/overmap/fighter/return_analyzable_air()
 	return cabin_air

--- a/nsv13/code/modules/overmap/fighters/fighters2.dm
+++ b/nsv13/code/modules/overmap/fighters/fighters2.dm
@@ -1764,12 +1764,12 @@ Utility modules can be either one of these types, just ensure you set its slot t
 
 /obj/structure/overmap/fighter/return_air()
 	var/obj/item/fighter_component/canopy/C = loadout.get_slot(HARDPOINT_SLOT_CANOPY)
-	if(canopy_open || !C)
+	if(canopy_open || !C || (C.obj_integrity <= 0))
 		return loc.return_air()
 	return cabin_air
 
 /obj/structure/overmap/fighter/remove_air(amount)
-	return cabin_air?.remove(amount)
+	return return_air()?.remove(amount)
 
 /obj/structure/overmap/fighter/return_analyzable_air()
 	return cabin_air

--- a/nsv13/code/modules/overmap/fighters/fighters2.dm
+++ b/nsv13/code/modules/overmap/fighters/fighters2.dm
@@ -1757,7 +1757,11 @@ Utility modules can be either one of these types, just ensure you set its slot t
 		loadout.process()
 
 	var/obj/item/fighter_component/canopy/C = loadout.get_slot(HARDPOINT_SLOT_CANOPY)
-	if(!C || (C.obj_integrity <= 0)) //Leak air if the canopy is breached.
+
+	// Leak air if the canopy is missing or broken
+	// and air is in the cabin
+	// and the fighter's environment isn't pressurized
+	if(( (!C || (C.obj_integrity <= 0)) && ( cabin_air && (cabin_air?.total_moles() > 0) && (cabin_air.return_pressure() > loc?.return_air()?.return_pressure()) ) ))
 		var/datum/gas_mixture/removed = cabin_air.remove(5)
 		qdel(removed)
 	update_icon()

--- a/nsv13/code/modules/overmap/overmap.dm
+++ b/nsv13/code/modules/overmap/overmap.dm
@@ -297,8 +297,11 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 			cabin_air = new
 			cabin_air.set_temperature(T20C)
 			cabin_air.set_volume(200)
-			cabin_air.set_moles(/datum/gas/oxygen, O2STANDARD*cabin_air.return_volume()/(R_IDEAL_GAS_EQUATION*cabin_air.return_temperature()))
-			cabin_air.set_moles(/datum/gas/nitrogen, N2STANDARD*cabin_air.return_volume()/(R_IDEAL_GAS_EQUATION*cabin_air.return_temperature()))
+			//101 kPa =
+			// PV=nRT
+			// PV/RT = n
+			cabin_air.set_moles(/datum/gas/oxygen, O2STANDARD*cabin_air.return_volume()*ONE_ATMOSPHERE/(R_IDEAL_GAS_EQUATION*cabin_air.return_temperature()))
+			cabin_air.set_moles(/datum/gas/nitrogen, N2STANDARD*cabin_air.return_volume()*ONE_ATMOSPHERE/(R_IDEAL_GAS_EQUATION*cabin_air.return_temperature()))
 			move_by_mouse = TRUE //You'll want this. Trust.
 			inertial_dampeners = FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the air removed when breathing be from return_air instead of cabin_air
Also makes air stop leaking if the outside has more pressure than the fighter

I wish I could just fix extools's share method but instead we have this. Auxtools when

## Why It's Good For The Game
You should be able to breathe if nothing is separating you from a place with normal atmos

## Changelog
:cl:
tweak: stopped fighter atmos leaking from a broken canopy if it's in pressurized areas
fix: air breathed while in a fighter is the same as you get from return_air
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
