### PR TITLE
Hotfix for social supplies cargo objective

### DIFF
--- a/nsv13/code/game/gamemodes/overmap/objectives/cargo/donation/social_supplies.dm
+++ b/nsv13/code/game/gamemodes/overmap/objectives/cargo/donation/social_supplies.dm
@@ -31,7 +31,7 @@
 	var/atom/parcel = /obj/item/smallDelivery
 	var/datum/freight_type/reagent/presents = new /datum/freight_type/object( parcel )
 	presents.target = 3
-	presents.item_name = "wrapped parcel"
+	presents.item_name = "3 wrapped parcels"
 	presents.ignore_inner_contents = TRUE
 
 	freight_types += cake

--- a/nsv13/code/game/gamemodes/overmap/objectives/cargo/donation/social_supplies.dm
+++ b/nsv13/code/game/gamemodes/overmap/objectives/cargo/donation/social_supplies.dm
@@ -7,10 +7,7 @@
 	// Pick a cake 
 	var/list/picked = pick( list(
 		/obj/item/reagent_containers/food/snacks/store/cake/plain,
-		/obj/item/reagent_containers/food/snacks/store/cake/carrot,
 		/obj/item/reagent_containers/food/snacks/store/cake/birthday,
-		/obj/item/reagent_containers/food/snacks/store/cake/cheese,
-		/obj/item/reagent_containers/food/snacks/store/cake/chocolate,
 		/obj/item/reagent_containers/food/snacks/store/cake/holy_cake,
 		/obj/item/reagent_containers/food/snacks/store/cake/pound_cake,
 	) )

--- a/nsv13/code/game/gamemodes/overmap/objectives/cargo/freight_type.dm
+++ b/nsv13/code/game/gamemodes/overmap/objectives/cargo/freight_type.dm
@@ -254,7 +254,8 @@ GLOBAL_LIST_INIT( blacklisted_paperwork_itemtypes, typecacheof( list(
 	var/list/containers = list( // We're not accepting chemicals in food 
 		/obj/item/reagent_containers/spray,
 		/obj/item/reagent_containers/glass,
-		/obj/item/reagent_containers/chemtank
+		/obj/item/reagent_containers/chemtank,
+		/obj/item/reagent_containers/food/drinks
 	)
 	target = 30 // Standard volume of a bottle 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removed a few cake types to discourage making custom cakes, the original intent in baking cakes was going through the crafting menu, I haven't refactored cargo objectives to permit submitting 1 of several options. I'll do this when I'm not about to do the sleep 

Permits submitting alcohol reagents in their mixed drinking glasses 

Updates the wrapped parcel objective briefing to specify three individually wrapped parcels

## Why It's Good For The Game

Objective clarity. Reducing the random cake options to avoid confusion over which kind of cake to make, and increasing possible reagent containers to submit 

## Changelog
:cl:
fix: Fix cargo objectives rejecting some cakes, and not accepting drinking glasses as a reagent container 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
