### PR TITLE
IFF and Hammerlock tweaks

### DIFF
--- a/nsv13/code/game/machinery/computer/salvage.dm
+++ b/nsv13/code/game/machinery/computer/salvage.dm
@@ -5,6 +5,7 @@
 	icon_screen = "salvage"
 	circuit = /obj/item/circuitboard/computer/salvage
 	var/max_salvage_range = 20 //must stay within N tiles of range to salvage a ship.
+	var/required_damage_percentage = 50
 	var/obj/structure/overmap/salvage_target = null //What are we currently salvaging?
 	var/static/can_salvage = TRUE //Cooldown
 	var/salvage_cooldown = 5 MINUTES
@@ -78,6 +79,9 @@
 			if((linked.active_boarding_target && !QDELETED(linked.active_boarding_target)))
 				playsound(pick('nsv13/sound/effects/computer/alarm.ogg','nsv13/sound/effects/computer/alarm_2.ogg'), 100, 1)
 				radio.talk_into(src, "WARNING: This console is already maintaining EWAR scrambling on [linked.active_boarding_target]. Confirmation required to proceed.", radio_channel)
+				return FALSE
+			if((OM.obj_integrity * 100 / initial(OM.obj_integrity)) > required_damage_percentage)
+				radio.talk_into(src, "Target is not sufficiently compromised for EWAR scrambling.", radio_channel)
 				return FALSE
 			radio.talk_into(src, "Electronic countermeasure deployment in progress.", radio_channel)
 			can_salvage = FALSE

--- a/nsv13/code/game/machinery/computer/salvage.dm
+++ b/nsv13/code/game/machinery/computer/salvage.dm
@@ -6,7 +6,7 @@
 	circuit = /obj/item/circuitboard/computer/salvage
 	var/max_salvage_range = 20 //must stay within N tiles of range to salvage a ship.
 	var/obj/structure/overmap/salvage_target = null //What are we currently salvaging?
-	var/can_salvage = TRUE //Cooldown
+	var/static/can_salvage = TRUE //Cooldown
 	var/salvage_cooldown = 5 MINUTES
 	var/obj/item/radio/radio //For alerts.
 	var/radio_key = /obj/item/encryptionkey/headset_sec
@@ -84,6 +84,8 @@
 			if(OM.ai_load_interior(linked))
 				linked.active_boarding_target = OM
 				addtimer(VARSET_CALLBACK(src, can_salvage, TRUE), salvage_cooldown)
+				OM.ai_controlled = FALSE
+				OM.apply_weapons()
 				radio.talk_into(src, "Enemy point defense systems scrambled. Bluefor strike teams cleared for approach.", radio_channel)
 			else
 				radio.talk_into(src, "Unable to scramble enemy point defense systems. Aborting...", radio_channel)

--- a/nsv13/code/game/machinery/iff_console.dm
+++ b/nsv13/code/game/machinery/iff_console.dm
@@ -131,7 +131,7 @@ If someone hacks it, you can always rebuild it.
 					player_system = SSstar_system.ships[OM]["target_system"]
 				var/datum/star_system/starting_point = SSstar_system.system_by_id(pick(player_system.adjacency_list))
 
-				var/datum/fleet/F = new /datum/fleet/interdiction/solgov
+				var/datum/fleet/F = new /datum/fleet/solgov/interdiction
 				starting_point.fleets += F
 				F.current_system = starting_point
 				F.assemble(starting_point)
@@ -139,7 +139,7 @@ If someone hacks it, you can always rebuild it.
 					if(length(ship.mobs_in_ship) && ship.reserved_z)
 						F.encounter(ship)
 				message_admins("Solgov interdictor fleet created at [starting_point].")
-				priority_announce("Contact with [GLOB.station_name] lost. Code Charlie Foxtrot.", "White Rapids Fleet Command")
+				priority_announce("Contact with [GLOB.station_name] lost. Code Charlie Foxtrot One Niner Eight Four.", "White Rapids Fleet Command")
 			return
 		if("pirate")
 			OM.faction = "nanotrasen"

