### PR TITLE
Adds option to use a different projectile type for overmap damage relaying.

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -106,6 +106,7 @@
 	var/impact_effect_type //what type of impact effect to show when hitting something
 	var/log_override = FALSE //is this type spammed enough to not log? (KAs)
 	var/faction = null //NSV13 - bullets need factions for collision checks
+	var/relay_projectile_type = null	//NSV13 - backend for some projectiles creating a different projectile than they are when relayed to a ship after hitting. I hate having this this far up in inheritance, but no overmap bullet subtype.
 	var/next_homing_process = 0 //Nsv13 - performance enhancements
 	var/homing_delay = 0.7 SECONDS //Nsv13 - performance enhancements. 1 second delay is noticeably slow
 	var/martial_arts_no_deflect = FALSE

--- a/nsv13/code/modules/overmap/weapons/damage.dm
+++ b/nsv13/code/modules/overmap/weapons/damage.dm
@@ -38,7 +38,8 @@ Bullet reactions
 			impact_sound_cooldown = TRUE
 			addtimer(VARSET_CALLBACK(src, impact_sound_cooldown, FALSE), 0.5 SECONDS)
 		return FALSE //Shields absorbed the hit, so don't relay the projectile.
-	relay_damage(P?.type)
+	var/relayed_type = P.relay_projectile_type ? P.relay_projectile_type : P.type
+	relay_damage(relayed_type)
 	if(!use_armour_quadrants)
 		. = ..()
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. This has absolutely zero effect on gameplay, but it adds a few lines of backend to support having a projectile create a different projectile type than it itself is when it relays itself to an overmap's z level.
This might be useful for some things that need different behavior for if on a ship z or if on an overmap, and don't want an entire split block for this situation.
I'd not put it into the parent type of projectile, but unfortunately we don't have a common parent type for overmap bullets, so it'll have to do.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Nothing using it yet, might become useful if someone feels like this behavior is wanted for their projectile.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: Adds some very minor backend for relayed projectiles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
