### PR TITLE
Makes superstructure crit slightly more explosive

### DIFF
--- a/nsv13/code/modules/overmap/weapons/damage.dm
+++ b/nsv13/code/modules/overmap/weapons/damage.dm
@@ -243,6 +243,6 @@ Bullet reactions
 
 /obj/effect/temp_visual/explosion_telegraph/Destroy()
 	var/turf/T = get_turf(src)
-	var/damage_level = ((damage_amount <= 20) ? 1 : ((damage_amount <= 100) ? 2 : ((damage_amount <= 200) ? 3 : 4)))
-	explosion(T,round(damage_level/3),round(damage_level*1.25),round(damage_level*1.5))
+	var/damage_level = ((damage_amount <= 20) ? 1 : ((damage_amount <= 75) ? 2 : ((damage_amount <= 150) ? 3 : 4)))
+	explosion(T,round(damage_level/2.5),round(damage_level*1.25),round(damage_level*2))
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Makes SScrit explosions more easily intenser (don't think about it too hard)

## Why It's Good For The Game

After seeing the changes to sscrit's explosion in action I and several others have noticed that there is a severe lack of big explosions on the ship during SScrit.

## Changelog
:cl:
balance: Increased deadliness of superstructure crit explosions.
/:cl:
