### PR TITLE
Fixes experimental ordnance launchers.

### DIFF
--- a/nsv13/code/modules/overmap/fighters/_fighters.dm
+++ b/nsv13/code/modules/overmap/fighters/_fighters.dm
@@ -1415,14 +1415,14 @@ Utility modules can be either one of these types, just ensure you set its slot t
 /obj/item/fighter_component/secondary/ordnance_launcher/tier2
 	name = "Upgraded Fighter Missile Rack"
 	tier = 2
-	max_ammo = 5
+	max_ammo = 8
 
 /obj/item/fighter_component/secondary/ordnance_launcher/tier3
 	name = "A-11 'Spacehog' Cluster-Freedom Launcher"
 	tier = 3
 	max_ammo = 15
 	weight = 1
-	burst_size = 2
+	burst_size = 1
 	fire_delay = 0.10 SECONDS
 
 //Specialist item for the superiority fighter.
@@ -1457,7 +1457,7 @@ Utility modules can be either one of these types, just ensure you set its slot t
 	tier = 3
 	max_ammo = 10
 	weight = 2
-	burst_size = 2
+	burst_size = 1
 
 /obj/item/fighter_component/secondary/ordnance_launcher/load(obj/structure/overmap/target, atom/movable/AM)
 	if(!istype(AM, accepted_ammo))

--- a/nsv13/code/modules/overmap/fighters/_fighters.dm
+++ b/nsv13/code/modules/overmap/fighters/_fighters.dm
@@ -1415,7 +1415,7 @@ Utility modules can be either one of these types, just ensure you set its slot t
 /obj/item/fighter_component/secondary/ordnance_launcher/tier2
 	name = "Upgraded Fighter Missile Rack"
 	tier = 2
-	max_ammo = 8
+	max_ammo = 5
 
 /obj/item/fighter_component/secondary/ordnance_launcher/tier3
 	name = "A-11 'Spacehog' Cluster-Freedom Launcher"


### PR DESCRIPTION
## About The Pull Request

Prevents Experimental ordnance launchers from destroying their projectiles as soon as you fire them. This was caused by them having a burst size of 2, meaning two would shoot out and instantly collide unless you got very lucky with time dilation or the spread of the ordnance.
## Why It's Good For The Game

Having an upgrade be actively detrimental isn't really ideal.

## Changelog
:cl:
fix: Experimental fighter ordnance launchers no longer destroy projectiles they fire.
/:cl: