### PR TITLE
Adds syndicate access to munitions cargo packs

### DIFF
--- a/nsv13/code/modules/cargo/packs.dm
+++ b/nsv13/code/modules/cargo/packs.dm
@@ -1,6 +1,6 @@
 /datum/supply_pack/munitions
 	group = "Munitions"
-	access_any = list(ACCESS_MUNITIONS, ACCESS_SYNDICATE)
+	access_any = list(ACCESS_MUNITIONS, ACCESS_SYNDICATE_REQUISITIONS)
 	crate_type = /obj/structure/closet/crate/secure/weapon
 
 /datum/supply_pack/munitions/railgun

--- a/nsv13/code/modules/cargo/packs.dm
+++ b/nsv13/code/modules/cargo/packs.dm
@@ -1,6 +1,6 @@
 /datum/supply_pack/munitions
 	group = "Munitions"
-	access = ACCESS_MUNITIONS
+	access_any = list(ACCESS_MUNITIONS, ACCESS_SYNDICATE)
 	crate_type = /obj/structure/closet/crate/secure/weapon
 
 /datum/supply_pack/munitions/railgun


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #1657 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Allows syndicate crews to use the goods they buy without excessive force

## Changelog
:cl:
tweak: Allowed syndicate crew to open munitions cargo crates
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
