### PR TITLE
Undo inertial dampener shake mitigation for same z-level explosions 

### DIFF
--- a/code/controllers/subsystem/explosion.dm
+++ b/code/controllers/subsystem/explosion.dm
@@ -259,7 +259,7 @@ SUBSYSTEM_DEF(explosions)
 				if(dist <= round(max_range + getviewsize(world.view)[1] - 2, 1))
 					M.playsound_local(epicenter, null, 100, 1, frequency, falloff = 5, S = explosion_sound)
 					if(baseshakeamount > 0)
-						shake_with_inertia(M, 25, clamp(baseshakeamount, 0, 10)) // NSV13 - Shaking the camera should be passed through shake_with_inertia, as explosions on the other side of the ship won't affect inertial dampener users 
+						shake_camera(M, 25, clamp(baseshakeamount, 0, 10))
 				// You hear a far explosion if you're outside the blast radius. Small bombs shouldn't be heard all over the station.
 				else if(dist <= far_dist)
 					var/far_volume = clamp(far_dist/2, FAR_LOWER, FAR_UPPER) // Volume is based on explosion size and dist
@@ -273,12 +273,12 @@ SUBSYSTEM_DEF(explosions)
 					if(baseshakeamount > 0 || devastation_range)
 						if(!baseshakeamount) // Devastating explosions rock the station and ground
 							baseshakeamount = devastation_range*3
-						shake_with_inertia(M, 10, clamp(baseshakeamount*0.25, 0, SHAKE_CLAMP)) // NSV13 - Shaking the camera should be passed through shake_with_inertia
+						shake_camera(M, 10, clamp(baseshakeamount*0.25, 0, SHAKE_CLAMP))
 				else if(!isspaceturf(get_turf(M)) && heavy_impact_range) // Big enough explosions echo throughout the hull
 					var/echo_volume = 40
 					if(devastation_range)
 						baseshakeamount = devastation_range
-						shake_with_inertia(M, 10, clamp(baseshakeamount*0.25, 0, SHAKE_CLAMP)) // NSV13 - Shaking the camera should be passed through shake_with_inertia
+						shake_camera(M, 10, clamp(baseshakeamount*0.25, 0, SHAKE_CLAMP))
 						echo_volume = 60
 					M.playsound_local(epicenter, null, echo_volume, 1, frequency, S = explosion_echo_sound, distance_multiplier = 0)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Undoes changes to explosion.dm from the original PR #1451. This previously mitigated the screen shake for nearby dampener users who would feel the ship shake from explosions caused by hostile ship weapons fire 

## Why It's Good For The Game

There's a potential upcoming beebase with supercruise that modifies a massive amount of files (the less files we have to worry about the better), screen shake from weapons fire explosions is such a niche thing to worry about that it doesn't need to be handled, and these machines are sparsely used in-game right now. A fair tradeoff 