--- a/nsv13/code/game/machinery/iff_console.dm
+++ b/nsv13/code/game/machinery/iff_console.dm
@@ -139,6 +139,7 @@ If someone hacks it, you can always rebuild it.
 					if(length(ship.mobs_in_ship) && ship.reserved_z)
 						F.encounter(ship)
 				message_admins("Solgov interdictor fleet created at [starting_point].")
+				priority_announce("Contact with [GLOB.station_name] lost. Code Charlie Foxtrot.", "White Rapids Fleet Command")
 			return
 		if("pirate")
 			OM.faction = "nanotrasen"

--- a/nsv13/code/game/machinery/iff_console.dm
+++ b/nsv13/code/game/machinery/iff_console.dm
@@ -42,7 +42,7 @@ If someone hacks it, you can always rebuild it.
 	else //And yeah, we want to mirror state here, so.
 		OM.faction = faction
 
-/obj.machinery/computer/iff_console/Destroy()
+/obj/machinery/computer/iff_console/Destroy()
 	QDEL_NULL(radio)
 	return ..()
 

--- a/nsv13/code/game/machinery/iff_console.dm
+++ b/nsv13/code/game/machinery/iff_console.dm
@@ -125,6 +125,20 @@ If someone hacks it, you can always rebuild it.
 		if("nanotrasen")
 			OM.faction = "syndicate"
 			faction = OM.faction
+			if(OM.role == MAIN_OVERMAP)	// Make Solgov come get them
+				var/datum/star_system/player_system = OM.current_system
+				if(!player_system)
+					player_system = SSstar_system.ships[OM]["target_system"]
+				var/datum/star_system/starting_point = SSstar_system.system_by_id(pick(player_system.adjacency_list))
+
+				var/datum/fleet/F = new /datum/fleet/interdiction/solgov
+				starting_point.fleets += F
+				F.current_system = starting_point
+				F.assemble(starting_point)
+				for(var/obj/structure/overmap/ship in starting_point.system_contents)
+					if(length(ship.mobs_in_ship) && ship.reserved_z)
+						F.encounter(ship)
+				message_admins("Solgov interdictor fleet created at [starting_point].")
 			return
 		if("pirate")
 			OM.faction = "nanotrasen"
@@ -132,18 +146,3 @@ If someone hacks it, you can always rebuild it.
 			return
 	//Fallback. Maybe we tried to IFF hack an IFF scrambled ship...?
 	OM.faction = initial(OM.faction)
-	if(OM.role == MAIN_OVERMAP)
-		// Make Solgov come get them
-		var/datum/star_system/player_system = OM.current_system
-		if(!player_system)
-			player_system = SSstar_system.ships[OM]["target_system"]
-		var/datum/star_system/starting_point = SSstar_system.system_by_id(pick(player_system.adjacency_list))
-
-		var/datum/fleet/F = new /datum/fleet/interdiction/solgov
-		starting_point.fleets += F
-		F.current_system = starting_point
-		F.assemble(starting_point)
-		for(var/obj/structure/overmap/OM in target.system_contents)
-			if(length(OM.mobs_in_ship) && OM.reserved_z)
-				F.encounter(OM)
-		message_admins("Solgov interdictor fleet created at [target].")

--- a/nsv13/code/game/machinery/iff_console.dm
+++ b/nsv13/code/game/machinery/iff_console.dm
@@ -58,6 +58,7 @@ If someone hacks it, you can always rebuild it.
 //Subtype for boarding. Starts emagged so the marines can get straight underway.
 /obj/machinery/computer/iff_console/boarding
 	start_emagged = TRUE
+	radio_channel = RADIO_CHANNEL_SYNDICATE
 
 /obj/machinery/computer/iff_console/emag_act()
 	. = ..()

--- a/nsv13/code/modules/overmap/ai-skynet.dm
+++ b/nsv13/code/modules/overmap/ai-skynet.dm
@@ -845,37 +845,6 @@ Adding tasks is easy! Just define a datum for it.
 	var/scan_delay = 30 SECONDS
 	var/scanning = FALSE
 
-/datum/fleet/interdiction/solgov
-	name = "\improper Solgov hunter fleet"
-	fighter_types = list(/obj/structure/overmap/nanotrasen/solgov/ai/fighter)
-	destroyer_types = list(/obj/structure/overmap/nanotrasen/solgov/ai/interdictor)
-	battleship_types = list(/obj/structure/overmap/nanotrasen/solgov/aetherwhisp/ai)
-	supply_types = list(/obj/structure/overmap/nanotrasen/solgov/carrier/ai)
-	alignment = "nanotrasen"
-	hide_movements = TRUE //They're "friendly" alright....
-	faction_id = FACTION_ID_NT
-	taunts = list("You are encroaching on our airspace, prepare to be destroyed", "You have entered SolGov secure airspace. Prepare to be destroyed", "You are in violation of the SolGov non-aggression agreement. Leave this airspace immediately.")
-	var/list/traitor_taunts = list("Rogue vessel, reset your identification codes immediately or be destroyed.", "The penalty for defection is death.", "Your crew is charged with treason and breach of contract. Lethal force is authorized.")
-	size = FLEET_DIFFICULTY_INSANE
-	greetings = list("Allied vessel. You will be scanned for compliance with the peacekeeper act in 30 seconds. We thank you for your compliance.")
-	var/scan_delay = 30 SECONDS
-	var/scanning = FALSE
-
-/datum/fleet/interdiction/solgov/encounter(obj/structure/overmap/OM)
-	// Same as parent but detects if the player ship is hostile and uses different taunts
-	if(OM.faction == alignment)
-		OM.hail(pick(greetings), name)
-	assemble(current_system)
-	if(OM.faction != alignment)
-		if(OM.alpha >= 150)
-			if(OM == SSstar_system.find_main_overmap())
-				OM.hail(pick(traitor_taunts), name)
-			else
-				OM.hail(pick(taunts), name)
-			last_encounter_time = world.time
-			if(audio_cues?.len)
-				OM.play_music(pick(audio_cues))
-
 /datum/fleet/solgov/assemble(datum/star_system/SS, difficulty)
 	. = ..()
 	if(!scanning)
@@ -897,6 +866,72 @@ Adding tasks is easy! Just define a datum for it.
 			shield_scan_target.hail("Scans have detected that you are in posession of prohibited technology. \n Your IFF signature has been marked as 'persona non grata'. \n In accordance with SGC-reg #10124, your ship and lives are now forfeit. Evacuate all civilian personnel immediately and surrender yourselves.", name)
 			shield_scan_target.relay_to_nearby('nsv13/sound/effects/ship/solgov_scan_alert.ogg', ignore_self=FALSE)
 			shield_scan_target.faction = shield_scan_target.name
