### PR TITLE
Makes the BSA station goal just the regular BSA

### DIFF
--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -20,8 +20,7 @@
 /datum/station_goal/bluespace_cannon/check_completion()
 	if(..())
 		return TRUE
-	//var/obj/machinery/bsa/full/B = locate() Nsv13 - Galactica moment
-	var/obj/machinery/ship_weapon/energy/beam/bsa/built/B = locate()
+	var/obj/machinery/bsa/full/B = locate()
 	if(B && !B.stat)
 		return TRUE
 	return FALSE
@@ -331,12 +330,8 @@
 	var/datum/effect_system/smoke_spread/s = new
 	s.set_up(4,get_turf(centerpiece))
 	s.start()
-	//Nsv13 - Galactica moment
-	var/obj/machinery/ship_weapon/energy/beam/bsa/built/cannon = new(get_turf(centerpiece),centerpiece.get_cannon_direction())
+	var/obj/machinery/bsa/full/cannon = new(get_turf(centerpiece),centerpiece.get_cannon_direction())
 	qdel(centerpiece.front)
 	qdel(centerpiece.back)
 	qdel(centerpiece)
-	new /obj/machinery/computer/sts_bsa_control(get_turf(src))
-	qdel(src)
-	// /Nsv13
 	return cannon


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Stops the station goal from being the overmap BSA

## Why It's Good For The Game
You really shouldn't be able to build 20 of these and annihilate entire planets just because you rolled a 1/3

## Changelog
:cl:
del: Removed construction of the NSV BSA from the station goal
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
