### PR TITLE
Fixes Ship-to-Ship Repairs

### DIFF
--- a/nsv13/code/modules/overmap/ai-skynet2.dm
+++ b/nsv13/code/modules/overmap/ai-skynet2.dm
@@ -1261,7 +1261,7 @@ Seek a ship thich we'll station ourselves around
 			if(OM.obj_integrity >= OM.max_integrity && OM.shots_left >= initial(OM.shots_left)) //No need to resupply this ship at all.
 				continue
 			resupply_target = OM
-			addtimer(CALLBACK(src, .proc/resupply), (30 + (100 - (OM.obj_integrity / OM.max_integrity) * 100 )))	//Resupply comperatively fast, but not instant. Repairs take longer.
+			addtimer(CALLBACK(src, .proc/resupply), 5 SECONDS)	//Resupply comperatively fast, but not instant. Repairs take longer.
 			resupplying++
 			break
 //Method to allow a supply ship to resupply other AIs.
@@ -1278,7 +1278,7 @@ Seek a ship thich we'll station ourselves around
 	if(torpStock > 0)
 		resupply_target.torpedoes = torpStock
 	resupply_target.shots_left = initial(resupply_target.shots_left)
-	resupply_target.try_repair(resupply_target.max_integrity - resupply_target.obj_integrity)
+	resupply_target.try_repair(resupply_target.max_integrity  * 0.1)
 	resupply_target = null
 
 /obj/structure/overmap/proc/can_board(obj/structure/overmap/ship)

--- a/nsv13/code/modules/overmap/ai-skynet2.dm
+++ b/nsv13/code/modules/overmap/ai-skynet2.dm
@@ -1278,7 +1278,7 @@ Seek a ship thich we'll station ourselves around
 	if(torpStock > 0)
 		resupply_target.torpedoes = torpStock
 	resupply_target.shots_left = initial(resupply_target.shots_left)
-	resupply_target.obj_integrity = resupply_target.max_integrity
+	resupply_target.try_repair(resupply_target.max_integrity - resupply_target.obj_integrity)
 	resupply_target = null
 
 /obj/structure/overmap/proc/can_board(obj/structure/overmap/ship)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Allows repairs by friendly ships to take you out of superstructure crit
Makes repairs happen over time instead of instantly after a delay
Fixes #1261

## Why It's Good For The Game
Carriers healing you can't trap you in crit anymore. Also it looks like it heals over time, now it does.

## Changelog
:cl:
tweak: resupply ships now repair damage over time
balance: ships resupplied by carriers no longer heal to full immediately
fix: being healed by a friendly ship no longer traps you in superstructure crit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
