### PR TITLE
Makes the gas monitor UI shorter

### DIFF
--- a/tgui/packages/tgui/interfaces/AtmosControlConsole.js
+++ b/tgui/packages/tgui/interfaces/AtmosControlConsole.js
@@ -10,7 +10,8 @@ export const AtmosControlConsole = (props, context) => {
   return (
     <Window
       width={400}
-      height={925}>
+      // NSV13 - height reduced to 400
+      height={400}>
       <Window.Content scrollable>
         <Section
           title={!!data.tank && sensors[0]?.long_name}>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the gas monitor UI shorter
Fixes #1623
![airtankgood](https://user-images.githubusercontent.com/17987483/153541382-cd44d5b4-8d20-4062-a65a-a57642e6b37c.png)

## Why It's Good For The Game
Window can be closed more easily

## Changelog
:cl:
tweak: Changed the height of the gas tank computer window
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
