### PR TITLE
Addresses a bunch of ambiguous naming and simillar in missile / torp stuff

### DIFF
--- a/nsv13/code/modules/munitions/ammunition/missiles/missile_parts.dm
+++ b/nsv13/code/modules/munitions/ammunition/missiles/missile_parts.dm
@@ -3,46 +3,39 @@
 	var/fits_type = null
 
 /obj/item/ship_weapon/parts/missile/warhead
-	name = "NTP-2 standard guided munition payload"
+	name = "NTP-2 standard missile payload"
 	icon = 'nsv13/icons/obj/munitions.dmi'
 	icon_state = "warhead"
-	desc = "A heavy warhead designed to be fitted to a torpedo. It's currently inert."
+	desc = "A heavy warhead designed to be fitted to a missile. It's currently inert."
 	w_class = WEIGHT_CLASS_HUGE
 	target_state = 6
 	var/build_path = /obj/item/ship_weapon/ammunition/missile
 	fits_type = /obj/item/ship_weapon/ammunition/missile/missile_casing //Used for warheads, missiles are different from torp.
 
-/obj/item/ship_weapon/parts/missile/warhead/decoy
-	name = "NTP-0x 'DCY' electronic countermeasure guided munition payload"
-	desc = "a decoy torpedo warhead"
-	icon_state = "warhead_decoy"
-	desc = "A simple electronic countermeasure wrapped in a metal casing. While these form inert missiles, they can be used to distract enemy anti-missile defenses to divert their flak away from other targets."
-	fits_type = /obj/item/ship_weapon/ammunition/torpedo/torpedo_casing
-	build_path = /obj/item/ship_weapon/ammunition/torpedo/decoy
 
 /obj/item/ship_weapon/parts/missile/guidance_system
-	name = "missile guidance system"
+	name = "munition guidance system"
 	icon = 'nsv13/icons/obj/munitions.dmi'
 	icon_state = "guidance"
-	desc = "A guidance module for a missile which allows them to lock onto a target inside their operational range. The microcomputer inside it is capable of performing thousands of calculations a second."
+	desc = "A guidance module for soon-to-be guided munitions, allowing them to lock onto a target inside their operational range. The microcomputer inside it is capable of performing thousands of calculations a second."
 	w_class = WEIGHT_CLASS_NORMAL
 	target_state = 2
 	var/accuracy = null
 
 /obj/item/ship_weapon/parts/missile/propulsion_system
-	name = "missile propulsion system"
+	name = "guided munition propulsion system"
 	icon = 'nsv13/icons/obj/munitions.dmi'
 	icon_state = "propulsion"
-	desc = "A gimballed thruster with an attachment nozzle, designed to be mounted in missile."
+	desc = "A gimballed thruster with an attachment nozzle, designed to be mounted in guided munitions."
 	w_class = WEIGHT_CLASS_BULKY
 	target_state = 0
 	var/speed = 1
 
 /obj/item/ship_weapon/parts/missile/iff_card //This should be abuseable via emag
-	name = "missile IFF card"
+	name = "guided munition IFF card"
 	icon = 'nsv13/icons/obj/munitions.dmi'
 	icon_state = "iff"
-	desc = "An IFF chip which allows a missile to distinguish friend from foe. The electronics contained herein are relatively simple, but they form a crucial part of any good missile."
+	desc = "An IFF chip which allows a guided munition to distinguish friend from foe. The electronics contained herein are relatively simple, but nonetheless crucial."
 	w_class = WEIGHT_CLASS_SMALL
 	target_state = 4
 	var/calibrated = FALSE

--- a/nsv13/code/modules/munitions/ammunition/torpedos/torpedo_parts.dm
+++ b/nsv13/code/modules/munitions/ammunition/torpedos/torpedo_parts.dm
@@ -8,7 +8,7 @@
 /obj/item/ship_weapon/parts/missile/warhead/decoy
 	name = "NTP-0x 'DCY' electronic countermeasure torpedo payload"
 	icon_state = "warhead_decoy"
-	desc = "A simple electronic countermeasure wrapped in a metal casing. While these form inert missiles, they can be used to distract enemy anti-missile defenses to divert their flak away from other targets."
+	desc = "A simple electronic countermeasure wrapped in a metal casing. While these form inert torpedoes, they can be used to distract enemy defenses to divert their flak away from other targets."
 	fits_type = /obj/item/ship_weapon/ammunition/torpedo/torpedo_casing
 	build_path = /obj/item/ship_weapon/ammunition/torpedo/decoy
 

--- a/nsv13/code/modules/munitions/ammunition/torpedos/torpedo_parts.dm
+++ b/nsv13/code/modules/munitions/ammunition/torpedos/torpedo_parts.dm
@@ -1,14 +1,19 @@
 /obj/item/ship_weapon/parts/missile/warhead/torpedo
