### PR TITLE
Makes solgov seals and flags not pixelshifted

### DIFF
--- a/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
@@ -1,6 +1,8 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aaf" = (
-/obj/structure/sign/solgov_seal,
+/obj/structure/sign/solgov_seal{
+	pixel_y = 26
+},
 /obj/machinery/chem_master/condimaster,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/kitchen)
@@ -2609,6 +2611,7 @@
 	dir = 8
 	},
 /obj/structure/sign/solgov_flag/right{
+	pixel_y = 26
 	layer = 2.79
 	},
 /turf/open/floor/carpet/ship/blue,
@@ -7554,6 +7557,7 @@
 /area/hydroponics)
 "eSB" = (
 /obj/structure/sign/solgov_flag/right{
+	pixel_y = 26
 	layer = 2.79
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
@@ -8392,7 +8396,9 @@
 /area/maintenance/department/medical)
 "fub" = (
 /obj/structure/table,
-/obj/structure/sign/solgov_seal,
+/obj/structure/sign/solgov_seal{
+	pixel_y = 26
+},
 /obj/item/storage/firstaid/regular{
 	pixel_x = 6;
 	pixel_y = 6
@@ -15533,6 +15539,7 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/structure/sign/solgov_flag/right{
+	pixel_y = 26
 	layer = 2.79
 	},
 /obj/structure/disposalpipe/segment{
@@ -22400,6 +22407,7 @@
 /area/maintenance/department/engine)
 "oMl" = (
 /obj/structure/sign/solgov_flag/right{
+	pixel_y = 26
 	layer = 2.79
 	},
 /obj/machinery/jukebox,
@@ -23596,6 +23604,7 @@
 /area/chapel/main)
 "pya" = (
 /obj/structure/sign/solgov_flag{
+	pixel_y = 26
 	layer = 2.79
 	},
 /turf/open/floor/carpet/ship/red_carpet,
@@ -26645,6 +26654,7 @@
 /area/medical/chemistry)
 "rCz" = (
 /obj/structure/sign/solgov_flag{
+	pixel_y = 26
 	layer = 2.79
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
@@ -27297,7 +27307,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/sign/solgov_seal,
+/obj/structure/sign/solgov_seal{
+	pixel_y = 26
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -27827,6 +27839,7 @@
 	dir = 4
 	},
 /obj/structure/sign/solgov_flag{
+	pixel_y = 26
 	layer = 2.79
 	},
 /turf/open/floor/carpet/ship/blue,
@@ -28586,7 +28599,9 @@
 /area/engine/engine_room)
 "sSm" = (
 /obj/structure/table/glass,
-/obj/structure/sign/solgov_seal,
+/obj/structure/sign/solgov_seal{
+	pixel_y = 26
+},
 /obj/machinery/light_switch/east,
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -30917,6 +30932,7 @@
 /area/engine/atmospherics_engine)
 "uzJ" = (
 /obj/structure/sign/solgov_flag{
+	pixel_y = 26
 	layer = 2.79
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -31566,6 +31582,7 @@
 	dir = 8
 	},
 /obj/structure/sign/solgov_flag{
+	pixel_y = 26
 	layer = 2.79
 	},
 /obj/structure/closet/secure_closet/hos,
@@ -32125,7 +32142,9 @@
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
 "vsb" = (
-/obj/structure/sign/solgov_seal,
+/obj/structure/sign/solgov_seal{
+	pixel_y = 26
+},
 /obj/structure/cable/yellow{
 	icon_state = "0-9"
 	},
@@ -32267,6 +32286,7 @@
 /area/engine/engine_smes)
 "vwM" = (
 /obj/structure/sign/solgov_flag/right{
+	pixel_y = 26
 	layer = 2.79
 	},
 /turf/open/floor/carpet/ship/red_carpet,

--- a/_maps/map_files/Aetherwhisp/Aetherwhisp2.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp2.dmm
@@ -180,6 +180,7 @@
 /area/maintenance/department/science/central)
 "agV" = (
 /obj/structure/sign/solgov_flag{
+	pixel_y = 26
 	layer = 2.79
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
@@ -876,6 +877,7 @@
 /area/medical/genetics)
 "aDf" = (
 /obj/structure/sign/solgov_flag/right{
+	pixel_y = 26
 	layer = 2.79
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
@@ -1162,6 +1164,7 @@
 /area/engine/engine_smes)
 "aMY" = (
 /obj/structure/sign/solgov_flag{
+	pixel_y = 26
 	layer = 2.79
 	},
 /turf/open/floor/carpet/ship/orange_carpet,
@@ -1430,7 +1433,9 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/bridge)
 "aYy" = (
-/obj/structure/sign/solgov_seal,
+/obj/structure/sign/solgov_seal{
+	pixel_y = 26
+},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
@@ -2058,6 +2063,7 @@
 "brD" = (
 /obj/machinery/computer/crew,
 /obj/structure/sign/solgov_flag/right{
+	pixel_y = 26
 	layer = 2.79
 	},
 /turf/open/floor/carpet/ship/blue{
@@ -2609,6 +2615,7 @@
 /area/medical/genetics)
 "bFE" = (
 /obj/structure/sign/solgov_flag/right{
+	pixel_y = 26
 	layer = 2.79
 	},
 /turf/open/floor/carpet/orange,
@@ -3468,7 +3475,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/sign/solgov_seal,
+/obj/structure/sign/solgov_seal{
+	pixel_y = 26
+},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -3488,7 +3497,9 @@
 /obj/machinery/recharger{
 	pixel_x = -7
 	},
-/obj/structure/sign/solgov_seal,
+/obj/structure/sign/solgov_seal{
+	pixel_y = 26
+},
 /turf/open/floor/carpet/ship,
 /area/bridge/secondary)
 "cqn" = (
@@ -6323,7 +6334,9 @@
 /area/bridge/meeting_room/council)
 "ezp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/obj/structure/sign/solgov_seal,
+/obj/structure/sign/solgov_seal{
+	pixel_y = 26
+},
 /obj/machinery/camera/autoname,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms)
@@ -6602,6 +6615,7 @@
 /area/quartermaster/storage)
 "eIc" = (
 /obj/structure/sign/solgov_flag{
+	pixel_y = 26
 	layer = 2.79
 	},
 /obj/machinery/suit_storage_unit/standard_unit,
@@ -7359,6 +7373,7 @@
 "fif" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/structure/sign/solgov_flag/right{
+	pixel_y = 26
 	layer = 2.79
 	},
 /turf/open/floor/carpet/ship/blue{
@@ -7820,7 +7835,9 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/obj/structure/sign/solgov_flag/right,
+/obj/structure/sign/solgov_flag/right{
+	pixel_y = 26
+	},
 /turf/open/floor/holofloor/wood,
 /area/science/computer_lab)
 "fyz" = (
@@ -10196,7 +10213,9 @@
 /turf/open/floor/plating,
 /area/science/computer_lab)
 "hgk" = (
-/obj/structure/sign/solgov_seal,
+/obj/structure/sign/solgov_seal{
+	pixel_y = 26
+},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "hgK" = (
@@ -11627,7 +11646,9 @@
 /area/nsv/weapons/starboard)
 "ikq" = (
 /obj/machinery/camera/autoname,
-/obj/structure/sign/solgov_seal,
+/obj/structure/sign/solgov_seal{
+	pixel_y = 26
+},
 /turf/open/floor/engine/vacuum,
 /area/nsv/hanger)
 "ikZ" = (
@@ -11660,6 +11681,7 @@
 /obj/item/aicard,
 /obj/item/computer_hardware/ai_slot,
 /obj/structure/sign/solgov_flag{
+	pixel_y = 26
 	layer = 2.79
 	},
 /turf/open/floor/carpet/ship/blue{
@@ -12304,6 +12326,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet/hop,
 /obj/structure/sign/solgov_flag/right{
+	pixel_y = 26
 	layer = 2.79
 	},
 /obj/item/radio/intercom/directional{
@@ -15519,7 +15542,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/obj/structure/sign/solgov_seal,
+/obj/structure/sign/solgov_seal{
+	pixel_y = 26
+},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -16187,6 +16212,7 @@
 	pixel_y = 5
 	},
 /obj/structure/sign/solgov_flag{
+	pixel_y = 26
 	layer = 2.79
 	},
 /turf/open/floor/holofloor/wood,
@@ -17062,6 +17088,7 @@
 	icon_state = "0-2"
 	},
 /obj/structure/sign/solgov_flag{
+	pixel_y = 26
 	layer = 2.79
 	},
 /turf/open/floor/wood,
@@ -17803,6 +17830,7 @@
 /area/ai_monitored/turret_protected/aisat/hallway)
 "mHQ" = (
 /obj/structure/sign/solgov_flag{
+	pixel_y = 26
 	layer = 2.79
 	},
 /obj/structure/table/glass,
@@ -18451,7 +18479,9 @@
 "njy" = (
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /obj/machinery/light_switch/west,
-/obj/structure/sign/solgov_seal,
+/obj/structure/sign/solgov_seal{
+	pixel_y = 26
+},
 /turf/open/floor/plating,
 /area/nsv/weapons/fore)
 "njz" = (
@@ -18578,6 +18608,7 @@
 /area/crew_quarters/dorms)
 "nmy" = (
 /obj/structure/sign/solgov_flag/right{
+	pixel_y = 26
 	layer = 2.79
 	},
 /turf/open/floor/carpet,
@@ -18798,6 +18829,7 @@
 "nwA" = (
 /obj/machinery/photocopier,
 /obj/structure/sign/solgov_flag/right{
+	pixel_y = 26
 	layer = 2.79
 	},
 /turf/open/floor/wood,
@@ -22549,7 +22581,9 @@
 /area/bridge/meeting_room/council)
 "pSM" = (
 /obj/machinery/mecha_part_fabricator,
-/obj/structure/sign/solgov_seal,
+/obj/structure/sign/solgov_seal{
+	pixel_y = 26
+},
 /turf/open/floor/engine,
 /area/science/robotics/lab)
 "pTc" = (
@@ -23352,6 +23386,7 @@
 	dir = 4
 	},
 /obj/structure/sign/solgov_flag/right{
+	pixel_y = 26
 	layer = 2.79
 	},
 /obj/machinery/photocopier,
@@ -24621,7 +24656,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "rnm" = (
-/obj/structure/sign/solgov_seal,
+/obj/structure/sign/solgov_seal{
+	pixel_y = 26
+},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/ship/preopen{
 	dir = 4;
@@ -25556,7 +25593,9 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 5
 	},
-/obj/structure/sign/solgov_seal,
+/obj/structure/sign/solgov_seal{
+	pixel_y = 26
+},
 /obj/structure/cable/pink{
 	icon_state = "0-8"
 	},
@@ -28495,6 +28534,7 @@
 	dir = 4
 	},
 /obj/structure/sign/solgov_flag{
+	pixel_y = 26
 	layer = 2.79
 	},
 /obj/machinery/computer/cargo/request,
@@ -28765,7 +28805,9 @@
 /area/maintenance/department/science/central)
 "ume" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
-/obj/structure/sign/solgov_seal,
+/obj/structure/sign/solgov_seal{
+	pixel_y = 26
+},
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/mixing)
 "umH" = (
@@ -31426,7 +31468,9 @@
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/xenobiology)
 "wys" = (
-/obj/structure/sign/solgov_seal,
+/obj/structure/sign/solgov_seal{
+	pixel_y = 26
+},
 /turf/open/floor/carpet,
 /area/library)
 "wyv" = (
@@ -31642,7 +31686,9 @@
 	},
 /area/bridge)
 "wFT" = (
-/obj/structure/sign/solgov_seal,
+/obj/structure/sign/solgov_seal{
+	pixel_y = 26
+},
 /obj/structure/rack,
 /obj/item/storage/box/monkeycubes{
 	pixel_x = 4;
@@ -32244,6 +32290,7 @@
 	},
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/structure/sign/solgov_flag{
+	pixel_y = 26
 	layer = 2.79
 	},
 /turf/open/floor/carpet/ship/blue{
@@ -32985,7 +33032,9 @@
 /turf/open/floor/engine,
 /area/bridge)
 "xAR" = (
-/obj/structure/sign/solgov_seal,
+/obj/structure/sign/solgov_seal{
+	pixel_y = 26
+},
 /obj/machinery/light{
 	dir = 1
 	},

--- a/_maps/map_files/Tycoon/Tycoon2.dmm
+++ b/_maps/map_files/Tycoon/Tycoon2.dmm
@@ -1677,12 +1677,10 @@
 /area/hallway/secondary/exit/departure_lounge)
 "aen" = (
 /obj/machinery/vending/snack/random,
-/obj/structure/sign/solgov_flag,
 /turf/open/floor/monotile/steel,
 /area/hallway/secondary/exit)
 "aeo" = (
 /obj/machinery/vending/cola/random,
-/obj/structure/sign/solgov_flag/right,
 /turf/open/floor/monotile/steel,
 /area/hallway/secondary/exit)
 "aep" = (
@@ -1805,12 +1803,10 @@
 /area/nsv/hanger/deck2)
 "aeE" = (
 /obj/structure/chair,
-/obj/structure/sign/solgov_flag,
 /turf/open/floor/monotile/steel,
 /area/hallway/secondary/exit)
 "aeF" = (
 /obj/structure/chair,
-/obj/structure/sign/solgov_flag/right,
 /turf/open/floor/monotile/steel,
 /area/hallway/secondary/exit)
 "aeG" = (
@@ -3857,11 +3853,9 @@
 /turf/open/floor/monotile/dark,
 /area/medical/surgery)
 "ajO" = (
-/obj/structure/sign/solgov_flag,
 /turf/open/floor/carpet/ship,
 /area/quartermaster/qm)
 "ajP" = (
-/obj/structure/sign/solgov_flag/right,
 /turf/open/floor/carpet/ship,
 /area/quartermaster/qm)
 "ajQ" = (
@@ -23409,7 +23403,6 @@
 	name = "Mess hall"
 	})
 "bgb" = (
-/obj/structure/sign/solgov_seal,
 /obj/machinery/camera/autoname,
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit/departure_lounge)
@@ -23883,7 +23876,6 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
-/obj/structure/sign/solgov_seal,
 /obj/machinery/light{
 	dir = 1
 	},

--- a/nsv13/code/game/turfs/custom_signs.dm
+++ b/nsv13/code/game/turfs/custom_signs.dm
@@ -3,14 +3,12 @@
 	desc = "A seal emblazened with a gold trim depicting the star, sol."
 	icon = 'nsv13/icons/obj/solgov_logos.dmi'
 	icon_state = "solgovseal"
-	pixel_y = 27
 
 /obj/structure/sign/solgov_flag
 	name = "solgov banner"
 	desc = "A large flag displaying the logo of solgov, the local government of the sol system."
 	icon = 'nsv13/icons/obj/solgov_logos.dmi'
 	icon_state = "solgovflag-left"
-	pixel_y = 26
 
 /obj/structure/sign/solgov_flag/right
 	icon_state = "solgovflag-right"


### PR DESCRIPTION
## About The Pull Request

Removes the pixelshifts on solgov related wall decorations and removes leftover solgov logos from the Tycoon.

## Why It's Good For The Game

Pixelshifts in object definitions bad (You're next viewscreens)

## Changelog
:cl:
del: Removed some old Solgov logos from Tycoon
code: Fixed solgov decorations being pixelshifted in their definition
/:cl: