### PR TITLE
Stops Github Actions from closing stale issues after 180 days

### DIFF
--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -16,4 +16,4 @@ jobs:
         stale-issue-label: 'Stale'
         exempt-issue-label: 'Triaged'
         days-before-stale: 30
-        days-before-close: 180
+        days-before-close: -1


### PR DESCRIPTION
## About The Pull Request

Does what it says

## Why It's Good For The <s>Game</s> Codebase

Old issues being closed is more annoying then it is helpful, seeing as we <s>are drowning in debt</s> have a somewhat slower development cycle, and looking at open issues every so often isn't that hard of a job for a maintainer to do.