### PR TITLE
Gauss gun runtime fix.

### DIFF
--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/gauss_gun.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/gauss_gun.dm
@@ -129,9 +129,8 @@
 
 /obj/machinery/ship_weapon/gauss_gun/Initialize()
 	. = ..()
-	cabin_air = new
+	cabin_air = new(200)
 	cabin_air.set_temperature(T20C)
-	cabin_air.set_volume(200)
 	cabin_air.set_moles(/datum/gas/oxygen, O2STANDARD*cabin_air.return_volume()/(R_IDEAL_GAS_EQUATION*cabin_air.return_temperature()))
 	cabin_air.set_moles(/datum/gas/nitrogen, N2STANDARD*cabin_air.return_volume()/(R_IDEAL_GAS_EQUATION*cabin_air.return_temperature()))
 	internal_tank = new /obj/machinery/portable_atmospherics/canister/air(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a gauss gun divided-by-zero runtime on initialize when trying to set atmosphere moles

## Changelog
:cl:
fix: fixes gauss gun runtime and cabin atmos(?)
/:cl: