### PR TITLE
Conveyor no longer fucks with gauss/ moves more normally

### DIFF
--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -159,8 +159,12 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 
 /obj/machinery/conveyor/proc/convey(items)
 	if(operating) //the problem with slightly delaying movement is that stuff gets confused right after the conveyors are turned off
+		var/turf/T = get_turf(src) //NSV13 Edit Start
+		if(!T)
+			return
 		for(var/M in items)
-			step(M, movedir)
+			if(M in T.contents) //The item being moved is still on the same spot when the callback was added.
+				step(M, movedir) //NSV13 Edit End
 
 // attack with item, place item on conveyor
 /obj/machinery/conveyor/attackby(obj/item/I, mob/user, params)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fixes #1544 

[Before](https://i.imgur.com/8Goysms.mp4)
[After](https://i.imgur.com/5eOejWK.mp4) <- beginning is a bit butchered due to my laptop liking to compete with the sun in heat generation

Conveyors move items using a callback.
And since items could move in the split second that the callback timer takes to trigger the /convey() proc, items were being moved regardless of where they are in relation to the conveyor, causing the conveyor to move items that are not on the conveyor itself.
Videos show how the old conveyors were able to completely fuck the gauss loading racks up.
Also shows how it moved freshly pulled crates from the conveyor (which happens in precise timings but i consider them pure RNG) that are just annoying to deal with.
Now i added a second check to the conveyor, that checks if the item that needs to be moved is actually on the same turf as the conveyor, and only moves it if the check actually passes.
For more info read the wall of text in #1544, or don't. I'm not your mother.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Please god of machinery please don't fuck up my precious gauss i beg you please.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixes conveyors moving items outside the conveyor's turf
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
