### PR TITLE
Adds a mining trader

### DIFF
--- a/nsv13/code/modules/overmap/traders.dm
+++ b/nsv13/code/modules/overmap/traders.dm
@@ -155,6 +155,19 @@
 	station_type = /obj/structure/overmap/trader/shipyard
 	image = "https://cdn.discordapp.com/attachments/701841640897380434/764540586732421120/unknown.png"
 
+/datum/trader/shallowstone
+	name = "Shallow Stone Station"
+	desc = "Rock and ore coming right to your door!"
+	shortname = "SSS"
+	faction_type = FACTION_ID_NT
+	greetings = list("Need something water drinkers?",\
+	"Have you come to dig or pay?",\
+	"We got minerals for you, so long as you've got a deposit for us.")
+	on_purchase = list("Maybe next time, dig it up yourself lazy gits!", "Credits have been withdrawn, Supplies inbound.", "Czanek would approve of this.", "If you're too afraid to get these yourself, I'm almost scared to give them to you. But money is money.")
+	sold_items = list(/datum/trader_item/mining_point_card, /datum/trader_item/gold, /datum/trader_item/diamond, /datum/trader_item/uranium, /datum/trader_item/silver, /datum/trader_item/bluespace_crystal, /datum/trader_item/titanium )
+	station_type = /obj/structure/overmap/trader/shipyard
+	image = "https://cdn.discordapp.com/attachments/612668662977134592/859132739147792444/unknown.png"   //I don't wanna do this but I'm also not going to break the mold as to make it hopefully easier in future to fix.
+
 /datum/trader/minsky
 	name = "Minsky Heavy Engineering"
 	desc = "Corporate approved aftermarket shipyard."

--- a/nsv13/code/modules/overmap/traders.dm
+++ b/nsv13/code/modules/overmap/traders.dm
@@ -165,7 +165,7 @@
 	"We got minerals for you, so long as you've got a deposit for us.")
 	on_purchase = list("Maybe next time, dig it up yourself lazy gits!", "Credits have been withdrawn, Supplies inbound.", "Czanek would approve of this.", "If you're too afraid to get these yourself, I'm almost scared to give them to you. But money is money.")
 	sold_items = list(/datum/trader_item/mining_point_card, /datum/trader_item/gold, /datum/trader_item/diamond, /datum/trader_item/uranium, /datum/trader_item/silver, /datum/trader_item/bluespace_crystal, /datum/trader_item/titanium )
-	station_type = /obj/structure/overmap/trader/shipyard
+	station_type = /obj/structure/overmap/trader/
 	image = "https://cdn.discordapp.com/attachments/612668662977134592/859132739147792444/unknown.png"   //I don't wanna do this but I'm also not going to break the mold as to make it hopefully easier in future to fix.
 
 /datum/trader/minsky

--- a/nsv13/code/modules/overmap/traders_items.dm
+++ b/nsv13/code/modules/overmap/traders_items.dm
@@ -71,6 +71,55 @@
 /datum/trader_item/ship_repair/on_purchase(obj/structure/overmap/OM)
 	OM.repair_all_quadrants(repair_amount, failure_chance)
 
+/datum/trader_item/mining_point_card
+	name = "Mining point card"
+	desc = "A mining point transfer card worth 500 at your local equipment vendor."
+	price = 500                                    //1:1 price because 2000 points can turn into 1000 credits.
+	stock = 5
+	unlock_path = /obj/item/card/mining_point_card
+
+/datum/trader_item/titanium
+	name = "Titanium"
+	desc = "A necessary part of any competent combat vessels armour."
+	price = 700                             //Price for minerals is roughly 6x their export value
+	stock = 30
+	unlock_path = /obj/item/stack/sheet/mineral/titanium
+
+/datum/trader_item/silver
+	name = "Silver"
+	desc = "Shiny, and affordable!."
+	price = 600
+	stock = 10
+	unlock_path = /obj/item/stack/sheet/mineral/silver
+
+/datum/trader_item/diamond
+	name = "Diamond"
+	desc = "Unlike some other places these don't come covered in blood. Only lots of sweat and tears."
+	price = 2000
+	stock = 4
+	unlock_path = /obj/item/stack/sheet/mineral/diamond
+
+/datum/trader_item/uranium
+	name = "Uranium"
+	desc = "Slightly radioactive, handle with care."
+	price = 650
+	stock = 8
+	unlock_path = /obj/item/stack/sheet/mineral/uranium
+
+/datum/trader_item/gold
+	name = "Gold"
+	desc = "Conducts electricity wonderfully! Just ask Steve."
+	price = 800
+	stock = 5
+	unlock_path = /obj/item/stack/sheet/mineral/gold
+
+/datum/trader_item/bluespace_crystal
+	name = "Bluespace crystal"
+	desc = "A wonder material which bent our world view, now it'll bend your wallet if you want some."
+	price = 1800
+	stock = 3
+	unlock_path = /obj/item/stack/sheet/bluespace_crystal
+
 /datum/trader_item/mac
 	name = "Magnetic Accelerator Cannon Kit"
 	desc = "Everything you need to build the big MAC."


### PR DESCRIPTION
## About The Pull Request

Adds Shallow Stone Station, a mining outpost where you can buy minerals from that you traditionally can't just get from cargo.

## Why It's Good For The Game

It gives the crew access to a limited supply of rare materials in the event they had bad luck with mining. And Titanium in the event no one is mining.

## Changelog
:cl:
add: adds a new mining trader
