### PR TITLE
adds photocopiers to CIC (every map that didnt have one)

### DIFF
--- a/_maps/map_files/Aetherwhisp/Aetherwhisp2.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp2.dmm
@@ -30777,10 +30777,10 @@
 /turf/open/floor/carpet/ship,
 /area/quartermaster/lobby)
 "wwB" = (
-/obj/structure/table/glass,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/machinery/photocopier,
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"

--- a/_maps/map_files/Atlas/atlas2.dmm
+++ b/_maps/map_files/Atlas/atlas2.dmm
@@ -6267,9 +6267,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/newscaster{
-	pixel_y = -28
-	},
+/obj/machinery/photocopier,
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
 "Fl" = (
@@ -7286,6 +7284,10 @@
 /area/bridge/cic)
 "JU" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/newscaster{
+	pixel_x = -28;
+	pixel_y = -28
+	},
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
 "JV" = (

--- a/_maps/map_files/Eclipse/Eclipse1.dmm
+++ b/_maps/map_files/Eclipse/Eclipse1.dmm
@@ -6748,6 +6748,7 @@
 /area/crew_quarters/bar)
 "Cp" = (
 /obj/machinery/light,
+/obj/machinery/photocopier,
 /turf/open/floor/plasteel,
 /area/bridge)
 "Cq" = (

--- a/_maps/map_files/Tycoon/Tycoon2.dmm
+++ b/_maps/map_files/Tycoon/Tycoon2.dmm
@@ -33768,6 +33768,7 @@
 	dir = 8;
 	icon_state = "camera"
 	},
+/obj/machinery/photocopier,
 /turf/open/floor/monotile/dark,
 /area/bridge{
 	name = "CIC"


### PR DESCRIPTION
i've been told to kill

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A photocopier is now present in every CIC.

## Why It's Good For The Game

bridge staff can now photocopy documents and give them to people

## Changelog
:cl:
add: added photocopier
del: destroyed a glass table
tweak: moved a newscaster
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
