### PR TITLE
No-kill traitor option

### DIFF
--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -74,7 +74,7 @@
 	if (GLOB.joined_player_list.len >= 30) // Less murderboning on lowpop thanks
 		is_hijacker = prob(10)
 	var/martyr_chance = FALSE
-	if (GLOB.joined_player_list.len >= CONFIG_GET(number/minpop_kill_objectives)) //NSV13 - dying is lazy, do your job
+	if (GLOB.joined_player_list.len >= CONFIG_GET(number/min_pop_kill_objectives)) //NSV13 - dying is lazy, do your job
 		martyr_chance = prob(20)
 	var/objective_count = is_hijacker 			//Hijacking counts towards number of objectives
 	if(!SSticker.mode.exchange_blue && SSticker.mode.traitors.len >= 8) 	//Set up an exchange if there are enough traitors
@@ -123,7 +123,7 @@
 		objective_count += forge_single_objective()
 
 	for(var/i = objective_count, i < CONFIG_GET(number/traitor_objectives_amount), i++)
-		if(length(GLOB.joined_player_list) >= CONFIG_GET(number/minpop_kill_objectives)) //NSV13 - no lowpop murder
+		if(length(GLOB.joined_player_list) >= CONFIG_GET(number/min_pop_kill_objectives)) //NSV13 - no lowpop murder
 			var/datum/objective/assassinate/kill_objective = new
 			kill_objective.owner = owner
 			kill_objective.find_target()
@@ -145,7 +145,7 @@
 
 /datum/antagonist/traitor/proc/forge_single_human_objective() //Returns how many objectives are added
 	.=1
-	if(prob(50) && (GLOB.joined_player_list.len >= CONFIG_GET(number/minpop_kill_objectives))) //NSV13 - no lowpop murder
+	if(prob(50) && (GLOB.joined_player_list.len >= CONFIG_GET(number/min_pop_kill_objectives))) //NSV13 - no lowpop murder
 		var/list/active_ais = active_ais()
 		if(active_ais.len && prob(100/GLOB.joined_player_list.len))
 			var/datum/objective/destroy/destroy_objective = new
@@ -177,7 +177,7 @@
 /datum/antagonist/traitor/proc/forge_single_AI_objective()
 	.=1
 	var/special_pick = rand(1,4)
-	if (GLOB.joined_player_list.len >= CONFIG_GET(number/minpop_kill_objectives)) //NSV13 - no lowpop murder
+	if (GLOB.joined_player_list.len >= CONFIG_GET(number/min_pop_kill_objectives)) //NSV13 - no lowpop murder
 		special_pick = rand(3,4)
 	switch(special_pick)
 		if(1)

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -121,10 +121,13 @@
 		objective_count += forge_single_objective()
 
 	for(var/i = objective_count, i < CONFIG_GET(number/traitor_objectives_amount), i++)
-		var/datum/objective/assassinate/kill_objective = new
-		kill_objective.owner = owner
-		kill_objective.find_target()
-		add_objective(kill_objective)
+		if(length(GLOB.joined_player_list) >= CONFIG_GET(number/minpop_kill_objectives)) //NSV13 - no lowpop murder
+			var/datum/objective/assassinate/kill_objective = new
+			kill_objective.owner = owner
+			kill_objective.find_target()
+			add_objective(kill_objective)
+		else
+			objective_count += forge_single_objective()
 
 	var/datum/objective/survive/exist/exist_objective = new
 	exist_objective.owner = owner
@@ -152,7 +155,7 @@
 			maroon_objective.owner = owner
 			maroon_objective.find_target()
 			add_objective(maroon_objective)
-		else
+		else if(length(GLOB.joined_player_list) >= CONFIG_GET(number/minpop_kill_objectives)) //NSV13 - no lowpop murder
 			var/datum/objective/assassinate/kill_objective = new
 			kill_objective.owner = owner
 			kill_objective.find_target()

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -73,7 +73,9 @@
 	var/is_hijacker = FALSE
 	if (GLOB.joined_player_list.len >= 30) // Less murderboning on lowpop thanks
 		is_hijacker = prob(10)
-	var/martyr_chance = prob(20)
+	var/martyr_chance = FALSE
+	if (GLOB.joined_player_list.len >= CONFIG_GET(number/minpop_kill_objectives)) //NSV13 - dying is lazy, do your job
+		martyr_chance = prob(20)
 	var/objective_count = is_hijacker 			//Hijacking counts towards number of objectives
 	if(!SSticker.mode.exchange_blue && SSticker.mode.traitors.len >= 8) 	//Set up an exchange if there are enough traitors
 		if(!SSticker.mode.exchange_red)
