### PR TITLE
Steph's CIC reworks, part 1: Atlas

### DIFF
--- a/_maps/map_files/Atlas/atlas2.dmm
+++ b/_maps/map_files/Atlas/atlas2.dmm
@@ -187,7 +187,6 @@
 /turf/open/floor/plasteel/grid/techfloor,
 /area/engine/gravity_generator)
 "aP" = (
-/obj/machinery/light,
 /obj/effect/turf_decal/tile/ship/half/green,
 /obj/structure/table/glass,
 /turf/open/floor/monotile/steel,
@@ -436,9 +435,6 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
@@ -636,11 +632,8 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "dk" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/closet/secure_closet/bridge,
 /obj/structure/extinguisher_cabinet/north,
+/obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
 "dl" = (
@@ -1541,6 +1534,9 @@
 /obj/structure/railing{
 	dir = 6
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "hr" = (
@@ -1560,13 +1556,6 @@
 	dir = 1
 	},
 /turf/open/floor/monotile/steel,
-/area/bridge/cic)
-"hw" = (
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/obj/structure/filingcabinet/chestdrawer,
-/turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "hx" = (
 /obj/item/storage/secure/safe/caps_spare,
@@ -1624,6 +1613,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
 "hV" = (
@@ -1683,6 +1675,9 @@
 /obj/structure/closet/radiation,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
@@ -1856,9 +1851,6 @@
 /area/maintenance/nsv/deck2/frame1/port)
 "iP" = (
 /obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -1953,7 +1945,6 @@
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
 "je" = (
-/obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/tile/ship/half/green{
 	dir = 1
 	},
@@ -2196,9 +2187,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
 	},
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
@@ -2833,6 +2821,9 @@
 /obj/structure/railing{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "nM" = (
@@ -2982,7 +2973,9 @@
 "ov" = (
 /obj/structure/closet/radiation,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/obj/machinery/computer/ship/viewscreen,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
 "ox" = (
@@ -4083,14 +4076,13 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
 "tY" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/power/apc/auto_name/west{
+	cell_type = /obj/item/stock_parts/cell/super
+	},
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "tZ" = (
@@ -4349,6 +4341,7 @@
 	dir = 1
 	},
 /obj/item/radio/intercom,
+/obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "vl" = (
@@ -4893,6 +4886,16 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/hallway)
+"xS" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "atlas_brief"
+	},
+/turf/open/floor/plating,
+/area/bridge/cic)
 "xT" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on,
 /obj/effect/turf_decal/stripes/line{
@@ -6615,6 +6618,9 @@
 /area/ai_monitored/turret_protected/aisat)
 "GG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
 "GJ" = (
@@ -6756,6 +6762,16 @@
 	},
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck1/hallway)
+"Hq" = (
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 1
+	},
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/hallway)
 "Ht" = (
 /obj/effect/turf_decal/tile/ship/half/green{
@@ -7267,9 +7283,6 @@
 "JM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
@@ -8696,6 +8709,14 @@
 /obj/item/bedsheet/captain,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/captain)
+"Qh" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "atlas_brief"
+	},
+/turf/open/floor/plating,
+/area/bridge/cic)
 "Qi" = (
 /obj/structure/chair/sofa/right{
 	dir = 8;
@@ -8883,6 +8904,12 @@
 	},
 /obj/structure/railing{
 	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
@@ -9313,7 +9340,6 @@
 /obj/machinery/camera/autoname{
 	dir = 8
 	},
-/obj/machinery/photocopier,
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "TU" = (
@@ -10053,9 +10079,6 @@
 /turf/open/floor/monotile/dark,
 /area/hydroponics)
 "XS" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
@@ -41435,7 +41458,7 @@ ei
 uj
 dF
 gq
-MQ
+Hq
 wu
 Sc
 XZ
@@ -42196,7 +42219,7 @@ PM
 cz
 Em
 aP
-Tc
+xS
 ov
 hP
 Rl
@@ -42204,7 +42227,7 @@ nL
 hq
 GG
 ij
-Tc
+Qh
 je
 Em
 wu
@@ -42449,7 +42472,7 @@ HI
 SX
 vu
 HG
-MQ
+ay
 wu
 ae
 aX
@@ -43223,7 +43246,7 @@ HG
 rb
 wu
 YC
-MZ
+Tc
 XS
 dC
 ek
@@ -43233,7 +43256,7 @@ ff
 ha
 ir
 tY
-zt
+Tc
 rb
 wu
 YC
@@ -44258,7 +44281,7 @@ TO
 eP
 fF
 gW
-hw
+TO
 nM
 Tc
 Tc

--- a/_maps/map_files/Atlas/atlas2.dmm
+++ b/_maps/map_files/Atlas/atlas2.dmm
@@ -1038,7 +1038,11 @@
 	icon_state = "2-4"
 	},
 /obj/structure/table/reinforced,
-/obj/item/megaphone/command,
+/obj/machinery/button/door{
+	id = "atlas_brief";
+	name = "courtroom_shutter";
+	pixel_y = 2
+	},
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "eS" = (
@@ -1051,6 +1055,21 @@
 /turf/open/floor/plasteel/stairs{
 	dir = 8
 	},
+/area/bridge/cic)
+"fd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "fe" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -1462,6 +1481,7 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
+/obj/item/megaphone/command,
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "gX" = (
@@ -1500,6 +1520,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "hh" = (
@@ -1691,6 +1714,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "is" = (
@@ -4081,6 +4107,7 @@
 /obj/machinery/power/apc/auto_name/west{
 	cell_type = /obj/item/stock_parts/cell/super
 	},
+/obj/structure/cable,
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "tZ" = (
@@ -4981,6 +5008,12 @@
 /obj/effect/landmark/start/depsec/medical,
 /turf/open/floor/monotile/steel,
 /area/medical/medbay)
+"yp" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/monotile/dark,
+/area/bridge/cic)
 "yq" = (
 /obj/machinery/computer/cryopod{
 	pixel_y = 26
@@ -43225,9 +43258,9 @@ Tc
 XS
 dC
 ek
-eH
-ff
-ff
+fd
+yp
+yp
 ha
 ir
 tY

--- a/_maps/map_files/Atlas/atlas2.dmm
+++ b/_maps/map_files/Atlas/atlas2.dmm
@@ -6298,14 +6298,14 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/computer/bounty{
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/modular_computer/console/preset/command{
 	dir = 4
 	},
 /obj/structure/railing{
 	dir = 9
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
 	},
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)

--- a/_maps/map_files/Atlas/atlas2.dmm
+++ b/_maps/map_files/Atlas/atlas2.dmm
@@ -735,14 +735,6 @@
 "dy" = (
 /obj/structure/table/reinforced,
 /obj/structure/railing,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "dz" = (
@@ -1432,16 +1424,6 @@
 /turf/open/openspace,
 /area/maintenance/nsv/deck2/frame1/central)
 "gN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom,
 /obj/structure/railing{
@@ -1559,14 +1541,6 @@
 /obj/structure/railing{
 	dir = 6
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "hr" = (
@@ -1793,6 +1767,9 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
@@ -2158,6 +2135,14 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
+"kb" = (
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "atlas_brief"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/bridge/cic)
 "kh" = (
 /obj/structure/railing{
 	dir = 1
@@ -2188,14 +2173,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/table/reinforced,
 /obj/structure/railing,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "kw" = (
@@ -2322,6 +2299,9 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
@@ -2853,13 +2833,6 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "nM" = (
@@ -3070,13 +3043,6 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "oO" = (
@@ -4382,16 +4348,6 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/item/radio/intercom,
 /turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
@@ -6069,13 +6025,6 @@
 	dir = 4;
 	name = "captain's chair"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "DK" = (
@@ -7390,16 +7339,6 @@
 /obj/structure/railing{
 	dir = 5
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "JU" = (
@@ -7588,16 +7527,6 @@
 /obj/structure/railing{
 	dir = 5
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "KI" = (
@@ -7673,13 +7602,6 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "Lj" = (
@@ -8300,14 +8222,6 @@
 /obj/structure/railing{
 	dir = 6
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "NJ" = (
@@ -8924,14 +8838,6 @@
 /obj/structure/railing{
 	dir = 6
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "Ra" = (
@@ -8978,16 +8884,6 @@
 /obj/structure/railing{
 	dir = 5
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "Rp" = (
@@ -9111,13 +9007,6 @@
 	dir = 4;
 	name = "weapon officer"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "Sh" = (
@@ -9645,19 +9534,9 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/button/door{
 	id = "atlas_brief";
 	name = "courtroom_shutter";
@@ -10159,14 +10038,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
 /obj/structure/table/reinforced,
 /obj/structure/railing,
 /turf/open/floor/carpet/royalblack,
@@ -10367,13 +10238,6 @@
 	dir = 4;
 	name = "helm officer"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "YL" = (
@@ -42844,7 +42708,7 @@ vu
 HG
 IY
 wu
-Sc
+Al
 Am
 Tc
 vj
@@ -43113,7 +42977,7 @@ oH
 QX
 Tc
 Tc
-MQ
+cX
 wu
 xR
 MS
@@ -43626,7 +43490,7 @@ ff
 By
 iG
 iP
-zt
+kb
 MQ
 wu
 Sc
@@ -43872,8 +43736,8 @@ Xw
 uG
 MQ
 wu
-Al
-Tc
+Sc
+MZ
 iB
 Lj
 IO
@@ -43883,8 +43747,8 @@ wY
 EZ
 NY
 kT
-Tc
-cX
+zt
+MQ
 wu
 Sc
 pB

--- a/_maps/map_files/Atlas/atlas2.dmm
+++ b/_maps/map_files/Atlas/atlas2.dmm
@@ -2807,7 +2807,6 @@
 /turf/open/floor/circuit/off,
 /area/ai_monitored/turret_protected/ai)
 "nK" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
@@ -7358,6 +7357,8 @@
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/carpet/blue,
 /area/bridge/cic)
 "JX" = (

--- a/_maps/map_files/Atlas/atlas2.dmm
+++ b/_maps/map_files/Atlas/atlas2.dmm
@@ -29,6 +29,10 @@
 	},
 /turf/open/floor/plasteel/grid/lino,
 /area/medical/medbay)
+"ae" = (
+/obj/effect/turf_decal/tile/ship/green,
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck1/hallway)
 "af" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Smoking area"
@@ -164,6 +168,17 @@
 /obj/machinery/light/small,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
+"aK" = (
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/green,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 1
+	},
+/obj/machinery/vending/snack/random,
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck1/hallway)
 "aO" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable{
@@ -171,6 +186,12 @@
 	},
 /turf/open/floor/plasteel/grid/techfloor,
 /area/engine/gravity_generator)
+"aP" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/ship/half/green,
+/obj/structure/table/glass,
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck1/hallway)
 "aS" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only,
@@ -189,6 +210,17 @@
 /obj/item/kitchen/fork,
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/bar/mess_hall)
+"aX" = (
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/green,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 4
+	},
+/obj/machinery/vending/snack/random,
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck1/hallway)
 "aY" = (
 /obj/machinery/door/airlock/ship/command{
 	name = "AI Core SMES";
@@ -401,15 +433,21 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
 "ck" = (
-/obj/structure/closet/radiation,
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/obj/machinery/airalarm{
-	pixel_y = 23
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/obj/machinery/camera/autoname,
-/obj/item/clothing/head/radiation,
-/obj/item/clothing/suit/radiation,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/computer/security{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 5
+	},
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "cm" = (
@@ -437,6 +475,19 @@
 /obj/structure/sign/warning,
 /turf/closed/wall/r_wall,
 /area/tcommsat/server)
+"ct" = (
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Bridge";
+	departmentType = 5;
+	name = "Bridge RC";
+	pixel_x = -32
+	},
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/bin,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/monotile/steel,
+/area/bridge/cic)
 "cx" = (
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
@@ -559,17 +610,6 @@
 /obj/structure/closet/radiation,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
-"da" = (
-/obj/structure/table/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/raven/seven,
-/turf/open/floor/monotile/steel,
-/area/bridge/cic)
 "db" = (
 /obj/structure/railing{
 	dir = 8
@@ -596,12 +636,11 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "dk" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
-/obj/effect/landmark/zebra_interlock_point,
+/obj/structure/closet/secure_closet/bridge,
+/obj/structure/extinguisher_cabinet/north,
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
 "dl" = (
@@ -694,15 +733,17 @@
 	},
 /area/tcommsat/server)
 "dy" = (
+/obj/structure/table/reinforced,
+/obj/structure/railing,
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 10
 	},
-/obj/machinery/holopad,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1
+	dir = 8
 	},
+/obj/machinery/door/firedoor/border_only,
 /obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/monotile/steel,
+/turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "dz" = (
 /obj/machinery/door/firedoor/border_only,
@@ -730,6 +771,17 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"dC" = (
+/obj/effect/landmark/start/bridge,
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/monotile/dark,
+/area/bridge/cic)
 "dE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -814,10 +866,17 @@
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms)
 "ec" = (
-/obj/structure/sign/ship/securearea/alt{
-	dir = 4
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 8;
+	icon_state = "bordercorner"
 	},
-/turf/closed/wall/r_wall,
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 1
+	},
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
+/turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "ee" = (
 /obj/structure/rack,
@@ -839,6 +898,12 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/bar/mess_hall)
+"ei" = (
+/obj/structure/sign/ship/nosmoking{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/ai_monitored/turret_protected/ai_upload)
 "ej" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -854,6 +919,16 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/steel,
+/area/bridge/cic)
+"ek" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "em" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
@@ -919,6 +994,18 @@
 /obj/effect/spawner/room/fivexthree,
 /turf/template_noop,
 /area/maintenance/nsv/deck2/frame1/port)
+"eH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/bridge/cic)
 "eI" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -967,12 +1054,25 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
+"eP" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/table/reinforced,
+/obj/item/megaphone/command,
+/turf/open/floor/monotile/dark,
+/area/bridge/cic)
 "eS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar/mess_hall)
+"fa" = (
+/turf/open/floor/plasteel/stairs{
+	dir = 8
+	},
+/area/bridge/cic)
 "fe" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -984,6 +1084,9 @@
 	dir = 8
 	},
 /turf/open/floor/monotile/steel,
+/area/bridge/cic)
+"ff" = (
+/turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "fl" = (
 /obj/machinery/door/airlock/ship/public{
@@ -1046,30 +1149,36 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"fp" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/monotile/dark,
+/area/bridge/cic)
 "fs" = (
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
 "ft" = (
-/obj/machinery/door/airlock/highsecurity/ship{
-	name = "CIC";
-	req_one_access_txt = "19"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/monotile/steel,
+/obj/effect/turf_decal/tile/ship/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/brown{
+	dir = 8
+	},
+/obj/effect/landmark/start/bridge,
+/obj/structure/chair/office{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "fv" = (
 /obj/machinery/button/door{
@@ -1124,6 +1233,21 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
+"fF" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/chair/office{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/bridge/cic)
 "fH" = (
 /obj/structure/chair/stool,
 /obj/structure/cable{
@@ -1290,12 +1414,6 @@
 /obj/item/lighter,
 /turf/open/floor/carpet/red,
 /area/security/detectives_office)
-"gH" = (
-/obj/structure/sign/ship/nosmoking{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/bridge/cic)
 "gK" = (
 /obj/effect/turf_decal/tile/ship/half/green{
 	dir = 8
@@ -1313,6 +1431,24 @@
 	},
 /turf/open/openspace,
 /area/maintenance/nsv/deck2/frame1/central)
+"gN" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/structure/table/reinforced,
+/obj/item/radio/intercom,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/carpet/royalblack,
+/area/bridge/cic)
 "gQ" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -1357,6 +1493,14 @@
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/chief)
+"gW" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/turf/open/floor/monotile/dark,
+/area/bridge/cic)
 "gX" = (
 /obj/effect/turf_decal/tile/ship/half/green{
 	dir = 8
@@ -1388,6 +1532,13 @@
 /obj/machinery/telecomms/processor/preset_four,
 /turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
+"ha" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/monotile/dark,
+/area/bridge/cic)
 "hh" = (
 /obj/machinery/holopad,
 /obj/structure/cable{
@@ -1401,10 +1552,22 @@
 /turf/closed/wall/steel,
 /area/maintenance/nsv/deck2/frame1/port)
 "hq" = (
-/obj/machinery/computer/crew{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/computer/ship/dradis{
 	dir = 8
 	},
-/turf/open/floor/carpet/blue,
+/obj/structure/railing{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "hr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -1424,6 +1587,20 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
+"hw" = (
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/structure/filingcabinet/chestdrawer,
+/turf/open/floor/monotile/dark,
+/area/bridge/cic)
+"hx" = (
+/obj/item/storage/secure/safe/caps_spare,
+/obj/structure/sign/ship/nosmoking{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/bridge/cic)
 "hy" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -1433,6 +1610,13 @@
 	},
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
+"hz" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/monotile/steel,
+/area/bridge/cic)
 "hA" = (
 /obj/effect/turf_decal/tile/ship/half/green{
 	dir = 1
@@ -1462,13 +1646,11 @@
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/bar/mess_hall)
 "hP" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/blue,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/monotile/steel,
 /area/bridge/cic)
 "hV" = (
 /obj/structure/cable{
@@ -1523,6 +1705,17 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
+"ij" = (
+/obj/structure/closet/radiation,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/turf/open/floor/monotile/steel,
+/area/bridge/cic)
+"ik" = (
+/obj/structure/closet/secure_closet/bridge,
+/turf/open/floor/monotile/steel,
+/area/bridge/cic)
 "in" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -1535,23 +1728,15 @@
 /turf/open/floor/monotile/dark,
 /area/medical/chemistry)
 "ir" = (
-/obj/machinery/door/airlock/highsecurity/ship{
-	name = "Lecture Theatre";
-	req_one_access_txt = "19"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/structure/chair/office{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+/obj/effect/landmark/start/bridge,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/carpet/blue,
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "is" = (
 /obj/effect/turf_decal/tile/ship/half/green{
@@ -1596,6 +1781,21 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plasteel/freezer,
 /area/maintenance/nsv/deck2/frame1/port)
+"iB" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/computer/security/mining{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/monotile/dark,
+/area/bridge/cic)
 "iD" = (
 /obj/machinery/computer/ship/viewscreen,
 /obj/machinery/computer/communications,
@@ -1614,21 +1814,17 @@
 /turf/open/floor/plasteel/grid/lino,
 /area/medical/medbay)
 "iG" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	dir = 4;
-	id = "atlas_brief"
+/obj/machinery/computer/station_alert{
+	dir = 8;
+	name = "ship alert console"
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/structure/railing{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/carpet/blue,
+/turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "iH" = (
 /obj/structure/sign/poster/contraband/communist_state,
@@ -1681,6 +1877,24 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/nsv/deck2/frame1/port)
+"iP" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/computer/atmos_alert{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/floor/monotile/dark,
+/area/bridge/cic)
 "iS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1700,6 +1914,22 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
+"iW" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 8
+	},
+/obj/machinery/vending/snack/random,
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck1/hallway)
 "iX" = (
 /obj/effect/decal/cleanable/glitter/white{
 	layer = 4.1;
@@ -1745,11 +1975,19 @@
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
+"je" = (
+/obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/tile/ship/half/green{
+	dir = 1
+	},
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck1/hallway)
 "jf" = (
-/obj/structure/sign/ship/securearea/alt{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "ji" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -1828,7 +2066,19 @@
 "jx" = (
 /obj/structure/sign/ship/deck,
 /turf/closed/wall/r_wall,
-/area/bridge/cic)
+/area/hallway/nsv/deck1/hallway)
+"jB" = (
+/obj/machinery/camera/autoname,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/green,
+/obj/machinery/vending/snack/random,
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck1/hallway)
 "jG" = (
 /obj/machinery/computer/security/wooden_tv,
 /turf/open/floor/carpet/red,
@@ -1936,7 +2186,17 @@
 /area/crew_quarters/bar/mess_hall)
 "ku" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet/blue,
+/obj/structure/table/reinforced,
+/obj/structure/railing,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "kw" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -1957,11 +2217,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/computer/ship/ordnance{
-	dir = 4;
-	req_access = null
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/turf/open/floor/carpet/blue,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/monotile/steel,
 /area/bridge/cic)
 "kz" = (
 /obj/structure/rack,
@@ -2048,6 +2310,21 @@
 /obj/structure/lattice/catwalk/over/ship,
 /turf/open/openspace,
 /area/maintenance/nsv/deck1/starboard)
+"kT" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/computer/cargo/request{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/monotile/dark,
+/area/bridge/cic)
 "kX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2158,11 +2435,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
-"lk" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/raven/six,
-/turf/open/floor/monotile/steel,
-/area/bridge/cic)
 "ll" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	name = "Hydroponics";
@@ -2334,9 +2606,10 @@
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/chief)
 "ml" = (
-/obj/effect/turf_decal/tile/ship/half/green,
-/obj/machinery/light,
-/turf/open/floor/monotile/steel,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/hallway)
 "mm" = (
 /obj/machinery/light/small,
@@ -2522,29 +2795,10 @@
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/hallway)
 "ns" = (
-/obj/machinery/computer/ship/tactical/console,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/sign/ship/nosmoking{
+	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/structure/sign/nanotrasen{
-	pixel_y = 26
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/monotile/steel,
-/area/bridge/cic)
-"nC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
-	},
-/obj/structure/closet/secure_closet/bridge,
-/turf/open/floor/monotile/dark,
+/turf/closed/wall/r_wall,
 /area/bridge/cic)
 "nD" = (
 /obj/structure/disposalpipe/segment{
@@ -2588,29 +2842,41 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "nL" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/computer/communications{
 	dir = 8
 	},
-/turf/open/floor/carpet/blue,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "nM" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/extinguisher_cabinet/north,
-/turf/open/floor/monotile/steel,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "nS" = (
 /obj/machinery/telecomms/server/presets/service,
@@ -2741,14 +3007,9 @@
 /turf/open/floor/plasteel/ship/riveted,
 /area/maintenance/nsv/deck2/frame1/port)
 "ov" = (
-/obj/machinery/computer/ship/navigation/console/end{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/effect/landmark/zebra_interlock_point,
+/obj/structure/closet/radiation,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
 "ox" = (
@@ -2802,21 +3063,21 @@
 	},
 /turf/open/floor/carpet/red,
 /area/security/detectives_office)
-"oG" = (
-/obj/machinery/computer/ship/dradis/minor/console{
-	dir = 1
+"oH" = (
+/obj/machinery/computer/ship/helm{
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/firedoor/border_only,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/monotile/steel,
-/area/bridge/cic)
-"oI" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4;
-	name = "briefing room chair"
-	},
-/turf/open/floor/carpet/blue,
+/turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "oO" = (
 /obj/structure/lattice/catwalk/over/ship,
@@ -2915,11 +3176,6 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
-"pm" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/raven_ship_sign,
-/turf/open/floor/monotile/steel,
-/area/bridge/cic)
 "ps" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -3028,16 +3284,6 @@
 /obj/item/trash/sosjerky,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/port)
-"pP" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/monotile/steel,
-/area/bridge/cic)
 "pR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -3151,15 +3397,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/port)
-"qA" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/obj/structure/closet/secure_closet/bridge,
-/turf/open/floor/monotile/dark,
-/area/bridge/cic)
 "qC" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -3210,31 +3447,14 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
-"qQ" = (
-/obj/machinery/computer/ship/dradis/console,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/computer/ship/viewscreen,
-/obj/machinery/camera/autoname,
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/monotile/steel,
-/area/bridge/cic)
 "qS" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/grid/lino,
 /area/medical/medbay)
 "qT" = (
-/obj/machinery/shuttle_manipulator{
-	layer = 2.75;
-	pixel_x = -15
-	},
-/obj/effect/turf_decal/raven/five,
 /obj/effect/landmark/nuclear_waste_spawner,
 /obj/effect/landmark/observer_start,
+/obj/machinery/holopad,
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
 "qU" = (
@@ -3323,14 +3543,14 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/open/floor/monotile/steel,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
+/turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "rs" = (
 /obj/structure/table/reinforced,
@@ -3547,22 +3767,6 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/aisat)
-"sm" = (
-/obj/structure/chair/office,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/landmark/start/bridge,
-/obj/item/radio/intercom{
-	pixel_x = -32;
-	pixel_y = -32
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/monotile/steel,
-/area/bridge/cic)
 "sp" = (
 /obj/machinery/computer/ship/viewscreen,
 /obj/structure/cable{
@@ -3633,11 +3837,6 @@
 	},
 /turf/open/floor/plasteel/grid/lino,
 /area/tcommsat/server)
-"sF" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/raven/one,
-/turf/open/floor/monotile/steel,
-/area/bridge/cic)
 "sH" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
@@ -3809,12 +4008,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/nsv/deck2/frame1/port)
-"tw" = (
-/obj/machinery/computer/ship/dradis/minor{
-	dir = 4
-	},
-/turf/open/floor/carpet/blue,
-/area/bridge/cic)
 "tx" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3850,14 +4043,6 @@
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
-"tF" = (
-/obj/item/radio/intercom/directional/north,
-/obj/structure/chair/comfy/shuttle{
-	dir = 4;
-	name = "briefing room chair"
-	},
-/turf/open/floor/carpet/blue,
-/area/bridge/cic)
 "tH" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/teleport/hub,
@@ -3887,15 +4072,6 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/maintenance/nsv/deck2/frame1/port)
-"tK" = (
-/obj/machinery/computer/communications/console{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/monotile/steel,
-/area/bridge/cic)
 "tM" = (
 /obj/effect/decal/cleanable/glitter/white{
 	layer = 4.1;
@@ -3941,13 +4117,15 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
 "tY" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor/border_only{
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/monotile/steel,
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/power/apc/auto_name/west,
+/turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "tZ" = (
 /obj/machinery/stasis,
@@ -3992,13 +4170,6 @@
 	},
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
-"uh" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/monotile/steel,
-/area/bridge/cic)
 "ui" = (
 /obj/structure/lattice/catwalk/over/ship,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -4068,12 +4239,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/cmo)
-"uA" = (
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin,
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/monotile/steel,
-/area/bridge/cic)
 "uG" = (
 /turf/closed/wall/steel,
 /area/crew_quarters/kitchen)
@@ -4202,17 +4367,6 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
-"ve" = (
-/obj/structure/table,
-/obj/item/megaphone/command,
-/obj/machinery/button/door{
-	id = "atlas_brief";
-	name = "courtroom_shutter";
-	pixel_x = -6
-	},
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/carpet/blue,
-/area/bridge/cic)
 "vf" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/stripes/line{
@@ -4224,11 +4378,22 @@
 /turf/open/floor/plasteel/grid/lino,
 /area/medical/medbay)
 "vj" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/holopad,
-/obj/machinery/door/firedoor/border_only,
+/obj/structure/table/reinforced,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/monotile/steel,
+/obj/item/radio/intercom,
+/turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "vl" = (
 /obj/effect/turf_decal/tile/ship/green{
@@ -4256,12 +4421,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/bar/mess_hall)
-"vr" = (
-/obj/machinery/computer/ship/salvage{
-	dir = 4
-	},
-/turf/open/floor/carpet/blue,
-/area/bridge/cic)
 "vs" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
@@ -4377,17 +4536,6 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
-"vS" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	dir = 4;
-	id = "atlas_brief"
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/carpet/blue,
-/area/bridge/cic)
 "vU" = (
 /obj/effect/turf_decal/tile/ship/green{
 	dir = 4
@@ -4553,25 +4701,16 @@
 /turf/open/floor/plasteel/grid/lino,
 /area/ai_monitored/nuke_storage)
 "wW" = (
-/obj/machinery/door/airlock/highsecurity/ship{
-	name = "CIC";
-	req_one_access_txt = "19"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only/directional/east,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/landmark/zebra_interlock_point,
-/obj/machinery/door/firedoor/border_only{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/monotile/steel,
@@ -4590,16 +4729,14 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
 "wY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/camera{
-	c_tag = "CIC - Fore";
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/monotile/steel,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "wZ" = (
 /obj/structure/railing,
@@ -4811,25 +4948,12 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/monotile/steel,
-/area/bridge/cic)
-"xV" = (
-/obj/machinery/computer/crew/console{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/monotile/steel,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "xY" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1{
@@ -4928,21 +5052,14 @@
 /area/maintenance/nsv/deck2/frame1/central)
 "yv" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/obj/structure/chair/comfy/shuttle{
-	color = "#696969";
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
 	dir = 4;
-	name = "captain's chair"
+	id = "atlas_brief"
 	},
-/obj/effect/landmark/start/captain,
-/turf/open/floor/carpet/blue,
+/turf/open/floor/plating,
 /area/bridge/cic)
 "yw" = (
 /obj/effect/turf_decal/tile/ship/half/green{
@@ -5058,6 +5175,14 @@
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/monotile/dark,
 /area/medical/medbay)
+"zt" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "atlas_brief"
+	},
+/turf/open/floor/plating,
+/area/bridge/cic)
 "zv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -5088,23 +5213,27 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
 "zJ" = (
-/obj/machinery/door/airlock/highsecurity/ship{
-	name = "CIC";
-	req_one_access_txt = "19"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/effect/landmark/zebra_interlock_point,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/monotile/steel,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 8;
+	icon_state = "bordercorner"
+	},
+/obj/effect/landmark/start/bridge,
+/obj/structure/chair/office{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "zK" = (
 /obj/structure/table,
@@ -5134,9 +5263,6 @@
 "zM" = (
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
@@ -5247,15 +5373,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/gravity_generator)
-"Ah" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	dir = 4;
-	id = "atlas_brief"
-	},
-/obj/structure/cable,
-/turf/open/floor/carpet/blue,
-/area/bridge/cic)
 "Aj" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -5470,6 +5587,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/central)
+"By" = (
+/obj/machinery/computer/monitor{
+	dir = 8;
+	name = "Bridge Power Monitoring Console"
+	},
+/obj/structure/railing{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/monotile/dark,
+/area/bridge/cic)
 "BD" = (
 /turf/open/floor/plasteel/grid/lino,
 /area/medical/medbay)
@@ -5543,17 +5673,6 @@
 	},
 /turf/open/floor/engine,
 /area/ai_monitored/turret_protected/aisat)
-"BP" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
-/obj/machinery/camera/autoname,
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/plasteel/grid/mono,
-/area/hallway/nsv/deck1/hallway)
 "BS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5943,21 +6062,21 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
-"DI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/carpet/blue,
-/area/bridge/cic)
 "DJ" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/chair/office{
-	dir = 4
+/obj/structure/chair/comfy/shuttle{
+	color = "#696969";
+	dir = 4;
+	name = "captain's chair"
 	},
-/turf/open/floor/carpet/blue,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "DK" = (
 /obj/effect/decal/cleanable/glitter/white{
@@ -6202,23 +6321,21 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
 "EZ" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "CIC";
-	departmentType = 5;
-	name = "Bridge RC";
-	pixel_x = 32
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/monotile/steel,
+/obj/machinery/computer/bounty{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "Fa" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -6289,13 +6406,19 @@
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
 "Fn" = (
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/monotile/steel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/computer/secure_data{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "Fp" = (
 /obj/structure/cable{
@@ -6391,17 +6514,22 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/obj/machinery/camera/autoname,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/monotile/steel,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/command{
+	name = "Bridge";
+	req_one_access_txt = "19"
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "FR" = (
 /obj/structure/sign/ship/deck{
@@ -6458,13 +6586,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
-"Gg" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/extinguisher_cabinet/south,
-/turf/open/floor/monotile/steel,
-/area/bridge/cic)
 "Gh" = (
 /obj/machinery/nuclearbomb/selfdestruct{
 	name = "ship self destruct terminal"
@@ -6544,16 +6665,7 @@
 /turf/open/floor/engine,
 /area/ai_monitored/turret_protected/aisat)
 "GG" = (
-/obj/machinery/modular_computer/console/preset/command{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
 "GJ" = (
@@ -6562,26 +6674,14 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/nsv/deck1/starboard)
-"GK" = (
-/obj/machinery/computer/console_placholder{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/monotile/steel,
-/area/bridge/cic)
 "GM" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/cmo)
 "GN" = (
-/obj/machinery/computer/ship/viewscreen,
-/obj/item/storage/secure/safe/caps_spare,
-/turf/closed/wall/r_wall,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "GT" = (
 /turf/open/floor/carpet/blue,
@@ -6665,13 +6765,19 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "Hk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/turf/open/floor/monotile/steel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/computer/prisoner/management{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "Hn" = (
 /obj/machinery/light{
@@ -6750,6 +6856,16 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/medical/medbay)
+"HF" = (
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 8;
+	icon_state = "bordercorner"
+	},
+/turf/open/floor/monotile/dark,
+/area/bridge/cic)
 "HG" = (
 /turf/closed/wall/steel,
 /area/maintenance/nsv/deck2/frame1/port)
@@ -6964,20 +7080,21 @@
 /turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
 "IO" = (
-/obj/machinery/light_switch/east,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/computer/crew{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
+/obj/structure/railing{
+	dir = 10
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "IP" = (
 /obj/structure/fluff/bleepypanel{
@@ -7087,13 +7204,6 @@
 /obj/item/stack/cable_coil/random,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/port)
-"Jj" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/monotile/steel,
-/area/bridge/cic)
 "Jk" = (
 /obj/structure/fluff/bleepypanel{
 	dir = 4
@@ -7114,24 +7224,17 @@
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
 "Jn" = (
-/obj/machinery/door/airlock/highsecurity/ship{
-	name = "CIC";
-	req_one_access_txt = "19"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/effect/landmark/zebra_interlock_point,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
@@ -7213,13 +7316,13 @@
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/bar/mess_hall)
 "JM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/blue,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/monotile/steel,
 /area/bridge/cic)
 "JN" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1{
@@ -7280,9 +7383,24 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "JS" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/raven/three,
-/turf/open/floor/monotile/steel,
+/obj/machinery/computer/ship/navigation{
+	dir = 8;
+	icon_state = "computer"
+	},
+/obj/structure/railing{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "JU" = (
 /obj/structure/disposalpipe/segment,
@@ -7385,16 +7503,6 @@
 /obj/structure/extinguisher_cabinet/south,
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/hallway)
-"Kq" = (
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Briefing";
-	departmentType = 5;
-	name = "Briefing Room RC";
-	pixel_x = -32
-	},
-/turf/open/floor/carpet/blue,
-/area/bridge/cic)
 "Kr" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -7447,8 +7555,8 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/chair{
+	dir = 8
 	},
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
@@ -7474,14 +7582,23 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/cmo)
 "KD" = (
-/obj/structure/chair/office{
+/obj/machinery/computer/ship/dradis{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/start/bridge,
 /obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/monotile/steel,
+/turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "KI" = (
 /obj/machinery/chem_dispenser,
@@ -7546,22 +7663,45 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/grid/lino,
 /area/medical/medbay)
-"Lj" = (
+"Li" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/computer/ship/tactical{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 4
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "0-2"
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/carpet/royalblack,
+/area/bridge/cic)
+"Lj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
-/obj/machinery/power/apc/highcap/fifteen_k{
-	dir = 1;
-	name = "CIC (Secondary) APC";
-	pixel_y = 26
-	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/computer/med_data{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
@@ -7648,18 +7788,6 @@
 "LL" = (
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/port)
-"LM" = (
-/obj/structure/closet/radiation,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
-	},
-/obj/item/clothing/head/radiation,
-/obj/item/clothing/suit/radiation,
-/turf/open/floor/monotile/dark,
-/area/bridge/cic)
 "LN" = (
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/monotile/dark,
@@ -7944,6 +8072,16 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/hallway)
+"MZ" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "atlas_brief"
+	},
+/turf/open/floor/plating,
+/area/bridge/cic)
 "Na" = (
 /obj/machinery/door/airlock/ship/public{
 	id_tag = "atlas_toilet_1";
@@ -8147,15 +8285,30 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "NI" = (
-/obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/raven/nine,
-/turf/open/floor/monotile/steel,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/computer/ship/salvage{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "NJ" = (
 /obj/structure/closet/emcloset,
@@ -8203,9 +8356,6 @@
 /turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
 "NY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
@@ -8213,12 +8363,20 @@
 	dir = 5
 	},
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "2-4"
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
-/obj/machinery/light_switch/south,
+/obj/machinery/computer/bounty{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "NZ" = (
@@ -8271,6 +8429,15 @@
 /obj/structure/railing/corner,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/port)
+"Op" = (
+/obj/effect/turf_decal/tile/ship/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/brown{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/bridge/cic)
 "Ou" = (
 /obj/structure/lattice/catwalk/over/ship,
 /obj/machinery/light/small{
@@ -8338,9 +8505,6 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/xo)
 "OB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 4
 	},
@@ -8437,14 +8601,11 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
 "Pe" = (
-/obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/turf/open/floor/monotile/steel,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/hallway)
 "Pf" = (
 /obj/effect/turf_decal/tile/ship/half/green,
@@ -8518,6 +8679,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
+/obj/effect/landmark/start/captain,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/captain)
 "PF" = (
@@ -8756,20 +8918,21 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/port)
 "QX" = (
-/obj/structure/chair/office,
+/obj/machinery/computer/ship/dradis{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 6
+	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 6
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 1
+	dir = 4
 	},
-/obj/machinery/firealarm{
-	pixel_x = 32;
-	pixel_y = -32
-	},
-/obj/effect/landmark/start/bridge,
+/obj/machinery/door/firedoor/border_only,
 /obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/monotile/steel,
+/turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "Ra" = (
 /obj/machinery/smartfridge/chemistry/preloaded,
@@ -8797,34 +8960,35 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/steel,
 /area/maintenance/nsv/deck2/frame1/port)
-"Rf" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/carpet/blue,
-/area/bridge/cic)
 "Rg" = (
 /obj/structure/hull_plate/end,
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
 "Rl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/computer/monitor{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/modular_computer/console/preset/command{
 	dir = 8
 	},
-/turf/open/floor/carpet/blue,
+/obj/structure/railing{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "Rp" = (
 /obj/machinery/computer/card/minor/hos,
@@ -8939,14 +9103,22 @@
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/hallway)
 "Sf" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/blue,
+/obj/structure/chair/comfy/shuttle{
+	color = "#696969";
+	dir = 4;
+	name = "weapon officer"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "Sh" = (
 /obj/effect/turf_decal/tile/ship/blue{
@@ -9090,18 +9262,6 @@
 /obj/structure/lattice,
 /turf/open/openspace,
 /area/maintenance/nsv/deck2/frame1/port)
-"SZ" = (
-/obj/machinery/computer/security/console{
-	dir = 5;
-	icon_screen = null
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/monotile/steel,
-/area/bridge/cic)
 "Tb" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -9233,20 +9393,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/nsv/deck1/hallway)
-"TF" = (
-/obj/machinery/computer/ship/helm/console,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/structure/sign/nanotrasen{
-	pixel_y = 26
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/monotile/steel,
-/area/bridge/cic)
 "TH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -9274,6 +9420,13 @@
 "TM" = (
 /turf/open/floor/monotile/dark,
 /area/medical/medbay)
+"TO" = (
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/machinery/photocopier,
+/turf/open/floor/monotile/dark,
+/area/bridge/cic)
 "TU" = (
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -9352,12 +9505,22 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet/south,
-/turf/open/floor/monotile/steel,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/airlock/ship/command{
+	name = "Bridge";
+	req_one_access_txt = "19"
+	},
+/turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "Ul" = (
 /obj/effect/turf_decal/tile/ship/half/green{
@@ -9473,14 +9636,39 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet/blue,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/button/door{
+	id = "atlas_brief";
+	name = "courtroom_shutter";
+	pixel_x = -9;
+	pixel_y = 2
+	},
+/obj/item/radio/intercom{
+	pixel_x = 6;
+	pixel_y = -1
+	},
+/turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "UN" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -9678,16 +9866,22 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
 "VV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/monotile/steel,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "VZ" = (
 /obj/structure/closet/firecloset,
@@ -9897,23 +10091,6 @@
 	},
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/hallway)
-"Xq" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/computer/monitor{
-	dir = 8;
-	name = "Bridge Power Monitoring Console"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/monotile/steel,
-/area/bridge/cic)
 "Xv" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9973,13 +10150,26 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
 "XH" = (
-/obj/structure/table/reinforced,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/raven/eight,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/turf/open/floor/monotile/steel,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/structure/table/reinforced,
+/obj/structure/railing,
+/turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "XK" = (
 /obj/effect/turf_decal/tile/ship/green{
@@ -9992,17 +10182,14 @@
 /turf/open/floor/monotile/dark,
 /area/hydroponics)
 "XS" = (
-/obj/machinery/computer/console_placholder{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/monotile/steel,
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "XT" = (
 /obj/machinery/power/terminal,
@@ -10052,12 +10239,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
-"Yd" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/turf/open/floor/carpet/blue,
-/area/bridge/cic)
 "Yj" = (
 /turf/open/floor/monotile/dark,
 /area/hydroponics)
@@ -10082,7 +10263,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet/north,
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
 "Yp" = (
@@ -10131,11 +10311,6 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
-"Yv" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/raven/four,
-/turf/open/floor/monotile/steel,
-/area/bridge/cic)
 "Yz" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -10186,6 +10361,21 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/port)
+"YK" = (
+/obj/structure/chair/comfy/shuttle{
+	color = "#696969";
+	dir = 4;
+	name = "helm officer"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/carpet/royalblack,
+/area/bridge/cic)
 "YL" = (
 /obj/effect/turf_decal/tile/ship/half/green{
 	dir = 8
@@ -41373,11 +41563,11 @@ Kp
 gq
 dF
 uj
-uj
+ei
 Ov
 zY
 RI
-uj
+ei
 uj
 dF
 gq
@@ -41627,7 +41817,7 @@ hk
 HT
 zV
 Sc
-Tc
+Am
 Tc
 Tc
 Yn
@@ -41884,17 +42074,17 @@ Re
 yw
 as
 ml
+aK
 Tc
-Tc
-uA
+ct
 OB
 UK
 DJ
 ku
 JU
-Jj
+hz
 Tc
-Tc
+iW
 Pe
 dg
 zf
@@ -42140,19 +42330,19 @@ Ku
 HG
 PM
 cz
-Sc
+Em
+aP
 Tc
-GK
 ov
 hP
 Rl
 nL
 hq
-pw
 GG
-dk
+ij
 Tc
-BP
+je
+Em
 wu
 Sc
 MS
@@ -42397,19 +42587,19 @@ vu
 HG
 MQ
 wu
-Sc
+ae
+aX
 Tc
-TF
-KD
+dk
 JM
-da
-Yv
-sF
-pw
-sm
-tK
+kx
+Vg
+Vg
+Vg
+ik
 Tc
-MQ
+jB
+gR
 wu
 Sc
 MS
@@ -42655,17 +42845,17 @@ HG
 IY
 wu
 Sc
+Am
 Tc
-qQ
 vj
 Sf
 XH
 qT
-pm
-pw
+gN
+YK
 dy
-oG
 Tc
+Am
 IY
 xn
 Sc
@@ -42915,13 +43105,13 @@ Sc
 Tc
 ns
 KD
-JM
+Li
 NI
-lk
+fa
 JS
-pw
+oH
 QX
-xV
+Tc
 Tc
 MQ
 wu
@@ -43169,17 +43359,17 @@ HG
 rb
 wu
 YC
-Tc
+MZ
 XS
-SZ
-JM
-kx
-vr
-tw
-pw
-Xq
+dC
+ek
+eH
+ff
+ff
+ha
+ir
 tY
-Tc
+zt
 rb
 wu
 YC
@@ -43426,18 +43616,18 @@ uG
 cX
 wu
 Sc
-Tc
-Tc
+MZ
+ck
 Fn
 Hk
-DI
-Yd
-pw
-Vg
-Gg
-Tc
-Tc
-cX
+eH
+ff
+ff
+By
+iG
+iP
+zt
+MQ
 wu
 Sc
 MS
@@ -43684,7 +43874,7 @@ MQ
 wu
 Al
 Tc
-Tc
+iB
 Lj
 IO
 rr
@@ -43692,9 +43882,9 @@ xU
 wY
 EZ
 NY
+kT
 Tc
-Tc
-MQ
+cX
 wu
 Sc
 pB
@@ -43943,13 +44133,13 @@ vs
 Tc
 ec
 zJ
-Tc
+HF
 GN
-ir
+fp
 jf
-Tc
+Op
 ft
-ec
+Op
 Tc
 ay
 Af
@@ -44198,15 +44388,15 @@ MU
 wu
 Sc
 Tc
-qA
+Tc
 VV
-Tc
-ve
-Rf
-Kq
-Tc
+TO
+eP
+fF
+gW
+hw
 nM
-nC
+Tc
 Tc
 MU
 wu
@@ -44455,15 +44645,15 @@ Np
 sf
 cD
 Tc
-ck
+Tc
 Ui
-Tc
-tF
+ns
 yv
-oI
-Tc
+yv
+yv
+hx
 FP
-LM
+Tc
 Tc
 cD
 sf
@@ -44714,11 +44904,11 @@ YC
 Tc
 Tc
 Jn
-gH
-vS
-iG
-Ah
-gH
+Yn
+Vg
+Vg
+Vg
+Yn
 wW
 Tc
 Tc
@@ -44971,11 +45161,11 @@ Sc
 zA
 lO
 Xz
-pP
-uh
 Kv
-uh
-pP
+Kv
+Kv
+Kv
+Kv
 ej
 lD
 nV

--- a/_maps/map_files/Atlas/atlas2.dmm
+++ b/_maps/map_files/Atlas/atlas2.dmm
@@ -897,12 +897,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
 "ek" = (
@@ -1144,12 +1138,6 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
 "ft" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -1527,7 +1515,6 @@
 /turf/closed/wall/steel,
 /area/maintenance/nsv/deck2/frame1/port)
 "hq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/computer/ship/dradis{
 	dir = 8
 	},
@@ -1574,10 +1561,13 @@
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
 "hz" = (
-/obj/structure/disposalpipe/trunk{
+/obj/machinery/camera/autoname{
 	dir = 1
 	},
-/obj/machinery/disposal/bin,
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/structure/closet/radiation,
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
 "hA" = (
@@ -1612,7 +1602,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -1673,9 +1662,6 @@
 /area/crew_quarters/kitchen)
 "ij" = (
 /obj/structure/closet/radiation,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -2134,6 +2120,18 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/bridge/cic)
+"ke" = (
+/obj/effect/turf_decal/tile/ship/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/brown{
+	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/monotile/dark,
+/area/bridge/cic)
 "kh" = (
 /obj/structure/railing{
 	dir = 1
@@ -2161,10 +2159,13 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
 "ku" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/table/reinforced,
-/obj/structure/railing,
-/turf/open/floor/carpet/royalblack,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/turf/open/floor/monotile/steel,
 /area/bridge/cic)
 "kw" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -2188,6 +2189,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
 "kz" = (
@@ -2531,7 +2533,6 @@
 "lO" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/extinguisher_cabinet/west,
-/obj/machinery/photocopier,
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
 "lY" = (
@@ -2814,7 +2815,6 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "nL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/computer/communications{
 	dir = 8
 	},
@@ -2824,17 +2824,17 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
 /turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "nM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
 	},
 /obj/machinery/light,
 /obj/effect/turf_decal/stripes/line{
@@ -2971,11 +2971,10 @@
 /turf/open/floor/plasteel/ship/riveted,
 /area/maintenance/nsv/deck2/frame1/port)
 "ov" = (
-/obj/structure/closet/radiation,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/photocopier,
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
 "ox" = (
@@ -3508,7 +3507,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "rs" = (
@@ -4650,12 +4649,6 @@
 /turf/open/floor/plasteel/grid/lino,
 /area/ai_monitored/nuke_storage)
 "wW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -4678,12 +4671,11 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
 "wY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
 	},
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
@@ -4911,7 +4903,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "xY" = (
@@ -6022,7 +6013,6 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "DJ" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/chair/comfy/shuttle{
 	color = "#696969";
 	dir = 4;
@@ -6273,8 +6263,6 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
 "EZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -6617,7 +6605,6 @@
 /turf/open/floor/engine,
 /area/ai_monitored/turret_protected/aisat)
 "GG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -6664,10 +6651,6 @@
 	icon_state = "control_stun";
 	name = "upload turret control panel";
 	pixel_x = -32
-	},
-/obj/machinery/camera{
-	c_tag = "CIC - Aft";
-	dir = 4
 	},
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
@@ -7355,7 +7338,9 @@
 /turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "JU" = (
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
 "JV" = (
@@ -7371,12 +7356,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/blue,
@@ -8283,12 +8262,6 @@
 /turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
 "NY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -8432,8 +8405,8 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/xo)
 "OB" = (
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
@@ -8895,7 +8868,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
@@ -8910,6 +8882,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
 	},
 /turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
@@ -9558,7 +9533,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/table/reinforced,
 /obj/structure/railing{
 	dir = 1
@@ -41450,7 +41424,7 @@ Kp
 gq
 dF
 uj
-ei
+uj
 Ov
 zY
 RI
@@ -41967,8 +41941,8 @@ ct
 OB
 UK
 DJ
-ku
-JU
+dy
+Vg
 hz
 Tc
 iW
@@ -42480,8 +42454,8 @@ Tc
 dk
 JM
 kx
-Vg
-Vg
+ku
+JU
 Vg
 ik
 Tc
@@ -44026,7 +44000,7 @@ fp
 jf
 Op
 ft
-Op
+ke
 Tc
 ay
 Af
@@ -44281,7 +44255,7 @@ TO
 eP
 fF
 gW
-TO
+ff
 nM
 Tc
 Tc
@@ -44534,7 +44508,7 @@ cD
 Tc
 Tc
 Ui
-ns
+Tc
 yv
 yv
 yv

--- a/_maps/map_files/Atlas/atlas2.dmm
+++ b/_maps/map_files/Atlas/atlas2.dmm
@@ -633,7 +633,7 @@
 /area/hallway/nsv/deck1/hallway)
 "dk" = (
 /obj/structure/extinguisher_cabinet/north,
-/obj/structure/filingcabinet/chestdrawer,
+/obj/structure/closet/secure_closet/bridge,
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
 "dl" = (
@@ -728,6 +728,7 @@
 "dy" = (
 /obj/structure/table/reinforced,
 /obj/structure/railing,
+/obj/item/paper_bin,
 /turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "dz" = (
@@ -861,6 +862,7 @@
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
+/obj/machinery/light_switch/east,
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "ee" = (
@@ -884,11 +886,11 @@
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/bar/mess_hall)
 "ei" = (
-/obj/structure/sign/ship/nosmoking{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/ai_upload)
+/obj/structure/table/reinforced,
+/obj/structure/railing,
+/obj/item/radio/intercom,
+/turf/open/floor/carpet/royalblack,
+/area/bridge/cic)
 "ej" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -1040,7 +1042,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
 	id = "atlas_brief";
-	name = "courtroom_shutter";
+	name = "Bridge Shutters";
 	pixel_y = 2
 	},
 /turf/open/floor/monotile/dark,
@@ -1425,7 +1427,6 @@
 /area/maintenance/nsv/deck2/frame1/central)
 "gN" = (
 /obj/structure/table/reinforced,
-/obj/item/radio/intercom,
 /obj/structure/railing{
 	dir = 1
 	},
@@ -1569,9 +1570,6 @@
 /area/bridge/cic)
 "hx" = (
 /obj/item/storage/secure/safe/caps_spare,
-/obj/structure/sign/ship/nosmoking{
-	dir = 4
-	},
 /turf/closed/wall/r_wall,
 /area/bridge/cic)
 "hy" = (
@@ -2559,6 +2557,7 @@
 "lO" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/extinguisher_cabinet/west,
+/obj/machinery/photocopier,
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
 "lY" = (
@@ -2791,7 +2790,7 @@
 /area/hallway/nsv/deck1/hallway)
 "ns" = (
 /obj/structure/sign/ship/nosmoking{
-	dir = 4
+	dir = 1
 	},
 /turf/closed/wall/r_wall,
 /area/bridge/cic)
@@ -2999,7 +2998,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/photocopier,
+/obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
 "ox" = (
@@ -3093,6 +3092,10 @@
 "oZ" = (
 /obj/machinery/computer/upload/ai{
 	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "AI Upload";
+	dir = 10
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -3210,10 +3213,6 @@
 "pE" = (
 /obj/effect/turf_decal/stripes/box,
 /obj/machinery/recharge_station,
-/obj/machinery/camera{
-	c_tag = "AI Upload";
-	dir = 8
-	},
 /turf/open/floor/monotile/steel,
 /area/ai_monitored/turret_protected/ai_upload)
 "pF" = (
@@ -6492,15 +6491,19 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/door/airlock/ship/command{
-	name = "Bridge";
-	req_one_access_txt = "19"
-	},
 /obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/command{
+	name = "Bridge";
+	req_one_access_txt = "19"
+	},
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "FR" = (
@@ -6683,6 +6686,9 @@
 	icon_state = "control_stun";
 	name = "upload turret control panel";
 	pixel_x = -32
+	},
+/obj/machinery/light_switch/west{
+	pixel_x = -19
 	},
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
@@ -8759,6 +8765,17 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/carpet/red,
 /area/security/detectives_office)
+"Qv" = (
+/obj/effect/turf_decal/tile/ship/green,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	dir = 10;
+	icon_state = "camera"
+	},
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck1/hallway)
 "Qw" = (
 /obj/effect/decal/cleanable/glitter/white{
 	layer = 4.1;
@@ -9440,6 +9457,10 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/effect/landmark/zebra_interlock_point,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /obj/machinery/door/airlock/ship/command{
 	name = "Bridge";
 	req_one_access_txt = "19"
@@ -9573,7 +9594,7 @@
 	},
 /obj/machinery/button/door{
 	id = "atlas_brief";
-	name = "courtroom_shutter";
+	name = "Bridge Shutters";
 	pixel_x = -9;
 	pixel_y = 2
 	},
@@ -10091,6 +10112,8 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/structure/extinguisher_cabinet/north,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "XT" = (
@@ -41462,7 +41485,7 @@ uj
 Ov
 zY
 RI
-ei
+uj
 uj
 dF
 gq
@@ -42239,7 +42262,7 @@ Qh
 je
 Em
 wu
-Sc
+Qv
 MS
 Va
 rO
@@ -42492,7 +42515,7 @@ ku
 JU
 Vg
 ik
-Tc
+ns
 jB
 gR
 wu
@@ -42748,7 +42771,7 @@ XH
 qT
 gN
 YK
-dy
+ei
 Tc
 Am
 IY
@@ -42998,7 +43021,7 @@ MQ
 wu
 Sc
 Tc
-ns
+Tc
 KD
 Li
 NI


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changed the CIC of the atlas to something with more INFORMATION, as per the name.
It keeps the armoured feel, adds side viewing windows, an elevated command section, and secondary bridge staff stations for engineering data, security data, medical data, and cargo stuff.

In-Game Screenshot:
![Screenshot 2021-09-30 001307](https://user-images.githubusercontent.com/56017258/135356077-3f05756b-8ace-4639-85ee-44e31ba92adb.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Don't skimp on CICs, we need more intel.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Tweaked the Atlas CIC to reorganize consoles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
