### PR TITLE
More Stairs

### DIFF
--- a/code/game/objects/structures/stairs.dm
+++ b/code/game/objects/structures/stairs.dm
@@ -45,7 +45,11 @@
 	if(!newloc || !AM)
 		return ..()
 	if(!isobserver(AM) && isTerminator() && (get_dir(src, newloc) == dir))
-		return stair_ascend(AM, newloc)
+		var/turf/target = get_step_multiz(get_turf(src), (dir|UP))
+		if(target == newloc) // Slightly jank, but this gets called twice mecause we move upwards out of the stair tile
+			return TRUE
+		stair_ascend(AM, target)
+		return FALSE // We don't want to cross onto the turf on the same Z as the stairs
 	return ..()
 
 /obj/structure/stairs/Cross(atom/movable/AM)
@@ -62,16 +66,12 @@
 /obj/structure/stairs/proc/stair_ascend(atom/movable/AM, turf/newloc)
 	var/turf/checking = get_step_multiz(get_turf(src), UP)
 	if(!istype(checking))
-		return
+		return FALSE
 	if(!checking.zPassIn(AM, UP, get_turf(src)))
-		return
-	var/turf/target = get_step_multiz(get_turf(src), (dir|UP))
-	if(istype(target) && !target.can_zFall(AM, null, get_step_multiz(target, DOWN)))			//Don't throw them into a tile that will just dump them back down.
-		if(newloc == target)
-			// Slight jank, but this call is happening because we tried to leave the stair tile. If it's targeting the right location, say yes.
-			return TRUE
-		else
-			return AM.Move(target)
+		return FALSE
+	if(istype(newloc) && !newloc.can_zFall(AM, null, get_step_multiz(newloc, DOWN)))			//Don't throw them into a tile that will just dump them back down.
+		return AM.Move(newloc) || AM.forceMove(newloc)
+	return FALSE
 
 
 /obj/structure/stairs/vv_edit_var(var_name, var_value)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Fixes bug where stairs with nothing blocking the turf behind them were broken
- Allows people to move into turfs occupied by dense objects again, but they won't be able to bring things with them in this case

## Why It's Good For The Game
Aetherwhisp engineering stairs should work again, and misplaced fire closets won't entirely block access to a deck

## Changelog
:cl:
fix: fixed bug where stairs without anything blocking behind them wouldn't let you ascend
tweak: dense objects no longer block moving up stairs, but only for the mob or object crossing them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
