### PR TITLE
Atlas Captain's Spare Safe Adjustment

### DIFF
--- a/_maps/map_files/Atlas/atlas2.dmm
+++ b/_maps/map_files/Atlas/atlas2.dmm
@@ -1566,8 +1566,10 @@
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
 "hx" = (
-/obj/item/storage/secure/safe/caps_spare,
-/turf/closed/wall/r_wall,
+/obj/item/storage/secure/safe/caps_spare{
+	pixel_x = -20
+	},
+/turf/open/floor/monotile/steel,
 /area/bridge/cic)
 "hy" = (
 /obj/structure/cable{
@@ -1586,6 +1588,9 @@
 	dir = 1
 	},
 /obj/structure/closet/radiation,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
 "hA" = (
@@ -6332,9 +6337,6 @@
 /turf/open/floor/plasteel/grid/lino,
 /area/medical/chemistry)
 "Fh" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/machinery/newscaster{
 	pixel_y = -28
 	},
@@ -41694,7 +41696,7 @@ Sc
 Am
 Tc
 Tc
-Yn
+hx
 yd
 Hb
 Vg
@@ -44525,7 +44527,7 @@ Tc
 yv
 yv
 yv
-hx
+Tc
 FP
 Tc
 Tc

--- a/_maps/map_files/Atlas/atlas2.dmm
+++ b/_maps/map_files/Atlas/atlas2.dmm
@@ -481,6 +481,9 @@
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin,
 /obj/machinery/firealarm/directional/north,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
 "cx" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Moves the Captain's Spare Safe on the Atlas

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Currently the safe is in a very vulnerable location and can be accessed outside of the bridge with a little knowledge.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balanced: Moved the Captain's Spare Safe to a more secure location on the Atlas
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