+
+/datum/fleet/solgov/interdiction
+	name = "\improper Solgov hunter fleet"
+	destroyer_types = list(/obj/structure/overmap/nanotrasen/solgov/ai/interdictor)
+	var/list/traitor_taunts = list("Rogue vessel, reset your identification codes immediately or be destroyed.", "The penalty for defection is death.", "Your crew is charged with treason and breach of contract. Lethal force is authorized.")
+	size = FLEET_DIFFICULTY_INSANE
+	var/players_fired_upon = FALSE
+	var/obj/structure/overmap/hunted_ship
+
+/datum/fleet/solgov/interdiction/New()
+	. = ..()
+	hunted_ship = SSstar_system.find_main_overmap()
+
+/datum/fleet/solgov/interdiction/move(datum/star_system/target, force=FALSE)
+	// If we're going home just delete us actually
+	// Don't let the players game the ability to make solgov show up
+	if(!hunted_ship && goal_system)
+		qdel(src)
+		return
+	if(!target && hunted_ship)
+		goal_system = hunted_ship.current_system
+	. = ..()
+	if(.)
+		navigate_to(goal_system)	//Anytime we successfully move we recalculate the route, since players like moving around alot.
+
+/datum/fleet/solgov/interdiction/assemble(datum/star_system/SS, difficulty)
+	. = ..()
+	for(var/obj/structure/overmap/OM as() in all_ships)
+		RegisterSignal(OM, COMSIG_ATOM_BULLET_ACT, .proc/check_bullet)
+
+/datum/fleet/solgov/interdiction/encounter(obj/structure/overmap/OM)
+	// Same as parent but detects if the player ship is hostile and uses different taunts
+	if(OM.faction == alignment)
+		OM.hail(pick(greetings), name)
+	assemble(current_system)
+	if(OM.faction != alignment)
+		if(OM.alpha >= 150)
+			if(OM == SSstar_system.find_main_overmap())
+				OM.hail(pick(traitor_taunts), name)
+				RegisterSignal(OM, COMSIG_SHIP_BOARDED, .proc/handle_iff_change)
+			else
+				OM.hail(pick(taunts), name)
+			last_encounter_time = world.time
+			if(audio_cues?.len)
+				OM.play_music(pick(audio_cues))
+
+/datum/fleet/solgov/interdiction/proc/check_bullet(obj/structure/overmap/source, obj/item/projectile/P)
+	if(P.overmap_firer?.role == MAIN_OVERMAP)
+		players_fired_upon = TRUE
+		for(var/obj/structure/overmap/OM as() in all_ships)
+			UnregisterSignal(OM, COMSIG_ATOM_BULLET_ACT)
+
+/datum/fleet/solgov/interdiction/proc/handle_iff_change(obj/structure/overmap/source)
+	switch(source.faction)
+		if("nanotrasen")
+			if(!players_fired_upon)
+				hunted_ship = null
+				goal_system = SSstar_system.system_by_id("Sol")
+				if(current_system == source.current_system)
+					source.hail("Don't let it happen again.", name)
+			else if(current_system == source.current_system)
+				source.hail("... That's not going to cut it anymore.", name)
+		if("syndicate")
+			// Anger
+			hunted_ship = source
+			goal_system = null
 
 /datum/fleet/New()
 	. = ..()

--- a/nsv13/code/modules/overmap/ai-skynet.dm
+++ b/nsv13/code/modules/overmap/ai-skynet.dm
@@ -855,7 +855,7 @@ Adding tasks is easy! Just define a datum for it.
 	hide_movements = TRUE //They're "friendly" alright....
 	faction_id = FACTION_ID_NT
 	taunts = list("You are encroaching on our airspace, prepare to be destroyed", "You have entered SolGov secure airspace. Prepare to be destroyed", "You are in violation of the SolGov non-aggression agreement. Leave this airspace immediately.")
-	var/list/traitor_taunts = list("Rogue vessel, reset your identification codes immediately or be destroyed.", "The penalty for defection is death.", "Your crew is charged with treason and breach of contract. Return to Sol to stand trial, or die here.")
+	var/list/traitor_taunts = list("Rogue vessel, reset your identification codes immediately or be destroyed.", "The penalty for defection is death.", "Your crew is charged with treason and breach of contract. Lethal force is authorized.")
 	size = FLEET_DIFFICULTY_INSANE
 	greetings = list("Allied vessel. You will be scanned for compliance with the peacekeeper act in 30 seconds. We thank you for your compliance.")
 	var/scan_delay = 30 SECONDS

--- a/nsv13/code/modules/overmap/ai-skynet.dm
+++ b/nsv13/code/modules/overmap/ai-skynet.dm
@@ -845,6 +845,37 @@ Adding tasks is easy! Just define a datum for it.
 	var/scan_delay = 30 SECONDS
 	var/scanning = FALSE
 
