### PR TITLE
Suit Storage will heal a little bit of toxin damage on IPCs

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -263,8 +263,12 @@
 		if(occupant)
 			if(uv_super | (obj_flags & EMAGGED)) //NSV13 Emagged flag check
 				mob_occupant.adjustFireLoss(rand(20, 36))
+				if(isipc(mob_occupant))	//NSV13 Edit (Ipc get toxin removed)
+					mob_occupant.adjustToxLoss(rand(-10, -15))
 			else
 				mob_occupant.adjustFireLoss(rand(10, 16))
+				if(isipc(mob_occupant))	//NSV13 Edit (Ipc get toxin removed)
+					mob_occupant.adjustToxLoss(rand(-5, -10))
 			mob_occupant.emote("scream")
 		addtimer(CALLBACK(src, .proc/cook), 50)
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A dead IPC's toxin damage cannot be healed meaning in some cases where his tox damage goes into the hundreds due to a radstorm he cannot be revived. System cleaner does not help a dead IPC heal his toxin damage. So i made a wacky way to heal some toxin damage from IPCs, being, stuffing them into a suit storage container and "cleansing" their body using the decontamination function.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Currently we have no way of getting rid of dead IPC toxin damage outside praying "halp tox bad ples heal"

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Suit Storage decontamination now heals minor toxin damage from IPCs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
