### PR TITLE
Makes superstructure crit explosion intensity vary depending on damage dealt to the ship.

### DIFF
--- a/nsv13/code/modules/overmap/armour/armour_quadrant.dm
+++ b/nsv13/code/modules/overmap/armour/armour_quadrant.dm
@@ -98,7 +98,7 @@
 		var/name = pick(GLOB.teleportlocs)
 		var/area/target = GLOB.teleportlocs[name]
 		var/turf/T = pick(get_area_turfs(target))
-		new /obj/effect/temp_visual/explosion_telegraph(T)
+		new /obj/effect/temp_visual/explosion_telegraph(T, damage_amount = input)
 		return
 
 	obj_integrity += max_integrity * percentile

--- a/nsv13/code/modules/overmap/ftl.dm
+++ b/nsv13/code/modules/overmap/ftl.dm
@@ -198,7 +198,7 @@
 					var/name = pick(GLOB.teleportlocs)
 					var/area/target = GLOB.teleportlocs[name]
 					var/turf/T = pick(get_area_turfs(target))
-					new /obj/effect/temp_visual/explosion_telegraph(T)
+					new /obj/effect/temp_visual/explosion_telegraph(T, damage_amount = ((world.time - structure_crit_init)*10/3))
 		SSstar_system.ships[src]["target_system"] = target_system
 		SSstar_system.ships[src]["from_time"] = world.time
 		SSstar_system.ships[src]["current_system"] = null

--- a/nsv13/code/modules/overmap/ftl.dm
+++ b/nsv13/code/modules/overmap/ftl.dm
@@ -198,7 +198,7 @@
 					var/name = pick(GLOB.teleportlocs)
 					var/area/target = GLOB.teleportlocs[name]
 					var/turf/T = pick(get_area_turfs(target))
-					new /obj/effect/temp_visual/explosion_telegraph(T, damage_amount = ((world.time - structure_crit_init)*10/3))
+					new /obj/effect/temp_visual/explosion_telegraph(T, damage_amount = ((world.time - structure_crit_init)/30))
 		SSstar_system.ships[src]["target_system"] = target_system
 		SSstar_system.ships[src]["from_time"] = world.time
 		SSstar_system.ships[src]["current_system"] = null

--- a/nsv13/code/modules/overmap/weapons/damage.dm
+++ b/nsv13/code/modules/overmap/weapons/damage.dm
@@ -112,7 +112,7 @@ Bullet reactions
 	else
 		target = pick(linked_areas)
 	var/turf/T = pick(get_area_turfs(target))
-	new /obj/effect/temp_visual/explosion_telegraph(T)
+	new /obj/effect/temp_visual/explosion_telegraph(T, damage_amount)
 
 /obj/structure/overmap/proc/handle_critical_failure_part_1()
 	var/ss_crit_timer = world.time - structure_crit_init
@@ -228,6 +228,10 @@ Bullet reactions
 	randomdir = 0
 	light_color = LIGHT_COLOR_ORANGE
 	layer = ABOVE_MOB_LAYER
+	var/damage_amount = 1
+
+/obj/effect/temp_visual/explosion_telegraph/New(loc, damage_amount)
+	. = ..()
 
 /obj/effect/temp_visual/explosion_telegraph/Initialize()
 	. = ..()
@@ -239,5 +243,6 @@ Bullet reactions
 
 /obj/effect/temp_visual/explosion_telegraph/Destroy()
 	var/turf/T = get_turf(src)
-	explosion(T,3,4,4)
+	var/damage_level = ((damage_amount <= 20) ? 1 : ((damage_amount <= 100) ? 2 : ((damage_amount <= 200) ? 3 : 4)))
+	explosion(T,round(damage_level/3),round(damage_level*1.25),round(damage_level*1.5))
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

This PR changes the amount of damage dealt by SScrit explosions, in the current revision they do less damage in total, but will be more spread out and the intensity will vary depending on how much damage is done to the ship at once. (Total explosion strentgh here is still subject to change based on information we gather from the testmerge.)
Explosions generated by jumping the ship while in SScrit are also changed, the longer the ship has been critically damaged for, the more damage you will take when jumping. This was done to encourage retreating out of a system early to avoid being swamped by a powerful enemy fleet if your ship isn't equipped to handle it.

## Why It's Good For The Game

One pdc bullet causing a size 3,4,4 explosion is a bit intense and often times I see ships that can recover fairly easily get shredded because of this. I feel like this will make superstructure crit feel more fair and give people a better chance to recover from it.

## Changelog
:cl:
balance: Changes how superstructure crit explosions work.
/:cl: