### PR TITLE
Fighter name consistincy issue

### DIFF
--- a/nsv13/code/modules/overmap/fighters/_fighters.dm
+++ b/nsv13/code/modules/overmap/fighters/_fighters.dm
@@ -1333,14 +1333,14 @@ Utility modules can be either one of these types, just ensure you set its slot t
 	ammo = list()
 
 /obj/item/fighter_component/primary/cannon
-	name = "30mm Vulcan Cannon"
+	name = "20mm Vulcan Cannon"
 	icon_state = "lightcannon"
 	accepted_ammo = /obj/item/ammo_box/magazine/light_cannon
 	burst_size = 2
 	fire_delay = 0.25 SECONDS
 
 /obj/item/fighter_component/primary/cannon/heavy
-	name = "40mm BRRRRTT Cannon"
+	name = "30mm BRRRRTT Cannon"
 	icon_state = "heavycannon"
 	accepted_ammo = /obj/item/ammo_box/magazine/heavy_cannon
 	weight = 2 //Sloooow down there.


### PR DESCRIPTION
## About The Pull Request

Changed the name of the light and heavy cannon names to match the ammo they actually use.

## Why It's Good For The Game

30mm gun doesn't shoot 20mm. Same with 40 and 30mm

## Changelog
:cl:
spellcheck: fixed a few typos
/:cl:
