### PR TITLE
Bambi2: Renames 50s to PDC, with associated card changes 

### DIFF
--- a/nsv13/code/datums/weapon_types.dm
+++ b/nsv13/code/datums/weapon_types.dm
@@ -239,18 +239,18 @@
 	selectable = FALSE
 	weapon_class = WEAPON_CLASS_LIGHT //AIs can fire light weaponry like this for free.
 
-/datum/ship_weapon/fiftycal
-	name = ".50 cals"
+/datum/ship_weapon/fiftycal // .50 cal flavored PDC bullets, which were previously just PDC flavored .50 cal turrets 
+	name = "PDC"
 	default_projectile_type = /obj/item/projectile/bullet/fiftycal
 	burst_size = 1
 	fire_delay = 0.35 SECONDS
 	range_modifier = 10
-	select_alert = "<span class='notice'>Activating .50 cals...</span>"
-	failure_alert = "<span class='warning'>DANGER: 50 cal gun systems not loaded.</span>"
+	select_alert = "<span class='notice'>Activating point defense system...</span>"
+	failure_alert = "<span class='warning'>DANGER: point defense system not loaded.</span>"
 	overmap_firing_sounds = list('nsv13/sound/weapons/pdc_single.ogg')
 	overmap_select_sound = 'nsv13/sound/effects/ship/mac_hold.ogg'
 	selectable = FALSE
-	weapon_class = WEAPON_CLASS_LIGHT //AIs can fire light weaponry like this for free.
+	weapon_class = WEIGHT_CLASS_NORMAL //AIs can fire light weaponry like this for free.
 
 /datum/ship_weapon/flak
 	name = "Flak cannon"

--- a/nsv13/code/datums/weapon_types.dm
+++ b/nsv13/code/datums/weapon_types.dm
@@ -250,7 +250,7 @@
 	overmap_firing_sounds = list('nsv13/sound/weapons/pdc_single.ogg')
 	overmap_select_sound = 'nsv13/sound/effects/ship/mac_hold.ogg'
 	selectable = FALSE
-	weapon_class = WEIGHT_CLASS_NORMAL //AIs can fire light weaponry like this for free.
+	weapon_class = WEAPON_CLASS_LIGHT //AIs can fire light weaponry like this for free.
 
 /datum/ship_weapon/flak
 	name = "Flak cannon"

--- a/nsv13/code/game/objects/items/nsv_circuitboards.dm
+++ b/nsv13/code/game/objects/items/nsv_circuitboards.dm
@@ -58,7 +58,7 @@
 	build_path = /obj/machinery/computer/ams
 
 /obj/item/circuitboard/computer/fiftycal
-	name = ".50 cal turret console (circuit)"
+	name = "PDC turret console (circuit)"
 	build_path = /obj/machinery/computer/fiftycal
 
 /obj/item/circuitboard/computer/ship/fighter_controller
@@ -74,7 +74,7 @@
 
 //50 Cal. guns
 /obj/item/circuitboard/machine/fiftycal
-	name = ".50 cal turret (circuitboard)"
+	name = "PDC turret (circuitboard)"
 	req_components = list(
 		/obj/item/stack/sheet/mineral/titanium = 20,
 		/obj/item/stack/sheet/mineral/copper = 10,
@@ -83,7 +83,7 @@
 	build_path = /obj/machinery/ship_weapon/fiftycal
 
 /obj/item/circuitboard/machine/fiftycal/super
-	name = "super .50 cal turret (circuitboard)"
+	name = "RPDC (circuitboard)"
 	req_components = list(
 		/obj/item/stack/sheet/mineral/titanium = 40,
 		/obj/item/stack/sheet/mineral/copper = 40,

--- a/nsv13/code/modules/cargo/packs.dm
+++ b/nsv13/code/modules/cargo/packs.dm
@@ -53,9 +53,9 @@
 	crate_type = /obj/structure/closet/crate/wooden
 	crate_name = "Captain Plasmasalt's finest gunpowder"
 
-/datum/supply_pack/munitions/fiftycal
-	name = ".50 cal deck gun rounds (x5)"
-	desc = "5 boxes of deck gun rounds, ideal for harassing small targets."
+/datum/supply_pack/munitions/pdc_ammo
+	name = "PDC turret rounds (x5)"
+	desc = "5 boxes of PDC turret rounds, ideal for repelling torpedoes and missiles."
 	cost = 1000
 	contains = list(/obj/item/ammo_box/magazine/pdc/fiftycal,
 					/obj/item/ammo_box/magazine/pdc/fiftycal,
@@ -493,4 +493,3 @@
 					/obj/item/ammo_box/magazine/m556,
 					/obj/item/ammo_box/magazine/m556,
 					/obj/item/ammo_box/magazine/m556)
-

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/50Cal.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/50Cal.dm
@@ -1,6 +1,7 @@
-//The .50 cal! A neat crew served weapon which replaces PDC.
+// The point defense system! A neat crew served weapon which replaces the .50 cal 
+// This file has so much borrowed code and name swaps from previous iterations of PDC
 /obj/machinery/ship_weapon/fiftycal
-	name = ".50 cal autocannon"
+	name = "PDC turret"
 	desc = "A formidable weapon operated by a gunner below deck, extremely effective at point defense though they struggle to damage larger targets."
 	icon = 'nsv13/icons/obj/munitions/deck_gun.dmi'
 	icon_state = "deck_gun"
@@ -10,7 +11,7 @@
 	semi_auto = TRUE
 	maintainable = FALSE
 	fire_mode = FIRE_MODE_50CAL
-	max_ammo = 200
+	max_ammo = 300
 	circuit = /obj/item/circuitboard/machine/fiftycal
 	var/gunning_component_type = /datum/component/overmap_gunning/fiftycal
 	var/mob/living/gunner
@@ -21,7 +22,7 @@
 
 
 /obj/machinery/ship_weapon/fiftycal/super
-	name = ".50 cal super pom pom turret"
+	name = "RPDC turret"
 	desc = "For when you need more bullets spat out more quickly."
 	icon_state = "deck_gun_super"
 	circuit = /obj/item/circuitboard/machine/fiftycal/super
@@ -109,8 +110,8 @@
 	return
 
 /obj/machinery/computer/fiftycal
-	name = ".50 cal autocannon console"
-	desc = "A computer that allows you to control a .50 cal deck gun, when paired with a turret above deck."
+	name = "PDC turret console"
+	desc = "A computer that allows you to control a PDC turret, when paired with a compatible turret directly above deck."
 	icon_screen = "50cal"
 	circuit = /obj/item/circuitboard/computer/fiftycal
 	var/obj/machinery/ship_weapon/fiftycal/turret
@@ -133,12 +134,17 @@
 
 /obj/machinery/computer/fiftycal/multitool_act(mob/living/user, obj/item/multitool/I)
 	. = ..()
-	if(!istype(I))
-		return FALSE
-	if(I.buffer && istype(I.buffer, /obj/machinery/ship_weapon/fiftycal))
-		turret = I.buffer
-		to_chat(user, "<span class='warning'>Successfully linked [src] to [I.buffer].")
-		I.buffer = null
+	// if(!istype(I))
+	// 	return FALSE
+	// if(I.buffer && istype(I.buffer, /obj/machinery/ship_weapon/fiftycal))
+	// 	turret = I.buffer
+	// 	to_chat(user, "<span class='warning'>Successfully linked [src] to [I.buffer].")
+	// 	I.buffer = null
+	turret = locate(/obj/machinery/ship_weapon/fiftycal) in SSmapping.get_turf_above(src)
+	if ( turret )
+		to_chat(user, "<span class='warning'>Successfully linked [src] to [turret].")
+	else 
+		to_chat(user, "<span class='warning'>Unable to locate a compatible turret above this deck! Try relocating the turret construction.")
 
 /obj/machinery/computer/fiftycal/attack_hand(mob/user)
 	. = ..()
@@ -148,10 +154,10 @@
 	turret.start_gunning(user)
 
 /obj/item/ammo_box/magazine/pdc/fiftycal
-	name = "50 caliber rounds"
+	name = "PDC turret rounds" // Just going to rename the current box to avoid a bunch of map changes, or creating duplicate code for a rename 
 	ammo_type = /obj/item/ammo_casing/fiftycal
 	caliber = "mm50pdc"
-	max_ammo = 200
+	max_ammo = 300
 
 /obj/item/ammo_box/magazine/pdc/fiftycal/examine(mob/user)
 	. = ..()

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/50Cal.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/50Cal.dm
@@ -158,6 +158,7 @@
 	ammo_type = /obj/item/ammo_casing/fiftycal
 	caliber = "mm50pdc"
 	max_ammo = 300
+	w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/ammo_box/magazine/pdc/fiftycal/examine(mob/user)
 	. = ..()

--- a/nsv13/code/modules/munitions/ship_weapons/ship_weapon_maintenance.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ship_weapon_maintenance.dm
@@ -1,7 +1,7 @@
 #define MSTATE_CLOSED 0
 #define MSTATE_UNSCREWED 1
 #define MSTATE_UNBOLTED 2
-#define MSTATE_PRIEDOUT 3
+// #define MSTATE_PRIEDOUT 3 // BEGONE
 
 /**
  * Give people a hint about what to do.
@@ -70,12 +70,12 @@
 	if(maint_state == MSTATE_UNSCREWED)
 		to_chat(user, "<span class='notice'>You begin unfastening the inner casing bolts on [src]...</span>")
 		if(tool.use_tool(src, user, 40, volume=100))
-			to_chat(user, "<span class='notice'>You unfasten the inner case bolts on [src].</span>")
+			to_chat(user, "<span class='notice'>You unfasten the inner case bolts on [src] and remove the inner casing.</span>")
 			maint_state = MSTATE_UNBOLTED
 			update_overlay()
 			return TRUE
 	else if(maint_state == MSTATE_UNBOLTED)
-		to_chat(user, "<span class='notice'>You begin fastening the inner casing bolts on [src]...</span>")
+		to_chat(user, "<span class='notice'>You begin adding the inner casing and fastening the inner casing bolts on [src]...</span>")
 		if(tool.use_tool(src, user, 40, volume=100))
 			to_chat(user, "<span class='notice'>You fasten the inner case bolts on [src].</span>")
 			maint_state = MSTATE_UNSCREWED
@@ -83,40 +83,43 @@
 			return TRUE
 
 /**
- * Removes or re-secures the inner casing to allow maintenance.
- * Transitions from MSTATE_UNBOLTED to MSTATE_PRIEDOUT.
- * Transitions from MSTATE_PRIEDOUT to MSTATE_UNBOLTED.
- * Returns TRUE if handled, FALSE otherwise.
+ * Deconstructs the machine. We no longer track the panel casing 
  */
 /obj/machinery/ship_weapon/crowbar_act(mob/user, obj/item/tool)
-	if(maint_state == MSTATE_UNBOLTED)
-		to_chat(user, "<span class='notice'>You begin prying the inner casing off [src]...</span>")
-		if(tool.use_tool(src, user, 40, volume=100))
-			to_chat(user, "<span class='notice'>You pry the inner casing off [src].</span>")
-			maint_state = MSTATE_PRIEDOUT
-			update_overlay()
-			if(prob(50))
-				to_chat(user, "<span class='warning'>Oil spurts out of the exposed machinery!</span>")
-				new /obj/effect/decal/cleanable/oil(user.loc)
-				reagents.clear_reagents()
+	// if(maint_state == MSTATE_UNBOLTED)
+	// 	to_chat(user, "<span class='notice'>You begin prying the inner casing off [src]...</span>")
+	// 	if(tool.use_tool(src, user, 40, volume=100))
+	// 		to_chat(user, "<span class='notice'>You pry the inner casing off [src].</span>")
+	// 		maint_state = MSTATE_PRIEDOUT
+	// 		update_overlay()
+	// 		if(prob(50))
+	// 			to_chat(user, "<span class='warning'>Oil spurts out of the exposed machinery!</span>")
+	// 			new /obj/effect/decal/cleanable/oil(user.loc)
+	// 			reagents.clear_reagents()
+	// 		return TRUE
+	// if(maint_state == MSTATE_PRIEDOUT)
+	// 	to_chat(user, "<span class='notice'>You begin slotting the inner casing back in [src]...</span>")
+	// 	if(tool.use_tool(src, user, 40, volume=100))
+	// 		to_chat(user, "<span class='notice'>You slot the inner casing back in [src].</span>")
+	// 		maint_state = MSTATE_UNBOLTED
+	// 		update_overlay()
+	// 		return TRUE
+	// . = ..()
+	if ( maint_state != MSTATE_UNBOLTED )
+		to_chat(user, "<span class='warning'>The inner casing bolts are fastened on [src]!</span>")
+		return FALSE
+	else 
+		if(default_deconstruction_crowbar(tool))
 			return TRUE
-	if(maint_state == MSTATE_PRIEDOUT)
-		to_chat(user, "<span class='notice'>You begin slotting the inner casing back in [src]...</span>")
-		if(tool.use_tool(src, user, 40, volume=100))
-			to_chat(user, "<span class='notice'>You slot the inner casing back in [src].</span>")
-			maint_state = MSTATE_UNBOLTED
-			update_overlay()
-			return TRUE
-	. = ..()
 
 /**
  * Tries to use item I to lubricate the machinery.
  */
 /obj/machinery/ship_weapon/proc/oil(obj/item/I, mob/user)
-	if(maint_state != MSTATE_PRIEDOUT)
-		to_chat(user, "<span class='notice'>You require access to the inner workings of [src].</span>")
-		return
-	else if((maint_state == MSTATE_PRIEDOUT) && istype(I, /obj/item/reagent_containers))
+	// if(maint_state != MSTATE_PRIEDOUT)
+	// 	to_chat(user, "<span class='notice'>You require access to the inner workings of [src].</span>")
+	// 	return
+	if((maint_state == MSTATE_UNBOLTED) && istype(I, /obj/item/reagent_containers))
 		if(I.reagents.has_reagent(/datum/reagent/oil, 10))
 			to_chat(user, "<span class='notice'>You start lubricating the inner workings of [src]...</span>")
 			if(!do_after(user, 2 SECONDS, target=src))
@@ -152,12 +155,12 @@
 			add_overlay("[initial(icon_state)]_screwdriver")
 		if(MSTATE_UNBOLTED)
 			add_overlay("[initial(icon_state)]_wrench")
-		if(MSTATE_PRIEDOUT)
-			add_overlay("[initial(icon_state)]_crowbar")
+		// if(MSTATE_PRIEDOUT)
+		// 	add_overlay("[initial(icon_state)]_crowbar")
 
 #undef MSTATE_CLOSED
 #undef MSTATE_UNSCREWED
 #undef MSTATE_UNBOLTED
-#undef MSTATE_PRIEDOUT
+// #undef MSTATE_PRIEDOUT
 
 #undef STATE_CHAMBERED

--- a/nsv13/code/modules/research/designs/ship_weapon_designs.dm
+++ b/nsv13/code/modules/research/designs/ship_weapon_designs.dm
@@ -20,10 +20,10 @@
 	category = list("Advanced Munitions")
 	departmental_flags = DEPARTMENTAL_FLAG_MUNITIONS
 
-//50 Cal.
+//50 Cal flavored PDC turrets 
 /datum/design/board/fiftycal
-	name = "Machine Design (.50 cal deck turret)"
-	desc = "Allows for the construction of a crew served, 50 cal deck turret."
+	name = "Machine Design (PDC turret)"
+	desc = "Allows for the construction of a crew served, PDC turret."
 	id = "fiftycal"
 	build_type = PROTOLATHE|IMPRINTER
 	materials = list(/datum/material/glass = 2000, /datum/material/copper = 2000, /datum/material/gold = 5000)
@@ -32,8 +32,8 @@
 	departmental_flags = DEPARTMENTAL_FLAG_MUNITIONS
 
 /datum/design/board/fiftycal/super
-	name = "Machine Design (.50 cal deck turret)"
-	desc = "Allows for the construction of a crew served, super 50 cal pompom turret."
+	name = "Machine Design (RPDC turret)"
+	desc = "Allows for the construction of a crew served, RPDC turret."
 	id = "fiftycal_super"
 	build_type = PROTOLATHE|IMPRINTER
 	materials = list(/datum/material/glass = 2000, /datum/material/copper = 2000, /datum/material/gold = 5000)
@@ -42,8 +42,8 @@
 	departmental_flags = DEPARTMENTAL_FLAG_MUNITIONS
 
 /datum/design/board/fiftycalcomp
-	name = "Computer Design (.50 cal deck turret control console)"
-	desc = "Allows for the construction of a control console for .50 cal deck guns."
+	name = "Computer Design (PDC turret control console)"
+	desc = "Allows for the construction of a control console for PDC deck guns."
 	id = "fiftycalcomp"
 	build_type = PROTOLATHE|IMPRINTER
 	materials = list(/datum/material/glass = 2000, /datum/material/copper = 2000, /datum/material/gold = 5000)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Tested for the following items:

- Rename 50s to PDCs and change ammo type
- Change magazine weight to WEIGHT_CLASS_NORMAL
- Make magazine size 300
- Add cargo packs for PDC ammo, remove 50 cal
- Link turret to console via Z level only
- BONUS: Fixed applying a crowbar not deconstructing the PDC turret. Oiling and maintenance is now performed after applying a wrench, not after applying a crowbar 

## Why It's Good For The Game

Project todo 

## Changelog
:cl:
tweak: Renamed 50 cal turrets to PDC, along with associated computer, ammunition, chip and research topics 
fix: Fixed PDC turrets and VLS loaders not deconstructing on applying a crowbar
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
