### PR TITLE
Fixes a multi-z disposal runtime

### DIFF
--- a/code/modules/recycling/disposal/holder.dm
+++ b/code/modules/recycling/disposal/holder.dm
@@ -22,6 +22,8 @@
 
 // initialize a holder from the contents of a disposal unit
 /obj/structure/disposalholder/proc/init(obj/machinery/disposal/D)
+	if(!istype(D, /obj/machinery/disposal))
+		return
 	gas = D.air_contents// transfer gas resv. into holder object
 
 	//Check for any living mobs trigger hasmob.

--- a/code/modules/recycling/disposal/holder.dm
+++ b/code/modules/recycling/disposal/holder.dm
@@ -22,7 +22,7 @@
 
 // initialize a holder from the contents of a disposal unit
 /obj/structure/disposalholder/proc/init(obj/machinery/disposal/D)
-	if(!istype(D, /obj/machinery/disposal))
+	if(!istype(D))
 		return
 	gas = D.air_contents// transfer gas resv. into holder object
 


### PR DESCRIPTION
## About The Pull Request

Something about spawning a holder in a multiz dispo pipe made it check vars of dispo machines... but there are no dispo machines. Yes this is also being merged on bee so no I'm not adding the funny tag. (https://github.com/BeeStation/BeeStation-Hornet/pull/4655)

## Why It's Good For The Game

Bug make runtime, runtime bad, me fix bug.

## Changelog
:cl:
fix: Fixed a bug where multi-z disposal pipes caused runtimes
/:cl:
