### PR TITLE
Makes shake_with_inertia() NOT kill performance

### DIFF
--- a/nsv13/code/game/machinery/inertial_dampener.dm
+++ b/nsv13/code/game/machinery/inertial_dampener.dm
@@ -3,6 +3,8 @@
 #define EfficiencyToRange(part_efficiency) (2.5 * (part_efficiency))
 #define RangeToEfficiency(range) ((range) / 2.5)
 
+GLOBAL_LIST_EMPTY(inertia_dampeners)
+
 /obj/machinery/inertial_dampener
 	name = "inertial dampener"
 	icon = 'nsv13/icons/obj/machinery/inertial_dampener.dmi'
@@ -35,7 +37,12 @@
 
 /obj/machinery/inertial_dampener/Initialize()
 	. = ..()
+	GLOB.inertia_dampeners += src
 	RefreshParts()
+
+/obj/machinery/inertial_dampener/Destroy()
+	GLOB.inertia_dampeners -= src
+	. = ..()
 
 /obj/machinery/inertial_dampener/proc/try_use_power()
 	var/turf/T = get_turf(src)

--- a/nsv13/code/game/machinery/inertial_dampener.dm
+++ b/nsv13/code/game/machinery/inertial_dampener.dm
@@ -42,7 +42,7 @@ GLOBAL_LIST_EMPTY(inertia_dampeners)
 
 /obj/machinery/inertial_dampener/Destroy()
 	GLOB.inertia_dampeners -= src
-	. = ..()
+	return ..()
 
 /obj/machinery/inertial_dampener/proc/try_use_power()
 	var/turf/T = get_turf(src)

--- a/nsv13/code/modules/mob/mob_helpers.dm
+++ b/nsv13/code/modules/mob/mob_helpers.dm
@@ -1,22 +1,24 @@
 
 /proc/shake_with_inertia(mob/M, duration=0, strength=1, dampenerData=null)
-	if ( M.ckey ) // These inertial dampener checks are probably expensive, we're only going to run calculations on people who are able to observe these camera shakes 
+	set waitfor = FALSE
+	if(M.ckey) // These inertial dampener checks are probably expensive, we're only going to run calculations on people who are able to observe these camera shakes 
 		var/nearestDistance = INFINITY
 		var/obj/machinery/inertial_dampener/nearestMachine = null
 
-		if ( dampenerData && islist( dampenerData ) )
+		if(dampenerData && islist(dampenerData))
 			// if we are already provided a nearest machine, we don't have to look for it 
 			var/list/D = dampenerData
-			nearestDistance = D[ "distance" ]
-			nearestMachine = D[ "machine" ] 
+			nearestDistance = D["distance"]
+			nearestMachine = D["machine"] 
 		else 
-			for(var/obj/machinery/inertial_dampener/machine in GLOB.machines)
-				var/dist = get_dist( M, machine )
-				if ( dist < nearestDistance && machine.on )
+			for(var/obj/machinery/inertial_dampener/machine in GLOB.inertia_dampeners)
+				CHECK_TICK	//Usually shouldn't happen but if someone makes 20000 dampeners for some reason might be useful.
+				var/dist = get_dist(M, machine)
+				if(dist < nearestDistance && machine.on)
 					nearestDistance = dist 
 					nearestMachine = machine
 
-		if ( nearestMachine ) 
-			strength = nearestMachine.reduceStrength( nearestDistance, strength ) 
+		if(nearestMachine) 
+			strength = nearestMachine.reduceStrength(nearestDistance, strength) 
 
-	shake_camera( M, duration, strength )
+	shake_camera(M, duration, strength)

--- a/nsv13/code/modules/mob/mob_helpers.dm
+++ b/nsv13/code/modules/mob/mob_helpers.dm
@@ -12,7 +12,6 @@
 			nearestMachine = D["machine"] 
 		else 
 			for(var/obj/machinery/inertial_dampener/machine in GLOB.inertia_dampeners)
-				CHECK_TICK	//Usually shouldn't happen but if someone makes 20000 dampeners for some reason might be useful.
 				var/dist = get_dist(M, machine)
 				if(dist < nearestDistance && machine.on)
 					nearestDistance = dist 

--- a/nsv13/code/modules/mob/mob_helpers.dm
+++ b/nsv13/code/modules/mob/mob_helpers.dm
@@ -5,13 +5,13 @@
 		var/nearestDistance = INFINITY
 		var/obj/machinery/inertial_dampener/nearestMachine = null
 
-		if(dampenerData && islist(dampenerData))
+		if(islist(dampenerData))
 			// if we are already provided a nearest machine, we don't have to look for it 
 			var/list/D = dampenerData
 			nearestDistance = D["distance"]
 			nearestMachine = D["machine"] 
 		else 
-			for(var/obj/machinery/inertial_dampener/machine in GLOB.inertia_dampeners)
+			for(var/obj/machinery/inertial_dampener/machine as anything in GLOB.inertia_dampeners)
 				var/dist = get_dist(M, machine)
 				if(dist < nearestDistance && machine.on)
 					nearestDistance = dist 

--- a/nsv13/code/modules/overmap/ftl.dm
+++ b/nsv13/code/modules/overmap/ftl.dm
@@ -281,7 +281,7 @@
 		var/obj/machinery/inertial_dampener/nearestMachine = null
 
 		// Going to helpfully pass this in after seasickness checks, to reduce duplicate machine checks
-		for(var/obj/machinery/inertial_dampener/machine in GLOB.inertia_dampeners)
+		for(var/obj/machinery/inertial_dampener/machine as anything in GLOB.inertia_dampeners)
 			var/dist = get_dist( M, machine )
 			if ( dist < nearestDistance && machine.on )
 				nearestDistance = dist

--- a/nsv13/code/modules/overmap/ftl.dm
+++ b/nsv13/code/modules/overmap/ftl.dm
@@ -281,7 +281,7 @@
 		var/obj/machinery/inertial_dampener/nearestMachine = null
 
 		// Going to helpfully pass this in after seasickness checks, to reduce duplicate machine checks
-		for(var/obj/machinery/inertial_dampener/machine in GLOB.machines)
+		for(var/obj/machinery/inertial_dampener/machine in GLOB.inertia_dampeners)
 			var/dist = get_dist( M, machine )
 			if ( dist < nearestDistance && machine.on )
 				nearestDistance = dist


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Shake with inertia, for every call, went through EVERY SINGLE thing in the machinery list. For every mob with a ckey in the worst case aka ship hits. That list has over 17000 things in it, roundstart!
This PR gives inertia dampeners their own list that can be gone through for it, and should NOT kill the server. Also has a check_tick and doesn't force procs to wait, as neither should be neccessary.
Edit: Jumps now also use that list, since those had the same issue (though obviously less pronounced since you don't get 10 jumps in a second usually)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
![](https://cdn.discordapp.com/attachments/602204840180842497/898999823087333386/unknown.png)
fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: shake_with_inertia and FTL shake no longer kill performance.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
