### PR TITLE
Adds helmetcam capability to helmets

### DIFF
--- a/_maps/map_files/Galactica/Galactica1.dmm
+++ b/_maps/map_files/Galactica/Galactica1.dmm
@@ -9617,11 +9617,11 @@
 /obj/item/clothing/suit/ship/squad,
 /obj/item/clothing/suit/ship/squad,
 /obj/item/clothing/suit/ship/squad,
-/obj/item/clothing/head/ship/squad,
-/obj/item/clothing/head/ship/squad,
-/obj/item/clothing/head/ship/squad,
-/obj/item/clothing/head/ship/squad,
-/obj/item/clothing/head/ship/squad,
+/obj/item/clothing/head/helmet/ship/squad,
+/obj/item/clothing/head/helmet/ship/squad,
+/obj/item/clothing/head/helmet/ship/squad,
+/obj/item/clothing/head/helmet/ship/squad,
+/obj/item/clothing/head/helmet/ship/squad,
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/security/armory)
 "AZ" = (

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -232,7 +232,7 @@
 /obj/machinery/computer/security/hos
 	name = "\improper Head of Security's camera console"
 	desc = "A custom security console with added access to the labor camp network."
-	network = list("ss13", "labor")
+	network = list("ss13", "labor", "headcam") //NSV13 added helmet cams
 	circuit = null
 
 /obj/machinery/computer/security/labor

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -22,8 +22,17 @@
 	var/obj/item/flashlight/seclite/attached_light
 	var/datum/action/item_action/toggle_helmet_flashlight/alight
 
+	//NSV13 - added helmet cams
+	var/obj/machinery/camera/builtInCamera = null
+	var/updating = FALSE
+
 /obj/item/clothing/head/helmet/Initialize()
 	. = ..()
+	if(builtInCamera && ispath(builtInCamera)) //NSV13 - added helmet cams
+		builtInCamera = new builtInCamera(src)
+		builtInCamera.c_tag = "Helmet Cam #[rand(0,999)]"
+		builtInCamera.network = list("headcam")
+		builtInCamera.internal_light = FALSE
 	if(attached_light)
 		alight = new(src)
 
@@ -36,8 +45,13 @@
 	else if(can_flashlight)
 		. += "It has a mounting point for a <b>seclite</b>."
 
+	if(builtInCamera) //NSV13 - added helmet cams
+		. += "It has a camera mounted on it. The camera looks like it can be <b>cut</b> off [src].</span>"
+
 /obj/item/clothing/head/helmet/Destroy()
 	QDEL_NULL(attached_light)
+	if(builtInCamera) //NSV13 - added helmet cams
+		QDEL_NULL(builtInCamera)
 	return ..()
 
 /obj/item/clothing/head/helmet/handle_atom_del(atom/A)
@@ -46,6 +60,7 @@
 		update_helmlight()
 		update_icon()
 		QDEL_NULL(alight)
+		QDEL_NULL(builtInCamera) //NSV13 added helmet cams
 	return ..()
 
 /obj/item/clothing/head/helmet/sec

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -144,6 +144,12 @@
 		jetpack = null
 		to_chat(user, "<span class='notice'>You successfully remove the jetpack from [src].</span>")
 		return
+	//NSV13 - added helmet cams
+	else if(istype(I, /obj/item/wallframe/camera))
+		helmet.attackby(I, user, params)
+	else if(I.tool_behaviour == TOOL_WIRECUTTER)
+		helmet.attackby(I, user, params)
+	//end NSV13
 	return ..()
 
 

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -145,9 +145,7 @@
 		to_chat(user, "<span class='notice'>You successfully remove the jetpack from [src].</span>")
 		return
 	//NSV13 - added helmet cams
-	else if(istype(I, /obj/item/wallframe/camera))
-		helmet.attackby(I, user, params)
-	else if(I.tool_behaviour == TOOL_WIRECUTTER)
+	else if(I.tool_behaviour == TOOL_WIRECUTTER || istype(I, /obj/item/wallframe/camera))
 		helmet.attackby(I, user, params)
 	//end NSV13
 	return ..()

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -660,7 +660,7 @@
 	for (var/obj/machinery/camera/C in GLOB.cameranet.cameras)
 		var/list/tempnetwork = C.network
 		//Nsv13 - AIs need to see the Rocinante.
-		if(!(is_station_level(C.z) || is_mining_level(C.z) || ("ss13" in tempnetwork)))
+		if(!(SHARES_OVERMAP_ALLIED(C, src)) || ("ss13" in tempnetwork)))
 			continue
 		if(!C.can_use())
 			continue

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -660,10 +660,7 @@
 	for (var/obj/machinery/camera/C in GLOB.cameranet.cameras)
 		var/list/tempnetwork = C.network
 		//Nsv13 - AIs need to see the Rocinante.
-		//if(!(is_station_level(C.z) || is_mining_level(C.z) || ("ss13" in tempnetwork)))
-		//	continue
-		//Nsv13 end.
-		if(!SHARES_OVERMAP_ALLIED(C, src) || ("ss13" in tempnetwork))
+		if(!(is_station_level(C.z) || is_mining_level(C.z) || ("ss13" in tempnetwork)))
 			continue
 		if(!C.can_use())
 			continue

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -660,7 +660,7 @@
 	for (var/obj/machinery/camera/C in GLOB.cameranet.cameras)
 		var/list/tempnetwork = C.network
 		//Nsv13 - AIs need to see the Rocinante.
-		if(!(SHARES_OVERMAP_ALLIED(C, src)) || ("ss13" in tempnetwork)))
+		if(!(SHARES_OVERMAP_ALLIED(C, src) || ("ss13" in tempnetwork)))
 			continue
 		if(!C.can_use())
 			continue

--- a/nsv13.dme
+++ b/nsv13.dme
@@ -3317,6 +3317,7 @@
 #include "nsv13\code\modules\client\loadout\loadout_donator.dm"
 #include "nsv13\code\modules\clothing\custom_clothes.dm"
 #include "nsv13\code\modules\clothing\custom_outfits.dm"
+#include "nsv13\code\modules\clothing\helmet_camera.dm"
 #include "nsv13\code\modules\clothing\masks\_masks.dm"
 #include "nsv13\code\modules\clothing\masks\hailer.dm"
 #include "nsv13\code\modules\collision\collision_helpers.dm"

--- a/nsv13/code/game/general_quarters/squad_vendor.dm
+++ b/nsv13/code/game/general_quarters/squad_vendor.dm
@@ -125,7 +125,7 @@
 /datum/squad_loadout
 	var/name = "Parent"
 	var/desc = "A standardised equipment set for Blue Phalanx marines. This set is designed for use in pressurized areas, it comes with lightweight armour to protect the wearer from most hazards."
-	var/list/items = list(/obj/item/clothing/under/ship/marine, /obj/item/clothing/suit/ship/squad, /obj/item/clothing/head/ship/squad, /obj/item/ammo_box/magazine/pistolm9mm/glock/lethal, /obj/item/gun/ballistic/automatic/pistol/glock)
+	var/list/items = list(/obj/item/clothing/under/ship/marine, /obj/item/clothing/suit/ship/squad, /obj/item/clothing/head/helmet/ship/squad, /obj/item/ammo_box/magazine/pistolm9mm/glock/lethal, /obj/item/gun/ballistic/automatic/pistol/glock)
 	var/list/must_return = list()
 	var/list/allowed_ranks = list(SQUAD_MARINE, SQUAD_SERGEANT)
 
@@ -135,7 +135,7 @@
 /datum/squad_loadout/space
 	name = "Squad Marine (Hazardous Environment)"
 	desc = "For hazardous, low pressure environments. This kit contains a reinforced skinsuit which, while slow, will protect marines from the elements."
-	items = list(/obj/item/clothing/under/ship/marine, /obj/item/clothing/suit/ship/squad/space, /obj/item/clothing/head/ship/squad/space, /obj/item/ammo_box/magazine/pistolm9mm/glock/lethal, /obj/item/gun/ballistic/automatic/pistol/glock)
+	items = list(/obj/item/clothing/under/ship/marine, /obj/item/clothing/suit/ship/squad/space, /obj/item/clothing/head/helmet/ship/squad/space, /obj/item/ammo_box/magazine/pistolm9mm/glock/lethal, /obj/item/gun/ballistic/automatic/pistol/glock)
 
 /datum/squad_loadout/New()
 	. = ..()
