### PR TITLE
Nerfs disposals

### DIFF
--- a/code/modules/recycling/disposal/pipe.dm
+++ b/code/modules/recycling/disposal/pipe.dm
@@ -118,17 +118,13 @@
 			var/canpush = TRUE
 			for(var/atom/movable/thing in entryturf.contents)
 				if(thing.density)
-					if(thing.anchored)
-						canpush = FALSE
-						break
-					else
-						var/turf/candidate = get_step(entryturf, direction)
-						for(var/atom/movable/otherthing in candidate.contents)
-							if(otherthing.density)
-								canpush = FALSE
-								break
-						if(!canpush)
+					var/turf/candidate = get_step(entryturf, direction)
+					for(var/atom/movable/otherthing in candidate.contents)
+						if(otherthing.density)
+							canpush = FALSE
 							break
+					if(!canpush)
+						break
 
 			if(!canpush)
 				for(var/turf/newentry in oview(1, entryturf))

--- a/code/modules/recycling/disposal/pipe.dm
+++ b/code/modules/recycling/disposal/pipe.dm
@@ -111,7 +111,32 @@
 	playsound(src, 'sound/machines/hiss.ogg', 50, 0, 0)
 	for(var/A in H)
 		var/atom/movable/AM = A
-		AM.forceMove(get_turf(src))
+		//NSV13 start - nerfs disposals stacking of dense objects
+		var/turf/entryturf = get_turf(src)
+		if(!entryturf.Enter(AM)) // something is blocking the tile
+			// can it be pushed?
+			var/canpush = TRUE
+			for(var/atom/movable/thing in entryturf.contents)
+				if(thing.density)
+					if(thing.anchored)
+						canpush = FALSE
+						break
+					else
+						var/turf/candidate = get_step(entryturf, direction)
+						for(var/atom/movable/otherthing in candidate.contents)
+							if(otherthing.density)
+								canpush = FALSE
+								break
+						if(!canpush)
+							break
+
+			if(!canpush)
+				for(var/turf/newentry in oview(1, entryturf))
+					if(newentry.Enter(AM, entryturf))
+						entryturf = newentry
+						break
+		AM.forceMove(entryturf)
+		//NSV13 end
 		AM.pipe_eject(direction)
 		if(target)
 			AM.throw_at(target, eject_range, 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Tries to find an empty turf for a thing when it pops out of disposals if it couldn't normally move into the destination turf

## Why It's Good For The Game
Makes people use things in intended ways

## Changelog
:cl:
tweak: objects shooting out of a disposals pipe will be shunted onto a different open tile if the original destination has a dense object there
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
