### PR TITLE
Fixes Dradis ghost radar bug

### DIFF
--- a/nsv13/code/modules/overmap/radar.dm
+++ b/nsv13/code/modules/overmap/radar.dm
@@ -90,12 +90,12 @@ Called by add_sensor_profile_penalty if remove_in is used.
 
 /obj/machinery/computer/ship/dradis/proc/send_radar_pulse()
 	var/obj/structure/overmap/OM = get_overmap()
-	if(!can_radar_pulse())
+	if(!OM || !can_radar_pulse())
 		return FALSE
-	OM?.send_radar_pulse()
+	OM.send_radar_pulse()
 	addtimer(VARSET_CALLBACK(src, sensor_range, base_sensor_range), RADAR_VISIBILITY_PENALTY)
 	sensor_range = world.maxx
-	OM?.add_sensor_profile_penalty(sensor_range, RADAR_VISIBILITY_PENALTY)
+	OM.add_sensor_profile_penalty(sensor_range, RADAR_VISIBILITY_PENALTY)
 
 /obj/machinery/computer/ship/dradis/examine(mob/user)
 	. = ..()
@@ -193,9 +193,9 @@ Called by add_sensor_profile_penalty if remove_in is used.
 		ui = new(user, src, "Dradis")
 		ui.open()
 
-/obj/machinery/computer/ship/dradis/ui_act(action, params, datum/tgui/ui, mob/user)
+/obj/machinery/computer/ship/dradis/ui_act(action, params)
 	. = ..()
-	if(isobserver(user))
+	if(isobserver(usr))
 		return
 	if(.)
 		return
@@ -377,11 +377,14 @@ Called by add_sensor_profile_penalty if remove_in is used.
 	data["showAnomalies"] = showAnomalies
 	data["sensor_range"] = sensor_range
 	data["width_mod"] = sensor_range / SENSOR_RANGE_DEFAULT
-	data["can_radar_pulse"] = can_radar_pulse()
 	data["sensor_mode"] = (sensor_mode == SENSOR_MODE_PASSIVE) ? "Passive Radar" : "Active Radar"
 	data["pulse_delay"] = "[radar_delay / 10]"
-	if(sensor_mode == SENSOR_MODE_RADAR && !isobserver(user) && can_radar_pulse())
-		send_radar_pulse()
+	if(can_radar_pulse())
+		data["can_radar_pulse"] = TRUE
+		if(sensor_mode == SENSOR_MODE_RADAR && !isobserver(user))
+			send_radar_pulse()
+	else
+		data["can_radar_pulse"] = FALSE
 	return data
 
 /datum/asset/simple/overmap_flight


### PR DESCRIPTION
fixes #1677

## About The Pull Request

Fixes two oversights with Dradis consoles. One in ui_data where `send_radar_pulse()` was unconditionally called if it was in active radar mode. And the other in ui_interact which used an invalid mob argument. Both of these allowed any mob (including observers) to spam call radar regardless of MIN_RADAR_DELAY.

## Changelog
:cl:
fix: Fixes Dradis ghost interaction
fix: Radar can no longer be spammed faster than the radar delay
/:cl:
