### PR TITLE
Rat Fix 2 : Disease boogaloo

### DIFF
--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -306,7 +306,7 @@
 
 /obj/effect/mob_spawn/human/corpse/assistant
 	name = "Midshipman" //Nsv13 - Crayon eaters
-	outfit = /datum/outfit/job/assistant
+	outfit = /datum/outfit/job/marine
 
 /obj/effect/mob_spawn/human/corpse/assistant/beesease_infection
 	disease = /datum/disease/beesease

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -58,7 +58,7 @@
 	death()
 
 /mob/living/simple_animal/mouse/death(gibbed, toast)
-	var/list/data = list("donor" = src, "viruses" = ratdisease) // NSV13 - Add mouse donor field for tracking later 
+	var/list/data = list("donor" = src.type, "viruses" = ratdisease) // NSV13 - Add mouse donor field for tracking later 
 	if(!ckey)
 		..(1)
 		if(!gibbed)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -18,13 +18,13 @@
 			if((D.spread_flags & DISEASE_SPREAD_SPECIAL) || (D.spread_flags & DISEASE_SPREAD_NON_CONTAGIOUS))
 				continue
 
-			if ( data[ "donor" ] && istype( data[ "donor" ], /mob/living/simple_animal/mouse ) && L ) // NSV13 - Lizards do not get rat viruses
-				if ( islizard( L ) ) 
+			if(data["donor"] == /mob/living/simple_animal/mouse && L) // NSV13 - Lizards do not get rat viruses
+				if(islizard(L)) 
 					continue 
 
-				if ( istype( L, /mob/living/carbon ) ) 
+				if(istype(L, /mob/living/carbon)) 
 					var/mob/living/carbon/C = L 
-					if( iscatperson(C) ) 
+					if(iscatperson(C)) 
 						continue 
 			// NSV13 end species check 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. Lizards / Cats still got diseases from mice due to it not working. This fixes that.
Also fixes a random runtime due to a assistant corpse not being a midshipman.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Lizards and Catpeople no longer get diseases from mice.. For real this time. Probably.
fix: No more random runtimes from a midshipman corpse spawn on some maps.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