+/datum/fleet/interdiction/solgov
+	name = "\improper Solgov hunter fleet"
+	fighter_types = list(/obj/structure/overmap/nanotrasen/solgov/ai/fighter)
+	destroyer_types = list(/obj/structure/overmap/nanotrasen/solgov/ai/interdictor)
+	battleship_types = list(/obj/structure/overmap/nanotrasen/solgov/aetherwhisp/ai)
+	supply_types = list(/obj/structure/overmap/nanotrasen/solgov/carrier/ai)
+	alignment = "nanotrasen"
+	hide_movements = TRUE //They're "friendly" alright....
+	faction_id = FACTION_ID_NT
+	taunts = list("You are encroaching on our airspace, prepare to be destroyed", "You have entered SolGov secure airspace. Prepare to be destroyed", "You are in violation of the SolGov non-aggression agreement. Leave this airspace immediately.")
+	var/list/traitor_taunts = list("Rogue vessel, reset your identification codes immediately or be destroyed.", "The penalty for defection is death.", "Your crew is charged with treason and breach of contract. Return to Sol to stand trial, or die here.")
+	size = FLEET_DIFFICULTY_INSANE
+	greetings = list("Allied vessel. You will be scanned for compliance with the peacekeeper act in 30 seconds. We thank you for your compliance.")
+	var/scan_delay = 30 SECONDS
+	var/scanning = FALSE
+
+/datum/fleet/interdiction/solgov/encounter(obj/structure/overmap/OM)
+	// Same as parent but detects if the player ship is hostile and uses different taunts
+	if(OM.faction == alignment)
+		OM.hail(pick(greetings), name)
+	assemble(current_system)
+	if(OM.faction != alignment)
+		if(OM.alpha >= 150)
+			if(OM == SSstar_system.find_main_overmap())
+				OM.hail(pick(traitor_taunts), name)
+			else
+				OM.hail(pick(taunts), name)
+			last_encounter_time = world.time
+			if(audio_cues?.len)
+				OM.play_music(pick(audio_cues))
+
 /datum/fleet/solgov/assemble(datum/star_system/SS, difficulty)
 	. = ..()
 	if(!scanning)
@@ -1358,7 +1389,7 @@ Seek a ship thich we'll station ourselves around
 	if(!OM.last_target)
 		OM.seek_new_target()
 	OM.brakes = TRUE
-	
+
 
 /obj/structure/overmap/proc/choose_goal()
 	//Populate the list of valid goals, if we don't already have them

--- a/nsv13/code/modules/overmap/types/solgov.dm
+++ b/nsv13/code/modules/overmap/types/solgov.dm
@@ -66,6 +66,22 @@
 	torpedoes = 10
 	missiles = 10
 
+// Solgov Kadesh? Solgov Kadesh.
+/obj/structure/overmap/nanotrasen/solgov/ai/interdictor
+	name = "Capiens class medium cruiser"
+	desc = "A SolGov pursuit craft, meant for tracking and cornering high value targets."
+	obj_integrity = 1200
+	max_integrity = 1200
+	integrity_failure = 1200
+	ai_flags = AI_FLAG_BATTLESHIP | AI_FLAG_DESTROYER | AI_FLAG_ELITE
+	max_tracking_range = 70
+	flak_battery_amount = 2
+	combat_dice_type = /datum/combat_dice/cruiser
+
+/obj/structure/overmap/nanotrasen/solgov/ai/interdictor/Initialize()
+	. = ..()
+	AddComponent(/datum/component/interdiction)
+
 /obj/structure/overmap/nanotrasen/solgov/aetherwhisp/ai
 	ai_controlled = TRUE
 	ai_flags = AI_FLAG_DESTROYER


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes a couple adjustments to hammerlock and IFF.
Vessels must be brought below 50% health to hammerlock, but once hammerlocked won't fire on the players. All EWAR consoles now share the hammerlock cooldown, preventing an edge case where the server might try to load more than one vessel at the same time.
Flipping a ship's IFF now makes radio announcements, and changing the main ship's IFF has additional consequences.

Minigame for hacking hopefully to follow if I can learn more React.

## Why It's Good For The Game
Hammerlock changes requested by the community to allow the crew to focus on the boarding process.
It is now more obvious when the IFF is being hacked, and there is incentive to not defect.

## Changelog
:cl:
tweak: Made all EWAR consoles share the cooldown
tweak: Hammerlocked vessels will no longer use combat AI
tweak: Added warnings when someone hacks the IFF console
balance: Vessels must be under 50% health to engage Hammerlock
add: Solgov interdiction fleet
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
