### PR TITLE
Changes the character slot limit from 3 to 14

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -5,7 +5,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	//doohickeys for savefiles
 	var/path
 	var/default_slot = 1				//Holder so it doesn't default to slot 1, rather the last one used
-	var/max_save_slots = 3
+	var/max_save_slots = 14
 
 	//non-preference stuff
 	var/muted = 0


### PR DESCRIPTION

## About The Pull Request

Does what it says on the tin, 
![More character slots](https://user-images.githubusercontent.com/71512494/123435249-a816a380-d5cd-11eb-9cba-fd9d4dfd96bb.png)


## Why It's Good For The Game

Having the ability to play more characters is nice. Also would be pretty necessary in the event we decide to mess around with FTL like races. 

## Changelog

tweak: Tweaks the preferences.dm file to allow for more character slots
