### PR TITLE
Stops ghosts from using the Dradis to ping

### DIFF
--- a/nsv13/code/modules/overmap/radar.dm
+++ b/nsv13/code/modules/overmap/radar.dm
@@ -190,8 +190,10 @@ Called by add_sensor_profile_penalty if remove_in is used.
 		ui = new(user, src, "Dradis")
 		ui.open()
 
-/obj/machinery/computer/ship/dradis/ui_act(action, params, datum/tgui/ui)
+/obj/machinery/computer/ship/dradis/ui_act(action, params, datum/tgui/ui, mob/user)
 	. = ..()
+	if(isobserver(user))
+		return
 	if(.)
 		return
 	if(!has_overmap())


### PR DESCRIPTION
## About The Pull Request

Makes it so ghosts can only view, instead of actively messing with, the Dradis console anymore.

## Why It's Good For The Game

Fixes #1449 
Ghost ping make Armada kill player bad

## Changelog
:cl:
fix: Fixed ghosts being able to ping using Dradis
/:cl:
