### PR TITLE
Stops gauss from auto-firing

### DIFF
--- a/nsv13/code/modules/munitions/ship_weapons/_ship_weapon.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/_ship_weapon.dm
@@ -432,11 +432,13 @@
 /obj/machinery/ship_weapon/proc/can_fire(shots = weapon_type.burst_size)
 	if((state < STATE_CHAMBERED) || !chambered) //Do we have a round ready to fire
 		return FALSE
-	if (maint_state != MSTATE_CLOSED) //Are we in maintenance?
+	if(maint_state != MSTATE_CLOSED) //Are we in maintenance?
 		return FALSE
 	if(state >= STATE_FIRING) //Are we in the process of shooting already?
 		return FALSE
 	if(maintainable && malfunction) //Do we need maintenance?
+		return FALSE
+	if(safety) // Is the safety on?
 		return FALSE
 	if(ammo?.len < shots) //Do we have enough ammo?
 		return FALSE

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/50Cal.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/50Cal.dm
@@ -66,9 +66,9 @@
 	start_gunning()
 
 /datum/component/overmap_gunning/proc/apply_settings(special_fx=FALSE, automatic=FALSE) //Until we have named variables, this should work
-	if(special_fx != null)
+	if(!isnull(special_fx))
 		src.special_fx = special_fx
-	if(automatic != null)
+	if(!isnull(automatic))
 		src.automatic = automatic
 
 /datum/component/overmap_gunning/proc/start_gunning()

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/50Cal.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/50Cal.dm
@@ -40,6 +40,7 @@
 //Unifying component for gauss / 50 cal gunning
 /datum/component/overmap_gunning
 	var/fire_mode = FIRE_MODE_GAUSS
+	var/automatic = FALSE
 	var/mob/living/holder = null
 	var/atom/movable/autofire_target
 	var/next_fire = 0
@@ -50,19 +51,25 @@
 /datum/component/overmap_gunning/fiftycal
 	fire_mode = FIRE_MODE_50CAL
 	fire_delay = 0.25 SECONDS
+	automatic = TRUE
 
 /datum/component/overmap_gunning/fiftycal/super
 	fire_mode = FIRE_MODE_50CAL
 	fire_delay = 0.1 SECONDS
 
-/datum/component/overmap_gunning/Initialize(obj/machinery/ship_weapon/fx_target, special_fx=FALSE)
+/datum/component/overmap_gunning/Initialize(obj/machinery/ship_weapon/fx_target)
 	. = ..()
 	if(!istype(parent, /mob/living)) //Needs at least this base prototype.
 		return COMPONENT_INCOMPATIBLE
-	src.special_fx = special_fx
 	src.fx_target = fx_target
 	holder = parent
 	start_gunning()
+
+/datum/component/overmap_gunning/proc/apply_settings(special_fx=FALSE, automatic=FALSE) //Until we have named variables, this should work
+	if(special_fx != null)
+		src.special_fx = special_fx
+	if(automatic != null)
+		src.automatic = automatic
 
 /datum/component/overmap_gunning/proc/start_gunning()
 	var/obj/structure/overmap/OM = holder.loc.get_overmap()
@@ -71,9 +78,12 @@
 		CRASH("Overmap gunning component created with no attached overmap.")
 	OM.gauss_gunners.Add(holder)
 	OM.start_piloting(holder, "secondary_gunner")
-	START_PROCESSING(SSfastprocess, src)
+	if(automatic)
+		START_PROCESSING(SSfastprocess, src)
 
-/datum/component/overmap_gunning/proc/onClick(atom/movable/target)
+/datum/component/overmap_gunning/proc/onClick(atom/movable/target, location, params)
+	if(!autofire_target)
+		autofire_target = target //When we start firing, we start firing at whatever you clicked on initially. When the user drags their mouse, this shall change.
 	if(world.time < next_fire || !autofire_target)
 		return FALSE
 	var/obj/structure/overmap/OM = holder.loc.get_overmap()
@@ -83,7 +93,7 @@
 	fx_target.fire(target)//You can only fire your gun, not someone else's.   //.fire_weapon(target, fire_mode)
 
 /datum/component/overmap_gunning/process()
-	if(!autofire_target)
+	if(!autofire_target || !automatic)
 		return
 	onClick(autofire_target)
 

--- a/nsv13/code/modules/overmap/overmap.dm
+++ b/nsv13/code/modules/overmap/overmap.dm
@@ -473,7 +473,7 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 		return FALSE
 	if(locate(user) in gauss_gunners) //Special case for gauss gunners here. Takes priority over them being the regular gunner.
 		var/datum/component/overmap_gunning/user_gun = user.GetComponent(/datum/component/overmap_gunning)
-		user_gun.onMouseDown(target)
+		user_gun.onClick(target)
 		return TRUE
 	if(user != gunner)
 		if(user == pilot)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the gauss not automatically fire every couple of seconds until you run dry.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Can choose targets better and use ammo more effectively

## Changelog
:cl:
tweak: Stops gauss gun from automatically firing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
