### PR TITLE
Tweaks overmap interior explosions on destruction

### DIFF
--- a/nsv13/code/modules/overmap/ai_interiors.dm
+++ b/nsv13/code/modules/overmap/ai_interiors.dm
@@ -32,11 +32,13 @@
 	special()
 
 /proc/overmap_explode(list/areas)
+	set waitfor = FALSE	//Lets not freeze everything
 	if(!areas)
 		return
 	for(var/area/AR in areas)
 		var/turf/T = pick(get_area_turfs(AR))
-		explosion(T,30,30,30)
+		explosion(T,7,0,0, ignorecap = TRUE)
+		sleep(5 SECONDS)
 
 /obj/structure/overmap/proc/decimate_area()
 	if(!linked_areas.len)

--- a/nsv13/code/modules/overmap/ai_interiors.dm
+++ b/nsv13/code/modules/overmap/ai_interiors.dm
@@ -32,7 +32,7 @@
 	special()
 
 /proc/overmap_explode(list/areas)
-	set waitfor = FALSE	//Lets not freeze everything
+	set waitfor = FALSE	//Lets not freeze the game ending and ship del
 	if(!areas)
 		return
 	for(var/area/AR in areas)

--- a/nsv13/code/modules/overmap/ai_interiors.dm
+++ b/nsv13/code/modules/overmap/ai_interiors.dm
@@ -38,7 +38,7 @@
 	for(var/area/AR in areas)
 		var/turf/T = pick(get_area_turfs(AR))
 		explosion(T,7,0,0, ignorecap = TRUE)
-		sleep(5 SECONDS)
+		sleep(3 SECONDS)
 
 /obj/structure/overmap/proc/decimate_area()
 	if(!linked_areas.len)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This changes the explosion that happen when a ship with an interior is destroyed to be 7-0-0 (deva-heavy-light), instead of 30-30-30. Now, this 30-30-30 was actually 4-8-16 because it didn't have ignorecap, so the real issue was the 1024 tiles of light explosion per explosion in every area in one operation.

Now it instead has 196 tile pure-deva explosions, which should still do more damage than the 4 radius deva ones before, with a 3 second wait before it triggers another (could probably juse use a check_tick instead, either should be fine but slow explosions is kinda neat.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Currently, the server just freezes when the main ship dies due to it trying to explode 100000 tiles in one tick. This makes it more managable of a load.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Overmap interior explosions when they are destroyed should now be less laggy (primary for ones with more areas)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
