### PR TITLE
Plasma cutter charge rate adjustments 

### DIFF
--- a/code/modules/projectiles/ammunition/energy/plasma.dm
+++ b/code/modules/projectiles/ammunition/energy/plasma.dm
@@ -2,10 +2,10 @@
 	projectile_type = /obj/item/projectile/plasma
 	select_name = "plasma burst"
 	fire_sound = 'sound/weapons/plasma_cutter.ogg'
-	delay = 20
+	delay = 15 //NSV
 	e_cost = 25
 
 /obj/item/ammo_casing/energy/plasma/adv
 	projectile_type = /obj/item/projectile/plasma/adv
-	delay = 15
+	delay = 10 //NSV
 	e_cost = 10

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -142,7 +142,6 @@
 	block_upgrade_walk = 1
 	sharpness = IS_SHARP
 	can_charge = FALSE
-	dead_cell = TRUE
 
 	heat = 3800
 	usesound = list('sound/items/welder.ogg', 'sound/items/welder2.ogg')
@@ -175,7 +174,7 @@
 			to_chat(user, "<span class='notice'>You try to insert [I] into [src], but it's fully charged.</span>") //my cell is round and full
 			return
 		I.use(1)
-		cell.give(50*charge_multiplier)
+		cell.give(200*charge_multiplier) //nsv
 		to_chat(user, "<span class='notice'>You insert [I] in [src], recharging it.</span>")
 	else
 		..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes the amount of ore needed to charge a plasmacutter
## Why It's Good For The Game

Charging a plasmacutter takes around 20 bits of ore, or 10 sheets of plasma, i spoke to some miners and they thought it was too high, so i lowered it to 5 ore. This is an inherited beestation change, but our mining is radically different, with less materials available

## Changelog
:cl:
tweak: tweaked the amount of material needed to charge a plasmacutter

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