-	name = "NTP-2 guided torpedo payload"
-	desc = "A payload that makes a standard torpedo payload"
+	name = "NTP-2 standard torpedo payload"
 	icon_state = "warhead"
-	desc = "An extremely heavy warhead designed to be fitted to a torpedo. This one has an inbuilt plasma charge to amplify its damage."
+	desc = "An extremely heavy warhead designed to be fitted to a torpedo. This one contains a standard explosive charge."
 	fits_type = /obj/item/ship_weapon/ammunition/torpedo/torpedo_casing
 	build_path = /obj/item/ship_weapon/ammunition/torpedo
 
+/obj/item/ship_weapon/parts/missile/warhead/decoy
+	name = "NTP-0x 'DCY' electronic countermeasure torpedo payload"
+	icon_state = "warhead_decoy"
+	desc = "A simple electronic countermeasure wrapped in a metal casing. While these form inert missiles, they can be used to distract enemy anti-missile defenses to divert their flak away from other targets."
+	fits_type = /obj/item/ship_weapon/ammunition/torpedo/torpedo_casing
+	build_path = /obj/item/ship_weapon/ammunition/torpedo/decoy
+
 /obj/item/ship_weapon/parts/missile/warhead/bunker_buster
-	name = "NTP-4 'BNKR' guided munition payload"
-	desc = "a bunker buster torpedo warhead"
+	name = "NTP-4 'BNKR' torpedo payload"
 	icon_state = "warhead_shredder"
 	desc = "An extremely heavy warhead designed to be fitted to a torpedo. This one has an inbuilt plasma charge to amplify its damage."
 	fits_type = /obj/item/ship_weapon/ammunition/torpedo/torpedo_casing
@@ -20,16 +25,16 @@
 	icon_state = "warhead_probe"
 	fits_type = /obj/item/ship_weapon/ammunition/torpedo/torpedo_casing
 	build_path = /obj/item/ship_weapon/ammunition/torpedo/probe
+
 /obj/item/ship_weapon/parts/missile/warhead/freight
-	name = "NTP-F 530mm freight torpedo"
-	desc = "A hollowed out nosecone that allows torpedoes to carry freight instead of an actual payload."
+	name = "NTP-F 530mm freight torpedo payload"
 	//icon_state = "warhead_freight"
+	desc = "A hollowed out nosecone that allows torpedoes to carry freight instead of an actual payload."
 	fits_type = /obj/item/ship_weapon/ammunition/torpedo/torpedo_casing
 	build_path = /obj/item/ship_weapon/ammunition/torpedo/freight
 
 /obj/item/ship_weapon/parts/missile/warhead/nuclear
 	name = "nuclear torpedo warhead"
-	desc = "a nuclear torpedo warhead"
 	icon_state = "warhead_nuclear"
 	desc = "An advanced warhead which carries a nuclear fission explosive. Torpedoes equipped with these can quickly annihilate targets with extreme prejudice, however they are extremely costly to produce."
 	fits_type = /obj/item/ship_weapon/ammunition/torpedo/torpedo_casing

--- a/nsv13/code/modules/research/designs/munitions_designs.dm
+++ b/nsv13/code/modules/research/designs/munitions_designs.dm
@@ -59,14 +59,60 @@
 	category = list("Advanced Munitions")
 	departmental_flags = DEPARTMENTAL_FLAG_CARGO|DEPARTMENTAL_FLAG_MUNITIONS
 
