### PR TITLE
Fixes infinite money caused by cheap crates

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -126,17 +126,23 @@
 /datum/supply_pack/emergency/firefighting
 	name = "Firefighting Crate"
 	desc = "Only you can prevent station fires. Partner up with two firefighter suits, gas masks, flashlights, large oxygen tanks, extinguishers, and hardhats!"
-	cost = 600
+	cost = 800 //NSV edit, upped price to avoid infinite money. Added one extra of each as compensation
 	contains = list(/obj/item/clothing/suit/fire/firefighter,
+					/obj/item/clothing/suit/fire/firefighter,
 					/obj/item/clothing/suit/fire/firefighter,
 					/obj/item/clothing/mask/gas,
 					/obj/item/clothing/mask/gas,
+					/obj/item/clothing/mask/gas,
+					/obj/item/flashlight,
 					/obj/item/flashlight,
 					/obj/item/flashlight,
 					/obj/item/tank/internals/oxygen/red,
 					/obj/item/tank/internals/oxygen/red,
+					/obj/item/tank/internals/oxygen/red,
 					/obj/item/extinguisher/advanced,
 					/obj/item/extinguisher/advanced,
+					/obj/item/extinguisher/advanced,
+					/obj/item/clothing/head/hardhat/red,
 					/obj/item/clothing/head/hardhat/red,
 					/obj/item/clothing/head/hardhat/red)
 	crate_name = "firefighting crate"
@@ -152,16 +158,20 @@
 /datum/supply_pack/emergency/internals
 	name = "Internals Crate"
 	desc = "Master your life energy and control your breathing with three breath masks, three emergency oxygen tanks and three large air tanks."//IS THAT A
-	cost = 600
+	cost = 800 //NSV edit, upped price to avoid infinite money. Added one extra of each as compensation.
 	contains = list(/obj/item/clothing/mask/gas,
 					/obj/item/clothing/mask/gas,
 					/obj/item/clothing/mask/gas,
+					/obj/item/clothing/mask/gas,
+					/obj/item/clothing/mask/breath,
 					/obj/item/clothing/mask/breath,
 					/obj/item/clothing/mask/breath,
 					/obj/item/clothing/mask/breath,
 					/obj/item/tank/internals/emergency_oxygen,
 					/obj/item/tank/internals/emergency_oxygen,
 					/obj/item/tank/internals/emergency_oxygen,
+					/obj/item/tank/internals/emergency_oxygen,
+					/obj/item/tank/internals/air,
 					/obj/item/tank/internals/air,
 					/obj/item/tank/internals/air,
 					/obj/item/tank/internals/air)
@@ -189,12 +199,15 @@
 /datum/supply_pack/emergency/plasmaman
 	name = "Plasmaman Supply Kit"
 	desc = "Keep those Plasmamen alive with two sets of Plasmaman outfits. Each set contains a plasmaman jumpsuit, internals tank, and helmet."
-	cost = 500 //50 credits per suit.
+	cost = 700 //50 credits per suit. ##NSV edit, upped the price to avoid infinite money from sending back the crates and manifest. Added one extra of each item as compenstation.
 	contains = list(/obj/item/clothing/under/plasmaman,
 					/obj/item/clothing/under/plasmaman,
+					obj/item/clothing/under/plasmaman
+					/obj/item/tank/internals/plasmaman/belt/full,
 					/obj/item/tank/internals/plasmaman/belt/full,
 					/obj/item/tank/internals/plasmaman/belt/full,
 					/obj/item/clothing/head/helmet/space/plasmaman,
+					/obj/item/clothing/head/helmet/space/plasmaman
 					/obj/item/clothing/head/helmet/space/plasmaman)
 	crate_name = "plasmaman supply kit"
 
@@ -399,8 +412,9 @@
 /datum/supply_pack/security/wall_flash
 	name = "Wall-Mounted Flash Crate"
 	desc = "Contains four wall-mounted flashes. Requires Security access to open."
-	cost = 600
+	cost = 800 //NSV edit, upped price to avoid infinite money, added one extra for compensation.
 	contains = list(/obj/item/storage/box/wall_flash,
+					/obj/item/storage/box/wall_flash,
 					/obj/item/storage/box/wall_flash,
 					/obj/item/storage/box/wall_flash,
 					/obj/item/storage/box/wall_flash)
