### PR TITLE
Makes job selection prioritize a few NSV critical jobs before main loop

### DIFF
--- a/_maps/map_files/Galactica/job_changes.dm
+++ b/_maps/map_files/Galactica/job_changes.dm
@@ -16,7 +16,7 @@
     total_positions = 5
     spawn_positions = 5
 
-/datum/job/munitions_technician/New()
+/datum/job/munitions_tech/New()
     ..()
     MAP_JOB_CHECK
     total_positions = 12


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Job selection will now try to assign 2 head positions, one engineer position, one munitions tech position, one bridge staff position, and one mining position before normal job selection.

## Why It's Good For The Game
I can ready up with less fear! Helps ensure round-critical roles are filled

## Changelog
:cl:
tweak: Tweaked job selection order to prioritize critical jobs
fix: Fixed the Galactica job changes file, which used the wrong path for the munitions tech job
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