-//Torp parts
+//Parts that fit Torps and Missiles
+
+/datum/design/guidance_system
+	name = "Guided Munition Guidance System"
+	desc = "The stock standard guidance system design for guided munitions"
+	id = "guidance_system"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 1000, /datum/material/glass = 2500, /datum/material/gold = 3000, /datum/material/copper = 2500)
+	build_path = /obj/item/ship_weapon/parts/missile/guidance_system
+	category = list("Advanced Munitions")
+	departmental_flags = DEPARTMENTAL_FLAG_MUNITIONS
+
+/datum/design/propulsion_system
+	name = "Guided Munition Propulsion System"
+	desc = "The stock standard propulsion system design for guided munitions"
+	id = "propulsion_system"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 10000, /datum/material/glass = 5000, /datum/material/titanium = 2500, /datum/material/plasma = 2500)
+	build_path = /obj/item/ship_weapon/parts/missile/propulsion_system
+	category = list("Advanced Munitions")
+	departmental_flags = DEPARTMENTAL_FLAG_MUNITIONS
+
+/datum/design/iff_card
+	name = "Guided Munition IFF Card"
+	desc = "The stock standard IFF card design for guided munitions"
+	id = "iff_card"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/glass = 20000, /datum/material/copper = 5000, /datum/material/gold = 5000)
+	build_path = /obj/item/ship_weapon/parts/missile/iff_card
+	category = list("Advanced Munitions")
+	departmental_flags = DEPARTMENTAL_FLAG_MUNITIONS
+
+//Missile Parts
+
+/datum/design/missile_warhead
+	name = "Standard Missile Warhead"
+	desc = "The stock standard warhead design for missiles"
+	id = "missile_warhead"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 5000, /datum/material/glass = 2500, /datum/material/copper = 2500)
+	build_path = /obj/item/ship_weapon/parts/missile/warhead
+	category = list("Advanced Munitions")
+	departmental_flags = DEPARTMENTAL_FLAG_MUNITIONS	
+
+
+//Torp Parts
+
 /datum/design/warhead
 	name = "Torpedo Warhead"
 	desc = "The stock standard warhead design for torpedos"
 	id = "warhead"
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 10000, /datum/material/glass = 2500, /datum/material/copper = 2500, /datum/material/plasma = 10000)
-	build_path = /obj/item/ship_weapon/parts/missile/warhead
+	build_path = /obj/item/ship_weapon/parts/missile/warhead/torpedo
 	category = list("Advanced Munitions")
 	departmental_flags = DEPARTMENTAL_FLAG_MUNITIONS
 
@@ -87,16 +133,6 @@
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 5000, /datum/material/glass = 2500, /datum/material/copper = 2500)
 	build_path = /obj/item/ship_weapon/parts/missile/warhead/decoy
-	category = list("Advanced Munitions")
-	departmental_flags = DEPARTMENTAL_FLAG_MUNITIONS
-
-/datum/design/missile_warhead
-	name = "Standard Missile Warhead"
-	desc = "A decoy warhead design for torpedos"
-	id = "missile_warhead"
-	build_type = PROTOLATHE
-	materials = list(/datum/material/iron = 5000, /datum/material/glass = 2500, /datum/material/copper = 2500)
-	build_path = /obj/item/ship_weapon/parts/missile/warhead
 	category = list("Advanced Munitions")
 	departmental_flags = DEPARTMENTAL_FLAG_MUNITIONS
 
@@ -129,36 +165,6 @@
 	build_path = /obj/item/ship_weapon/parts/missile/warhead/probe
 	category = list("Advanced Munitions")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
-
-/datum/design/guidance_system
-	name = "Torpedo Guidance System"
-	desc = "The stock standard guidance system design for torpedos"
-	id = "guidance_system"
-	build_type = PROTOLATHE
-	materials = list(/datum/material/iron = 1000, /datum/material/glass = 2500, /datum/material/gold = 3000, /datum/material/copper = 2500)
-	build_path = /obj/item/ship_weapon/parts/missile/guidance_system
-	category = list("Advanced Munitions")
-	departmental_flags = DEPARTMENTAL_FLAG_MUNITIONS
-
-/datum/design/propulsion_system
-	name = "Torpedo Propulsion System"
-	desc = "The stock standard propulsion system design for torpedos"
-	id = "propulsion_system"
-	build_type = PROTOLATHE
-	materials = list(/datum/material/iron = 10000, /datum/material/glass = 5000, /datum/material/titanium = 2500, /datum/material/plasma = 2500)
-	build_path = /obj/item/ship_weapon/parts/missile/propulsion_system
-	category = list("Advanced Munitions")
-	departmental_flags = DEPARTMENTAL_FLAG_MUNITIONS
-
-/datum/design/iff_card
-	name = "Torpedo IFF Card"
-	desc = "The stock standard IFF card design for torpedos"
-	id = "iff_card"
-	build_type = PROTOLATHE
-	materials = list(/datum/material/glass = 20000, /datum/material/copper = 5000, /datum/material/gold = 5000)
-	build_path = /obj/item/ship_weapon/parts/missile/iff_card
-	category = list("Advanced Munitions")
-	departmental_flags = DEPARTMENTAL_FLAG_MUNITIONS
 
 //Naval Cannons
 /datum/design/naval_shell


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. Anything that fits both is renamed into guided munition(s) whatever, anything that only fits one has the correct one in its name. Also fixes the descriptions of some parts, plus moves them to places where they make sense (the decoy warhead was in missile parts when it only fit torpedoes for some reason)
Oh, and fixes the fact the torpedo warhead option was printing missile warheads.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Ahelp I can't fit this warhead into torp despite it being named torp warhead, please help.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Printing torpedo warheads now prints torpedo warheads.
spellcheck: Corrects a bunch of stuff related to guided munition components.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