@@ -1632,7 +1646,7 @@
 /datum/supply_pack/service/cargo_supples
 	name = "Cargo Supplies Crate"
 	desc = "Sold everything that wasn't bolted down? You can get right back to work with this crate containing stamps, an export scanner, destination tagger, hand labeler and some package wrapping."
-	cost = 500
+	cost = 700    //NSV edit, upped the price to avoid infinite money from sending back the crates and manifest.
 	contains = list(/obj/item/stamp,
 					/obj/item/stamp/denied,
 					/obj/item/export_scanner,
@@ -1764,9 +1778,10 @@
 /datum/supply_pack/service/lightbulbs
 	name = "Replacement Lights"
 	desc = "May the light of Aether shine upon this station! Or at least, the light of forty two light tubes and twenty one light bulbs."
-	cost = 500
+	cost = 800 //NSV Edit, price change from 500-800 and one extra box added as compensation. To avoid infinite money with manifests.
 	contains = list(/obj/item/storage/box/lights/mixed,
 					/obj/item/storage/box/lights/mixed,
+					/obj/item/storage/box/lights/mixed
 					/obj/item/storage/box/lights/mixed)
 	crate_name = "replacement lights"
 
@@ -1981,7 +1996,7 @@
 /datum/supply_pack/organic/hydroponics
 	name = "Hydroponics Crate"
 	desc = "Supplies for growing a great garden! Contains two bottles of ammonia, two Plant-B-Gone spray bottles, a hatchet, cultivator, plant analyzer, as well as a pair of leather gloves and a botanist's apron."
-	cost = 600
+	cost = 800 //NSV edit, upped price to avoid infinite money
 	contains = list(/obj/item/reagent_containers/spray/plantbgone,
 					/obj/item/reagent_containers/spray/plantbgone,
 					/obj/item/reagent_containers/glass/bottle/ammonia,
@@ -2052,7 +2067,7 @@
 /datum/supply_pack/organic/seeds
 	name = "Seeds Crate"
 	desc = "Big things have small beginnings. Contains fourteen different seeds."
-	cost = 600
+	cost = 800 //NSV edit, upped price to avoid infinite money
 	contains = list(/obj/item/seeds/chili,
 					/obj/item/seeds/cotton,
 					/obj/item/seeds/berry,
@@ -2515,7 +2530,7 @@
 /datum/supply_pack/costumes_toys/chess_white
 	name = "White Chess Piece Crate"
 	desc = "Look at you, playing a nerd game within a nerd game!"
-	cost = 500
+	cost = 800 //NSV edit, upped price to avoid infinite money
 	contains = list(
 		/obj/item/cardboard_cutout/adaptive/chess/king,
 		/obj/item/cardboard_cutout/adaptive/chess/queen,
@@ -2539,7 +2554,7 @@
 /datum/supply_pack/costumes_toys/chess_black
 	name = "Black Chess Piece Crate"
 	desc = "Look at you, playing a nerd game within a nerd game!"
-	cost = 500
+	cost = 800 //NSV edit, upped price to avoid infinite money
 	contains = list(
 		/obj/item/cardboard_cutout/adaptive/chess/black/king,
 		/obj/item/cardboard_cutout/adaptive/chess/black/queen,
@@ -2567,21 +2582,21 @@
 /datum/supply_pack/costumes_toys/wardrobes/autodrobe
 	name = "Autodrobe Supply Crate"
 	desc = "Autodrobe missing your favorite dress? Solve that issue today with this autodrobe refill."
-	cost = 600
+	cost = 800 //NSV edit, upped price to avoid infinite money
 	contains = list(/obj/item/vending_refill/autodrobe)
 	crate_name = "autodrobe supply crate"
 
 /datum/supply_pack/costumes_toys/wardrobes/cargo
 	name = "Cargo Wardrobe Supply Crate"
 	desc = "This crate contains a refill for the CargoDrobe."
-	cost = 600
+	cost = 800 //NSV edit, upped price to avoid infinite money
 	contains = list(/obj/item/vending_refill/wardrobe/cargo_wardrobe)
 	crate_name = "cargo department supply crate"
 
 /datum/supply_pack/costumes_toys/wardrobes/engineering
 	name = "Engineering Wardrobe Supply Crate"
 	desc = "This crate contains refills for the EngiDrobe and AtmosDrobe."
-	cost = 600
+	cost = 800 //NSV edit, upped price to avoid infinite money
 	contains = list(/obj/item/vending_refill/wardrobe/engi_wardrobe,
 					/obj/item/vending_refill/wardrobe/atmos_wardrobe)
 	crate_name = "engineering department wardrobe supply crate"
@@ -2600,7 +2615,7 @@
 /datum/supply_pack/costumes_toys/wardrobes/hydroponics
 	name = "Hydrobe Supply Crate"
 	desc = "This crate contains a refill for the Hydrobe."
-	cost = 600
+	cost = 800 //NSV edit, upped price to avoid infinite money
 	contains = list(/obj/item/vending_refill/wardrobe/hydro_wardrobe)
 	crate_name = "hydrobe supply crate"
 
@@ -2641,7 +2656,7 @@
 /datum/supply_pack/misc/artsupply
 	name = "Art Supplies"
 	desc = "Make some happy little accidents with six canvasses, two easels, and two rainbow crayons!"
-	cost = 500
+	cost = 800 //NSV edit, upped price to avoid infinite money
 	contains = list(/obj/structure/easel,
 					/obj/structure/easel,
 					/obj/item/canvas/nineteenXnineteen,
@@ -2666,7 +2681,7 @@
 /datum/supply_pack/misc/bigband
 	name = "Big Band Instrument Collection"
 	desc = "Get your sad station movin' and groovin' with this fine collection! Contains nine different instruments!"
-	cost = 600
+	cost = 800 //NSV edit, upped price to avoid infinite money
 	crate_name = "Big band musical instruments collection"
 	contains = list(/obj/item/instrument/violin,
 					/obj/item/instrument/guitar,
@@ -2729,7 +2744,7 @@
 /datum/supply_pack/misc/wrapping_paper
 	name = "Festive Wrapping Paper Crate"
 	desc = "Want to mail your loved ones gift-wrapped chocolates, stuffed animals, the Clown's severed head? You can do all that, with this crate full of wrapping paper."
-	cost = 500
+	cost = 800 //NSV edit, upped price to avoid infinite money
 	contains = list(/obj/item/stack/wrapping_paper)
 	crate_type = /obj/structure/closet/crate/wooden
 	crate_name = "festive wrapping paper crate"
@@ -2761,8 +2776,10 @@
 /datum/supply_pack/misc/toner
 	name = "Toner Crate"
 	desc = "Spent too much ink printing butt pictures? Fret not, with these six toner refills, you'll be printing butts 'till the cows come home!'"
-	cost = 600
+	cost = 800 //NSV edit, upped price to avoid infinite money. Added two more for compensation
 	contains = list(/obj/item/toner,
+					/obj/item/toner,
+					/obj/item/toner,
 					/obj/item/toner,
 					/obj/item/toner,
 					/obj/item/toner,

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -199,15 +199,15 @@
 /datum/supply_pack/emergency/plasmaman
 	name = "Plasmaman Supply Kit"
 	desc = "Keep those Plasmamen alive with two sets of Plasmaman outfits. Each set contains a plasmaman jumpsuit, internals tank, and helmet."
-	cost = 700 //50 credits per suit. ##NSV edit, upped the price to avoid infinite money from sending back the crates and manifest. Added one extra of each item as compenstation.
+	cost = 700 //50 credits per suit. #NSV edit, upped the price to avoid infinite money from sending back the crates and manifest. Added one extra of each item as compenstation.
 	contains = list(/obj/item/clothing/under/plasmaman,
 					/obj/item/clothing/under/plasmaman,
-					obj/item/clothing/under/plasmaman
+					/obj/item/clothing/under/plasmaman,
 					/obj/item/tank/internals/plasmaman/belt/full,
 					/obj/item/tank/internals/plasmaman/belt/full,
 					/obj/item/tank/internals/plasmaman/belt/full,
 					/obj/item/clothing/head/helmet/space/plasmaman,
-					/obj/item/clothing/head/helmet/space/plasmaman
+					/obj/item/clothing/head/helmet/space/plasmaman,
 					/obj/item/clothing/head/helmet/space/plasmaman)
 	crate_name = "plasmaman supply kit"
 
@@ -1781,7 +1781,7 @@
 	cost = 800 //NSV Edit, price change from 500-800 and one extra box added as compensation. To avoid infinite money with manifests.
 	contains = list(/obj/item/storage/box/lights/mixed,
 					/obj/item/storage/box/lights/mixed,
-					/obj/item/storage/box/lights/mixed
+					/obj/item/storage/box/lights/mixed,
 					/obj/item/storage/box/lights/mixed)
 	crate_name = "replacement lights"
 

--- a/nsv13/code/modules/cargo/packs.dm
+++ b/nsv13/code/modules/cargo/packs.dm
@@ -271,7 +271,7 @@
 
 /datum/supply_pack/munitions/light_cannon
 	name = "Light Cannon Ammunition"
-	desc = "5 boxes of light cannon ammunition for use in fighters."
+	desc = "10 boxes of light cannon ammunition for use in fighters."
 	cost = 1000
 	contains = list(/obj/item/ammo_box/magazine/light_cannon,
 					/obj/item/ammo_box/magazine/light_cannon,
@@ -287,7 +287,7 @@
 
 /datum/supply_pack/munitions/heavy_cannon
 	name = "Heavy Cannon Ammunition"
-	desc = "5 boxes of heavy cannon ammunition for use in fighters."
+	desc = "10 boxes of heavy cannon ammunition for use in fighters."
 	cost = 1000
 	contains = list(/obj/item/ammo_box/magazine/heavy_cannon,
 					/obj/item/ammo_box/magazine/heavy_cannon,

--- a/nsv13/code/modules/cargo/packs.dm
+++ b/nsv13/code/modules/cargo/packs.dm
@@ -272,8 +272,13 @@
 /datum/supply_pack/munitions/light_cannon
 	name = "Light Cannon Ammunition"
 	desc = "5 boxes of light cannon ammunition for use in fighters."
-	cost = 500
+	cost = 1000
 	contains = list(/obj/item/ammo_box/magazine/light_cannon,
+					/obj/item/ammo_box/magazine/light_cannon,
+					/obj/item/ammo_box/magazine/light_cannon,
+					/obj/item/ammo_box/magazine/light_cannon,
+					/obj/item/ammo_box/magazine/light_cannon,
+					/obj/item/ammo_box/magazine/light_cannon,
 					/obj/item/ammo_box/magazine/light_cannon,
 					/obj/item/ammo_box/magazine/light_cannon,
 					/obj/item/ammo_box/magazine/light_cannon,
@@ -283,8 +288,13 @@
 /datum/supply_pack/munitions/heavy_cannon
 	name = "Heavy Cannon Ammunition"
 	desc = "5 boxes of heavy cannon ammunition for use in fighters."
-	cost = 500
+	cost = 1000
 	contains = list(/obj/item/ammo_box/magazine/heavy_cannon,
+					/obj/item/ammo_box/magazine/heavy_cannon,
+					/obj/item/ammo_box/magazine/heavy_cannon,
+					/obj/item/ammo_box/magazine/heavy_cannon,
+					/obj/item/ammo_box/magazine/heavy_cannon,
+					/obj/item/ammo_box/magazine/heavy_cannon,
 					/obj/item/ammo_box/magazine/heavy_cannon,
 					/obj/item/ammo_box/magazine/heavy_cannon,
 					/obj/item/ammo_box/magazine/heavy_cannon,


### PR DESCRIPTION
## About The Pull Request

Tweaks the cost of crates to prevent people from ordering cheap crates and returning them to CC with a stamped manifest. Giving them more money than they started with on top of the ordered items. Also adds extra items to tweaked price crates where it made sense to

## Why It's Good For The Game

Infinite money punjabi 360p no virus glitch is not epic to have. There's always going to be "that guy" who tries to game the system
## Changelog

tweak: tweaked cargo prices and contents
fixes: #1461
