### PR TITLE
Lower Player Req Medical Event

### DIFF
--- a/code/modules/events/heart_attack.dm
+++ b/code/modules/events/heart_attack.dm
@@ -3,7 +3,8 @@
 	typepath = /datum/round_event/heart_attack
 	weight = 20
 	max_occurrences = 2
-	min_players = 40 // To avoid shafting lowpop
+	earliest_start = 10 MINUTES		//NSV13
+	min_players = 15				//NSV13
 
 /datum/round_event/heart_attack/start()
 	var/list/heart_attack_contestants = list()

--- a/code/modules/events/spontaneous_appendicitis.dm
+++ b/code/modules/events/spontaneous_appendicitis.dm
@@ -1,10 +1,10 @@
 /datum/round_event_control/spontaneous_appendicitis
 	name = "Spontaneous Appendicitis"
 	typepath = /datum/round_event/spontaneous_appendicitis
-	weight = 10 
+	weight = 10
 	max_occurrences = 4
 	earliest_start = 10 MINUTES
-	min_players = 25 // This sucks when there's no medical staff
+	min_players = 15 //NSV13
 
 /datum/round_event/spontaneous_appendicitis
 	fakeable = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR changes the min players of the Heart Attack & Spontaneous Appendicitis to hopefully give med players a little more to do.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More events relating to medical at a lower pop values (15 rather than 40)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Lowered min players on Heart Attack to 15
balance: Lowered min players on Spontaneous Appendicitis to 15
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
