### PR TITLE
Fixes the mako boarding ship not loading its interior on roundstart

### DIFF
--- a/_maps/templates/boarding/syndicate/mako.dmm
+++ b/_maps/templates/boarding/syndicate/mako.dmm
@@ -57,8 +57,7 @@
 /area/ruin/powered/nsv13/boarding_interior)
 "bw" = (
 /turf/open/floor/plasteel/stairs/medium{
-	dir = 4;
-	icon_state = "stairs-m"
+	dir = 4
 	},
 /area/ruin/powered/nsv13/boarding_interior)
 "bW" = (
@@ -512,7 +511,6 @@
 /obj/structure/chair/comfy/shuttle{
 	color = "#696969";
 	dir = 4;
-	icon_state = "shuttle_chair";
 	name = "bridge chair"
 	},
 /obj/machinery/door/firedoor/border_only/directional/west,
@@ -706,10 +704,6 @@
 /obj/structure/shuttle/engine/router,
 /turf/closed/wall/r_wall,
 /area/ruin/powered/nsv13/boarding_interior)
-"PT" = (
-/mob/living/carbon/human/ai_boarder/syndicate/pistol,
-/turf/open/floor/carpet/red,
-/area/ruin/powered/nsv13/boarding_interior)
 "Qz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -759,7 +753,6 @@
 /obj/structure/chair/comfy/shuttle{
 	color = "#696969";
 	dir = 4;
-	icon_state = "shuttle_chair";
 	name = "captain's chair"
 	},
 /mob/living/simple_animal/hostile/syndicate/civilian{
@@ -794,10 +787,6 @@
 	},
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
-/area/ruin/powered/nsv13/boarding_interior)
-"Vu" = (
-/mob/living/carbon/human/ai_boarder/syndicate/shotgun,
-/turf/open/floor/carpet/red,
 /area/ruin/powered/nsv13/boarding_interior)
 "VD" = (
 /obj/structure/hull_plate,
@@ -30692,7 +30681,7 @@ Ca
 lT
 sE
 sE
-PT
+sE
 pe
 Cb
 hS
@@ -34279,7 +34268,7 @@ fG
 sE
 sE
 sE
-Vu
+sE
 sE
 sE
 sE

--- a/nsv13/code/modules/overmap/types/syndicate.dm
+++ b/nsv13/code/modules/overmap/types/syndicate.dm
@@ -8,7 +8,7 @@
 	icon_state = "default"
 	faction = "syndicate"
 	supply_pod_type = /obj/structure/closet/supplypod/syndicate_odst
-	returns_rejected_cargo = FALSE // We won't send freight torpedoes to our enemies, we'll send actual torpedoes to our enemies 
+	returns_rejected_cargo = FALSE // We won't send freight torpedoes to our enemies, we'll send actual torpedoes to our enemies
 
 //Player Versions
 
@@ -70,6 +70,10 @@
     name = "Mako class patrol frigate (interior)"
     mappath = "_maps/templates/boarding/syndicate/mako.dmm"
 
+/datum/map_template/boarding/mako
+    name = "Mako class patrol frigate (interior)"
+    mappath = "_maps/templates/boarding/syndicate/mako.dmm"
+
 /obj/structure/overmap/syndicate/ai //Generic bad guy #10000. GRR.
 	name = "Mako class patrol frigate"
 	icon = 'nsv13/icons/overmap/new/syndicate/frigate.dmi'
@@ -89,7 +93,7 @@
 	armor = list("overmap_light" = 30, "overmap_medium" = 20, "overmap_heavy" = 30)
 	ai_flags = AI_FLAG_DESTROYER
 	combat_dice_type = /datum/combat_dice/frigate
-	possible_interior_maps = list(/datum/map_template/boarding)
+	possible_interior_maps = list(/datum/map_template/boarding/mako)
 
 
 /datum/map_template/boarding/mako_carrier


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes the mako boarding ship not loading its interior on roundstart. EWAR would spit errors and softlock the gamemode

## Why It's Good For The Game

fix man good

## Changelog
:cl:
fix: Fixed the mako boarding ship not loading its interior on roundstart
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