@@ -145,32 +145,32 @@
 /datum/squad_loadout/leader
 	name = "Squad Leader (Standard)"
 	desc = "For hazardous, low pressure environments. This kit contains a reinforced skinsuit which, while slow, will protect marines from the elements."
-	items = list(/obj/item/clothing/under/ship/marine, /obj/item/megaphone, /obj/item/clothing/suit/ship/squad, /obj/item/clothing/head/ship/squad/leader, /obj/item/ammo_box/magazine/pistolm9mm/glock/lethal, /obj/item/gun/ballistic/automatic/pistol/glock)
+	items = list(/obj/item/clothing/under/ship/marine, /obj/item/megaphone, /obj/item/clothing/suit/ship/squad, /obj/item/clothing/head/helmet/ship/squad/leader, /obj/item/ammo_box/magazine/pistolm9mm/glock/lethal, /obj/item/gun/ballistic/automatic/pistol/glock)
 	allowed_ranks = list(SQUAD_LEAD)
 
 /datum/squad_loadout/leader/space
 	name = "Squad Leader (Hazardous Environment)"
 	desc = "For hazardous, low pressure environments. This kit contains a reinforced skinsuit which, while slow, will protect marines from the elements."
-	items = list(/obj/item/clothing/under/ship/marine, /obj/item/megaphone, /obj/item/clothing/suit/ship/squad/space, /obj/item/clothing/head/ship/squad/space, /obj/item/ammo_box/magazine/pistolm9mm/glock/lethal, /obj/item/gun/ballistic/automatic/pistol/glock)
+	items = list(/obj/item/clothing/under/ship/marine, /obj/item/megaphone, /obj/item/clothing/suit/ship/squad/space, /obj/item/clothing/head/helmet/ship/squad/space, /obj/item/ammo_box/magazine/pistolm9mm/glock/lethal, /obj/item/gun/ballistic/automatic/pistol/glock)
 
 /datum/squad_loadout/engineer
 	name = "Squad Engineer (Standard)"
 	desc = "This kit contains everything a squad engineer needs to effect repairs in non-hazardous environments. Recommended only for planetside operations where speed is necessary."
-	items = list(/obj/item/clothing/under/ship/marine/engineer, /obj/item/storage/belt/utility/full, /obj/item/storage/box/damage_control, /obj/item/clothing/glasses/welding, /obj/item/clothing/suit/ship/squad, /obj/item/clothing/head/ship/squad, /obj/item/ammo_box/magazine/pistolm9mm/glock/lethal, /obj/item/gun/ballistic/automatic/pistol/glock)
+	items = list(/obj/item/clothing/under/ship/marine/engineer, /obj/item/storage/belt/utility/full, /obj/item/storage/box/damage_control, /obj/item/clothing/glasses/welding, /obj/item/clothing/suit/ship/squad, /obj/item/clothing/head/helmet/ship/squad, /obj/item/ammo_box/magazine/pistolm9mm/glock/lethal, /obj/item/gun/ballistic/automatic/pistol/glock)
 	allowed_ranks = list(SQUAD_ENGI)
 
 /datum/squad_loadout/engineer/space
 	name = "Squad Engineer (Hazardous Environment)"
 	desc = "For hazardous, low pressure environments. This kit contains everything a squad engineer needs to effect repairs in the heat of battle, no matter the condition of the ship they're on."
-	items = list(/obj/item/clothing/under/ship/marine/engineer, /obj/item/storage/belt/utility/full, /obj/item/storage/box/damage_control, /obj/item/clothing/glasses/welding, /obj/item/clothing/suit/ship/squad/space,/obj/item/clothing/head/ship/squad/space, /obj/item/ammo_box/magazine/pistolm9mm/glock/lethal, /obj/item/gun/ballistic/automatic/pistol/glock)
+	items = list(/obj/item/clothing/under/ship/marine/engineer, /obj/item/storage/belt/utility/full, /obj/item/storage/box/damage_control, /obj/item/clothing/glasses/welding, /obj/item/clothing/suit/ship/squad/space,/obj/item/clothing/head/helmet/ship/squad/space, /obj/item/ammo_box/magazine/pistolm9mm/glock/lethal, /obj/item/gun/ballistic/automatic/pistol/glock)
 
 /datum/squad_loadout/medic
 	name = "Squad Medic (Standard)"
 	desc = "A kit containing battlefield medical equipment and light squad armour."
-	items = list(/obj/item/clothing/under/ship/marine/medic, /obj/item/storage/firstaid/regular, /obj/item/reagent_containers/medspray/sterilizine, /obj/item/reagent_containers/medspray/styptic, /obj/item/clothing/suit/ship/squad, /obj/item/clothing/head/ship/squad, /obj/item/ammo_box/magazine/pistolm9mm/glock/lethal, /obj/item/gun/ballistic/automatic/pistol/glock)
+	items = list(/obj/item/clothing/under/ship/marine/medic, /obj/item/storage/firstaid/regular, /obj/item/reagent_containers/medspray/sterilizine, /obj/item/reagent_containers/medspray/styptic, /obj/item/clothing/suit/ship/squad, /obj/item/clothing/head/helmet/ship/squad, /obj/item/ammo_box/magazine/pistolm9mm/glock/lethal, /obj/item/gun/ballistic/automatic/pistol/glock)
 	allowed_ranks = list(SQUAD_MEDIC)
 
 /datum/squad_loadout/medic/space
 	name = "Squad Medic (Hazardous Environment)"
 	desc = "For hazardous, low pressure environments. This kit contains specialist equipment for treating common battlefield injuries."
-	items = list(/obj/item/clothing/under/ship/marine/medic, /obj/item/storage/firstaid/regular, /obj/item/reagent_containers/medspray/sterilizine, /obj/item/reagent_containers/medspray/styptic, /obj/item/storage/firstaid/o2, /obj/item/clothing/suit/ship/squad/space, /obj/item/clothing/head/ship/squad/space, /obj/item/ammo_box/magazine/pistolm9mm/glock/lethal, /obj/item/gun/ballistic/automatic/pistol/glock)
+	items = list(/obj/item/clothing/under/ship/marine/medic, /obj/item/storage/firstaid/regular, /obj/item/reagent_containers/medspray/sterilizine, /obj/item/reagent_containers/medspray/styptic, /obj/item/storage/firstaid/o2, /obj/item/clothing/suit/ship/squad/space, /obj/item/clothing/head/helmet/ship/squad/space, /obj/item/ammo_box/magazine/pistolm9mm/glock/lethal, /obj/item/gun/ballistic/automatic/pistol/glock)

--- a/nsv13/code/modules/clothing/helmet_camera.dm
+++ b/nsv13/code/modules/clothing/helmet_camera.dm
@@ -1,0 +1,68 @@
+/obj/item/clothing/head/helmet/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/wallframe/camera))
+		if(builtInCamera)
+			to_chat(user, "<span class='warning'>[src] already has a camera.</span>")
+			return
+		if(src == user.get_item_by_slot(ITEM_SLOT_HEAD)) //Make sure the player is not wearing the suit before applying the upgrade.
+			to_chat(user, "<span class='warning'>You cannot install the upgrade to [src] while wearing it.</span>")
+			return
+		if(user.transferItemToLoc(I, src))
+			builtInCamera = new /obj/machinery/camera(src)
+			builtInCamera.c_tag = "Helmet Cam #[rand(0,999)]"
+			builtInCamera.network = list("headcam")
+			builtInCamera.internal_light = FALSE
+			QDEL_NULL(I)
+			to_chat(user, "<span class='notice'>You successfully attach the camera to [src].</span>")
+			return
+	else if(I.tool_behaviour == TOOL_WIRECUTTER)
+		if(!builtInCamera)
+			to_chat(user, "<span class='warning'>[src] has no camera installed.</span>")
+			return
+		if(src == user.get_item_by_slot(ITEM_SLOT_HEAD))
+			to_chat(user, "<span class='warning'>You cannot remove the camera from [src] while wearing it.</span>")
+			return
+
+		new /obj/item/wallframe/camera(drop_location())
+		QDEL_NULL(builtInCamera)
+		to_chat(user, "<span class='notice'>You successfully remove the camera from [src].</span>")
+		return
+	else
+		return ..()
+
+/obj/item/clothing/head/helmet/equipped(mob/equipper, slot)
+	. = ..()
+	if(ishuman(equipper))
+		var/mob/living/carbon/human/H = equipper
+
+		if(slot && slot != ITEM_SLOT_HEAD)
+			on_drop(equipper)
+			return
+		if(builtInCamera && H)
+			builtInCamera.c_tag = "Helmet Cam #[rand(0,999)]"
+			builtInCamera.forceMove(equipper) //I hate this. But, it's necessary.
+			RegisterSignal(equipper, COMSIG_MOVABLE_MOVED, .proc/update_camera_location)
+
+/obj/item/clothing/head/helmet/dropped(mob/user)
+	. = ..()
+	on_drop(user)
+
+/obj/item/clothing/head/helmet/proc/on_drop(mob/user)
+	if(builtInCamera && !QDELETED(builtInCamera))
+		UnregisterSignal(user, COMSIG_MOVABLE_MOVED)
+		update_camera_location(get_turf(src))
+		builtInCamera.forceMove(src) //Snap the camera back into us.
+
+/obj/item/clothing/head/helmet/proc/do_camera_update(oldLoc)
+	if(builtInCamera && !QDELETED(builtInCamera) && oldLoc != get_turf(loc))
+		GLOB.cameranet.updatePortableCamera(builtInCamera)
+	updating = FALSE
+
+#define SILICON_CAMERA_BUFFER 10
+/obj/item/clothing/head/helmet/proc/update_camera_location(oldLoc)
+	if(!oldLoc)
+		oldLoc = get_turf(loc)
+	oldLoc = get_turf(oldLoc)
+	if(!QDELETED(builtInCamera) && !updating)
+		updating = TRUE
+		addtimer(CALLBACK(src, .proc/do_camera_update, oldLoc), SILICON_CAMERA_BUFFER)
+#undef SILICON_CAMERA_BUFFER

