### PR TITLE
Fixes armour pumps breaking if multitooled with an invalid buffer

### DIFF
--- a/nsv13/code/modules/overmap/armour/nano_pump.dm
+++ b/nsv13/code/modules/overmap/armour/nano_pump.dm
@@ -125,12 +125,12 @@
 	. = FALSE
 	if(!multitool_check_buffer(user, tool))
 		return
-	apnw?.apnp -= src
 	var/obj/item/multitool/M = tool
-	if(!isnull(M.buffer))
+	if(!isnull(M.buffer) && istype(M.buffer, /obj/machinery/armour_plating_nanorepair_well))
+		apnw?.apnp -= src
 		apnw = M.buffer
-	apnw.apnp += src
-	M.buffer = null
+		apnw.apnp += src
+		M.buffer = null
 	quadrant = input(user, "Direct nano-repair pump to which quadrant?", "[name]") as null|anything in list("forward_port", "forward_starboard", "aft_port", "aft_starboard")
 	playsound(src, 'sound/items/flashlight_on.ogg', 100, TRUE)
 	to_chat(user, "<span class='notice'>Buffer transfered</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. If the buffer isn't a nanowell, it should just do nothing and not set it to said invalid thing and runtime & cry, This fixes that.
Fixes #1306 (probably)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Multitooling an armour pump no longer breaks it if the buffer isn't an armour well.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
