### PR TITLE
Tweaks cannon ammo text

### DIFF
--- a/nsv13/code/modules/munitions/ammunition/cannon_ammo.dm
+++ b/nsv13/code/modules/munitions/ammunition/cannon_ammo.dm
@@ -1,6 +1,6 @@
 /obj/item/ammo_box/magazine/light_cannon
-	name = "light cannon ammo (20x102mm)"
-	desc = "A box of .s0 caliber rounds which can be loaded into a light fighter cannon."
+	name = "light cannon ammo"
+	desc = "A box of 20x102mm caliber rounds which can be loaded into a light fighter cannon."
 	icon = 'nsv13/icons/obj/ammo.dmi'
 	icon_state = "pdc"
 	ammo_type = /obj/item/ammo_casing/light_cannon
@@ -8,8 +8,8 @@
 	max_ammo = 500
 
 /obj/item/ammo_box/magazine/heavy_cannon
-	name = "heavy cannon ammo (30x173mm)"
-	desc = "A box of .30 caliber rounds which can be loaded into a heavy fighter cannon."
+	name = "heavy cannon ammo"
+	desc = "A box of 30x173mm caliber rounds which can be loaded into a heavy fighter cannon."
 	icon = 'nsv13/icons/obj/ammo.dmi'
 	icon_state = "pdc"
 	ammo_type = /obj/item/ammo_casing/heavy_cannon

--- a/nsv13/code/modules/munitions/ammunition/cannon_ammo.dm
+++ b/nsv13/code/modules/munitions/ammunition/cannon_ammo.dm
@@ -1,6 +1,6 @@
 /obj/item/ammo_box/magazine/light_cannon
 	name = "light cannon ammo"
-	desc = "A box of 20x102mm caliber rounds which can be loaded into a light fighter cannon."
+	desc = "A box of 20x102mm ammunition which can be loaded into a light fighter cannon."
 	icon = 'nsv13/icons/obj/ammo.dmi'
 	icon_state = "pdc"
 	ammo_type = /obj/item/ammo_casing/light_cannon
@@ -9,7 +9,7 @@
 
 /obj/item/ammo_box/magazine/heavy_cannon
 	name = "heavy cannon ammo"
-	desc = "A box of 30x173mm caliber rounds which can be loaded into a heavy fighter cannon."
+	desc = "A box of 30x173mm ammunition which can be loaded into a heavy fighter cannon."
 	icon = 'nsv13/icons/obj/ammo.dmi'
 	icon_state = "pdc"
 	ammo_type = /obj/item/ammo_casing/heavy_cannon


### PR DESCRIPTION
## About The Pull Request

Changes light and heavy fighter cannon ammo descriptions to be more accurate.

## Why It's Good For The Game

A 30mm round is not a .30cal and I have no clue what the hell an .s0 caliber round is but I'm fairly certain it's not a 20mm. Just bugged me every time I examined it.

## Changelog

tweak: tweaked fighter cannon ammo descriptions and name

