### PR TITLE
SD overload ranges tweak

### DIFF
--- a/nsv13/code/modules/power/stormdrive.dm
+++ b/nsv13/code/modules/power/stormdrive.dm
@@ -654,7 +654,7 @@ Control Rods
 	radiation_pulse(src, (heat * radiation_modifier), 2)
 	ambient_temp_bleed()
 
-	if(last_power_produced > 2000000) //2MW
+	if(last_power_produced > 3000000) //3MW
 		handle_overload()
 
 	var/turf/T = get_turf(src)
@@ -944,12 +944,12 @@ Control Rods
 
 /obj/machinery/atmospherics/components/binary/stormdrive_reactor/proc/handle_overload()
 	switch(last_power_produced)
-		if(2000000 to 3000000) //2MW to 3MW
+		if(3000000 to 5000000) //3MW to 5MW
 			if(prob(0.1))
 				for(var/obj/machinery/light/L in orange(8, src))
 					if(prob(25))
 						L.flicker()
-		if(3000000 to 5000000) //3MW to 5MW
+		if(5000000 to 8000000) //5MW to 8MW
 			if(prob(0.1))
 				for(var/obj/machinery/light/L in orange(25, src))
 					if(prob(25))
@@ -958,7 +958,7 @@ Control Rods
 				for(var/obj/machinery/light/L in orange(8, src))
 					if(prob(25))
 						L.flicker()
-		if(5000000 to 10000000) //5MW to 10MW
+		if(8000000 to 12000000) //8MW to 12MW
 			if(prob(0.1))
 				for(var/ar in SSmapping.areas_in_z["[z]"])
 					var/area/AR = ar
@@ -975,7 +975,8 @@ Control Rods
 				for(var/obj/machinery/power/grounding_rod/R in orange(5, src))
 					R.take_damage(rand(25, 50))
 				tesla_zap(src, 5, 1000)
-		if(10000000 to INFINITY) //10MW+
+				reactor_stability -= rand(5, 10)
+		if(12000000 to INFINITY) //12MW+
 			if(prob(1))
 				for(var/obj/machinery/light/L in GLOB.machines)
 					if(prob(50) && shares_overmap(src, L))
@@ -987,6 +988,7 @@ Control Rods
 				for(var/obj/machinery/power/grounding_rod/R in orange(8, src))
 					R.take_damage(rand(25, 75))
 				tesla_zap(src, 8, 2000)
+				reactor_stability -= rand(10, 20)
 
 /obj/machinery/atmospherics/components/binary/stormdrive_reactor/update_icon() //include overlays for radiation output levels and power output levels (ALSO 1k+ levels)
 	if(state == REACTOR_STATE_MELTDOWN)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR ups the overload ranges for the stormdrive.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Previously the overload ranges were set for having a generally lower power output due to the ship not requiring much power overall.

This change will bring it more in line with what is intended post 3MW APNW update.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Rebalanced Stormdrive overload ranges
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
