### PR TITLE
Gauss tweaks

### DIFF
--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/gauss_gun.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/gauss_gun.dm
@@ -316,6 +316,16 @@
 	var/loading = FALSE //stop you loading the same torp over and over
 	var/obj/machinery/ship_weapon/gauss_gun/gun
 	var/autoload = FALSE //Allows for AMBER compatability with Gauss.
+	///Amount of gauss rounds starting from the bottom of the rack that are fully opaque
+	var/full_alpha_count = 3
+	///Amount of alpha reduced with each subsequent gauss round added to the rack
+	var/alpha_interval = 40
+	///Minimum alpha for vis_contents
+	var/min_alpha = 70
+	///Maximum alpha for vis_contents
+	var/max_alpha = 255
+	///pixel_y offset for each gauss round in the rack
+	var/ammo_offset_y = 5
 
 /obj/item/circuitboard/gauss_rack_upgrade
 	name = "Gauss Rack Autoload Module (Circuit)"
@@ -450,9 +460,10 @@
 	if(!capacity)
 		return
 	var/i = 1
+	var/startalpha = 255 + (full_alpha_count * alpha_interval)
 	for(var/obj/item/ship_weapon/ammunition/gauss/G in vis_contents)
-		G.pixel_y = (i*5)
-		G.alpha = clamp(335 - (i*40), 70, 255) //3 full alpha rounds and then more transparency
+		G.pixel_y = (i*ammo_offset_y)
+		G.alpha = clamp(startalpha - (i*alpha_interval), min_alpha, max_alpha) //3 full alpha rounds and then more transparency
 		i++
 
 /obj/structure/gauss_rack/attack_hand(mob/user)

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/gauss_gun.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/gauss_gun.dm
@@ -325,7 +325,7 @@
 	///Maximum alpha for vis_contents
 	var/max_alpha = 255
 	///pixel_y offset for each gauss round in the rack
-	var/ammo_offset_y = 5
+	var/ammo_offset_y = 4
 
 /obj/item/circuitboard/gauss_rack_upgrade
 	name = "Gauss Rack Autoload Module (Circuit)"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so the [top part of the gauss rounds inside the gauss rack are transparent](https://i.imgur.com/ccwsMLK.png) so you can actually see behind the rack.
Gauss rack vertical offset lowered by 1
Gauss rack loses autoload functionality when the circuit is ejected.
"Unload all" now only unloads the ammo instead of literally everything inside like the autoload circuit.
Spamming eject on a piece of ammo inside the UI no longer makes the ammo % go lower than intended.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I would like to see behind gauss racks.
Fixes gud

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Gauss ammo in gauss loading rack becomes more transparent the higher up it goes
tweak: Offset in gauss loading racks made tighter
tweak: "Unload all ammunition from rack" in gauss loading racks no longer ejects the autoload circuit
tweak: Gauss loading rack loses autoload functionality if autoload circuit is ejected
fix: fixed spamming the eject button in gauss loading rack ui to cause the ammo % bar to go waay lower than it should
fix: fixed the offsets of the ammo on gauss loading racks to get fucky
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