@@ -126,7 +128,7 @@
 			kill_objective.owner = owner
 			kill_objective.find_target()
 			add_objective(kill_objective)
-		else
+		else //NSV13 - fallback for less killing
 			objective_count += forge_single_objective()
 
 	var/datum/objective/survive/exist/exist_objective = new
@@ -143,7 +145,7 @@
 
 /datum/antagonist/traitor/proc/forge_single_human_objective() //Returns how many objectives are added
 	.=1
-	if(prob(50))
+	if(prob(50) && (GLOB.joined_player_list.len >= CONFIG_GET(number/minpop_kill_objectives))) //NSV13 - no lowpop murder
 		var/list/active_ais = active_ais()
 		if(active_ais.len && prob(100/GLOB.joined_player_list.len))
 			var/datum/objective/destroy/destroy_objective = new
@@ -155,7 +157,7 @@
 			maroon_objective.owner = owner
 			maroon_objective.find_target()
 			add_objective(maroon_objective)
-		else if(length(GLOB.joined_player_list) >= CONFIG_GET(number/minpop_kill_objectives)) //NSV13 - no lowpop murder
+		else
 			var/datum/objective/assassinate/kill_objective = new
 			kill_objective.owner = owner
 			kill_objective.find_target()
@@ -175,6 +177,8 @@
 /datum/antagonist/traitor/proc/forge_single_AI_objective()
 	.=1
 	var/special_pick = rand(1,4)
+	if (GLOB.joined_player_list.len >= CONFIG_GET(number/minpop_kill_objectives)) //NSV13 - no lowpop murder
+		special_pick = rand(3,4)
 	switch(special_pick)
 		if(1)
 			var/datum/objective/block/block_objective = new

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -73,8 +73,8 @@
 	var/is_hijacker = FALSE
 	if (GLOB.joined_player_list.len >= 30) // Less murderboning on lowpop thanks
 		is_hijacker = prob(10)
-	var/martyr_chance = FALSE
-	if (GLOB.joined_player_list.len >= CONFIG_GET(number/min_pop_kill_objectives)) //NSV13 - dying is lazy, do your job
+	var/martyr_chance = FALSE //NSV13 - dying is lazy, do your job
+	if (GLOB.joined_player_list.len >= CONFIG_GET(number/min_pop_kill_objectives))
 		martyr_chance = prob(20)
 	var/objective_count = is_hijacker 			//Hijacking counts towards number of objectives
 	if(!SSticker.mode.exchange_blue && SSticker.mode.traitors.len >= 8) 	//Set up an exchange if there are enough traitors

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -170,6 +170,9 @@ MIDROUND_ANTAG CHANGELING
 MIDROUND_ANTAG WIZARD
 #MIDROUND_ANTAG  MONKEY
 
+## NSV13 - minimum number of ready players to enable traitor objectives where murder is reasonable/expected
+MIN_POP_KILL_OBJECTIVES 15
+
 ## Uncomment these for overrides of the minimum / maximum number of players in a round type.
 ## If you set any of these occasionally check to see if you still need them as the modes
 ## will still be actively rebalanced around the SUGGESTED populations, not your overrides.

--- a/nsv13/code/controllers/configuration/entries/game_options.dm
+++ b/nsv13/code/controllers/configuration/entries/game_options.dm
@@ -9,3 +9,7 @@
 
 /datum/config_entry/string/alert_zebra_upto
 	config_entry_value = "Attention all hands assume defense condition zebra. Compartmental interlocks have now been activated, prepare for incoming fire."
+
+/datum/config_entry/number/min_pop_kill_objectives
+	config_entry_value = 15
+	min_val = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR introduces a config option - MIN_POP_KILL_OBJECTIVES - for the minimum number of connected players for objectives where killing is likely or required. This means that if the number of ready players is above the minimum for traitors but below the new option, there can be traitors but they will have non-lethal objectives.
The following objectives will be disabled if the number of ready players is below the minimum:
- Martyr (Die a glorious death)
- Assassinate
- Destroy (Destroy AI)
- Maroon (Prevent target from leaving alive. The AI protect objective will still have this paired with it.)
- Block (No organics on the shuttle)
- Purge (No mutant humanoids on the shuttle)

## Why It's Good For The Game
Antags add variety, but we can't have them on lowpop because they often have to kill people and we need warm bodies to operate the ship. This is an attempt to fix that.

## Changelog
:cl:
balance: Modified traitor antag gamemode to support lower populations
config: Introduced a pop requirement for traitor objectives that often require death
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
