### PR TITLE
Armada sieging now freezes Sol system combat

### DIFF
--- a/nsv13/code/modules/overmap/fleet_combat/solar_siege.dm
+++ b/nsv13/code/modules/overmap/fleet_combat/solar_siege.dm
@@ -5,10 +5,6 @@ Note: This expects the EDF to be in Sol, and not somewhere in Brazil due to admi
 */
 
 /datum/star_system/sol/handle_combat()
-	. = ..()
-	if(. == COMBAT_SKIPPED)
-		return
-
 	var/datum/fleet/siege_fleet
 	var/datum/fleet/defense_fleet
 
@@ -38,3 +34,6 @@ Note: This expects the EDF to be in Sol, and not somewhere in Brazil due to admi
 	else if(solar_siege_cycles_left < solar_siege_cycles_needed)
 		solar_siege_cycles_left = solar_siege_cycles_needed
 		priority_announce("Hostile invasion fleet in Sol has been successfully neutralized. All vessels are to return to their regular patrol patterns.", "White Rapids Fleetwide Announcement")
+	
+	if(!siege_fleet)
+		return ..()

--- a/nsv13/code/modules/overmap/fleet_combat/solar_siege.dm
+++ b/nsv13/code/modules/overmap/fleet_combat/solar_siege.dm
@@ -37,3 +37,5 @@ Note: This expects the EDF to be in Sol, and not somewhere in Brazil due to admi
 	
 	if(!siege_fleet)
 		return ..()
+	else
+		return COMBAT_SKIPPED


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title.
While it was interesting for players to arrive to both fleets already banged up, it's kinda anticlimatic for them to drop everything and rush there just for one nuke ship to remain or something like that.
Additionally it'll prevent all jank related to strength of any related fleets finishing combat pre siege timer end.
Yes, this means players *need* to be there now and can't just sometimes be lucky and have the EDF win it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Should be way better and cause less jank than the current implementation.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: The armada sieging Sol now freezes simulated combat in the system.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