--- a/nsv13/code/modules/clothing/helmet_camera.dm
+++ b/nsv13/code/modules/clothing/helmet_camera.dm
@@ -61,7 +61,6 @@
 /obj/item/clothing/head/helmet/proc/update_camera_location(oldLoc)
 	if(!oldLoc)
 		oldLoc = get_turf(loc)
-	oldLoc = get_turf(oldLoc)
 	if(!QDELETED(builtInCamera) && !updating)
 		updating = TRUE
 		addtimer(CALLBACK(src, .proc/do_camera_update, oldLoc), SILICON_CAMERA_BUFFER)

--- a/nsv13/code/modules/clothing/helmet_camera.dm
+++ b/nsv13/code/modules/clothing/helmet_camera.dm
@@ -9,7 +9,7 @@
 		if(user.transferItemToLoc(I, src))
 			builtInCamera = new /obj/machinery/camera(src)
 			builtInCamera.c_tag = "Helmet Cam #[rand(0,999)]"
-			builtInCamera.network = list("headcam")
+			builtInCamera.network = list("headcam", "ss13")
 			builtInCamera.internal_light = FALSE
 			QDEL_NULL(I)
 			to_chat(user, "<span class='notice'>You successfully attach the camera to [src].</span>")

--- a/nsv13/code/modules/clothing/helmet_camera.dm
+++ b/nsv13/code/modules/clothing/helmet_camera.dm
@@ -47,13 +47,13 @@
 	on_drop(user)
 
 /obj/item/clothing/head/helmet/proc/on_drop(mob/user)
-	if(builtInCamera && !QDELETED(builtInCamera))
+	if(!QDELETED(builtInCamera))
 		UnregisterSignal(user, COMSIG_MOVABLE_MOVED)
 		update_camera_location(get_turf(src))
 		builtInCamera.forceMove(src) //Snap the camera back into us.
 
 /obj/item/clothing/head/helmet/proc/do_camera_update(oldLoc)
-	if(builtInCamera && !QDELETED(builtInCamera) && oldLoc != get_turf(loc))
+	if(!QDELETED(builtInCamera) && oldLoc != get_turf(loc))
 		GLOB.cameranet.updatePortableCamera(builtInCamera)
 	updating = FALSE
 


### PR DESCRIPTION
## About The Pull Request
Puts the squad helmetcam capability into the helmet object. Provides a way to upgrade more helmets with it, including hardsuit helmets. Converts squad helmets to being real helmets instead of hats.

## Why It's Good For The Game
These are nifty and good for reconnaissance

## Changelog
:cl:
add: Helmets can have cameras attached to them, removable by wirecutter.
code: Squad helmets are actual helmets
/:cl:
