### PR TITLE
Moves the fighter ammo to the missile storage room on tycoon

### DIFF
--- a/_maps/map_files/Tycoon/Tycoon1.dmm
+++ b/_maps/map_files/Tycoon/Tycoon1.dmm
@@ -6949,10 +6949,6 @@
 /obj/item/fighter_component/avionics,
 /obj/item/fighter_component/avionics,
 /obj/structure/rack,
-/obj/item/ammo_box/magazine/nsv/heavy_cannon,
-/obj/item/ammo_box/magazine/nsv/heavy_cannon,
-/obj/item/ammo_box/magazine/nsv/heavy_cannon,
-/obj/item/ammo_box/magazine/nsv/light_cannon,
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
 "LI" = (

--- a/_maps/map_files/Tycoon/Tycoon2.dmm
+++ b/_maps/map_files/Tycoon/Tycoon2.dmm
@@ -315,10 +315,24 @@
 /turf/open/floor/carpet/ship,
 /area/nsv/crew_quarters/heads/maa)
 "aaR" = (
+/obj/item/ammo_box/magazine/nsv/heavy_cannon,
+/obj/item/ammo_box/magazine/nsv/heavy_cannon,
+/obj/item/ammo_box/magazine/nsv/heavy_cannon,
+/obj/item/ammo_box/magazine/nsv/heavy_cannon,
+/obj/item/ammo_box/magazine/nsv/heavy_cannon,
+/obj/item/ammo_box/magazine/nsv/heavy_cannon,
+/obj/item/ammo_box/magazine/nsv/light_cannon,
+/obj/item/ammo_box/magazine/nsv/light_cannon,
+/obj/item/ammo_box/magazine/nsv/light_cannon,
+/obj/item/ammo_box/magazine/nsv/light_cannon,
+/obj/item/ammo_box/magazine/nsv/light_cannon,
+/obj/item/ammo_box/magazine/nsv/light_cannon,
+/obj/item/ammo_box/magazine/nsv/light_cannon,
+/obj/item/ammo_box/magazine/nsv/light_cannon,
+/obj/structure/rack,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/reagent_dispensers/fueltank/cryogenic_fuel,
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2)
 "aaS" = (
@@ -48921,6 +48935,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"qBr" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/fueltank/cryogenic_fuel,
+/turf/open/floor/plating,
+/area/nsv/hanger/deck2)
 "qBT" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 1
@@ -90526,7 +90547,7 @@ xsc
 aam
 bIy
 aaG
-aaG
+qBr
 aaR
 aam
 bfj


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Moves the fighter ammo from the figher building area to the missile storage room
Fixes #1561
## Why It's Good For The Game
It makes it so you don't have to stumble around the flight deck looking for the fighter building area to get some ammo.

## Changelog
:cl:
fix: fixes #1561
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
