### PR TITLE
Monotiles as plating and plated catwalk fixes

### DIFF
--- a/code/game/objects/structures/catwalk.dm
+++ b/code/game/objects/structures/catwalk.dm
@@ -42,3 +42,7 @@
 	for(var/obj/structure/cable/C in T)
 		C.deconstruct()
 	..()
+
+// NSV13 - allow cable laying on open plated catwalk
+/obj/structure/lattice/catwalk/proc/can_lay_cable()
+	return FALSE

--- a/code/game/objects/structures/catwalk.dm
+++ b/code/game/objects/structures/catwalk.dm
@@ -39,8 +39,9 @@
 
 /obj/structure/lattice/catwalk/deconstruct()
 	var/turf/T = loc
-	for(var/obj/structure/cable/C in T)
-		C.deconstruct()
+	if(!istype(src, /obj/structure/lattice/catwalk/over/ship)) // NSV13 - don't cut cables if the catwalk goes *over* the cables
+		for(var/obj/structure/cable/C in T)
+			C.deconstruct()
 	..()
 
 // NSV13 - allow cable laying on open plated catwalk

--- a/code/game/turfs/open/floor/plating.dm
+++ b/code/game/turfs/open/floor/plating.dm
@@ -169,7 +169,9 @@
 	return
 
 /turf/open/floor/plating/can_have_cabling()
-	if(locate(/obj/structure/lattice/catwalk, src))
-		return 0
+	// NSV13 - let us put cables into open plated catwalk tiles
+	var/obj/structure/lattice/catwalk/C = locate(/obj/structure/lattice/catwalk, src)
+	if(C)
+		return C.can_lay_cable()
 	return 1
 

--- a/code/game/turfs/open/openspace.dm
+++ b/code/game/turfs/open/openspace.dm
@@ -22,6 +22,11 @@ GLOBAL_DATUM_INIT(openspace_backdrop_one_for_all, /atom/movable/openspace_backdr
 	var/can_build_on = TRUE
 
 	intact = 0
+
+	var/static/list/allowed_floors = typecacheof(list(
+			/obj/item/stack/tile/plasteel,
+			/obj/item/stack/tile/mono)) // NSV13 - allow building floor with monotiles
+
 /turf/open/openspace/airless
 	initial_gas_mix = AIRLESS_ATMOS
 
@@ -121,12 +126,12 @@ GLOBAL_DATUM_INIT(openspace_backdrop_one_for_all, /atom/movable/openspace_backdr
 		else
 			to_chat(user, "<span class='warning'>You need one rod to build a lattice.</span>")
 		return
-	if(istype(C, /obj/item/stack/tile/plasteel))
+	if(allowed_floors[C.type]) // NSV13 - allow building with monotiles
 		if(!CanCoverUp())
 			return
 		var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
 		if(L)
-			var/obj/item/stack/tile/plasteel/S = C
+			var/obj/item/stack/tile/S = C // NSV13 - genericized to all tile stacks allowed
 			if(S.use(1))
 				qdel(L)
 				playsound(src, 'sound/weapons/genhit.ogg', 50, 1)

--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -25,6 +25,10 @@
 
 	vis_flags = VIS_INHERIT_ID	//when this be added to vis_contents of something it be associated with something on clicking, important for visualisation of turf in openspace and interraction with openspace that show you turf.
 
+	var/static/list/allowed_floors = typecacheof(list(
+			/obj/item/stack/tile/plasteel,
+			/obj/item/stack/tile/mono)) // NSV13 - allow building floor with monotiles
+
 /turf/open/space/basic/New()	//Do not convert to Initialize
 	//This is used to optimize the map loader
 	return
@@ -123,10 +127,10 @@
 		else
 			to_chat(user, "<span class='warning'>You need one rod to build a lattice.</span>")
 		return
-	if(istype(C, /obj/item/stack/tile/plasteel))
+	if(allowed_floors[C.type]) // NSV13 - allow building with monotiles
 		var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
 		if(L)
-			var/obj/item/stack/tile/plasteel/S = C
+			var/obj/item/stack/tile/S = C // NSV13 - genericized to all tile stacks allowed
 			if(S.use(1))
 				qdel(L)
 				playsound(src, 'sound/weapons/genhit.ogg', 50, 1)

--- a/nsv13/code/game/objects/structures/catwalk.dm
+++ b/nsv13/code/game/objects/structures/catwalk.dm
@@ -24,10 +24,17 @@
 				break
 	if(I.use_tool(src, user, 0.5 SECONDS, volume=50))
 		user.visible_message("[user] flips [hatch_open ? "closed" : "open"] [src]'s maintenance hatch.",
-			"<span class='notice'>you flip [hatch_open ? "closed" : "open"] [src]'s maintenance hatch.</span>")
+			"<span class='notice'>You flip [hatch_open ? "closed" : "open"] [src]'s maintenance hatch.</span>")
 		hatch_open = !hatch_open
 		update_icon()
 	return TRUE
+
+/obj/structure/lattice/catwalk/over/ship/attackby(obj/item/C, mob/user, params)
+	message_admins("Attacking catwalk with [C]")
+	if(hatch_open && !(C.tool_behaviour == TOOL_CROWBAR))
+		var/turf/T = get_turf(src)
+		return T.attackby(C, user, params)
+	return ..()
 
 /obj/structure/lattice/catwalk/over/ship/update_icon()
 	. = ..()
@@ -41,3 +48,6 @@
 		obj_flags |= BLOCK_Z_FALL
 		smooth = SMOOTH_TRUE
 		queue_smooth(src)
+
+/obj/structure/lattice/catwalk/over/ship/can_lay_cable()
+	return hatch_open

--- a/nsv13/code/game/objects/structures/catwalk.dm
+++ b/nsv13/code/game/objects/structures/catwalk.dm
@@ -29,13 +29,6 @@
 		update_icon()
 	return TRUE
 
-/obj/structure/lattice/catwalk/over/ship/attackby(obj/item/C, mob/user, params)
-	message_admins("Attacking catwalk with [C]")
-	if(hatch_open && !(C.tool_behaviour == TOOL_CROWBAR))
-		var/turf/T = get_turf(src)
-		return T.attackby(C, user, params)
-	return ..()
-
 /obj/structure/lattice/catwalk/over/ship/update_icon()
 	. = ..()
 	if(hatch_open)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Allows cables to be placed in open plated catwalks
- Stops cables underneath plated catwalks being cut when the catwalk is removed
- Allows monotiles to be used as plating

Fixes #1379
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes repairs easier

## Changelog
:cl:
tweak: Monotiles can be used on lattice to make floor plating
fix: Cables can now be put back into plated catwalk tiles
fix: Cutting apart a plated catwalk no longer cuts cables underneath it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
