### PR TITLE
Fixes some door related things on Gladius

### DIFF
--- a/_maps/map_files/Gladius/Gladius1.dmm
+++ b/_maps/map_files/Gladius/Gladius1.dmm
@@ -115,6 +115,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port/aft)
 "adc" = (
@@ -303,6 +304,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/aft)
 "ahL" = (
@@ -364,6 +366,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons/starboard)
 "akc" = (
@@ -623,6 +626,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/nsv/hanger/notkmcstupidhanger/atc)
 "apY" = (
@@ -706,6 +710,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "asI" = (
@@ -752,6 +757,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/ai_monitored/storage/eva)
 "atB" = (
@@ -765,6 +771,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/freezer,
 /area/medical/virology)
 "atC" = (
@@ -924,6 +931,7 @@
 	name = "Munitions Projects";
 	req_one_access_txt = "3;69"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/nsv/weapons/starboard)
 "axK" = (
@@ -1086,6 +1094,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/bridge/meeting_room)
 "aCo" = (
@@ -1113,6 +1122,7 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/light,
 /area/medical/medbay/lobby)
 "aCt" = (
@@ -1312,6 +1322,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/light,
 /area/medical/storage)
 "aHD" = (
@@ -1878,6 +1889,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/teleporter)
 "aZw" = (
@@ -2101,6 +2113,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/nsv/briefingroom)
 "bep" = (
@@ -2244,6 +2257,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard/aft)
 "big" = (
@@ -2689,6 +2703,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/vacant_room/commissary)
 "brt" = (
@@ -2822,6 +2837,7 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/security/prison)
 "bwm" = (
@@ -2930,6 +2946,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/monotile/steel,
 /area/science/mixing)
 "bBk" = (
@@ -3143,6 +3162,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/secondary/command)
 "bGp" = (
@@ -3219,6 +3239,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/monotile/light,
 /area/security/brig)
 "bHH" = (
@@ -3483,6 +3505,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/science/mixing)
 "bNK" = (
@@ -4113,6 +4136,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/science/research)
 "cef" = (
@@ -4319,6 +4343,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/frame1/central)
 "ciq" = (
@@ -4439,6 +4464,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port/fore)
 "cla" = (
@@ -4622,6 +4648,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
 "cqb" = (
@@ -4734,6 +4761,7 @@
 	id = "plumbing_shutters";
 	name = "chemical factory shutters"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/light,
 /area/medical/nsv/plumbing)
 "crS" = (
@@ -5105,6 +5133,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/science/server)
 "cyU" = (
@@ -5125,6 +5154,7 @@
 	dir = 4;
 	icon_state = "pipe"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard/aft)
 "cyV" = (
@@ -5184,6 +5214,7 @@
 	dir = 4;
 	icon_state = "support_beam"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/aft)
 "czL" = (
@@ -5263,6 +5294,7 @@
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/science/server)
 "cCC" = (
@@ -5655,7 +5687,7 @@
 	sensor_tag = "hangar_airlock_sensor_left";
 	text = "I"
 	},
-/turf/closed/wall/ship,
+/turf/closed/wall/r_wall/ship,
 /area/nsv/hanger/notkmcstupidhanger/launchtube/left/airlock)
 "cOJ" = (
 /obj/machinery/airalarm{
@@ -5749,6 +5781,7 @@
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess{
 	name = "Maintenance Access Deck 1 Central Hallway"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "cQQ" = (
@@ -5926,6 +5959,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/science/research)
 "cWq" = (
@@ -5963,6 +5997,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/turf_decal/delivery,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/ai_monitored/security/armory)
 "cXF" = (
@@ -6073,6 +6108,7 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons/starboard)
 "daM" = (
@@ -6155,6 +6191,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/security/warden)
 "dci" = (
@@ -6283,6 +6320,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
 "deH" = (
@@ -6555,6 +6593,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/light,
 /area/medical/virology)
 "djv" = (
@@ -6711,6 +6750,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms/nsv/state_room)
 "doI" = (
@@ -7030,6 +7070,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/central)
 "dxZ" = (
@@ -7280,6 +7321,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/medical/patients_rooms/room_b)
 "dDL" = (
@@ -7346,8 +7388,14 @@
 /turf/open/floor/plating,
 /area/hallway/nsv/deck1/frame1/starboard)
 "dEs" = (
-/turf/closed/wall/ship,
-/area/nsv/hanger/notkmcstupidhanger/launchtube/left/airlock)
+/obj/effect/turf_decal/ship/delivery/yellow,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "bridge_lockdown";
+	name = "bridge lockdown shutters"
+	},
+/turf/open/floor/monotile/dark,
+/area/nsv/briefingroom)
 "dEw" = (
 /obj/item/stack/sheet/mineral/sandstone,
 /turf/open/floor/plating,
@@ -7808,6 +7856,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/bridge/meeting_room)
 "dQO" = (
@@ -8466,6 +8515,7 @@
 	name = "Infirmary";
 	req_one_access_txt = "5"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/light,
 /area/medical/medbay/lobby)
 "eiR" = (
@@ -8629,6 +8679,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/hallway/nsv/deck1/frame1/central)
 "emn" = (
@@ -9047,12 +9098,14 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/frame1/central)
 "ewy" = (
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/effect/turf_decal/ship/delivery/yellow,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/secondary/command)
 "ewG" = (
@@ -9071,6 +9124,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/aft)
 "ewQ" = (
@@ -9109,6 +9163,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/science/nanite)
 "exc" = (
@@ -9191,6 +9246,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/medical/chemistry)
 "eyq" = (
@@ -9198,8 +9254,19 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "eys" = (
-/turf/closed/wall/ship,
-/area/nsv/hanger/notkmcstupidhanger/launchtube/right/airlock)
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck1/aft)
 "eyA" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9426,6 +9493,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/ship,
 /area/nsv/hanger)
 "eDL" = (
@@ -9454,6 +9522,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/security/prison)
 "eEj" = (
@@ -9492,6 +9561,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/science/research)
 "eEY" = (
@@ -9689,6 +9759,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/security/prison)
 "eHF" = (
@@ -9743,6 +9814,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/light,
 /area/medical/virology)
 "eIA" = (
@@ -9814,6 +9886,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
 "eJq" = (
@@ -9856,6 +9929,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/security/prison)
 "eKj" = (
@@ -10211,6 +10285,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "eTL" = (
@@ -10251,6 +10326,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/science/xenobiology)
 "eUw" = (
@@ -10661,6 +10737,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/medical/genetics)
 "ffK" = (
@@ -10744,6 +10821,7 @@
 	name = "Maintenance Access Bridge Quarters";
 	req_one_access_txt = "19"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port/fore)
 "fhB" = (
@@ -10899,6 +10977,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port/aft)
 "fmU" = (
@@ -11236,6 +11315,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/frame1/starboard)
 "ftY" = (
@@ -11480,6 +11560,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced/spawner,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/light,
 /area/medical/chemistry)
 "fzC" = (
@@ -11798,6 +11879,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "fGK" = (
@@ -11843,6 +11925,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/ridged/steel,
 /area/security/brig)
 "fIE" = (
@@ -11914,6 +11997,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons/starboard)
 "fKx" = (
@@ -11932,6 +12016,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons/starboard)
 "fKJ" = (
@@ -12146,6 +12231,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/light,
 /area/medical/surgery)
 "fQw" = (
@@ -12261,6 +12347,7 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/security/prison)
 "fUr" = (
@@ -12291,6 +12378,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/teleporter)
 "fVh" = (
@@ -12413,6 +12501,7 @@
 /obj/machinery/door/airlock/ship/glass{
 	req_one_access_txt = "72, 73"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/notkmcstupidhanger/pilot)
 "fWD" = (
@@ -12885,6 +12974,7 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port/fore)
 "gjJ" = (
@@ -13343,6 +13433,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/grid/lino,
 /area/security/warden)
 "gwi" = (
@@ -13613,6 +13704,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/frame1/starboard)
 "gDP" = (
@@ -13783,6 +13875,7 @@
 	name = "Launch Platform Airlock #2";
 	req_one_access_txt = "79"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/nsv/hanger/notkmcstupidhanger/launchtube/right/airlock)
 "gHG" = (
@@ -13889,6 +13982,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "gJF" = (
@@ -14040,6 +14134,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons/starboard)
 "gNR" = (
@@ -14064,6 +14159,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/nsv/squad)
 "gOS" = (
@@ -14311,6 +14407,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/tech/grid,
 /area/nsv/hanger)
 "gVl" = (
@@ -14472,6 +14569,7 @@
 	name = "Munitions Projects";
 	req_one_access_txt = "3;69"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/nsv/weapons/starboard)
 "gXP" = (
@@ -14500,6 +14598,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "gZn" = (
@@ -14688,6 +14787,7 @@
 	id = "briglockdown";
 	name = "brig shutters"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "hck" = (
@@ -14856,6 +14956,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "hgO" = (
@@ -14907,6 +15008,7 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/effect/turf_decal/ship/delivery/yellow,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/secondary/command)
 "hid" = (
@@ -14961,6 +15063,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "hiN" = (
@@ -15121,6 +15224,7 @@
 	name = "Launch Platform Airlock #1";
 	req_one_access_txt = "79"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/nsv/hanger/notkmcstupidhanger/launchtube/left/airlock)
 "hlS" = (
@@ -15766,6 +15870,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/hangar)
 "hAg" = (
@@ -15837,6 +15942,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/science/research)
 "hCz" = (
@@ -15990,6 +16096,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
 "hGl" = (
@@ -16004,6 +16111,7 @@
 	},
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/advanced_airlock_controller/directional/west,
 /turf/open/floor/plasteel/ridged/steel,
 /area/nsv/hanger)
 "hHq" = (
@@ -16738,6 +16846,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/ship/public/glass/turbolift,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/shuttle/turbolift)
 "hYU" = (
@@ -16755,6 +16864,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/gateway)
 "hZQ" = (
@@ -16858,6 +16968,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "ice" = (
@@ -16958,6 +17069,7 @@
 	name = "Maintenance Access Deck 1 Central Hallway"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port/fore)
 "ieO" = (
@@ -16990,6 +17102,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/nsv/hanger)
 "ifX" = (
@@ -17014,6 +17127,7 @@
 	req_one_access_txt = "79"
 	},
 /obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/nsv/hanger/notkmcstupidhanger/launchtube/right/airlock)
 "igA" = (
@@ -17168,6 +17282,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "ijq" = (
@@ -17178,6 +17293,9 @@
 /obj/machinery/door/airlock/ship/external/glass{
 	name = "Launch Platform Access";
 	req_one_access_txt = "79"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
 	},
 /turf/open/floor/monotile/steel,
 /area/nsv/hanger)
@@ -17210,6 +17328,7 @@
 	id = "gateshutter";
 	name = "Gateway Shutter"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/gateway)
 "ikr" = (
@@ -17227,6 +17346,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard/aft)
 "ikE" = (
@@ -17272,6 +17392,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/science/mixing)
 "ilW" = (
@@ -17302,6 +17423,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/bridge)
 "imB" = (
@@ -17413,6 +17535,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons/starboard)
 "ipl" = (
@@ -17557,6 +17680,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "isQ" = (
@@ -17587,6 +17711,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms/nsv/state_room)
 "itJ" = (
@@ -17827,6 +17952,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/frame1/central)
 "izm" = (
@@ -17949,6 +18075,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port/fore)
 "iBF" = (
@@ -18402,6 +18529,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons/ordnance)
 "iOn" = (
@@ -18429,6 +18559,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/science/robotics/mechbay)
 "iOO" = (
@@ -18545,8 +18676,12 @@
 /turf/open/floor/monotile/light,
 /area/medical/surgery/aux)
 "iRC" = (
-/turf/closed/wall/ship,
-/area/nsv/hanger/notkmcstupidhanger/atc)
+/obj/effect/turf_decal/ship/delivery/yellow,
+/obj/machinery/computer/ship/dradis/minor{
+	dir = 1
+	},
+/turf/open/floor/monotile/steel,
+/area/nsv/weapons/starboard)
 "iRO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -18749,6 +18884,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "iVN" = (
@@ -18960,6 +19096,7 @@
 /obj/machinery/door/window/northright{
 	name = "Brig Infirmary"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/light,
 /area/medical/chemistry)
 "jaU" = (
@@ -19508,6 +19645,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/hangar)
 "jog" = (
@@ -19635,6 +19773,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "jrv" = (
@@ -19679,6 +19818,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/science/xenobiology)
 "jsm" = (
@@ -19728,6 +19868,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/science/xenobiology)
 "jsO" = (
@@ -19926,6 +20067,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/storage/satellite)
 "jxS" = (
@@ -20008,6 +20150,8 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/tech/grid,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "jAx" = (
@@ -20029,6 +20173,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/tech/grid,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "jBt" = (
@@ -20063,6 +20209,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/ship/delivery/yellow,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons/starboard)
 "jCo" = (
@@ -20079,6 +20226,7 @@
 	dir = 4;
 	icon_state = "pipe"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port/aft)
 "jCE" = (
@@ -20141,6 +20289,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/ridged/steel,
 /area/ai_monitored/storage/eva)
 "jET" = (
@@ -20196,6 +20345,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/hallway/nsv/deck1/frame1/central)
 "jGK" = (
@@ -20379,6 +20529,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/hangar)
 "jKn" = (
@@ -20466,6 +20617,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/medical/medbay/lobby)
 "jMf" = (
@@ -20523,6 +20675,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port/fore)
 "jNS" = (
@@ -20575,6 +20728,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/grid/lino,
 /area/security/warden)
 "jPn" = (
@@ -20738,6 +20892,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/science/robotics/mechbay)
 "jUB" = (
@@ -21341,6 +21496,8 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/monotile/light,
 /area/security/brig)
 "klF" = (
@@ -21394,6 +21551,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/hanger/notkmcstupidhanger/pilot)
 "kni" = (
@@ -21529,6 +21687,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard/aft)
 "kpK" = (
@@ -21668,6 +21827,7 @@
 	name = "Infirmary";
 	req_one_access_txt = "5"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/light,
 /area/medical/medbay/lobby)
 "ksS" = (
@@ -21899,6 +22059,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "kzd" = (
@@ -21991,6 +22152,7 @@
 	name = "Bridge";
 	req_access_txt = "19"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/nsv/briefingroom)
 "kAL" = (
@@ -22130,6 +22292,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/nsv/crew_quarters/heads/maa)
 "kEu" = (
@@ -22187,6 +22350,9 @@
 	id_tag = "hangar_airlock_exterior_left";
 	name = "Launch Platform Airlock #1";
 	req_one_access_txt = "79"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
 	},
 /turf/open/floor/pod/dark,
 /area/nsv/hanger/notkmcstupidhanger/launchtube/left/airlock)
@@ -22256,6 +22422,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/science/storage)
 "kJS" = (
@@ -22374,6 +22541,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/weapons)
 "kNd" = (
@@ -22480,6 +22648,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "kPa" = (
@@ -22763,6 +22932,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/nsv/weapons/starboard)
 "kVD" = (
@@ -22807,6 +22977,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons/starboard)
 "kWE" = (
@@ -22832,6 +23003,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms/nsv/state_room)
 "kXg" = (
@@ -23411,6 +23583,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/bridge)
 "ljW" = (
@@ -23453,6 +23626,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/nsv/squad)
 "lku" = (
@@ -23476,6 +23650,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
 "llx" = (
@@ -23507,6 +23682,7 @@
 	dir = 4;
 	icon_state = "pipe"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/bridge/meeting_room)
 "llX" = (
@@ -23787,6 +23963,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/medical/genetics/cloning)
 "lsE" = (
@@ -24074,6 +24251,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/security/nuke_storage)
 "lBv" = (
@@ -24211,6 +24389,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/security/brig)
 "lFh" = (
@@ -24453,6 +24632,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/security/brig)
 "lMe" = (
@@ -24470,6 +24650,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/gateway)
 "lMy" = (
@@ -24651,6 +24832,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "lPH" = (
@@ -24716,6 +24900,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port/fore)
 "lQL" = (
@@ -24772,6 +24957,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port/aft)
 "lSm" = (
@@ -24811,6 +24997,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/nsv/squad)
 "lSJ" = (
@@ -24836,6 +25023,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "lTl" = (
@@ -24944,6 +25132,7 @@
 	name = "Ordnance Freight Elevator";
 	req_one_access_txt = "31;69"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/techmaint,
 /area/shuttle/turbolift/secondary)
 "lXF" = (
@@ -25163,6 +25352,8 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/nsv/officerquarters)
 "mef" = (
@@ -25252,6 +25443,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/heads/hor)
 "mfv" = (
@@ -25268,6 +25460,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/ai_monitored/security/armory)
 "mfE" = (
@@ -25415,6 +25608,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/security/prison)
 "mim" = (
@@ -25432,6 +25626,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/dorms/nsv/state_room)
 "min" = (
@@ -25774,6 +25969,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/frame1/starboard)
 "msV" = (
@@ -25941,6 +26137,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "mwl" = (
@@ -26115,6 +26312,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/hanger)
 "myR" = (
@@ -26262,6 +26460,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/freezer,
 /area/medical/virology)
 "mDc" = (
@@ -26288,6 +26487,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/hangar)
 "mDn" = (
@@ -26322,6 +26522,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port/fore)
 "mDB" = (
@@ -26467,6 +26668,9 @@
 	layer = 2.12;
 	name = "privacy shutters"
 	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/xo)
 "mGl" = (
@@ -26480,6 +26684,7 @@
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess{
 	name = "Maintenance Access Deck 1 Aft Hallway"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port/aft)
 "mGn" = (
@@ -26910,7 +27115,7 @@
 	sensor_tag = "hangar_airlock_sensor_right";
 	text = "I"
 	},
-/turf/closed/wall/ship,
+/turf/closed/wall/r_wall/ship,
 /area/nsv/hanger/notkmcstupidhanger/launchtube/right/airlock)
 "mQL" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -27458,6 +27663,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/ridged/steel,
 /area/ai_monitored/storage/eva)
 "neu" = (
@@ -27474,6 +27680,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/nsv/officerquarters)
 "nez" = (
@@ -27809,6 +28017,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/light,
 /area/medical/nsv/plumbing)
 "nlX" = (
@@ -27822,6 +28031,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/light,
 /area/medical/medbay/lobby)
 "nmb" = (
@@ -27964,6 +28174,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port/aft)
 "npP" = (
@@ -28002,6 +28213,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/science/research)
 "nqE" = (
@@ -28051,6 +28263,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/vacant_room/commissary)
 "nri" = (
@@ -28201,6 +28414,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/security/detectives_office)
 "nvK" = (
@@ -28391,6 +28605,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/nsv/hanger)
 "nBw" = (
@@ -28577,6 +28792,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/light,
 /area/medical/sleeper)
 "nGq" = (
@@ -28593,6 +28809,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/aft)
 "nGU" = (
@@ -28755,6 +28972,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "nKG" = (
@@ -28825,6 +29043,7 @@
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess{
 	name = "Maintenance Access Deck 1 Central Hallway"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/central)
 "nOd" = (
@@ -28861,6 +29080,8 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/monotile/light,
 /area/security/brig)
 "nPy" = (
@@ -29011,6 +29232,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port/aft)
 "nUa" = (
@@ -29251,6 +29473,9 @@
 	id = "rnd_shutters";
 	name = "research shutters"
 	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/monotile/steel,
 /area/science/lab)
 "oaH" = (
@@ -29281,6 +29506,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "obm" = (
@@ -29641,6 +29867,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/medical/patients_rooms/room_a)
 "ojq" = (
@@ -29726,6 +29953,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons/starboard)
 "olI" = (
@@ -29827,6 +30055,8 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/nsv/officerquarters)
 "onQ" = (
@@ -29938,6 +30168,9 @@
 	dir = 1;
 	id = "robotics_shutters"
 	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/monotile/steel,
 /area/science/robotics/lab)
 "opx" = (
@@ -30200,6 +30433,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard/aft)
 "oxY" = (
@@ -30697,6 +30931,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/medical/morgue)
 "oLp" = (
@@ -30771,6 +31006,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/light,
 /area/medical/surgery/aux)
 "oMe" = (
@@ -30866,6 +31102,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/security/checkpoint/science/research)
 "oOn" = (
@@ -31055,6 +31292,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/science/storage)
 "oSg" = (
@@ -31070,6 +31308,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/ship/delivery/yellow,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/science/research)
 "oSE" = (
@@ -31087,6 +31326,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/science/explab)
 "oSK" = (
@@ -31128,6 +31368,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/nsv/officerquarters)
 "oTn" = (
@@ -31165,6 +31406,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/nsv/officerquarters)
 "oTJ" = (
@@ -31178,6 +31420,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/nsv/officerquarters)
 "oUf" = (
@@ -31549,6 +31792,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "pbm" = (
@@ -31606,6 +31850,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/science/robotics/lab)
 "pde" = (
@@ -31622,6 +31867,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/security/prison)
 "pdJ" = (
@@ -31745,6 +31991,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/security/prison)
 "pgP" = (
@@ -31859,6 +32106,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/grid/lino,
 /area/ai_monitored/turret_protected/aisat_interior)
 "phZ" = (
@@ -31875,6 +32123,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/aft)
 "pih" = (
@@ -31996,6 +32245,8 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/monotile/light,
 /area/security/brig)
 "pkz" = (
@@ -32012,6 +32263,7 @@
 	dir = 4;
 	icon_state = "pipe"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "pkJ" = (
@@ -32062,6 +32314,7 @@
 	name = "Spares Bay";
 	req_one_access_txt = "71"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/tech/grid,
 /area/nsv/hanger)
 "plr" = (
@@ -32129,6 +32382,7 @@
 	name = "Bridge";
 	req_access_txt = "19"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/nsv/briefingroom)
 "pnK" = (
@@ -32169,6 +32423,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/light,
 /area/medical/surgery)
 "pou" = (
@@ -32404,6 +32659,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/light,
 /area/medical/surgery)
 "psG" = (
@@ -32635,6 +32891,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/aft)
 "pxj" = (
@@ -32651,6 +32908,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/light,
 /area/medical/storage)
 "pyd" = (
@@ -32993,6 +33251,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/grid/lino,
 /area/ai_monitored/turret_protected/aisat_interior)
 "pIy" = (
@@ -33454,6 +33713,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/ship,
 /area/nsv/hanger)
 "pWd" = (
@@ -33551,6 +33811,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/weapons)
 "qae" = (
@@ -33618,6 +33879,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/security/brig)
 "qbs" = (
@@ -33654,6 +33916,9 @@
 	id_tag = "hangar_airlock_exterior_right";
 	name = "Launch Platform Airlock #2";
 	req_one_access_txt = "79"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
 	},
 /turf/open/floor/pod/dark,
 /area/nsv/hanger/notkmcstupidhanger/launchtube/right/airlock)
@@ -33855,6 +34120,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "qim" = (
@@ -33874,6 +34140,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons/ordnance)
 "qiu" = (
@@ -34187,6 +34456,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "qqi" = (
@@ -34212,6 +34482,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "qqG" = (
@@ -34533,6 +34804,7 @@
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess{
 	name = "Maintenance Access Deck 1 Aft Hallway"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port/aft)
 "qyC" = (
@@ -34671,6 +34943,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/ship/delivery/yellow,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/science/research)
 "qBM" = (
@@ -34692,6 +34965,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port/fore)
 "qBP" = (
@@ -34935,6 +35209,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "qHC" = (
@@ -35292,6 +35569,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
 "qPW" = (
@@ -35485,6 +35763,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port/aft)
 "qVi" = (
@@ -35530,6 +35809,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/science/nsv/astronomy)
 "qVE" = (
@@ -36151,6 +36431,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "rnp" = (
@@ -36196,6 +36477,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "rot" = (
@@ -36215,6 +36497,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port/aft)
 "roD" = (
@@ -36371,6 +36654,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/hallway/nsv/deck1/aft)
 "rse" = (
@@ -36509,6 +36793,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "rxH" = (
@@ -36646,6 +36931,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/turf_decal/ship/delivery/yellow,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons/starboard)
 "rBh" = (
@@ -36944,6 +37230,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/frame1/central)
 "rJs" = (
@@ -37761,6 +38048,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/ai_monitored/security/armory)
 "shM" = (
@@ -38146,6 +38434,7 @@
 	name = "Bridge";
 	req_access_txt = "19"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/nsv/briefingroom)
 "ssN" = (
@@ -38177,6 +38466,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/light,
 /area/medical/virology)
 "sth" = (
@@ -38396,6 +38686,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/nsv/crew_quarters/heads/maa)
 "syd" = (
@@ -38509,6 +38800,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/medical/genetics/cloning)
 "sAo" = (
@@ -38538,6 +38830,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/light,
 /area/medical/virology)
 "sAq" = (
@@ -38805,6 +39098,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port/fore)
 "sGl" = (
@@ -38859,6 +39153,7 @@
 	id = "cell3_ld";
 	name = "Cell 3 Lockdown"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/security/prison)
 "sHn" = (
@@ -38958,6 +39253,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/heads/cmo)
 "sJn" = (
@@ -39008,6 +39304,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/hanger)
 "sJV" = (
@@ -39459,6 +39756,7 @@
 /obj/machinery/door/airlock/ship/glass{
 	req_one_access_txt = "72,73"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/notkmcstupidhanger/pilot)
 "sTN" = (
@@ -39633,6 +39931,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/light,
 /area/medical/medbay/aft)
 "sWV" = (
@@ -39709,6 +40008,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/weapons)
 "sYk" = (
@@ -39816,6 +40116,9 @@
 	req_one_access_txt = "79"
 	},
 /obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
 /turf/open/floor/pod/dark,
 /area/nsv/hanger/notkmcstupidhanger/launchtube/right/airlock)
 "tbd" = (
@@ -39919,6 +40222,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "tcm" = (
@@ -40015,6 +40319,7 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/medical/morgue)
 "teN" = (
@@ -40064,6 +40369,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/nsv/briefingroom)
 "tgl" = (
@@ -40108,6 +40414,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/security/warden)
 "tit" = (
@@ -40133,6 +40440,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/medical/nsv/psychology)
 "tiA" = (
@@ -40339,6 +40647,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons/starboard)
 "toI" = (
@@ -40824,6 +41133,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/ai_monitored/security/armory)
 "tDB" = (
@@ -40840,6 +41150,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/hallway/nsv/deck1/frame1/starboard)
 "tDF" = (
@@ -40895,6 +41206,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons/ordnance)
 "tEq" = (
@@ -40926,13 +41240,10 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/aft)
 "tFC" = (
-/obj/machinery/door/poddoor/ship{
-	dir = 4;
-	id = "fiftycalpublic";
-	name = "Public Access 50cal room"
-	},
-/turf/open/floor/monotile/steel,
-/area/nsv/weapons/starboard)
+/obj/structure/grille,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "tFK" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
 /obj/structure/cable,
@@ -41107,6 +41418,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons/starboard)
 "tNS" = (
@@ -41214,6 +41526,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/central)
 "tPU" = (
@@ -41282,6 +41595,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/hangar)
 "tQP" = (
@@ -41339,6 +41653,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/tech/grid,
 /area/nsv/weapons/starboard)
 "tRR" = (
@@ -41383,6 +41698,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/light,
 /area/medical/sleeper)
 "tSO" = (
@@ -41456,6 +41772,7 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/light,
 /area/medical/medbay/lobby)
 "tWA" = (
@@ -41732,6 +42049,8 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/structure/disposalpipe/trunk,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/monotile/light,
 /area/security/brig)
 "ucN" = (
@@ -42158,6 +42477,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/hanger)
 "upn" = (
@@ -42221,6 +42541,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/bridge)
 "uqS" = (
@@ -42490,6 +42811,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/light,
 /area/medical/chemistry)
 "uxV" = (
@@ -42689,6 +43011,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "uBv" = (
@@ -42715,6 +43038,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/tech/grid,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "uCl" = (
@@ -42925,6 +43250,7 @@
 /obj/machinery/door/airlock/ship/glass{
 	req_one_access_txt = "72, 73"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/notkmcstupidhanger/pilot)
 "uHJ" = (
@@ -43302,7 +43628,7 @@
 	},
 /obj/machinery/button/door{
 	id = "munitionsPDC";
-	name = "PDC and Flak Rack Access";
+	name = "AMS control room Access";
 	pixel_y = 24;
 	req_one_access_txt = "69"
 	},
@@ -43312,6 +43638,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons/starboard)
 "uQr" = (
@@ -43371,6 +43698,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons/starboard)
 "uRj" = (
@@ -43644,6 +43972,7 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/aft)
 "uYK" = (
@@ -43706,6 +44035,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "uZE" = (
@@ -43722,6 +44052,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/light,
 /area/medical/sleeper)
 "uZF" = (
@@ -43916,6 +44247,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
 "vcL" = (
@@ -43943,6 +44275,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/hallway/nsv/deck1/frame1/starboard)
 "vdA" = (
@@ -43977,7 +44310,6 @@
 "vev" = (
 /obj/structure/lattice/catwalk/over/ship,
 /obj/structure/rack,
-/obj/item/circuitboard/computer/fiftycal,
 /obj/item/multitool,
 /turf/open/floor/plating,
 /area/nsv/weapons/starboard)
@@ -44544,6 +44876,7 @@
 	dir = 1;
 	icon_state = "support_beam"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/aft)
 "vsq" = (
@@ -44712,6 +45045,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/ship/techfloor/alt,
 /area/nsv/hanger/notkmcstupidhanger/pilot)
 "vvA" = (
@@ -44738,6 +45072,7 @@
 	name = "Launch Platform Airlock #1";
 	req_one_access_txt = "79"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/nsv/hanger/notkmcstupidhanger/launchtube/left/airlock)
 "vvK" = (
@@ -44797,6 +45132,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "vxo" = (
@@ -45092,6 +45428,11 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/airlock/ship/command/glass{
+	name = "Bridge Quarters";
+	req_access_txt = "19"
+	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/nsv/officerquarters)
 "vFd" = (
@@ -45260,6 +45601,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/science/research)
 "vJe" = (
@@ -45578,6 +45920,7 @@
 	name = "Spares Bay";
 	req_one_access_txt = "71"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/tech/grid,
 /area/nsv/hanger)
 "vTg" = (
@@ -45717,6 +46060,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "vWv" = (
@@ -45836,6 +46180,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons/starboard)
 "vZz" = (
@@ -46023,6 +46368,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/frame1/starboard)
 "wey" = (
@@ -46101,6 +46447,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port/aft)
 "wfU" = (
@@ -46138,6 +46485,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/ship,
 /area/nsv/hanger)
 "wgJ" = (
@@ -46209,6 +46557,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons/ordnance)
 "wia" = (
@@ -46321,15 +46672,16 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms/nsv/state_room)
 "wli" = (
-/obj/machinery/door/airlock/glass_large/ship{
-	name = "Bridge Quarters";
-	req_one_access_txt = "19"
-	},
 /obj/effect/turf_decal/tile/ship/full/blue,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/airlock/ship/command/glass{
+	name = "Bridge Quarters";
+	req_access_txt = "19"
+	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/nsv/officerquarters)
 "wlp" = (
@@ -46558,6 +46910,7 @@
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess{
 	name = "Maintenance Access Deck 1 Central Hallway"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/central)
 "wqr" = (
@@ -46667,6 +47020,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/xo)
 "wsB" = (
@@ -46926,6 +47280,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port/aft)
 "wyd" = (
@@ -47056,6 +47411,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port/aft)
 "wCC" = (
@@ -47198,6 +47554,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "wGn" = (
@@ -47229,6 +47588,7 @@
 	name = "Launch Platform Airlock #2";
 	req_one_access_txt = "79"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/nsv/hanger/notkmcstupidhanger/launchtube/right/airlock)
 "wGX" = (
@@ -47553,6 +47913,7 @@
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess{
 	name = "Maintenance Access Deck 1 Central Hallway"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "wPS" = (
@@ -47779,6 +48140,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/hos)
 "wWD" = (
@@ -48109,6 +48471,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/ship,
 /area/nsv/hanger)
 "xdU" = (
@@ -48722,6 +49085,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/light,
 /area/security/prison)
 "xuF" = (
@@ -49198,6 +49562,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "xEU" = (
@@ -49312,6 +49677,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/maintenance/department/bridge)
 "xIr" = (
@@ -49418,6 +49784,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "xKH" = (
@@ -49444,6 +49811,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/science/research)
 "xLA" = (
@@ -49711,6 +50079,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/security/main)
 "xSJ" = (
@@ -49749,6 +50118,7 @@
 /obj/machinery/door/airlock/ship/glass{
 	req_one_access_txt = "72,73"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/notkmcstupidhanger/pilot)
 "xTo" = (
@@ -49787,6 +50157,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/security/checkpoint/medical)
 "xTA" = (
@@ -49876,6 +50247,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "xUR" = (
@@ -50148,6 +50520,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/security/brig)
 "ybF" = (
@@ -50357,6 +50730,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/medical/medbay/lobby)
 "yhV" = (
@@ -50436,6 +50810,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/science/robotics/lab)
 "yjm" = (
@@ -66384,7 +66759,7 @@ dDK
 cyX
 pCX
 icr
-irD
+eys
 icr
 eYd
 eYd
@@ -69753,7 +70128,7 @@ pJj
 pJj
 xTi
 sTL
-pJj
+vVF
 vVF
 vVF
 bxB
@@ -71808,7 +72183,7 @@ kmH
 xyZ
 xyZ
 xyZ
-pJj
+vVF
 vVF
 vVF
 wcI
@@ -74373,10 +74748,10 @@ ivz
 veB
 doL
 pKJ
-xMZ
-xMZ
-xMZ
-xMZ
+efk
+efk
+efk
+efk
 efk
 efk
 efk
@@ -74630,7 +75005,7 @@ ivz
 veB
 doL
 pKJ
-xMZ
+efk
 xSs
 hGV
 mfW
@@ -75144,7 +75519,7 @@ ivz
 uan
 doL
 sMG
-xMZ
+efk
 vMa
 xZS
 pBr
@@ -75400,10 +75775,10 @@ jYx
 ivz
 uke
 nle
-dEs
-dEs
-dEs
-dEs
+pjg
+pjg
+pjg
+pjg
 pjg
 pjg
 lwl
@@ -75657,7 +76032,7 @@ jYx
 ivz
 uan
 uLS
-dEs
+pjg
 jqK
 wlR
 vaq
@@ -76685,7 +77060,7 @@ jYx
 ivz
 uqV
 dsX
-dEs
+pjg
 uoH
 cVY
 uoH
@@ -76941,8 +77316,8 @@ mLV
 yiN
 ivz
 rkC
-xMZ
-dEs
+efk
+pjg
 cOu
 uts
 uts
@@ -77198,7 +77573,7 @@ fnu
 vfd
 hhI
 smo
-iRC
+ejZ
 qde
 qOQ
 qOQ
@@ -77455,7 +77830,7 @@ mLV
 jYx
 ivz
 cQw
-iRC
+ejZ
 jQU
 gkX
 lML
@@ -77969,7 +78344,7 @@ mLV
 jYx
 ivz
 cQw
-iRC
+ejZ
 iJa
 ndH
 gkX
@@ -78226,7 +78601,7 @@ mLV
 jYx
 ivz
 kkR
-iRC
+ejZ
 hrO
 oUy
 qOQ
@@ -78483,8 +78858,8 @@ mLV
 jYx
 ivz
 mlr
-xMZ
-eys
+efk
+sRO
 mQp
 pfY
 pfY
@@ -78741,7 +79116,7 @@ tzF
 ivz
 uqV
 nYc
-eys
+sRO
 ljY
 rtS
 ljY
@@ -79769,7 +80144,7 @@ fgX
 fgX
 oQY
 uzw
-eys
+sRO
 fDv
 efa
 dwQ
@@ -80026,10 +80401,10 @@ doL
 doL
 uAW
 xMZ
-eys
-eys
-eys
-eys
+sRO
+sRO
+sRO
+sRO
 sRO
 gId
 lwl
@@ -81564,8 +81939,8 @@ tok
 kVn
 gNQ
 wzW
-tFC
-tFC
+nmT
+nmT
 nmT
 nmT
 nmT
@@ -82081,7 +82456,7 @@ nmT
 hUQ
 ost
 gIG
-ycp
+iRC
 nmT
 nmT
 nmT
@@ -92117,7 +92492,7 @@ bEM
 jVZ
 nrx
 aaa
-aaa
+tFC
 aaa
 aaa
 aaa
@@ -92373,8 +92748,8 @@ qAa
 iRs
 jVZ
 nrx
-aaa
-aaa
+nrx
+tFC
 aaa
 aaa
 aaa
@@ -92631,7 +93006,7 @@ bEM
 jVZ
 nrx
 aaa
-aaa
+tFC
 aaa
 aaa
 aaa
@@ -92888,7 +93263,7 @@ vcd
 jVZ
 nrx
 aaa
-aaa
+tFC
 aaa
 aaa
 aaa
@@ -93145,7 +93520,7 @@ ePO
 jVZ
 jNT
 aaa
-aaa
+tFC
 aaa
 aaa
 aaa
@@ -93402,7 +93777,7 @@ aMQ
 jVZ
 nrx
 aaa
-aaa
+tFC
 aaa
 aaa
 aaa
@@ -93658,8 +94033,8 @@ emN
 dKx
 jVZ
 nrx
-aaa
-aaa
+nrx
+tFC
 aaa
 aaa
 aaa
@@ -93916,7 +94291,7 @@ jVZ
 jVZ
 nrx
 aaa
-aaa
+tFC
 aaa
 aaa
 aaa
@@ -94889,7 +95264,7 @@ ods
 qBa
 qBa
 pSv
-gYz
+dEs
 pZE
 ooi
 ooi

--- a/_maps/map_files/Gladius/Gladius2.dmm
+++ b/_maps/map_files/Gladius/Gladius2.dmm
@@ -904,6 +904,9 @@
 	name = "Custodial Closet shutters"
 	},
 /obj/effect/turf_decal/ship/delivery/yellow,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/monotile/steel,
 /area/janitor)
 "aGm" = (
@@ -1019,6 +1022,7 @@
 	dir = 4
 	},
 /obj/item/reagent_containers/food/snacks/onionrings,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/crew_quarters/kitchen)
 "aLw" = (
@@ -1033,6 +1037,7 @@
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess{
 	name = "Maintenance Access Deck 1 Central Hallway"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/central)
 "aLP" = (
@@ -1089,6 +1094,7 @@
 	id = "Secure Storage";
 	name = "Secure Storage"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/engine/storage)
 "aOr" = (
@@ -1124,6 +1130,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "aQo" = (
@@ -1178,6 +1185,7 @@
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess{
 	name = "Maintenance Access Arrivals"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/starboard)
 "aSM" = (
@@ -1224,6 +1232,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port/aft)
 "aUk" = (
@@ -1633,6 +1642,7 @@
 /obj/machinery/door/airlock/ship/public{
 	name = "Deck 2 Aft Emergency Storage"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "bkd" = (
@@ -1699,6 +1709,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "bmk" = (
@@ -1994,6 +2005,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/hallway/nsv/deck2/frame1/starboard)
 "bvI" = (
@@ -2105,6 +2117,7 @@
 /obj/machinery/modular_computer/console/preset/engineering{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/techmaint,
 /area/engine/engineering/reactor_core)
 "bzu" = (
@@ -2135,6 +2148,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/starboard)
 "bAK" = (
@@ -2423,6 +2437,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "bKq" = (
@@ -2495,6 +2510,7 @@
 /obj/machinery/door/airlock/ship{
 	name = "Locker Room"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/locker)
 "bMY" = (
@@ -2690,6 +2706,7 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/secondary/entry)
 "bVV" = (
@@ -2740,6 +2757,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/engine/engineering/reactor_control)
 "bYf" = (
@@ -3201,6 +3219,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/tcommsat/computer)
 "clo" = (
@@ -3329,6 +3348,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port/fore)
 "cpv" = (
@@ -3929,6 +3949,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard/fore)
 "cFc" = (
@@ -3983,6 +4004,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port/fore)
 "cGw" = (
@@ -4071,6 +4093,7 @@
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess{
 	name = "Maintenance Access Crew Quarters"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "cIY" = (
@@ -4087,6 +4110,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "cJa" = (
@@ -4200,6 +4224,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/locker)
 "cLF" = (
@@ -4645,7 +4670,7 @@
 "ddP" = (
 /obj/machinery/door/airlock/ship/station/mining{
 	name = "Cargo Office";
-	req_one_access_txt = "31;41;48;69;72"
+	req_one_access_txt = "31;41;48"
 	},
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -4658,6 +4683,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/quartermaster/office)
 "der" = (
@@ -4726,6 +4752,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "dfZ" = (
@@ -5491,6 +5518,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Chapel"
+	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/chapel/main)
 "dIF" = (
@@ -5606,6 +5637,7 @@
 /area/maintenance/nsv/deck2/port/fore)
 "dKB" = (
 /obj/machinery/door/firedoor/border_only/directional/east,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "dKK" = (
@@ -5983,6 +6015,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port/fore)
 "dWI" = (
@@ -6612,6 +6645,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/starboard)
 "erx" = (
@@ -6648,6 +6682,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "esJ" = (
@@ -6881,6 +6916,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/starboard)
 "ezE" = (
@@ -6985,6 +7021,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/quartermaster/sorting)
 "eCD" = (
@@ -7009,6 +7046,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard/fore)
 "eCN" = (
@@ -7046,6 +7084,10 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Crew Quarters Access"
+	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/crew_quarters/locker)
 "eDt" = (
@@ -7171,6 +7213,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard/aft)
 "eGA" = (
@@ -7191,6 +7234,7 @@
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess{
 	name = "Maintenance Access Crew Quarters"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/starboard)
 "eGJ" = (
@@ -7445,6 +7489,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons/gauss)
 "eLK" = (
@@ -7466,6 +7511,7 @@
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess{
 	name = "Maintenance Access Laundromat"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "eMm" = (
@@ -7605,6 +7651,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port/fore)
 "eTs" = (
@@ -7666,6 +7713,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/secondary/exit/departure_lounge)
 "eUp" = (
@@ -7829,6 +7877,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port/aft)
 "fap" = (
@@ -7997,6 +8046,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "feU" = (
@@ -8227,6 +8277,7 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/quartermaster/qm)
 "fjF" = (
@@ -8502,6 +8553,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/central)
 "foe" = (
@@ -8710,6 +8762,7 @@
 	dir = 8
 	},
 /obj/structure/lattice/catwalk/over/ship,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/engine/engine_smes)
 "fva" = (
@@ -8990,6 +9043,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/engine/gravity_generator)
 "fBh" = (
@@ -9085,6 +9139,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard/fore)
 "fEg" = (
@@ -9167,6 +9222,8 @@
 "fGy" = (
 /obj/structure/window/reinforced/spawner,
 /obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "fGB" = (
@@ -9187,6 +9244,7 @@
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess{
 	name = "Maintenance Access Cryogenics"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "fGV" = (
@@ -9202,6 +9260,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/starboard)
 "fHe" = (
@@ -9239,6 +9298,8 @@
 /area/engine/engineering/reactor_core)
 "fIx" = (
 /obj/structure/window/reinforced/spawner,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "fIX" = (
@@ -9269,6 +9330,8 @@
 	icon_state = "right";
 	name = "Theatre Stage"
 	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "fJF" = (
@@ -9420,6 +9483,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/chapel/office)
 "fMB" = (
@@ -9769,6 +9833,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "fYs" = (
@@ -9785,6 +9850,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "fYt" = (
@@ -9827,6 +9893,7 @@
 	name = "Ordnance Freight Elevator";
 	req_one_access_txt = "31;69"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/techmaint,
 /area/shuttle/turbolift/secondary)
 "fYT" = (
@@ -9919,6 +9986,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port/aft)
 "gbs" = (
@@ -10024,6 +10092,7 @@
 	name = "Reactor Core Access";
 	req_one_access_txt = "10"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/techmaint,
 /area/engine/engineering/reactor_core)
 "gdA" = (
@@ -10047,6 +10116,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "gdU" = (
@@ -10089,6 +10159,8 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "geN" = (
@@ -10154,6 +10226,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "ghF" = (
@@ -10271,6 +10344,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/crew_quarters/kitchen)
 "gla" = (
@@ -10737,6 +10811,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
 "gxX" = (
@@ -11058,6 +11133,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/construction)
 "gIL" = (
@@ -11188,6 +11264,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/chapel/main)
 "gNl" = (
@@ -12194,6 +12271,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard/fore)
 "hqi" = (
@@ -12264,6 +12342,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "hse" = (
@@ -12614,6 +12693,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/tech/grid,
 /area/chapel/main)
 "hDw" = (
@@ -12858,6 +12938,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "hMN" = (
@@ -12922,6 +13003,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/kitchen)
 "hOp" = (
@@ -13569,6 +13651,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard/aft)
 "igh" = (
@@ -13617,6 +13700,7 @@
 	dir = 4;
 	icon_state = "pipe"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/quartermaster/qm)
 "iht" = (
@@ -13706,6 +13790,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/starboard)
 "ikB" = (
@@ -13757,6 +13842,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/storage/tech)
 "ilG" = (
@@ -13834,6 +13920,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/kitchen/coldroom)
 "imV" = (
@@ -13879,6 +13966,7 @@
 	req_access_txt = "28"
 	},
 /obj/item/pen,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
 "inW" = (
@@ -13913,6 +14001,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "ioy" = (
@@ -13953,6 +14042,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
 "ipH" = (
@@ -13992,21 +14082,26 @@
 /turf/open/floor/carpet/red,
 /area/nsv/weapons/gauss)
 "iqf" = (
-/obj/machinery/door/airlock/glass_large/ship{
-	name = "Bar"
-	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Bar"
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "iqk" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Bar"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -14080,14 +14175,15 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "isP" = (
-/obj/machinery/door/airlock/glass_large/ship{
-	name = "Bar"
-	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Bar"
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "isQ" = (
@@ -14262,6 +14358,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/engine/break_room)
 "iwi" = (
@@ -14925,6 +15022,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "iRB" = (
@@ -15157,6 +15255,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/chapel/office)
 "iYR" = (
@@ -15253,6 +15352,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/ship,
 /area/engine/break_room)
 "jaU" = (
@@ -15447,7 +15547,6 @@
 /turf/open/floor/monotile/dark,
 /area/engine/gravity_generator)
 "jiA" = (
-/obj/structure/plasticflaps/opaque,
 /obj/machinery/door/poddoor/ship/preopen{
 	dir = 8;
 	id = "atmos";
@@ -15459,6 +15558,7 @@
 /obj/machinery/disposal/deliveryChute{
 	dir = 8
 	},
+/obj/structure/plasticflaps/opaque,
 /turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "jiB" = (
@@ -15507,10 +15607,10 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/engine/corridor)
 "jkL" = (
-/obj/structure/plasticflaps/opaque,
 /obj/structure/disposaloutlet{
 	dir = 1
 	},
+/obj/structure/plasticflaps/opaque,
 /obj/structure/disposalpipe/trunk{
 	dir = 2
 	},
@@ -15588,6 +15688,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard/fore)
 "joi" = (
@@ -15751,6 +15852,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/hallway/nsv/deck2/frame1/central)
 "jsI" = (
@@ -15883,6 +15985,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "jwp" = (
@@ -15934,6 +16037,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port/aft)
 "jxQ" = (
@@ -16584,9 +16688,6 @@
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/locker)
 "jTD" = (
-/obj/machinery/door/airlock/glass_large/ship{
-	name = "Chapel"
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -16598,6 +16699,10 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Chapel"
+	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/chapel/main)
 "jTO" = (
@@ -16610,6 +16715,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/starboard)
 "jTW" = (
@@ -16946,11 +17052,11 @@
 /turf/open/floor/plasteel/grid/steel,
 /area/engine/atmos)
 "keN" = (
-/obj/structure/plasticflaps/opaque,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
 /obj/structure/disposaloutlet,
+/obj/structure/plasticflaps/opaque,
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
 "keX" = (
@@ -17054,6 +17160,7 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/grid/techfloor/grid,
 /area/engine/engineering/reactor_core)
 "kgF" = (
@@ -17192,6 +17299,7 @@
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess{
 	name = "Maintenance Access Auxiliary Tool Storage"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "knb" = (
@@ -17599,6 +17707,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/central)
 "kAZ" = (
@@ -17750,6 +17859,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Library"
+	},
 /turf/open/floor/carpet/green,
 /area/library)
 "kHD" = (
@@ -17820,6 +17932,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port/fore)
 "kJx" = (
@@ -18104,6 +18217,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "kTQ" = (
@@ -18354,6 +18468,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
 "lcg" = (
@@ -18557,6 +18672,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
 "lhB" = (
@@ -18573,22 +18689,6 @@
 /obj/machinery/gravity_generator/main/station,
 /turf/open/floor/monotile/dark,
 /area/engine/gravity_generator)
-"lhO" = (
-/obj/machinery/door/airlock/glass_large/ship{
-	bound_height = 64;
-	bound_width = 32;
-	dir = 4;
-	name = "Library";
-	pixel_x = -32
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/carpet/green,
-/area/library)
 "liJ" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -18666,6 +18766,7 @@
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess{
 	name = "Maintenance Access Garden"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard/fore)
 "ljS" = (
@@ -18824,6 +18925,7 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/quartermaster/sorting)
 "lqn" = (
@@ -19060,6 +19162,7 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/quartermaster/sorting)
 "lwu" = (
@@ -19140,6 +19243,7 @@
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess{
 	name = "Maintenance Access Deck 1 Central Hallway"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/central)
 "lyw" = (
@@ -19505,6 +19609,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/secondary/exit/departure_lounge)
 "lIC" = (
@@ -20157,6 +20262,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/secondary/service)
 "mbl" = (
@@ -20351,6 +20457,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/engine/storage)
 "mfX" = (
@@ -20391,6 +20498,7 @@
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/engine/engineering/reactor_control)
 "mgd" = (
@@ -20866,6 +20974,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/techmaint,
 /area/engine/engineering/reactor_core)
 "mtJ" = (
@@ -20920,6 +21029,7 @@
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess{
 	name = "Maintenance Access Deck 1 Central Hallway"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard/fore)
 "mvj" = (
@@ -21142,6 +21252,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/engine/gravity_generator)
 "mAN" = (
@@ -21177,6 +21288,7 @@
 	id = "gaussgang";
 	name = "public ballistics access"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons/gauss)
 "mBf" = (
@@ -21337,6 +21449,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/janitor)
 "mFC" = (
@@ -21383,12 +21496,12 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/fitness/recreation)
 "mGu" = (
-/obj/machinery/door/airlock/glass_large/ship{
-	name = "Library"
-	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
+	},
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Library"
 	},
 /turf/open/floor/carpet/green,
 /area/library)
@@ -21429,6 +21542,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/secondary/exit/departure_lounge)
 "mJh" = (
@@ -21626,6 +21740,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/storage/primary)
 "mRc" = (
@@ -21677,13 +21792,14 @@
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "mTz" = (
-/obj/machinery/door/airlock/glass_large/ship{
-	name = "Cryogenic Storage"
-	},
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Cryogenic Storage"
+	},
 /turf/open/floor/monotile/light,
 /area/crew_quarters/cryopods)
 "mTJ" = (
@@ -21750,6 +21866,7 @@
 	id = "gaussgang";
 	name = "public ballistics access"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons/gauss)
 "mUP" = (
@@ -21766,9 +21883,6 @@
 /turf/open/floor/plasteel/techmaint,
 /area/engine/engineering/reactor_core)
 "mVM" = (
-/obj/machinery/door/airlock/glass_large/ship{
-	name = "Crew Quarters Access"
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
@@ -21778,6 +21892,10 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Crew Quarters Access"
+	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/locker)
 "mWj" = (
@@ -21822,6 +21940,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/ship/engineering/glass,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/engine/break_room)
 "mWV" = (
@@ -22036,6 +22155,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/starboard)
 "ncE" = (
@@ -22259,6 +22379,7 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/ship/engineering/glass,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/engine/break_room)
 "njg" = (
@@ -22795,6 +22916,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/starboard)
 "nBq" = (
@@ -22813,6 +22935,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "nBW" = (
@@ -22870,6 +22993,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/ship,
 /area/engine/break_room)
 "nDu" = (
@@ -22972,6 +23096,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/lawoffice)
 "nHG" = (
@@ -22985,6 +23110,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "nHN" = (
@@ -23190,6 +23316,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/lawoffice)
 "nNa" = (
@@ -23845,6 +23972,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/hallway/nsv/deck2/frame1/central)
 "odt" = (
@@ -23866,6 +23994,7 @@
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess{
 	name = "Maintenance Access Cryogenics"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/light,
 /area/maintenance/department/crew_quarters/dorms)
 "odH" = (
@@ -24351,6 +24480,7 @@
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/starboard)
 "ouH" = (
@@ -24591,6 +24721,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard/fore)
 "oAN" = (
@@ -24955,6 +25086,7 @@
 /obj/item/clothing/head/hardhat{
 	pixel_y = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/techmaint,
 /area/engine/engineering/reactor_core)
 "oOi" = (
@@ -25058,6 +25190,7 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "oRZ" = (
@@ -25094,6 +25227,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "oTA" = (
@@ -25163,14 +25297,15 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "oWR" = (
-/obj/machinery/door/airlock/glass_large/ship{
-	name = "Locker Room"
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Locker Room"
+	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/locker)
 "oWX" = (
@@ -25699,6 +25834,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port/aft)
 "pjw" = (
@@ -25840,6 +25976,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/techmaint,
 /area/engine/engineering/reactor_core)
 "pnY" = (
@@ -26085,6 +26222,7 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/quartermaster/office)
 "puB" = (
@@ -26359,6 +26497,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
 "pEa" = (
@@ -26394,6 +26533,7 @@
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess{
 	name = "Maintenance Access Deck 1 Central Hallway"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "pFB" = (
@@ -26600,6 +26740,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/ship,
 /area/engine/break_room)
 "pLu" = (
@@ -26745,6 +26886,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/techmaint,
 /area/engine/engineering/reactor_core)
 "pOj" = (
@@ -26863,6 +27005,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/crew_quarters/kitchen)
 "pRK" = (
@@ -26994,6 +27137,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard/fore)
 "pVe" = (
@@ -27324,6 +27468,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/secondary/entry)
 "qdM" = (
@@ -27449,6 +27594,10 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard/fore)
+"qiW" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/closed/wall/r_wall/ship,
+/area/engine/engineering/reactor_core)
 "qjq" = (
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /obj/machinery/door/firedoor/border_only{
@@ -27479,6 +27628,7 @@
 	dir = 4;
 	icon_state = "pipe"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/starboard)
 "qjA" = (
@@ -27587,6 +27737,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/starboard)
 "qlR" = (
@@ -27887,6 +28038,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/locker)
 "quK" = (
@@ -28129,6 +28281,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/security/checkpoint/supply)
 "qAq" = (
@@ -28183,6 +28336,9 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Library"
+	},
 /turf/open/floor/carpet/green,
 /area/library)
 "qCf" = (
@@ -28218,6 +28374,7 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/ship/public/glass/turbolift,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/shuttle/turbolift)
 "qDb" = (
@@ -28311,6 +28468,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/warehouse)
 "qFN" = (
@@ -28320,6 +28478,7 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/warehouse)
 "qFP" = (
@@ -28484,6 +28643,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
 "qLX" = (
@@ -28562,6 +28722,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/engine/engineering/reactor_core)
 "qOi" = (
@@ -28789,6 +28950,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/crew_quarters/kitchen)
 "qTz" = (
@@ -28836,6 +28998,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/locker)
 "qVm" = (
@@ -29120,6 +29283,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/quartermaster/office)
 "qZS" = (
@@ -29163,6 +29327,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/storage/art)
 "raH" = (
@@ -29176,6 +29341,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/storage/tools)
 "raW" = (
@@ -29246,6 +29412,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/dorms)
 "rdt" = (
@@ -29283,6 +29450,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "rea" = (
@@ -29304,6 +29472,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/green,
 /area/crew_quarters/dorms)
 "rev" = (
@@ -29406,6 +29575,7 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "ric" = (
@@ -29537,8 +29707,9 @@
 	},
 /obj/machinery/door/airlock/ship/station/mining{
 	name = "Cargo Bay";
-	req_one_access_txt = "31;41;48;69;72"
+	req_one_access_txt = "31;41;48"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/quartermaster/office)
 "rmj" = (
@@ -29567,6 +29738,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/quartermaster/office)
 "rmP" = (
@@ -29597,6 +29769,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/starboard)
 "rnx" = (
@@ -29622,6 +29795,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/storage/tech)
 "rnY" = (
@@ -29738,6 +29912,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "rqg" = (
@@ -29750,6 +29925,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/locker)
 "rqB" = (
@@ -30361,6 +30537,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
 "rKR" = (
@@ -30428,6 +30605,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/tcommsat/computer)
 "rLQ" = (
@@ -30868,6 +31046,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "rXs" = (
@@ -30955,6 +31134,7 @@
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess{
 	name = "Maintenance Access Pool"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard/fore)
 "sbh" = (
@@ -31151,6 +31331,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/quartermaster/office)
 "sgO" = (
@@ -31164,6 +31345,7 @@
 /obj/item/pen,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/firedoor/border_only/directional/north,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/quartermaster/sorting)
 "she" = (
@@ -31205,6 +31387,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "siT" = (
@@ -31227,6 +31410,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "sjg" = (
@@ -31249,6 +31433,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "sjp" = (
@@ -31397,6 +31582,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/starboard)
 "smI" = (
@@ -31599,6 +31785,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard/aft)
 "stw" = (
@@ -31882,6 +32069,7 @@
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess{
 	name = "Maintenance Access Deck 1 Central Hallway"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port/fore)
 "sBm" = (
@@ -31920,6 +32108,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hydroponics/garden)
 "sEh" = (
@@ -32034,9 +32223,6 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
 "sGR" = (
-/obj/machinery/door/airlock/glass_large/ship{
-	name = "Pool"
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
@@ -32047,6 +32233,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Pool"
+	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/fitness/recreation)
 "sHi" = (
@@ -32059,13 +32249,6 @@
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
-/turf/open/floor/monotile/steel,
-/area/crew_quarters/fitness/recreation)
-"sHo" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/fitness/recreation)
 "sHq" = (
@@ -32552,6 +32735,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/security/checkpoint/customs)
 "sUO" = (
@@ -32708,6 +32892,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
 "sYG" = (
@@ -32965,12 +33150,17 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port/fore)
 "thV" = (
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Cryogenic Storage"
+	},
 /turf/open/floor/monotile/light,
 /area/crew_quarters/cryopods)
 "tip" = (
@@ -33092,6 +33282,7 @@
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess{
 	name = "Maintenance Access Deck 1 Central Hallway"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "tlh" = (
@@ -33901,6 +34092,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/quartermaster/miningoffice)
 "tKn" = (
@@ -34059,6 +34251,7 @@
 "tNK" = (
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/camera/autoname,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "tOG" = (
@@ -34297,6 +34490,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/ship/delivery/yellow,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/techmaint,
 /area/engine/engineering/reactor_core)
 "tYg" = (
@@ -34435,6 +34629,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard/fore)
 "ubz" = (
@@ -34842,6 +35037,7 @@
 	dir = 4
 	},
 /obj/structure/lattice/catwalk/over/ship/dark,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/hallway/nsv/deck2/frame1/central)
 "urG" = (
@@ -35149,6 +35345,7 @@
 	dir = 4;
 	icon_state = "pipe"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/central)
 "uAd" = (
@@ -35309,6 +35506,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port/fore)
 "uEO" = (
@@ -35767,8 +35965,9 @@
 	},
 /obj/machinery/door/airlock/ship/station/mining{
 	name = "Cargo Bay";
-	req_one_access_txt = "31;41;48;69;72"
+	req_one_access_txt = "31;41;48"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/quartermaster/office)
 "uTj" = (
@@ -36133,6 +36332,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/techmaint,
 /area/engine/engine_smes)
 "vhl" = (
@@ -36150,6 +36350,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard/fore)
 "vhu" = (
@@ -36286,6 +36487,7 @@
 	name = "Engineering Construction Storage";
 	req_one_access_txt = "10;24"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/engine/storage)
 "vme" = (
@@ -36348,6 +36550,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/techmaint,
 /area/engine/engineering/reactor_core)
 "vop" = (
@@ -36377,13 +36580,14 @@
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
 "vpa" = (
-/obj/machinery/door/airlock/glass_large/ship{
-	name = "Pool"
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Pool"
+	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/fitness/recreation)
 "vpo" = (
@@ -36641,6 +36845,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/starboard)
 "vvB" = (
@@ -36959,6 +37164,7 @@
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/engine/engineering/reactor_control)
 "vIH" = (
@@ -37010,6 +37216,7 @@
 /obj/machinery/door/airlock/ship/engineering/glass{
 	req_one_access_txt = "32,19"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/engine/break_room)
 "vKj" = (
@@ -37048,6 +37255,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "vKY" = (
@@ -37115,6 +37323,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/engine/engineering/reactor_control)
 "vMl" = (
@@ -37318,10 +37527,11 @@
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess{
 	name = "Maintenance Access Theatre"
 	},
-/obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port/aft)
 "vRV" = (
@@ -37438,6 +37648,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/locker)
 "vUJ" = (
@@ -37493,6 +37704,7 @@
 /obj/structure/lattice/catwalk/over/ship/dark,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "vVX" = (
@@ -37609,6 +37821,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "wau" = (
@@ -38017,6 +38230,15 @@
 	},
 /turf/open/floor/monotile/light,
 /area/crew_quarters/cryopods)
+"wnO" = (
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "woy" = (
 /obj/machinery/telecomms/server/presets/medical,
 /obj/effect/turf_decal/tile/blue{
@@ -38068,6 +38290,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port/fore)
 "wqq" = (
@@ -38117,6 +38340,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "wrh" = (
@@ -38317,6 +38541,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "wwi" = (
@@ -38680,6 +38905,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/starboard)
 "wHO" = (
@@ -38735,6 +38961,7 @@
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess{
 	req_one_access_txt = "69"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/nsv/weapons/gauss)
 "wKx" = (
@@ -38853,6 +39080,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Locker Room"
+	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/locker)
 "wPb" = (
@@ -39225,6 +39456,7 @@
 /obj/machinery/door/airlock/ship/engineering/glass{
 	req_one_access_txt = "32,19"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/engine/break_room)
 "xas" = (
@@ -39274,6 +39506,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard/fore)
 "xcA" = (
@@ -39347,6 +39580,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/starboard)
 "xeX" = (
@@ -39476,6 +39710,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/techmaint,
 /area/engine/engine_smes)
 "xjl" = (
@@ -39671,6 +39906,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard/aft)
 "xnC" = (
@@ -39872,6 +40108,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/techmaint,
 /area/engine/engineering/hangar)
 "xsn" = (
@@ -39974,6 +40211,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/grid/techfloor/grid,
 /area/storage/tcom)
 "xwj" = (
@@ -39999,6 +40237,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/starboard)
 "xwN" = (
@@ -40135,6 +40374,7 @@
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess{
 	name = "Maintenance Access Deck 1 Aft Hallway"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port/aft)
 "xCA" = (
@@ -40237,6 +40477,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/heads/chief)
 "xEt" = (
@@ -40404,6 +40645,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port/fore)
 "xKq" = (
@@ -40633,6 +40875,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "xQK" = (
@@ -54973,7 +55216,7 @@ cCg
 ecj
 ecj
 nbM
-ecj
+qiW
 bpQ
 ski
 xLu
@@ -69379,7 +69622,7 @@ xZR
 mYw
 nlB
 nlB
-dLL
+wnO
 pbC
 ydc
 mDb
@@ -81446,7 +81689,7 @@ qtW
 qtW
 qtW
 qBX
-lhO
+qBX
 qtW
 xbl
 xbl
@@ -87899,7 +88142,7 @@ lCu
 mtJ
 rZS
 bxX
-sHo
+vpa
 hdo
 kXo
 qEr
@@ -89184,7 +89427,7 @@ lLq
 rOs
 rOs
 art
-sHo
+vpa
 hdo
 kXo
 jEN


### PR DESCRIPTION
## About The Pull Request

Removes doubledoors from Gladius, adds zebra interlock helpers where appropriate, and fixes the hangar airlock not working 9/10 times.

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/43698041/124334906-d3365f80-db98-11eb-8315-d7c01ad2b12f.png)
Now it doesn't. :garfieldsmoking:

## Changelog
:cl:
add: Added more GQ firelock helpers on Gladius
fix: Fixed Gladius' hangar airlock
del: Removed double doors from Gladius
/:cl:
