### PR TITLE
Makes felinids more socially acceptable

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -104,7 +104,7 @@
 		if(prob(5))
 			M.visible_message("<span class='warning'>[M] [pick("dry heaves!","coughs!","splutters!")]</span>")
 		if(prob(10))
-			var/sick_message = pick("You feel nauseous.", "You're nya't feeling so good.","You feel like your insides are melting.","You feel illsies.")
+			var/sick_message = pick("You feel nauseous.", "You're not feeling so good.","You feel like your insides are melting.","You feel ill.")
 			to_chat(M, "<span class='notice'>[sick_message]</span>")
 		if(prob(15))
 			var/obj/item/organ/guts = pick(M.internal_organs)

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -104,7 +104,7 @@
 		if(prob(5))
 			M.visible_message("<span class='warning'>[M] [pick("dry heaves!","coughs!","splutters!")]</span>")
 		if(prob(10))
-			var/sick_message = pick("You feel nauseous.", "You're not feeling so good.","You feel like your insides are melting.","You feel ill.")
+			var/sick_message = pick("You feel nauseous.", "You're not feeling so good.","You feel like your insides are melting.","You feel ill.") //NSV13
 			to_chat(M, "<span class='notice'>[sick_message]</span>")
 		if(prob(15))
 			var/obj/item/organ/guts = pick(M.internal_organs)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes uwuspeak when felinids are sick
## Why It's Good For The Game
If the ship gets nuked for uwuspeak, why should it be in code

## Changelog
:cl:
tweak: tweaked the messages felinids get when sick


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
