### PR TITLE
Changes light fighter gameplay slightly.

### DIFF
--- a/nsv13/code/modules/munitions/ammunition/cannon_ammo.dm
+++ b/nsv13/code/modules/munitions/ammunition/cannon_ammo.dm
@@ -5,8 +5,8 @@
 	icon_state = "light"
 	ammo_type = /obj/item/ammo_casing/light_cannon
 	caliber = "mm20"
-	max_ammo = 500
-	
+	max_ammo = 150
+
 /obj/item/ammo_box/magazine/nsv/heavy_cannon
 	name = "heavy cannon ammo"
 	desc = "A box of 30x173mm ammunition which can be loaded into a heavy fighter cannon."

--- a/nsv13/code/modules/overmap/fighters/_fighters.dm
+++ b/nsv13/code/modules/overmap/fighters/_fighters.dm
@@ -1350,7 +1350,7 @@ Utility modules can be either one of these types, just ensure you set its slot t
 	icon_state = "lightcannon"
 	accepted_ammo = /obj/item/ammo_box/magazine/nsv/light_cannon
 	burst_size = 2
-	fire_delay = 0.25 SECONDS
+	fire_delay = 0.20 SECONDS
 
 /obj/item/fighter_component/primary/cannon/heavy
 	name = "30mm BRRRRTT Cannon"

--- a/nsv13/code/modules/overmap/weapons/projectiles_fx.dm
+++ b/nsv13/code/modules/overmap/weapons/projectiles_fx.dm
@@ -168,7 +168,7 @@ Misc projectile types, effects, think of this as the special FX file.
 	name = "triton cruise missile"
 	icon_state = "conventional_missile"
 	speed = 1
-	damage = 175
+	damage = 250
 	valid_angle = 120
 	homing_turn_speed = 25
 	range = 250
@@ -239,7 +239,7 @@ Misc projectile types, effects, think of this as the special FX file.
 	tracer_type = /obj/effect/projectile/tracer/disabler
 	muzzle_type = /obj/effect/projectile/muzzle/disabler
 	impact_type = /obj/effect/projectile/impact/disabler
-	
+
 /obj/item/projectile/beam/laser/point_defense
 	name = "laser pointer"
 	damage = 30


### PR DESCRIPTION


## About The Pull Request
Reduces light cannon ammo capacity. Increases ROF slightly and increases missile damage. 

## Why It's Good For The Game

Diversity is the spice of life. The heavy and light fighter play more or less the same right now. With minor tactical differences. This PR would shake up light fighter gameplay to more short and snappy conflict with a larger emphasis on missiles and RTBing.
This does increase missile damage overall but as is. Missiles are never used offensively by the player ship and the player ship has more than enough defenses against enemy missiles. Even if they get through the damage isn't too rough.

## Changelog
:cl:
tweak: Light fighter cannon holds only 150 rounds.
balance: Light fighter cannon has a higher ROF
balance: Missiles do more damage
/:cl:

