### PR TITLE
adds Hulljuice pack in cargo

### DIFF
--- a/nsv13/code/modules/cargo/packs.dm
+++ b/nsv13/code/modules/cargo/packs.dm
@@ -493,3 +493,12 @@
 					/obj/item/ammo_box/magazine/m556,
 					/obj/item/ammo_box/magazine/m556,
 					/obj/item/ammo_box/magazine/m556)
+
+/datum/supply_pack/engineering/hulljuice
+	name = "Hulljuice Tank Crate"
+	desc = "Keep yourself afloat aboard the ship with some healthy hull repair JUICE! It includes one tank and two extinguishers. Apply liberally to damaged hull plates"
+	cost = 1200
+	contains = list(/obj/structure/reagent_dispensers/foamtank/hull_repair_juice,
+					/obj/item/extinguisher/advanced/hull_repair_juice,
+					/obj/item/extinguisher/advanced/hull_repair_juice)
+	crate_name = "engineering crate"


### PR DESCRIPTION
adds Hulljuice tank + two extinguishers as a pack to order at cargo

## About The Pull Request

It simply adds a hulljuice tank and two extinguishers orderable in cargo at a price of 1200 credits

## Why It's Good For The Game

some maps don't have them and this would compensate for it

## Changelog
🆑
add: added hull juice tank pack orderable in cargo
/🆑