### PR TITLE
Reordered asteroid research tech nodes

### DIFF
--- a/nsv13/code/modules/mining/asteroid.dm
+++ b/nsv13/code/modules/mining/asteroid.dm
@@ -2,13 +2,22 @@ GLOBAL_LIST_EMPTY(asteroid_spawn_markers)		//handles mining asteroids, kind of s
 
 //Credit to floyd for the backbone of this code
 
-/datum/techweb_node/mineral_mining
-	id = "mineral_mining"
-	display_name = "Deep core asteroid mining"
-	description = "Upgrades for the mining ship's asteroid arrestor, allowing it to lock on to more valuable asteroid cores.."
+/datum/techweb_node/mineral_nonferrous
+	id = "mineral_nonferrous"
+	display_name = "Polytrinic asteroid mining equipment"
+	description = "Upgrades for the mining ship's asteroid arrestor and dradis console, allowing it to detect and lock on to more specific mineral compositions in asteroid cores."
 	prereq_ids = list("base")
-	design_ids = list("deepcore1", "deepcore2")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
+	design_ids = list("deepcore1", "asteroidscanner")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
+	export_price = 5000
+
+/datum/techweb_node/mineral_exotic
+	id = "mineral_exotic"
+	display_name = "Phasic asteroid mining equipment"
+	description = "Advanced arrestor and dradis console upgrade for the mining ship, allowing it to handle any asteroid with a mineral composition at it's core."
+	prereq_ids = list("mineral_nonferrous")
+	design_ids = list("deepcore2", "asteroidscanner2")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 12500)
 	export_price = 5000
 
 /datum/design/deepcore1
@@ -30,15 +39,6 @@ GLOBAL_LIST_EMPTY(asteroid_spawn_markers)		//handles mining asteroids, kind of s
 	build_path = /obj/item/deepcore_upgrade/max
 	category = list("Asteroid Mining")
 	departmental_flags = DEPARTMENTAL_FLAG_CARGO | DEPARTMENTAL_FLAG_SCIENCE
-
-/datum/techweb_node/mineral_scanning
-	id = "mineral_scanning"
-	display_name = "Asteroid core sensors"
-	description = "Upgrades for dradis computers, allowing them to scan for mineral rich asteroids."
-	prereq_ids = list("base")
-	design_ids = list("asteroidscanner", "asteroidscanner2")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
-	export_price = 5000
 
 /datum/design/asteroidscanner
 	name = "Tier II asteroid sensor module"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When researching asteroid mining nodes, you either research both or you don't. One of the tech nodes was for T2 and T3 arrestor and the other tech node was T2 and T3 sensor. To get any good use out of them you have to research both because just having one of the two is not gonna be useful.

With this PR i have converted the asteroid mining techs into [a T2 asteroid mining tech node and a T3 asteroid mining tech node](https://i.imgur.com/QB5EjEj.png).
The T2 asteroid tech node has the T2 arrestor and the T2 sensor bundled together for 7500 research points.
The T3 asteroid tech node has the T3 arrestor and the T3 sensor for 12500 research points with a dependency on the T2 node.

Total research point requirements are the same with both totaling 20000 good boi points.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

More sensible research progress for asteroid mining.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Asteroid mining research nodes are now bundled together into their respective tiers (Tier 2, Tier 3)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
