### PR TITLE
Fixes any proc using mobs_in_ship without typechecks runtiming

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -25,9 +25,11 @@
 	remove_from_dead_mob_list()
 	remove_from_alive_mob_list()
 	focus = null
+	//NSV13 change - Cleans up mobs_in_ship list on mob delete.
 	if(last_overmap)
 		last_overmap.mobs_in_ship -= src
 		last_overmap = null
+	//NSV13 change end.
 	for (var/alert in alerts)
 		clear_alert(alert, TRUE)
 	if(observers?.len)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
One would think it'd be safe to use as anything with that list as there should only be mobs in it.
Well, thats what you thought, in reality it's not cleaned up when mobs are deleted and full of null refs.
This makes mobs be removed from their ship's mob list on deletion, hopefully solving that problem.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Turns out that list was NOT safe.
Fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Things using mobs_in_ship no longer break as soon as one mob on one is deleted.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
