### PR TITLE
Removes Rocinante from Tycoon, adds mining sabre launchsite, plus minor bugfixes 

### DIFF
--- a/_maps/map_files/Tycoon/Tycoon1.dmm
+++ b/_maps/map_files/Tycoon/Tycoon1.dmm
@@ -4,8 +4,7 @@
 /area/space)
 "ab" = (
 /obj/machinery/light{
-	dir = 1;
-	icon_state = "tube"
+	dir = 1
 	},
 /turf/open/floor/monotile/steel,
 /area/nsv/briefingroom)
@@ -595,7 +594,6 @@
 	},
 /obj/machinery/holopad,
 /obj/item/radio/intercom{
-	name = "intra ship intercom";
 	pixel_y = -26
 	},
 /turf/open/floor/carpet/ship,
@@ -944,7 +942,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	name = "intra ship intercom";
 	pixel_y = -26
 	},
 /turf/open/floor/monotile/steel,
@@ -1156,8 +1153,7 @@
 /area/hallway/nsv/deck1/hallway)
 "dm" = (
 /obj/machinery/light{
-	dir = 1;
-	icon_state = "tube"
+	dir = 1
 	},
 /obj/machinery/computer/ship/viewscreen,
 /obj/structure/table/reinforced,
@@ -1418,12 +1414,24 @@
 "dT" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/ship/preopen{
-	dir = 2;
 	id = "bridge_blast";
 	name = "CIC blast doors"
 	},
 /turf/open/floor/plating,
 /area/nsv/briefingroom)
+"dU" = (
+/obj/machinery/door/airlock/ship/external{
+	name = "Mining Shuttle Airlock";
+	req_one_access_txt = "31;48"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/miningdock)
 "dV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -1779,7 +1787,6 @@
 "eP" = (
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom{
-	name = "intra ship intercom";
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -2140,6 +2147,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=loc4d2";
+	location = "loc3d2"
+	},
 /turf/open/floor/monotile/dark,
 /area/nsv/briefingroom)
 "fG" = (
@@ -2218,7 +2229,6 @@
 	icon_state = "plant-10"
 	},
 /obj/item/radio/intercom{
-	name = "intra ship intercom";
 	pixel_x = -26
 	},
 /turf/open/floor/monotile/steel,
@@ -2339,8 +2349,7 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "fY" = (
 /obj/structure/sign/ship/deck{
-	dir = 8;
-	icon_state = "deck-1"
+	dir = 8
 	},
 /turf/closed/wall/ship,
 /area/hallway/nsv/deck1/hallway)
@@ -2350,8 +2359,7 @@
 /area/hallway/nsv/deck1/hallway)
 "ga" = (
 /obj/structure/sign/ship/deck{
-	dir = 4;
-	icon_state = "deck-1"
+	dir = 4
 	},
 /turf/closed/wall/ship,
 /area/hallway/nsv/deck1/hallway)
@@ -2447,6 +2455,20 @@
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
 	})
+"gn" = (
+/obj/machinery/door/airlock/ship/station/mining{
+	name = "Mining Equipment";
+	req_one_access_txt = "48"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/miningdock)
 "go" = (
 /obj/machinery/door/airlock/ship/hatch{
 	name = "Teleporter Room";
@@ -2570,7 +2592,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/item/radio/intercom{
-	name = "intra ship intercom";
 	pixel_x = -26
 	},
 /turf/open/floor/monotile/dark,
@@ -2794,8 +2815,7 @@
 	req_one_access_txt = "19"
 	},
 /turf/open/floor/plasteel/stairs/old{
-	dir = 1;
-	icon_state = "stairs-old"
+	dir = 1
 	},
 /area/nsv/briefingroom)
 "gU" = (
@@ -2806,6 +2826,10 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=loc1d2";
+	location = "loc4d2"
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
@@ -3204,7 +3228,6 @@
 	pixel_y = 26
 	},
 /obj/item/radio/intercom{
-	name = "intra ship intercom";
 	pixel_x = -26
 	},
 /turf/open/floor/monotile/steel,
@@ -3330,6 +3353,21 @@
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
 	})
+"ii" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/quartermaster/miningdock)
 "ij" = (
 /obj/effect/turf_decal/ship/delivery{
 	color = "#8B0000"
@@ -3509,7 +3547,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/item/radio/intercom{
-	name = "intra ship intercom";
 	pixel_y = -26
 	},
 /obj/structure/cable{
@@ -3813,6 +3850,10 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=loc2d2";
+	location = "loc1d2"
+	},
 /turf/open/floor/carpet/blue,
 /area/hallway/nsv/deck1/hallway)
 "jm" = (
@@ -4162,7 +4203,6 @@
 "jO" = (
 /obj/machinery/computer/station_alert{
 	dir = 1;
-	icon_state = "computer";
 	name = "ship alert console"
 	},
 /turf/open/floor/carpet/blue,
@@ -4171,8 +4211,7 @@
 	})
 "jP" = (
 /obj/machinery/computer/squad_manager{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop{
@@ -4361,6 +4400,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
+"kj" = (
+/obj/effect/turf_decal/loading_area,
+/turf/open/floor/monotile/dark/airless,
+/area/space/nearstation)
 "kl" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -4964,9 +5007,7 @@
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
 "lw" = (
-/obj/machinery/ship_weapon/gauss_gun/north{
-	pixel_x = -44
-	},
+/obj/machinery/ship_weapon/gauss_gun/north,
 /turf/open/floor/engine/airless,
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
@@ -4997,6 +5038,10 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=loc3d2";
+	location = "loc2d2"
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
 "lA" = (
@@ -5125,7 +5170,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	name = "intra ship intercom";
 	pixel_y = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -5300,9 +5344,7 @@
 /turf/open/floor/monotile/steel,
 /area/storage/eva)
 "mj" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -5331,8 +5373,7 @@
 /area/storage/eva)
 "mm" = (
 /obj/structure/fluff/support_beam{
-	dir = 1;
-	icon_state = "support_beam"
+	dir = 1
 	},
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only,
@@ -5791,85 +5832,68 @@
 	},
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
-"nt" = (
-/obj/effect/turf_decal/caution/stand_clear,
-/turf/open/floor/monotile/airless,
-/area/space/nearstation)
 "nu" = (
 /turf/open/floor/monotile/airless,
 /area/space/nearstation)
-"nv" = (
-/obj/machinery/light/runway,
-/turf/open/floor/monotile/airless,
-/area/space/nearstation)
 "nw" = (
-/obj/effect/turf_decal/ship/borderfloor/gunmetal{
-	dir = 8;
-	icon_state = "borderfloor_white"
+/obj/machinery/door/airlock/ship/external/glass{
+	name = "Flight deck access";
+	req_one_access_txt = "79;13"
 	},
-/turf/open/floor/monotile/dark/airless,
-/area/space/nearstation)
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/monotile/steel,
+/area/nsv/hanger/deck3{
+	name = "Air traffic control pod"
+	})
 "nx" = (
-/obj/effect/turf_decal/ship/borderfloor/gunmetal{
-	dir = 4;
-	icon_state = "borderfloor_white"
-	},
-/turf/open/floor/monotile/dark/airless,
-/area/space/nearstation)
-"ny" = (
-/obj/effect/turf_decal/ship/borderfloor/gunmetal{
-	dir = 10;
-	icon_state = "borderfloor_white"
-	},
-/turf/open/floor/monotile/dark/airless,
-/area/space/nearstation)
-"nz" = (
-/obj/effect/turf_decal/ship/borderfloor/gunmetal,
-/turf/open/floor/monotile/dark/airless,
-/area/space/nearstation)
-"nA" = (
-/obj/effect/turf_decal/ship/borderfloor/gunmetal{
-	dir = 6;
-	icon_state = "borderfloor_white"
-	},
-/turf/open/floor/monotile/dark/airless,
-/area/space/nearstation)
-"nB" = (
-/turf/open/floor/monotile/light/airless,
-/area/space/nearstation)
-"nC" = (
 /obj/effect/turf_decal/ship/borderfloor,
 /obj/effect/turf_decal/ship/borderfloor{
-	dir = 1;
-	icon_state = "borderfloor"
+	dir = 1
 	},
 /turf/open/floor/light{
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/space/nearstation)
-"nD" = (
+"ny" = (
+/obj/machinery/lazylift_button,
+/turf/open/floor/monotile/dark/airless,
+/area/space/nearstation)
+"nA" = (
+/turf/open/floor/monotile/light/airless,
+/area/space/nearstation)
+"nB" = (
 /obj/effect/turf_decal/ship/borderfloor/gunmetal{
-	dir = 9;
-	icon_state = "borderfloor_white"
+	dir = 9
 	},
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
+"nC" = (
+/obj/machinery/light/runway,
+/turf/open/floor/monotile/airless,
+/area/space/nearstation)
+"nD" = (
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/open/floor/monotile/airless,
+/area/space/nearstation)
 "nE" = (
 /obj/effect/turf_decal/ship/borderfloor/gunmetal{
-	dir = 1;
-	icon_state = "borderfloor_white"
+	dir = 8
 	},
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
 "nF" = (
 /obj/effect/turf_decal/ship/borderfloor/gunmetal{
-	dir = 5;
-	icon_state = "borderfloor_white"
+	dir = 4
 	},
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
 "nG" = (
-/obj/effect/turf_decal/loading_area,
+/obj/effect/turf_decal/loading_area/white{
+	color = "#964B00";
+	dir = 4
+	},
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
 "nH" = (
@@ -5891,49 +5915,41 @@
 /area/space/nearstation)
 "nL" = (
 /obj/effect/turf_decal/ship/borderfloor/gunmetal{
-	dir = 9;
-	icon_state = "borderfloor_white"
+	dir = 9
 	},
 /turf/open/floor/monotile/dark/airless,
 /area/nsv/weapons/gauss)
 "nM" = (
 /obj/effect/turf_decal/ship/borderfloor/gunmetal{
-	dir = 1;
-	icon_state = "borderfloor_white"
+	dir = 1
 	},
 /turf/open/floor/monotile/dark/airless,
 /area/nsv/weapons/gauss)
 "nN" = (
 /obj/effect/turf_decal/ship/borderfloor/gunmetal{
-	dir = 5;
-	icon_state = "borderfloor_white"
+	dir = 5
 	},
 /turf/open/floor/monotile/dark/airless,
 /area/nsv/weapons/gauss)
 "nO" = (
 /obj/effect/turf_decal/ship/borderfloor/gunmetal{
-	dir = 8;
-	icon_state = "borderfloor_white"
+	dir = 8
 	},
 /turf/open/floor/monotile/dark/airless,
 /area/nsv/weapons/gauss)
 "nP" = (
 /obj/effect/turf_decal/ship/borderfloor/gunmetal{
-	dir = 4;
-	icon_state = "borderfloor_white"
+	dir = 4
 	},
 /turf/open/floor/monotile/dark/airless,
 /area/nsv/weapons/gauss)
 "nQ" = (
-/obj/machinery/ship_weapon/gauss_gun/north{
-	pixel_x = -44
-	},
+/obj/machinery/ship_weapon/gauss_gun/north,
 /turf/open/floor/monotile/dark/airless,
 /area/nsv/weapons/gauss)
 "nR" = (
 /obj/effect/turf_decal/ship/borderfloor/gunmetal{
-	dir = 10;
-	icon_state = "borderfloor_white"
+	dir = 10
 	},
 /turf/open/floor/monotile/dark/airless,
 /area/nsv/weapons/gauss)
@@ -5948,11 +5964,15 @@
 /area/nsv/weapons/gauss)
 "nU" = (
 /obj/effect/turf_decal/ship/borderfloor/gunmetal{
-	dir = 6;
-	icon_state = "borderfloor_white"
+	dir = 6
 	},
 /turf/open/floor/monotile/dark/airless,
 /area/nsv/weapons/gauss)
+"nW" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/ladder,
+/turf/open/openspace,
+/area/quartermaster/miningdock)
 "ob" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -5960,6 +5980,31 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/storage/eva)
+"om" = (
+/obj/machinery/atmospherics/pipe/simple/multiz,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/obj/machinery/meter{
+	pixel_x = 5;
+	pixel_y = 5;
+	target_layer = 3
+	},
+/turf/open/floor/plating,
+/area/quartermaster/miningdock)
+"oW" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
 "pe" = (
 /obj/machinery/light{
 	dir = 1
@@ -6037,6 +6082,20 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat)
+"qI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/quartermaster/miningdock)
 "qO" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -6070,7 +6129,6 @@
 	req_one_access_txt = "13"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
@@ -6086,6 +6144,10 @@
 /obj/item/aiModule/core/full/custom,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"rk" = (
+/obj/structure/overmap/small_craft/transport/sabre/mining,
+/turf/open/floor/engine/airless,
+/area/space/nearstation)
 "rl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -6117,7 +6179,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/item/radio/intercom{
-	name = "intra ship intercom";
 	pixel_y = 26
 	},
 /obj/machinery/camera/autoname,
@@ -6128,6 +6189,10 @@
 /obj/item/stack/sheet/iron/fifty,
 /turf/open/floor/monotile/dark,
 /area/teleporter)
+"rM" = (
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/plating,
+/area/quartermaster/miningdock)
 "rQ" = (
 /obj/effect/turf_decal/ship/delivery,
 /turf/open/floor/monotile/dark/airless,
@@ -6139,6 +6204,35 @@
 /obj/item/aiModule/supplied/protectStation,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"sd" = (
+/obj/machinery/computer/ship/dradis/minor{
+	dir = 4
+	},
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
+"sj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/advanced_airlock_controller{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/quartermaster/miningdock)
+"sm" = (
+/obj/machinery/camera/autoname{
+	dir = 4;
+	name = "Mining Magcats";
+	network = list("ss13","hangar")
+	},
+/turf/open/floor/monotile/dark/airless,
+/area/space/nearstation)
 "sP" = (
 /obj/structure/rack,
 /obj/item/fighter_component/fuel_tank,
@@ -6167,6 +6261,25 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/monotile,
 /area/ai_monitored/nuke_storage)
+"tf" = (
+/obj/machinery/camera/autoname{
+	name = "Mining Magcats";
+	network = list("ss13","hangar")
+	},
+/turf/open/floor/monotile/dark/airless,
+/area/space/nearstation)
+"tu" = (
+/obj/structure/disposalpipe/junction/flip{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
 "tx" = (
 /obj/structure/hull_plate/end{
 	dir = 1
@@ -6190,6 +6303,21 @@
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
 	})
+"ud" = (
+/obj/machinery/door/airlock/ship/external{
+	name = "Mining Shuttle Airlock";
+	req_one_access_txt = "31;48"
+	},
+/turf/open/floor/plating,
+/area/quartermaster/miningdock)
+"uf" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/disposalpipe/trunk/multiz/down{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/openspace,
+/area/quartermaster/miningdock)
 "uo" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/ship/preopen{
@@ -6228,6 +6356,24 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
+"uT" = (
+/obj/machinery/camera/autoname{
+	dir = 1;
+	name = "Mining Magcats";
+	network = list("ss13","hangar")
+	},
+/turf/open/floor/monotile/dark/airless,
+/area/space/nearstation)
+"uZ" = (
+/obj/effect/turf_decal/ship/borderfloor/gunmetal{
+	dir = 1
+	},
+/turf/open/floor/monotile/dark/airless,
+/area/space/nearstation)
+"vc" = (
+/obj/structure/sign/ship/deck,
+/turf/closed/wall/r_wall/ship,
+/area/quartermaster/miningdock)
 "vf" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/monotile/steel,
@@ -6245,6 +6391,10 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/primary/aft)
+"vl" = (
+/obj/structure/reagent_dispensers/fueltank/cryogenic_fuel,
+/turf/open/floor/monotile/dark/airless,
+/area/space/nearstation)
 "vu" = (
 /obj/machinery/advanced_airlock_controller/directional/east,
 /turf/open/floor/plasteel/grid/steel,
@@ -6315,6 +6465,12 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/aisat)
+"wk" = (
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
 "wm" = (
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck3{
@@ -6370,6 +6526,49 @@
 /obj/effect/turf_decal/ship/delivery/yellow,
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
+"wX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "48"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/miningdock)
+"xb" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/quartermaster/miningdock)
+"xf" = (
+/obj/effect/turf_decal/ship/delivery{
+	color = "#964B00"
+	},
+/turf/open/floor/monotile/dark/airless,
+/area/space/nearstation)
 "xw" = (
 /obj/machinery/door/poddoor/ship/preopen{
 	dir = 8;
@@ -6403,6 +6602,16 @@
 /obj/machinery/computer/iff_console,
 /turf/open/floor/monotile/steel,
 /area/ai_monitored/nuke_storage)
+"yr" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/storage/toolbox/mechanical,
+/obj/structure/rack,
+/obj/item/radio,
+/obj/item/radio,
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
 "yw" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	req_one_access_txt = "13"
@@ -6420,9 +6629,7 @@
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/central)
 "yG" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -6433,6 +6640,10 @@
 /obj/item/hand_tele,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/heads/captain)
+"yV" = (
+/obj/effect/turf_decal/ship/borderfloor/gunmetal,
+/turf/open/floor/monotile/dark/airless,
+/area/space/nearstation)
 "yZ" = (
 /turf/closed/wall/r_wall/ship,
 /area/hallway/nsv/deck1/hallway)
@@ -6498,6 +6709,10 @@
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/circuit/red,
 /area/ai_monitored/turret_protected/aisat)
+"zW" = (
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/quartermaster/miningdock)
 "AF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -6547,6 +6762,17 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"Bq" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
+"BI" = (
+/obj/effect/turf_decal/bot_white,
+/obj/vehicle/sealed/car/realistic/fighter_tug,
+/turf/open/floor/monotile/dark/airless,
+/area/space/nearstation)
 "CA" = (
 /obj/machinery/camera/motion{
 	dir = 1
@@ -6559,6 +6785,20 @@
 	},
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
+"CJ" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/quartermaster/miningdock)
 "Da" = (
 /obj/machinery/camera/autoname{
 	name = "Fighter Tarmac";
@@ -6572,6 +6812,14 @@
 	},
 /turf/open/openspace,
 /area/shuttle/turbolift/shaft)
+"Dv" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
+"DA" = (
+/obj/machinery/status_display/ai/east,
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
 "DP" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/structure/reagent_dispensers/fueltank/cryogenic_fuel,
@@ -6604,6 +6852,14 @@
 	},
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
+"EM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
 "EV" = (
 /obj/machinery/computer/security/telescreen/squadcam{
 	pixel_x = 32
@@ -6631,6 +6887,30 @@
 /obj/machinery/light,
 /turf/open/floor/monotile/steel,
 /area/storage/eva)
+"Fq" = (
+/obj/machinery/door/airlock/ship/public/glass/turbolift{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/plasteel/grid/steel,
+/area/shuttle/turbolift/tertiary)
+"Fy" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
 "Fz" = (
 /obj/machinery/camera/autoname{
 	name = "Gold Magcats";
@@ -6699,10 +6979,20 @@
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
 	})
+"Gt" = (
+/obj/structure/closet/secure_closet/miner,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
 "Gv" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
 /turf/open/floor/plating,
 /area/storage/eva)
+"GA" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/openspace,
+/area/quartermaster/miningdock)
 "GD" = (
 /obj/structure/rack,
 /obj/item/fighter_component/battery,
@@ -6713,6 +7003,20 @@
 /obj/item/fighter_component/canopy,
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
+"GM" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-21";
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/machinery/newscaster{
+	pixel_x = 28
+	},
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
 "GS" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/suit/ship/squad/bomber,
@@ -6738,6 +7042,21 @@
 /obj/machinery/light,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat)
+"Ho" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/quartermaster/miningdock)
 "Hr" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -6747,6 +7066,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/central)
+"Hy" = (
+/obj/effect/turf_decal/ship/borderfloor/gunmetal{
+	dir = 6
+	},
+/turf/open/floor/monotile/dark/airless,
+/area/space/nearstation)
 "HC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -6769,6 +7094,10 @@
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
 	})
+"Il" = (
+/obj/structure/lattice/catwalk,
+/turf/open/openspace,
+/area/quartermaster/miningdock)
 "Im" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6803,6 +7132,20 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
+"IJ" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/obj/machinery/disposal/bin,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
 "IR" = (
 /obj/structure/railing{
 	dir = 4
@@ -6826,6 +7169,21 @@
 /obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall/ship,
 /area/hallway/nsv/deck1/hallway)
+"Jm" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/quartermaster/miningdock)
+"Jp" = (
+/turf/closed/wall/r_wall/ship,
+/area/quartermaster/miningdock)
 "JE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6835,6 +7193,17 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/ai_monitored/turret_protected/ai_upload)
+"JH" = (
+/obj/machinery/lazylift_button,
+/turf/closed/wall/r_wall/ship,
+/area/shuttle/turbolift/tertiary)
+"JQ" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/quartermaster/miningdock)
 "JS" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/monotile/dark,
@@ -6897,6 +7266,24 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/steel,
 /area/nsv/briefingroom)
+"KI" = (
+/obj/effect/turf_decal/ship/borderfloor/gunmetal{
+	dir = 10
+	},
+/turf/open/floor/monotile/dark/airless,
+/area/space/nearstation)
+"KJ" = (
+/obj/effect/turf_decal/ship/delivery{
+	color = "#964B00"
+	},
+/obj/structure/fighter_launcher{
+	dir = 4;
+	name = "Gold 2"
+	},
+/turf/open/floor/monotile/dark/airless,
+/area/nsv/hanger/deck3{
+	name = "Air traffic control pod"
+	})
 "KS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6945,6 +7332,9 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/central)
+"Lt" = (
+/turf/open/floor/plating,
+/area/quartermaster/miningdock)
 "Lw" = (
 /obj/item/fighter_component/avionics,
 /obj/item/fighter_component/avionics,
@@ -6970,6 +7360,12 @@
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
 	})
+"Me" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/openspace,
+/area/shuttle/turbolift/tertiary)
 "Mg" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -6992,6 +7388,18 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/ai_monitored/turret_protected/ai_upload)
+"Ml" = (
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
+"Mq" = (
+/obj/structure/closet/secure_closet/engineering_welding{
+	anchored = 1;
+	name = "pitstop locker";
+	req_access = null;
+	req_one_access_txt = "48"
+	},
+/turf/open/floor/monotile/dark/airless,
+/area/space/nearstation)
 "Mt" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /turf/open/floor/monotile/dark/airless,
@@ -7000,6 +7408,15 @@
 /obj/structure/reagent_dispensers/foamtank/hull_repair_juice,
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
+"MI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/quartermaster/miningdock)
 "MM" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -7007,10 +7424,41 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/monotile/steel,
 /area/nsv/briefingroom)
+"Na" = (
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/quartermaster/miningdock)
 "Ne" = (
 /obj/machinery/light/floor,
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
+"Nt" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/security/telescreen/atc,
+/obj/item/radio/intercom{
+	pixel_x = -26
+	},
+/obj/machinery/computer/ship/viewscreen,
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
+"Nx" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/security/telescreen/atc,
+/obj/item/radio/intercom{
+	pixel_x = -26
+	},
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
+"ND" = (
+/obj/machinery/modular_computer/console/preset/civilian{
+	dir = 4
+	},
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
 "NP" = (
 /obj/effect/landmark/start/ai/secondary,
 /turf/open/floor/monotile/dark,
@@ -7035,6 +7483,20 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/primary/aft)
+"Ol" = (
+/obj/machinery/power/deck_relay,
+/obj/machinery/door/window/northleft,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/quartermaster/miningdock)
 "OF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
@@ -7054,12 +7516,28 @@
 /obj/structure/grille,
 /turf/open/floor/monotile/dark,
 /area/maintenance/nsv/deck1/aft)
+"Pb" = (
+/obj/machinery/requests_console{
+	department = "Mining";
+	pixel_x = 28
+	},
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
 "Pf" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/openspace,
 /area/shuttle/turbolift/shaft)
+"Pk" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/quartermaster/miningdock)
 "PJ" = (
 /obj/machinery/door/airlock/ship/public/glass/turbolift{
 	dir = 4
@@ -7096,6 +7574,25 @@
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
+"Qp" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/quartermaster/miningdock)
 "Qq" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	name = "Flight deck access";
@@ -7106,6 +7603,15 @@
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
 	})
+"Qs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
 "Qx" = (
 /obj/structure/table,
 /obj/item/stack/packageWrap,
@@ -7127,6 +7633,10 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/teleporter)
+"QC" = (
+/obj/structure/closet/secure_closet/miner,
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
 "QF" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /turf/open/floor/engine/airless,
@@ -7231,6 +7741,10 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"RJ" = (
+/obj/machinery/status_display/evac/east,
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
 "RM" = (
 /obj/machinery/newscaster{
 	pixel_x = -31
@@ -7263,6 +7777,16 @@
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
 	})
+"Sr" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/quartermaster/miningdock)
 "Ss" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -7300,6 +7824,12 @@
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/aisat)
+"SF" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
 "Tl" = (
 /obj/structure/rack,
 /obj/item/fighter_component/armour_plating,
@@ -7344,6 +7874,15 @@
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
 	})
+"TR" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/quartermaster/miningdock)
 "TY" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -7351,6 +7890,9 @@
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
 	})
+"Uc" = (
+/turf/closed/wall/r_wall/ship,
+/area/shuttle/turbolift/tertiary)
 "Ug" = (
 /obj/structure/fighter_launcher{
 	name = "Auxiliary 2"
@@ -7396,6 +7938,9 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/nsv/briefingroom)
+"Uy" = (
+/turf/open/openspace,
+/area/shuttle/turbolift/tertiary)
 "UH" = (
 /obj/machinery/camera/autoname{
 	name = "Fighter Tarmac #2";
@@ -7403,6 +7948,11 @@
 	},
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
+"UV" = (
+/obj/structure/table/reinforced,
+/obj/machinery/camera/autoname,
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
 "UW" = (
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/engine/airless,
@@ -7422,6 +7972,12 @@
 /obj/machinery/atmospherics/components/binary/dp_vent_pump,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
+"Vp" = (
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/light/floor,
+/obj/machinery/light/runway,
+/turf/open/floor/monotile/dark/airless,
+/area/space/nearstation)
 "VB" = (
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/nsv/deck1/aft)
@@ -7480,6 +8036,13 @@
 /obj/structure/grille,
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
+"Xy" = (
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/quartermaster/miningdock)
 "XE" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/structure/rack,
@@ -7519,10 +8082,13 @@
 /obj/machinery/lazylift_button,
 /turf/closed/wall/r_wall/ship,
 /area/shuttle/turbolift/shaft)
+"YI" = (
+/obj/machinery/vendor/mining,
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
 "YJ" = (
 /obj/structure/fluff/support_beam{
-	dir = 4;
-	icon_state = "support_beam"
+	dir = 4
 	},
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only,
@@ -7533,6 +8099,14 @@
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
 	})
+"YM" = (
+/obj/machinery/camera/autoname{
+	dir = 8;
+	name = "Mining Magcats";
+	network = list("ss13","hangar")
+	},
+/turf/open/floor/monotile/dark/airless,
+/area/space/nearstation)
 "YZ" = (
 /obj/structure/chair/stool,
 /turf/open/floor/monotile/steel,
@@ -7548,6 +8122,33 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/teleporter)
+"Zf" = (
+/obj/effect/turf_decal/ship/borderfloor/gunmetal{
+	dir = 5
+	},
+/turf/open/floor/monotile/dark/airless,
+/area/space/nearstation)
+"Zm" = (
+/obj/machinery/atmospherics/pipe/simple/multiz,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/meter{
+	pixel_x = -5;
+	pixel_y = -5;
+	target_layer = 1
+	},
+/turf/open/floor/plating,
+/area/quartermaster/miningdock)
 "ZJ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -36204,7 +36805,7 @@ bl
 ho
 cH
 Ba
-Qq
+nw
 TY
 Rc
 ax
@@ -37233,7 +37834,7 @@ as
 Sg
 as
 hn
-ax
+ny
 Mt
 ax
 hZ
@@ -40363,32 +40964,32 @@ Wi
 iC
 no
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+iu
+au
+au
+au
+au
+au
+au
+au
+au
+au
+au
+au
+au
+au
+au
+au
+au
+au
+au
+au
+au
+au
+au
+au
+au
+au
 ac
 aa
 aa
@@ -40620,32 +41221,32 @@ Wi
 iC
 no
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 aa
 aa
@@ -40877,32 +41478,32 @@ yZ
 iC
 no
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 aa
 aa
@@ -41134,32 +41735,32 @@ iC
 iC
 no
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 aa
 aa
@@ -41391,32 +41992,32 @@ iC
 no
 ax
 ax
-iu
-au
-au
-au
-au
-au
-au
-au
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 aa
 aa
@@ -41647,33 +42248,33 @@ Gv
 iC
 no
 ax
-nt
-nv
-nu
-nu
-nu
-nu
-nu
-nv
-nt
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 aa
 aa
@@ -41901,36 +42502,36 @@ ml
 mL
 Fm
 Gv
-iC
-no
-ax
-nu
-nw
-ny
-nB
-nC
-nB
 nD
-nw
+nC
 nu
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+nu
+nu
+nu
+nu
+nC
+nD
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 aa
 aa
@@ -42158,36 +42759,36 @@ mj
 ob
 lZ
 Gv
-iC
-no
-ax
 nu
-hS
-nz
-nB
-nC
+nE
+KI
+nA
+nx
+nA
 nB
 nE
-nG
 nu
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+hX
+ax
+ax
+ax
+ax
+ax
+hX
+ax
+ax
+ax
+ax
+ax
+ax
+hX
+ax
+ax
+ax
+ax
+ax
 ac
 aa
 aa
@@ -42415,36 +43016,36 @@ Yf
 Yf
 Yf
 Yf
-iC
-no
-ax
 nu
 hS
-nz
-nB
-nC
-nB
-nE
-nG
+yV
+nA
+nx
+nA
+uZ
+kj
 nu
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 aa
 aa
@@ -42672,36 +43273,36 @@ iC
 iC
 iC
 iC
-iC
-no
-ax
 nu
 hS
-nz
-nB
-nC
-nB
-nE
-nG
+yV
+nA
+nx
+nA
+uZ
+kj
 nu
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 aa
 aa
@@ -42929,36 +43530,36 @@ iC
 iC
 iC
 iC
-iC
-no
-ax
 nu
 hS
-nz
-nB
-nC
-nB
-nE
-nG
+yV
+nA
+nx
+nA
+uZ
+kj
 nu
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+Jp
+Jp
+zW
+zW
+zW
+Jp
+Jp
+Jp
+zW
+zW
+zW
+zW
+Jp
+Jp
+ax
+ax
+ax
+ax
+ax
 ac
 aa
 aa
@@ -43186,36 +43787,36 @@ jj
 jj
 jj
 jj
-jj
-np
-ax
 nu
 hS
-nz
-nB
-nC
-nB
-nE
-nG
+yV
+nA
+nx
+nA
+uZ
+kj
 nu
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+zW
+Gt
+QC
+QC
+QC
+YI
+Jp
+Nt
+sd
+ND
+ND
+sd
+Nx
+zW
+ax
+ax
+ax
+ax
+ax
 ac
 aa
 aa
@@ -43443,36 +44044,36 @@ ax
 ax
 ax
 ax
-ax
-ax
-ax
 nu
 hS
-nz
-nB
-nC
-nB
-nE
-nG
+yV
+nA
+nx
+nA
+uZ
+kj
 nu
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+zW
+Ml
+Ho
+Pk
+Sr
+Ml
+vc
+UV
+ii
+Pk
+Pk
+xb
+oW
+zW
+ax
+ax
+ax
+ax
+ax
 ac
 aa
 aa
@@ -43697,39 +44298,39 @@ iC
 no
 ax
 ax
-nr
-bW
-bW
-aK
+ax
 ax
 ax
 nu
 hS
-nz
-nB
-nC
-nB
-nE
-nG
+yV
+nA
+nx
+nA
+uZ
+kj
 nu
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+zW
+Dv
+qI
+MI
+Jm
+EM
+gn
+Bq
+Qp
+MI
+MI
+CJ
+SF
+zW
+ax
+ax
+ax
+ax
+ax
 ac
 aa
 aa
@@ -43953,39 +44554,39 @@ dS
 iC
 no
 ax
-nr
-ac
-ac
-ac
-af
+ax
+ax
 ax
 ax
 nu
 hS
-nz
-nB
-nC
-nB
-nE
-nG
+yV
+nA
+nx
+nA
+uZ
+kj
 nu
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+zW
+yr
+wk
+Ml
+DA
+Fy
+Jp
+IJ
+tu
+RJ
+Pb
+Qs
+GM
+zW
+ax
+ax
+ax
+ax
 ac
 ac
 aa
@@ -44210,40 +44811,40 @@ dS
 iC
 no
 ax
-it
-ac
-lI
-ac
-af
 ax
+ax
+lI
 ax
 nu
 hS
-nz
-nB
-nC
-nB
-nE
-nG
+yV
+nA
+nx
+nA
+uZ
+kj
 nu
-it
+ax
+ax
+Jp
+Uc
+JH
+Fq
+Uc
+Uc
+Jp
+Jp
+wX
+Jp
+Jp
+dU
+Jp
+Jp
+ax
 ac
+ax
 ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
 ac
 aa
 aa
@@ -44464,40 +45065,40 @@ gC
 mQ
 eE
 dT
+iC
 no
 ax
 ax
-it
 lI
 lI
 lI
-af
-ax
-ax
 nu
+hS
+yV
+nA
 nx
 nA
-nB
-nC
-nB
-nF
-nx
+uZ
+kj
 nu
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+Uc
+Uy
+Uy
+Uy
+Uc
+Il
+GA
+Zm
+rM
+Jp
+sj
+Lt
+Jp
+ax
+ax
 ac
 ac
 ac
@@ -44721,39 +45322,39 @@ gC
 kP
 eE
 dT
+iC
 no
 ax
 ax
-it
-ac
+ax
 lI
-ac
-af
+ax
+nu
+hS
+yV
+nA
+nx
+nA
+uZ
+kj
+nu
 ax
 ax
-nt
-nv
-nu
-nu
-nu
-nu
-nu
-nv
-nt
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+Uc
+Uy
+Uy
+Uy
+Uc
+nW
+Il
+Ol
+JQ
+Jp
+TR
+Xy
+Jp
+ax
 ac
 ac
 aa
@@ -44981,37 +45582,37 @@ dT
 no
 ax
 ax
-it
-ac
-ac
-ac
-ac
-bW
-bW
-bW
-bW
-bW
-bW
-bW
-bW
-bW
-bW
-bW
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+nu
+nF
+Hy
+nA
+nx
+nA
+Zf
+nF
+nu
+ax
+ax
+ax
+Uc
+Uy
+Me
+Uy
+Uc
+Il
+uf
+om
+Na
+Jp
+ud
+Jp
+Jp
+ax
+ax
 ac
 aa
 aa
@@ -45238,36 +45839,36 @@ dT
 no
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+nD
+nC
+nu
+nu
+nu
+nu
+nu
+nC
+nD
+ax
+ax
+ax
+Uc
+Uc
+Uc
+Uc
+Uc
+Jp
+Jp
+Jp
+Jp
+Jp
+ax
+ax
+ax
+ax
 ac
 ac
 aa
@@ -45495,37 +46096,37 @@ dT
 no
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+sm
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+sm
+ax
+ax
+ax
+ax
+ax
 ac
 aa
 aa
@@ -45752,36 +46353,36 @@ dT
 no
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 ac
 aa
@@ -46009,37 +46610,37 @@ dT
 no
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+nG
+ax
+ax
+ax
+nG
+ax
+ax
+ax
+hA
+hA
+hA
+Vp
+hA
+hA
+hA
+ax
+ax
+ax
+ax
+ax
+hX
+ax
+ax
+ax
+ax
+ax
 ac
 aa
 aa
@@ -46266,36 +46867,36 @@ dT
 no
 ax
 ax
-it
+ax
+ax
+ax
+ax
+ax
+xf
+ax
+ax
+ax
+xf
+ax
+ax
+ax
+hA
 ac
 ac
+hA
 ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+rk
+hA
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 ac
 aa
@@ -46523,37 +47124,37 @@ dS
 no
 ax
 ax
-it
+ax
+ax
+ax
+ax
+ax
+xf
+ax
+ax
+ax
+xf
+ax
+ax
+ax
+hA
 ac
 ac
+hA
 ac
 ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+hA
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 aa
 aa
@@ -46780,36 +47381,36 @@ dS
 no
 ax
 ax
-it
+ax
+ax
+ax
+ib
+ax
+KJ
+ax
+hX
+ax
+KJ
+ax
+ib
+ax
+hA
+hA
+hA
+lN
+hA
+hA
+hA
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
 ac
 ac
 aa
@@ -47037,35 +47638,35 @@ dS
 no
 ax
 ax
-it
+ax
+ax
+ax
+ib
+ax
+xf
+ax
+hZ
+ax
+xf
+ax
+ib
+ax
+hA
 ac
+rk
+hA
 ac
+rk
+hA
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
 ac
 ac
 ac
@@ -47294,34 +47895,34 @@ dS
 no
 ax
 ax
-it
+ax
+ax
+ax
+ib
+ax
+xf
+uT
+Xp
+tf
+xf
+ax
+ib
+ax
+hA
 ac
 ac
+hA
 ac
 ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+hA
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 aa
 aa
@@ -47551,33 +48152,33 @@ iC
 no
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ib
+ax
+xf
+ax
+ib
+ax
+xf
+ax
+ib
+ax
+hA
+hA
+hA
+lN
+hA
+hA
+hA
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 ac
 aa
@@ -47808,34 +48409,34 @@ jj
 np
 ax
 ax
-it
+ax
+ax
+ax
+ib
+ax
+xf
+ax
+ic
+ax
+xf
+ax
+ib
+ax
+hA
 ac
 ac
+hA
 ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+rk
+hA
+ax
+ax
+ax
 ax
 hX
 ax
-ac
-ac
+ax
+ax
 ac
 aa
 aa
@@ -48065,33 +48666,33 @@ ax
 ax
 ax
 ax
-it
+ax
+ax
+ax
+ax
+ax
+xf
+ax
+ax
+ax
+xf
+ax
+ax
+ax
+BI
 ac
 ac
+hA
 ac
 ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+hA
+ax
+ax
+ax
 hX
 ae
 hX
-ac
+ax
 ac
 ac
 aa
@@ -48322,34 +48923,34 @@ ax
 ax
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+xf
+ax
+ax
+ax
+xf
+ax
+ax
+ax
+hA
+hA
+hA
+lN
+hA
+hA
+hA
+ax
+ax
+ax
 ax
 hX
 ax
-ac
-ac
+ax
+ax
 ac
 aa
 aa
@@ -48579,33 +49180,33 @@ ax
 ax
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+nG
+ax
+ax
+ax
+nG
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 ac
 aa
@@ -48836,34 +49437,34 @@ ax
 ax
 ax
 ax
-it
+ax
+ax
+ax
+ax
+ax
+xf
+ax
+ax
+ax
+xf
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
 ac
 aa
 aa
@@ -49087,39 +49688,39 @@ ax
 UW
 ax
 ax
+lC
+mC
+hR
 ax
 ax
 ax
 ax
 ax
 ax
-it
+ax
+hX
+xf
+ax
+hA
+ax
+xf
+hX
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
 ac
 ac
 aa
@@ -49350,32 +49951,32 @@ ax
 ax
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+xf
+ax
+hA
+ax
+xf
+ax
+ax
+ax
+lI
+vl
+Mq
+YM
+ax
+vl
+lI
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 aa
 aa
@@ -49607,31 +50208,31 @@ ax
 ax
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+xf
+ax
+hA
+ax
+xf
+ax
+ax
+lI
+lI
+lJ
+lJ
+lJ
+lJ
+lJ
+lI
+lI
+ax
+ax
+ax
+ax
 ac
 ac
 aa
@@ -49864,32 +50465,32 @@ ax
 ax
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+xf
+ax
+hA
+ax
+xf
+ax
+ax
+ax
+lI
+ax
+ax
+sm
+ax
+ax
+lI
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 aa
 aa
@@ -50121,31 +50722,31 @@ ax
 ax
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+xf
+ax
+hA
+ax
+xf
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 ac
 aa
@@ -50378,32 +50979,32 @@ ax
 ax
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+xf
+ax
+hA
+ax
+xf
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 aa
 aa
@@ -50629,37 +51230,37 @@ UW
 UW
 ax
 ax
+lC
+mC
+hR
 ax
 ax
 ax
 ax
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+xf
+ax
+hA
+ax
+xf
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 ac
 aa
@@ -50892,32 +51493,32 @@ ax
 ax
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+xf
+ax
+hA
+ax
+xf
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 aa
 aa
@@ -51149,31 +51750,31 @@ ax
 ax
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+xf
+ax
+hA
+ax
+xf
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 ac
 aa
@@ -51406,32 +52007,32 @@ ax
 ax
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+xf
+ax
+hA
+ax
+xf
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 aa
 aa
@@ -51663,31 +52264,31 @@ ax
 ax
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+xf
+ax
+hA
+ax
+xf
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 ac
 aa
@@ -51920,32 +52521,32 @@ ax
 ax
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+xf
+ax
+hA
+ax
+xf
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 aa
 aa
@@ -52171,37 +52772,37 @@ ax
 ax
 ax
 UW
+lC
+mC
+hR
 ax
 ax
 ax
 ax
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+hZ
+xf
+ax
+hA
+ax
+xf
+hZ
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 ac
 aa
@@ -52434,32 +53035,32 @@ ax
 ax
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+xf
+ax
+hA
+ax
+xf
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 aa
 aa
@@ -52691,31 +53292,31 @@ ax
 ax
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+xf
+ax
+hA
+ax
+xf
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 ac
 aa
@@ -52948,32 +53549,32 @@ ax
 ax
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+xf
+ax
+hA
+ax
+xf
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 aa
 aa
@@ -53205,31 +53806,31 @@ ax
 ax
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+xf
+ax
+hA
+ax
+xf
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 ac
 aa
@@ -53462,32 +54063,32 @@ ax
 ax
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+xf
+ax
+hA
+ax
+xf
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 aa
 aa
@@ -53713,37 +54314,37 @@ ax
 ax
 ax
 UW
+lC
+mC
+hR
 ax
 ax
 ax
 ax
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+xf
+ax
+hA
+ax
+xf
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 ac
 aa
@@ -53976,32 +54577,32 @@ ax
 ax
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+xf
+ax
+hA
+ax
+xf
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 aa
 aa
@@ -54233,31 +54834,31 @@ ax
 ax
 ax
 ax
-it
+ax
+ax
+ax
+ax
+ax
+xf
+ax
+hA
+ax
+xf
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
+ax
 ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
 ac
 ac
 aa
@@ -54490,28 +55091,28 @@ ax
 ax
 ax
 ax
-it
+ax
+ax
+ax
+ax
+ax
+xf
+ax
+hA
+ax
+xf
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
 ac
 ac
 ac
@@ -54747,27 +55348,27 @@ ax
 ax
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+xf
+ax
+hA
+ax
+xf
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 aa
 aa
@@ -55004,26 +55605,26 @@ ax
 ax
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+xf
+ax
+hA
+ax
+xf
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 ac
 aa
@@ -55255,33 +55856,33 @@ UW
 UW
 UW
 ax
+lC
+mC
+hR
 ax
 ax
 ax
 ax
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ia
+xf
+ax
+hA
+ax
+xf
+ia
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 aa
 aa
@@ -55518,26 +56119,26 @@ ax
 ax
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+xf
+ax
+hA
+ax
+xf
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 ac
 aa
@@ -55775,27 +56376,27 @@ ax
 ax
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+xf
+ax
+hA
+ax
+xf
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 aa
 aa
@@ -56032,26 +56633,26 @@ ax
 ax
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+xf
+ax
+hA
+ax
+xf
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 ac
 aa
@@ -56289,27 +56890,27 @@ ax
 ax
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+xf
+ax
+hA
+ax
+xf
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 aa
 aa
@@ -56546,26 +57147,26 @@ ax
 ax
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+xf
+ax
+hA
+ax
+xf
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 ac
 aa
@@ -56797,33 +57398,33 @@ ax
 ax
 ax
 ax
+lC
+mC
+hR
 ax
 ax
 ax
 ax
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+xf
+ax
+hA
+ax
+xf
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 aa
 aa
@@ -57060,26 +57661,26 @@ ax
 ax
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+xf
+ax
+hA
+ax
+xf
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 ac
 aa
@@ -57317,27 +57918,27 @@ ax
 ax
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+xf
+ax
+hA
+ax
+xf
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 aa
 aa
@@ -57574,26 +58175,26 @@ ax
 ax
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+xf
+ax
+hA
+ax
+xf
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 ac
 aa
@@ -57831,27 +58432,27 @@ ax
 ax
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+xf
+ax
+hA
+ax
+xf
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 aa
 aa
@@ -58088,26 +58689,26 @@ ax
 ax
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+xf
+ax
+hA
+ax
+xf
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 ac
 aa
@@ -58339,33 +58940,33 @@ ax
 ax
 ax
 ax
+lC
+mC
+hR
 ax
 ax
 ax
 ax
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ib
+xf
+ax
+hA
+ax
+xf
+ib
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 aa
 aa
@@ -58602,26 +59203,26 @@ ax
 ax
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+xf
+ax
+hA
+ax
+xf
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 ac
 aa
@@ -58859,27 +59460,27 @@ ax
 ax
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+xf
+ax
+hA
+ax
+xf
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 aa
 aa
@@ -59116,26 +59717,26 @@ ax
 ax
 ax
 ax
-it
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+xf
+ax
+hA
+ax
+xf
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 ac
 aa
@@ -59373,27 +59974,27 @@ ax
 ax
 ax
 ax
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+xf
+ax
+hA
+ax
+xf
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 aa
 aa
@@ -59630,26 +60231,26 @@ ax
 ax
 ax
 ax
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+xf
+hA
+hA
+hA
+xf
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 ac
 aa
@@ -59881,33 +60482,33 @@ ax
 ax
 ax
 ax
+lC
+mC
+hR
 ax
 ax
 ax
 ax
 ax
 ax
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
 aa
 aa
@@ -60144,25 +60745,25 @@ ax
 ax
 ax
 ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ac
+ax
 ac
+ax
 ac
+ax
 ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
 ac
 ac
 ac
@@ -60400,18 +61001,18 @@ ax
 ax
 ax
 ax
+ac
 ax
 ac
+ax
 ac
+ax
 ac
+ax
 ac
+ax
 ac
-ac
-ac
-ac
-ac
-ac
-ac
+ax
 ac
 ac
 ac
@@ -60656,7 +61257,7 @@ ax
 ax
 ax
 ax
-ax
+ac
 ax
 ac
 ac

--- a/_maps/map_files/Tycoon/Tycoon1.dmm
+++ b/_maps/map_files/Tycoon/Tycoon1.dmm
@@ -1424,13 +1424,10 @@
 	name = "Mining Shuttle Airlock";
 	req_one_access_txt = "31;48"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grid/steel,
+/turf/open/floor/plating,
 /area/quartermaster/miningdock)
 "dV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -2060,6 +2057,10 @@
 /area/crew_quarters/heads/hop{
 	name = "Executive officer's Office"
 	})
+"fv" = (
+/obj/machinery/light,
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
 "fw" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -2456,10 +2457,6 @@
 	name = "Air traffic control pod"
 	})
 "gn" = (
-/obj/machinery/door/airlock/ship/station/mining{
-	name = "Mining Equipment";
-	req_one_access_txt = "48"
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -2467,7 +2464,11 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/grid/steel,
+/obj/machinery/door/airlock/ship/station/mining{
+	name = "Mining Equipment";
+	req_one_access_txt = "48"
+	},
+/turf/open/floor/monotile/steel,
 /area/quartermaster/miningdock)
 "go" = (
 /obj/machinery/door/airlock/ship/hatch{
@@ -3353,21 +3354,6 @@
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
 	})
-"ii" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/monotile/dark,
-/area/quartermaster/miningdock)
 "ij" = (
 /obj/effect/turf_decal/ship/delivery{
 	color = "#8B0000"
@@ -6001,8 +5987,26 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
+"oz" = (
+/obj/machinery/modular_computer/console/preset/civilian{
+	dir = 4
+	},
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
+"oS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/turf/open/floor/monotile/dark,
+/area/quartermaster/miningdock)
 "oW" = (
-/obj/structure/table/reinforced,
+/obj/machinery/suit_storage_unit/mining/eva,
 /turf/open/floor/monotile/steel,
 /area/quartermaster/miningdock)
 "pe" = (
@@ -6011,6 +6015,25 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/aisat)
+"pj" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
+"pn" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/airlock/ship/external{
+	name = "Mining Shuttle Airlock";
+	req_one_access_txt = "31;48"
+	},
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
 "pq" = (
 /obj/structure/fighter_launcher{
 	dir = 4;
@@ -6034,6 +6057,22 @@
 /obj/item/fighter_component/targeting_sensor,
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
+"pJ" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/quartermaster/miningdock)
 "pU" = (
 /obj/machinery/door/airlock/ship/hatch{
 	dir = 4;
@@ -6058,10 +6097,30 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/aisat)
+"qe" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/quartermaster/miningdock)
 "qg" = (
 /obj/vehicle/sealed/car/realistic/fighter_tug,
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
+"qk" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-21";
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
 "qq" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -6083,10 +6142,6 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat)
 "qI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -6094,6 +6149,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/monotile/dark,
 /area/quartermaster/miningdock)
 "qO" = (
@@ -6164,6 +6220,18 @@
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
+"ro" = (
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
+"rt" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
 "rz" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -6205,25 +6273,24 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "sd" = (
-/obj/machinery/computer/ship/dradis/minor{
-	dir = 4
-	},
-/turf/open/floor/monotile/steel,
-/area/quartermaster/miningdock)
-"sj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/advanced_airlock_controller{
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer1{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/monotile/dark,
+/area/quartermaster/miningdock)
+"sj" = (
+/obj/machinery/suit_storage_unit/mining/eva,
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/monotile/steel,
 /area/quartermaster/miningdock)
 "sm" = (
 /obj/machinery/camera/autoname{
@@ -6269,14 +6336,14 @@
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
 "tu" = (
-/obj/structure/disposalpipe/junction/flip{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/monotile/steel,
 /area/quartermaster/miningdock)
@@ -6304,11 +6371,17 @@
 	name = "Air traffic control pod"
 	})
 "ud" = (
-/obj/machinery/door/airlock/ship/external{
-	name = "Mining Shuttle Airlock";
-	req_one_access_txt = "31;48"
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/monotile/dark,
 /area/quartermaster/miningdock)
 "uf" = (
 /obj/structure/lattice/catwalk,
@@ -6356,6 +6429,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
+"uB" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/monotile/dark,
+/area/quartermaster/miningdock)
 "uT" = (
 /obj/machinery/camera/autoname{
 	dir = 1;
@@ -6545,22 +6630,30 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/turf/open/floor/plasteel/grid/steel,
+/turf/open/floor/plating,
 /area/quartermaster/miningdock)
 "xb" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
-	},
+/obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/quartermaster/miningdock)
+"xc" = (
 /obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/monotile/dark,
 /area/quartermaster/miningdock)
 "xf" = (
@@ -6606,10 +6699,8 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/item/storage/toolbox/mechanical,
-/obj/structure/rack,
-/obj/item/radio,
-/obj/item/radio,
+/obj/machinery/airalarm/directional/east,
+/obj/structure/closet/secure_closet/miner,
 /turf/open/floor/monotile/steel,
 /area/quartermaster/miningdock)
 "yw" = (
@@ -6657,6 +6748,10 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/teleporter)
+"zr" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/quartermaster/miningdock)
 "zu" = (
 /obj/structure/overmap/small_craft/transport/sabre,
 /turf/open/floor/engine/airless,
@@ -6749,6 +6844,14 @@
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
 	})
+"Bb" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/security/telescreen/atc,
+/obj/item/radio/intercom{
+	pixel_x = -26
+	},
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
 "Bp" = (
 /obj/machinery/porta_turret/ai,
 /obj/item/radio/intercom{
@@ -6764,8 +6867,8 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "Bq" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/steel,
 /area/quartermaster/miningdock)
 "BI" = (
@@ -6773,6 +6876,15 @@
 /obj/vehicle/sealed/car/realistic/fighter_tug,
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
+"BN" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/security/telescreen/atc,
+/obj/item/radio/intercom{
+	pixel_x = -26
+	},
+/obj/machinery/computer/ship/viewscreen,
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
 "CA" = (
 /obj/machinery/camera/motion{
 	dir = 1
@@ -6786,18 +6898,16 @@
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
 "CJ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
 	},
-/turf/open/floor/monotile/dark,
+/turf/open/floor/plating,
 /area/quartermaster/miningdock)
 "Da" = (
 /obj/machinery/camera/autoname{
@@ -6812,8 +6922,24 @@
 	},
 /turf/open/openspace,
 /area/shuttle/turbolift/shaft)
-"Dv" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+"Du" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/airlock/ship/station/mining{
+	name = "Mining Equipment";
+	req_one_access_txt = "48"
+	},
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
+"Dz" = (
+/obj/machinery/newscaster{
+	pixel_x = 28
+	},
 /turf/open/floor/monotile/steel,
 /area/quartermaster/miningdock)
 "DA" = (
@@ -6838,6 +6964,10 @@
 /obj/structure/overmap/small_craft/combat/light,
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
+"ED" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
 "EE" = (
 /obj/structure/table/glass,
 /obj/effect/spawner/lootdrop/aimodule_harmless,
@@ -6900,6 +7030,12 @@
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/grid/steel,
 /area/shuttle/turbolift/tertiary)
+"Ft" = (
+/obj/machinery/computer/ship/dradis/minor{
+	dir = 4
+	},
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
 "Fy" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -6981,7 +7117,6 @@
 	})
 "Gt" = (
 /obj/structure/closet/secure_closet/miner,
-/obj/machinery/airalarm/directional/west,
 /turf/open/floor/monotile/steel,
 /area/quartermaster/miningdock)
 "Gv" = (
@@ -7004,18 +7139,11 @@
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
 "GM" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/camera/autoname{
+	dir = 8
 	},
-/obj/item/kirbyplants{
-	icon_state = "plant-21";
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/machinery/newscaster{
-	pixel_x = 28
-	},
-/turf/open/floor/monotile/steel,
+/obj/machinery/light/small,
+/turf/open/floor/plating,
 /area/quartermaster/miningdock)
 "GS" = (
 /obj/structure/table/reinforced,
@@ -7043,9 +7171,6 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat)
 "Ho" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -7084,6 +7209,22 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
+"HK" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-21";
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
+"HZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
 "Ie" = (
 /obj/structure/fighter_launcher{
 	dir = 4;
@@ -7133,18 +7274,19 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "IJ" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 2
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/machinery/disposal/bin,
-/obj/machinery/light{
-	dir = 4
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/firealarm{
-	pixel_y = 24
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
 	},
-/turf/open/floor/monotile/steel,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/turf/open/floor/monotile/dark,
 /area/quartermaster/miningdock)
 "IR" = (
 /obj/structure/railing{
@@ -7231,6 +7373,9 @@
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
 	})
+"Kc" = (
+/turf/open/floor/monotile/dark,
+/area/quartermaster/miningdock)
 "Kn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -7333,7 +7478,17 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/central)
 "Lt" = (
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
 /area/quartermaster/miningdock)
 "Lw" = (
 /obj/item/fighter_component/avionics,
@@ -7409,10 +7564,14 @@
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
 "MI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
@@ -7436,27 +7595,39 @@
 /obj/machinery/light/floor,
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
+"Nf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
 "Nt" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/security/telescreen/atc,
-/obj/item/radio/intercom{
-	pixel_x = -26
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
 	},
-/obj/machinery/computer/ship/viewscreen,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/station/mining{
+	name = "Mining Equipment";
+	req_one_access_txt = "48"
+	},
 /turf/open/floor/monotile/steel,
 /area/quartermaster/miningdock)
 "Nx" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/security/telescreen/atc,
-/obj/item/radio/intercom{
-	pixel_x = -26
+/obj/machinery/requests_console{
+	department = "Mining";
+	pixel_x = 28
 	},
 /turf/open/floor/monotile/steel,
 /area/quartermaster/miningdock)
 "ND" = (
-/obj/machinery/modular_computer/console/preset/civilian{
-	dir = 4
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/monotile/steel,
 /area/quartermaster/miningdock)
 "NP" = (
@@ -7512,16 +7683,44 @@
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
 	})
+"OX" = (
+/obj/machinery/disposal/bin,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
 "Pa" = (
 /obj/structure/grille,
 /turf/open/floor/monotile/dark,
 /area/maintenance/nsv/deck1/aft)
 "Pb" = (
-/obj/machinery/requests_console{
-	department = "Mining";
-	pixel_x = 28
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
 	},
 /turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
+"Pc" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
 /area/quartermaster/miningdock)
 "Pf" = (
 /obj/machinery/light{
@@ -7535,6 +7734,12 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/quartermaster/miningdock)
@@ -7574,23 +7779,26 @@
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
-"Qp" = (
-/obj/structure/disposalpipe/segment{
+"Qg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/monotile/dark,
+/area/quartermaster/miningdock)
+"Qn" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
+"Qp" = (
+/obj/structure/disposalpipe/junction/flip{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/dark,
 /area/quartermaster/miningdock)
 "Qq" = (
@@ -7604,13 +7812,19 @@
 	name = "Air traffic control pod"
 	})
 "Qs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
+/obj/machinery/advanced_airlock_controller{
+	pixel_y = 24
 	},
-/turf/open/floor/monotile/steel,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/quartermaster/miningdock)
 "Qx" = (
 /obj/structure/table,
@@ -7634,7 +7848,12 @@
 /turf/open/floor/monotile/dark,
 /area/teleporter)
 "QC" = (
-/obj/structure/closet/secure_closet/miner,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/monotile/steel,
 /area/quartermaster/miningdock)
 "QF" = (
@@ -7741,9 +7960,23 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/ai_upload)
-"RJ" = (
-/obj/machinery/status_display/evac/east,
+"RI" = (
+/obj/structure/table/reinforced,
+/obj/machinery/camera/autoname,
 /turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
+"RJ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/monotile/dark,
 /area/quartermaster/miningdock)
 "RM" = (
 /obj/machinery/newscaster{
@@ -7820,15 +8053,16 @@
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
 	})
+"Sz" = (
+/obj/machinery/status_display/evac/east,
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
 "SD" = (
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/aisat)
 "SF" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
-	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/plating,
 /area/quartermaster/miningdock)
 "Tl" = (
 /obj/structure/rack,
@@ -7875,13 +8109,14 @@
 	name = "Air traffic control pod"
 	})
 "TR" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/monotile/dark,
 /area/quartermaster/miningdock)
 "TY" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1,
@@ -7949,8 +8184,10 @@
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
 "UV" = (
-/obj/structure/table/reinforced,
-/obj/machinery/camera/autoname,
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/radio,
+/obj/item/radio,
 /turf/open/floor/monotile/steel,
 /area/quartermaster/miningdock)
 "UW" = (
@@ -7981,6 +8218,22 @@
 "VB" = (
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/nsv/deck1/aft)
+"VF" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/quartermaster/miningdock)
+"VI" = (
+/obj/structure/tank_dispenser/oxygen,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
 "VY" = (
 /obj/structure/chair/stool,
 /obj/machinery/camera/autoname{
@@ -8037,11 +8290,8 @@
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
 "Xy" = (
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/obj/machinery/light/small,
-/turf/open/floor/plating,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/monotile/steel,
 /area/quartermaster/miningdock)
 "XE" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
@@ -41485,6 +41735,7 @@ ax
 ax
 ax
 ax
+hX
 ax
 ax
 ax
@@ -41494,15 +41745,14 @@ ax
 ax
 ax
 ax
+hX
 ax
 ax
 ax
 ax
 ax
 ax
-ax
-ax
-ax
+hX
 ax
 ac
 aa
@@ -42005,11 +42255,11 @@ ax
 ax
 ax
 ax
-ax
-ax
-ax
-ax
-ax
+Jp
+Jp
+Jp
+Jp
+Jp
 ax
 ax
 ax
@@ -42256,17 +42506,17 @@ ax
 ax
 ax
 ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
+Jp
+Jp
+zW
+zW
+zW
+Jp
+Jp
+Ml
+Ml
+HK
+Jp
 ax
 ax
 ax
@@ -42513,17 +42763,17 @@ nC
 nD
 ax
 ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
+zW
+oW
+Ml
+Ml
+Ml
+UV
+Jp
+Ml
+Kc
+Ml
+Jp
 ax
 ax
 ax
@@ -42770,24 +43020,24 @@ nE
 nu
 ax
 ax
-hX
-ax
-ax
-ax
-ax
-ax
-hX
-ax
-ax
-ax
-ax
-ax
-ax
-hX
-ax
-ax
-ax
-ax
+zW
+oW
+ud
+IJ
+RJ
+Xy
+zr
+Ml
+Kc
+fv
+Jp
+Jp
+zW
+zW
+zW
+zW
+Jp
+Jp
 ax
 ac
 aa
@@ -43027,24 +43277,24 @@ kj
 nu
 ax
 ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
+zW
+oW
+xb
+Lt
+TR
+Ml
+zr
+Ml
+Kc
+ro
+Jp
+BN
+Ft
+oz
+oz
+Ft
+Bb
+zW
 ax
 ac
 aa
@@ -43284,24 +43534,24 @@ kj
 nu
 ax
 ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
+zW
+sj
+wk
+QC
+Ml
+VI
+Jp
+Qn
+Qg
+rt
+Jp
+RI
+Pc
+VF
+VF
+pJ
+ED
+zW
 ax
 ac
 aa
@@ -43543,22 +43793,22 @@ ax
 ax
 Jp
 Jp
-zW
-zW
-zW
+Jp
+Nt
 Jp
 Jp
 Jp
+Ml
+oS
+pj
+Du
+HZ
+uB
+qe
+qe
+xc
+rt
 zW
-zW
-zW
-zW
-Jp
-Jp
-ax
-ax
-ax
-ax
 ax
 ac
 aa
@@ -43800,22 +44050,22 @@ ax
 ax
 zW
 Gt
+Ml
 QC
-QC
-QC
+Ml
 YI
 Jp
-Nt
+Ml
 sd
 ND
-ND
-sd
+Jp
+OX
 Nx
+Sz
+Ml
+Dz
+qk
 zW
-ax
-ax
-ax
-ax
 ax
 ac
 aa
@@ -44056,23 +44306,23 @@ nu
 ax
 ax
 zW
-Ml
+Gt
 Ho
 Pk
 Sr
 Ml
 vc
-UV
-ii
-Pk
-Pk
-xb
-oW
-zW
-ax
-ax
-ax
-ax
+Ml
+sd
+fv
+Jp
+Jp
+Jp
+Jp
+Jp
+Jp
+Jp
+Jp
 ax
 ac
 aa
@@ -44313,7 +44563,7 @@ nu
 ax
 ax
 zW
-Dv
+Gt
 qI
 MI
 Jm
@@ -44321,11 +44571,11 @@ EM
 gn
 Bq
 Qp
-MI
-MI
+Nf
+pn
 CJ
 SF
-zW
+Jp
 ax
 ax
 ax
@@ -44572,17 +44822,17 @@ ax
 zW
 yr
 wk
-Ml
+Pb
 DA
 Fy
 Jp
-IJ
+Ml
 tu
-RJ
-Pb
+Ml
+Jp
 Qs
 GM
-zW
+Jp
 ax
 ax
 ax
@@ -45094,9 +45344,9 @@ GA
 Zm
 rM
 Jp
-sj
-Lt
-Jp
+ax
+ax
+ax
 ax
 ax
 ac
@@ -45351,9 +45601,9 @@ Il
 Ol
 JQ
 Jp
-TR
-Xy
-Jp
+ax
+ax
+ax
 ax
 ac
 ac
@@ -45608,9 +45858,9 @@ uf
 om
 Na
 Jp
-ud
-Jp
-Jp
+ax
+ax
+ax
 ax
 ax
 ac

--- a/_maps/map_files/Tycoon/Tycoon2.dmm
+++ b/_maps/map_files/Tycoon/Tycoon2.dmm
@@ -1749,6 +1749,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile/steel,
 /area/nsv/hanger/deck2)
 "aex" = (
@@ -4348,9 +4351,6 @@
 /turf/open/floor/engine,
 /area/medical/medbay/lobby)
 "akR" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -18681,6 +18681,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
 /turf/open/floor/monotile/steel,
 /area/nsv/hanger/deck2)
 "aWB" = (
@@ -38189,19 +38191,10 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "bKf" = (
-/obj/machinery/power/apc/auto_name/north{
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
 /obj/structure/lattice/catwalk/over/ship,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2)
 "bKg" = (
@@ -40649,6 +40642,9 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck2)
 "cZf" = (
@@ -42064,6 +42060,16 @@
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/quartermaster/storage)
+"fpP" = (
+/obj/effect/turf_decal/tile/orange{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/orange,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/monotile/dark,
+/area/nsv/hanger/deck2)
 "frs" = (
 /obj/machinery/computer/ship/munitions_computer/west,
 /obj/effect/turf_decal/stripes/line{
@@ -47899,6 +47905,12 @@
 	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
+"oyB" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/monotile/steel,
+/area/nsv/hanger/deck2)
 "oAa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
@@ -50895,6 +50907,12 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
+"tDl" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/monotile/steel,
+/area/nsv/hanger/deck2)
 "tDy" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/airalarm{
@@ -52821,6 +52839,12 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/engine/atmos)
+"xcx" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/monotile/steel,
+/area/nsv/hanger/deck2)
 "xdR" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -83440,7 +83464,7 @@ lhC
 lhC
 lhC
 lhC
-bKf
+bAU
 akR
 bAV
 iDb
@@ -84726,7 +84750,7 @@ fbx
 fbx
 fbx
 bAU
-bAV
+bKf
 bAV
 bAV
 bAV
@@ -84983,7 +85007,7 @@ bip
 bip
 bDY
 agl
-aMn
+fpP
 aMn
 aMn
 aMn
@@ -85240,7 +85264,7 @@ bip
 bip
 bDY
 bBg
-abx
+oyB
 abx
 abx
 abx
@@ -85497,8 +85521,8 @@ bip
 bip
 bDY
 aiw
-abx
-abx
+xcx
+tDl
 aew
 aWA
 ago

--- a/_maps/map_files/Tycoon/Tycoon2.dmm
+++ b/_maps/map_files/Tycoon/Tycoon2.dmm
@@ -457,9 +457,6 @@
 /area/nsv/weapons/fore)
 "abp" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/power/apc/auto_name/north{
-	pixel_y = 24
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -806,7 +803,7 @@
 /area/hallway/nsv/deck2/frame1/central)
 "aco" = (
 /obj/machinery/door/airlock/ship/security/glass{
-	req_one_access_txt = "2"
+	req_one_access_txt = "2;34"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4055,6 +4052,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=loc10";
+	location = "loc9"
+	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "akp" = (
@@ -4590,6 +4591,10 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=loc12";
+	location = "loc11"
 	},
 /turf/open/floor/monotile/dark,
 /area/medical/medbay/central)
@@ -6724,6 +6729,7 @@
 "arb" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/kitchen)
 "arc" = (
@@ -8147,6 +8153,12 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
+"avD" = (
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/shuttle/turbolift/tertiary)
 "avI" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light/runway/delay2,
@@ -10591,7 +10603,7 @@
 "aEr" = (
 /obj/machinery/door/airlock/ship/security/glass{
 	name = "Evidence";
-	req_one_access_txt = "2"
+	req_one_access_txt = "2;34"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -11543,6 +11555,10 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=loc9";
+	location = "loc8"
+	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "aGs" = (
@@ -12040,7 +12056,7 @@
 "aHv" = (
 /obj/machinery/door/airlock/ship/security/glass{
 	name = "Security Equipment";
-	req_one_access_txt = "1;4"
+	req_one_access_txt = "1;4;34"
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -15273,8 +15289,16 @@
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "aOA" = (
-/turf/closed/wall/ship,
-/area/quartermaster/miningdock)
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=loc8";
+	location = "loc7"
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/fitness/recreation)
 "aOB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -15291,22 +15315,20 @@
 "aOE" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/camera/autoname,
-/obj/structure/closet/secure_closet/miner,
 /obj/item/radio/intercom{
 	pixel_x = -26
 	},
 /turf/open/floor/plating,
-/area/quartermaster/miningdock)
+/area/quartermaster/storage)
 "aOF" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/closet/secure_closet/miner,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/quartermaster/miningdock)
+/area/quartermaster/storage)
 "aOH" = (
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/port)
@@ -16080,6 +16102,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/monotile/dark,
 /area/engine/engine_smes)
 "aQB" = (
@@ -22340,6 +22363,10 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=loc11";
+	location = "loc10"
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
 "bdZ" = (
@@ -23410,19 +23437,6 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit/departure_lounge)
-"bgc" = (
-/obj/machinery/door/airlock/ship/external{
-	name = "Mining Shuttle Airlock";
-	req_one_access_txt = "31;48"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/quartermaster/miningdock)
 "bgd" = (
 /obj/structure/table/reinforced,
 /obj/machinery/camera/autoname,
@@ -26350,7 +26364,7 @@
 /area/hallway/nsv/deck2/frame1/port)
 "bmn" = (
 /obj/machinery/door/airlock/ship/security/glass{
-	req_one_access_txt = "2"
+	req_one_access_txt = "2;34"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26636,6 +26650,10 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=loc2";
+	location = "loc1"
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/port)
@@ -32128,7 +32146,8 @@
 /area/quartermaster/storage)
 "bxA" = (
 /obj/machinery/door/airlock/ship/station/mining{
-	name = "Mining Equipment"
+	name = "Mining Equipment";
+	req_one_access_txt = "48"
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -32663,7 +32682,7 @@
 "byJ" = (
 /obj/machinery/door/airlock/ship/security/glass{
 	name = "Security Equipment";
-	req_one_access_txt = "1;4"
+	req_one_access_txt = "1;4;34"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -36015,7 +36034,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/ship/security/glass{
-	req_one_access_txt = "2"
+	req_one_access_txt = "2;34"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -36068,6 +36087,10 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=loc4";
+	location = "loc3-1"
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
@@ -36158,7 +36181,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/ship/security/glass{
-	req_one_access_txt = "2"
+	req_one_access_txt = "2;34"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -37564,8 +37587,9 @@
 /turf/closed/wall/r_wall/ship,
 /area/quartermaster/storage)
 "bID" = (
+/obj/machinery/lazylift_button,
 /turf/closed/wall/r_wall/ship,
-/area/quartermaster/miningdock)
+/area/shuttle/turbolift/tertiary)
 "bIE" = (
 /turf/closed/wall/r_wall/ship,
 /area/hallway/secondary/exit/departure_lounge)
@@ -37653,7 +37677,7 @@
 "bIT" = (
 /obj/machinery/door/airlock/ship/security/glass{
 	name = "Brig Infirmary";
-	req_one_access_txt = "2"
+	req_one_access_txt = "2;34"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -37688,7 +37712,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/ship/security/glass{
 	name = "Evidence";
-	req_one_access_txt = "2"
+	req_one_access_txt = "2;34"
 	},
 /turf/open/floor/monotile/steel,
 /area/security/prison)
@@ -37847,28 +37871,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"bJr" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plating,
-/area/quartermaster/miningdock)
-"bJs" = (
-/obj/structure/closet/secure_closet/miner,
-/obj/machinery/power/apc/auto_name/north{
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/quartermaster/miningdock)
 "bJt" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -37881,18 +37883,13 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/quartermaster/miningdock)
+/area/quartermaster/storage)
 "bJu" = (
-/obj/structure/closet/secure_closet/miner,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/quartermaster/miningdock)
+/area/quartermaster/storage)
 "bJv" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -37914,27 +37911,10 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
-/area/quartermaster/miningdock)
-"bJy" = (
-/obj/machinery/requests_console{
-	department = "Mining";
-	pixel_y = -30
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/quartermaster/miningdock)
+/area/quartermaster/storage)
 "bJz" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	name = "Mining dock";
@@ -37951,7 +37931,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
-/area/quartermaster/miningdock)
+/area/quartermaster/storage)
 "bJA" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -37996,13 +37976,18 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/structure/disposalpipe/junction/flip{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "bJE" = (
@@ -39033,18 +39018,6 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/space,
 /area/engine/atmos)
-"bMo" = (
-/obj/docking_port/stationary{
-	dir = 4;
-	dwidth = 3;
-	height = 5;
-	id = "mining_home";
-	name = "mining shuttle bay";
-	roundstart_template = /datum/map_template/shuttle/mining/box;
-	width = 7
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "bMp" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/ladder,
@@ -39208,6 +39181,22 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/ammo_sorter{
+	dir = 8;
+	id = "atlas_missilebay";
+	name = "Missile Casings"
+	},
+/obj/item/ship_weapon/ammunition/missile/missile_casing,
+/obj/item/ship_weapon/ammunition/missile/missile_casing,
+/obj/item/ship_weapon/ammunition/missile/missile_casing,
+/obj/item/ship_weapon/ammunition/missile/missile_casing,
+/obj/item/ship_weapon/ammunition/missile/missile_casing,
+/obj/item/ship_weapon/ammunition/missile/missile_casing,
+/obj/item/ship_weapon/ammunition/missile/missile_casing,
+/obj/item/ship_weapon/ammunition/missile/missile_casing,
+/obj/item/ship_weapon/ammunition/missile/missile_casing,
+/obj/item/ship_weapon/ammunition/missile/missile_casing,
+/obj/item/ship_weapon/ammunition/missile/missile_casing,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
 "bXF" = (
@@ -40389,9 +40378,8 @@
 /turf/open/floor/plating,
 /area/medical/virology)
 "cDF" = (
-/obj/machinery/vendor/mining,
 /turf/open/floor/plating,
-/area/quartermaster/miningdock)
+/area/quartermaster/storage)
 "cED" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
 	dir = 4
@@ -40695,12 +40683,6 @@
 /obj/item/book/manual/wiki/rbmk,
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
-"ddh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/quartermaster/miningdock)
 "ddD" = (
 /obj/effect/turf_decal/tile/orange{
 	dir = 8
@@ -40726,18 +40708,15 @@
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
 "dhL" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
-	},
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/machinery/light,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
 /obj/effect/landmark/zebra_interlock_point,
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
+	},
 /turf/open/floor/monotile/dark,
 /area/bridge{
 	name = "CIC"
@@ -40787,6 +40766,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=loc7";
+	location = "loc6"
+	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "dmM" = (
@@ -40867,6 +40850,10 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"dzX" = (
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "dAh" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/visible,
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -40911,10 +40898,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/missile_builder/assembler{
+/obj/machinery/missile_builder/screwdriver{
 	dir = 4
 	},
-/obj/item/ship_weapon/parts/missile/guidance_system,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
 "dFv" = (
@@ -41345,6 +41331,10 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/grid/steel,
 /area/engine/engineering/reactor_control)
+"eno" = (
+/obj/machinery/lazylift/master,
+/turf/open/floor/monotile/dark,
+/area/shuttle/turbolift/tertiary)
 "enx" = (
 /obj/item/reagent_containers/food/drinks/sillycup{
 	pixel_x = -5;
@@ -41937,6 +41927,10 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/fitness/recreation)
+"ffp" = (
+/obj/structure/ladder,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "ffH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -41991,6 +41985,20 @@
 /area/nsv/hanger/storage{
 	name = "Munitions Control Room"
 	})
+"fnN" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=loc3";
+	location = "loc2"
+	},
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/frame1/central)
 "foc" = (
 /obj/structure/closet/lasertag/red,
 /obj/machinery/newscaster{
@@ -42967,6 +42975,10 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -27
 	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=loc1";
+	location = "loc12"
+	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "gVQ" = (
@@ -43781,6 +43793,24 @@
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/service)
+"ihA" = (
+/obj/machinery/atmospherics/pipe/simple/multiz,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/obj/machinery/meter{
+	pixel_x = 5;
+	pixel_y = 5;
+	target_layer = 3
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "iiq" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel/tech/grid{
@@ -43812,9 +43842,6 @@
 /obj/structure/chair/office{
 	dir = 8;
 	name = "tactical chair"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
 	},
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
@@ -44160,9 +44187,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/missile_builder{
+/obj/machinery/missile_builder/assembler{
 	dir = 4
 	},
+/obj/item/ship_weapon/parts/missile/guidance_system,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
 "iNo" = (
@@ -44423,6 +44451,12 @@
 	},
 /turf/closed/wall/r_wall/ship,
 /area/engine/atmospherics_engine)
+"jkO" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/shuttle/turbolift/tertiary)
 "jld" = (
 /obj/structure/weightmachine/stacklifter,
 /obj/structure/cable{
@@ -44480,17 +44514,14 @@
 	name = "Mess hall"
 	})
 "jnA" = (
+/obj/machinery/computer/ship/dradis/minor{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
 /obj/structure/window/reinforced{
 	dir = 4;
 	layer = 2.9
 	},
-/obj/machinery/computer/ship/dradis/minor{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/bridge{
 	name = "CIC"
@@ -44499,8 +44530,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/missile_builder/screwdriver{
-	dir = 4
+/obj/machinery/computer/ammo_sorter{
+	dir = 8;
+	id = "atlas_missilebay"
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
@@ -44540,6 +44572,20 @@
 /obj/item/trash/sosjerky,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"jrs" = (
+/obj/machinery/power/deck_relay,
+/obj/machinery/door/window/northleft,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "jsb" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -44860,9 +44906,6 @@
 	dir = 8;
 	name = "tactical chair"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/bridge{
@@ -45046,22 +45089,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/ammo_sorter{
+/obj/machinery/conveyor/slow{
 	dir = 1;
-	id = "atlas_missilebay";
-	name = "Missile Casings"
+	id = "torp"
 	},
-/obj/item/ship_weapon/ammunition/missile/missile_casing,
-/obj/item/ship_weapon/ammunition/missile/missile_casing,
-/obj/item/ship_weapon/ammunition/missile/missile_casing,
-/obj/item/ship_weapon/ammunition/missile/missile_casing,
-/obj/item/ship_weapon/ammunition/missile/missile_casing,
-/obj/item/ship_weapon/ammunition/missile/missile_casing,
-/obj/item/ship_weapon/ammunition/missile/missile_casing,
-/obj/item/ship_weapon/ammunition/missile/missile_casing,
-/obj/item/ship_weapon/ammunition/missile/missile_casing,
-/obj/item/ship_weapon/ammunition/missile/missile_casing,
-/obj/item/ship_weapon/ammunition/missile/missile_casing,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
 "kit" = (
@@ -45411,9 +45442,6 @@
 	},
 /obj/machinery/computer/ship/dradis/minor,
 /obj/machinery/computer/ship/viewscreen,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/bridge{
@@ -46116,6 +46144,10 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
+"lEE" = (
+/obj/machinery/camera/autoname,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "lGr" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -46254,6 +46286,19 @@
 /obj/structure/lattice/catwalk/over/ship,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/gauss)
+"lPA" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=loc5";
+	location = "loc4"
+	},
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/frame1/central)
 "lRd" = (
 /obj/structure/sink{
 	dir = 8;
@@ -46776,6 +46821,22 @@
 	},
 /turf/closed/wall/r_wall/ship,
 /area/engine/atmospherics_engine)
+"mIL" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=loc6";
+	location = "loc5"
+	},
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/frame1/central)
 "mJh" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 4
@@ -46895,6 +46956,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"mPM" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "mPU" = (
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -47142,6 +47210,13 @@
 	},
 /turf/open/floor/plasteel/ship,
 /area/security/prison)
+"nmN" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=loc3-1";
+	location = "loc3"
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/secondary/exit)
 "noR" = (
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/computer/ship/munitions_computer/west,
@@ -47337,21 +47412,6 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/maintenance/nsv/hangar)
-"nDD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/advanced_airlock_controller{
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/quartermaster/miningdock)
 "nEa" = (
 /turf/open/floor/carpet/red,
 /area/nsv/weapons/fore)
@@ -47532,9 +47592,6 @@
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons/gauss)
 "nPv" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
 /obj/structure/rack,
 /obj/item/ship_weapon/parts/missile/propulsion_system,
 /obj/item/ship_weapon/parts/missile/propulsion_system,
@@ -48308,6 +48365,12 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/monotile/steel,
 /area/engine/engineering/reactor_core)
+"pvj" = (
+/obj/machinery/door/airlock/ship/public/glass/turbolift{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/turbolift/tertiary)
 "pwx" = (
 /obj/machinery/light{
 	dir = 4
@@ -49610,6 +49673,30 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"rAy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/meter{
+	pixel_x = -5;
+	pixel_y = -5;
+	target_layer = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/multiz,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "rCv" = (
 /obj/machinery/computer/ship/helm/console,
 /obj/effect/turf_decal/stripes/line{
@@ -49964,9 +50051,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/computer/ammo_sorter{
-	id = "atlas_missilebay"
+/obj/machinery/missile_builder/assembler{
+	dir = 4
 	},
+/obj/item/ship_weapon/parts/missile/propulsion_system,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
 "sfZ" = (
@@ -50029,6 +50117,30 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/engine/engineering/hangar)
+"soJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "48"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "spa" = (
 /obj/effect/turf_decal/pool,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -51213,14 +51325,8 @@
 /turf/open/floor/plasteel/ship/padded,
 /area/maintenance/port)
 "uir" = (
-/obj/machinery/computer/shuttle_flight/mining{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/quartermaster/miningdock)
+/turf/open/floor/monotile/dark,
+/area/shuttle/turbolift/tertiary)
 "uiz" = (
 /obj/machinery/newscaster{
 	pixel_y = -32
@@ -51333,13 +51439,6 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/maintenance/nsv/weapons)
-"uDu" = (
-/obj/machinery/door/airlock/ship/external{
-	name = "Mining Shuttle Airlock";
-	req_one_access_txt = "31;48"
-	},
-/turf/open/floor/plating,
-/area/quartermaster/miningdock)
 "uEb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
@@ -51352,7 +51451,8 @@
 /area/medical/virology)
 "uFW" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 4
+	dir = 4;
+	piping_layer = 1
 	},
 /turf/open/floor/plasteel/tech/grid{
 	initial_gas_mix = "TEMP=2.7"
@@ -52011,6 +52111,11 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
+"vQm" = (
+/obj/structure/disposalpipe/trunk/multiz,
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "vRI" = (
 /obj/structure/cable,
 /obj/machinery/power/solar{
@@ -52037,8 +52142,8 @@
 /turf/open/floor/plating,
 /area/space)
 "vUD" = (
-/turf/open/floor/plating,
-/area/quartermaster/miningdock)
+/turf/closed/wall/r_wall/ship,
+/area/shuttle/turbolift/tertiary)
 "vVm" = (
 /obj/item/beacon,
 /turf/open/floor/mineral/plastitanium/red/airless,
@@ -52251,10 +52356,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/missile_builder/assembler{
+/obj/machinery/missile_builder{
 	dir = 4
 	},
-/obj/item/ship_weapon/parts/missile/propulsion_system,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
 "wqk" = (
@@ -52671,10 +52775,6 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "wZk" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
-	},
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /obj/item/pen,
@@ -52682,10 +52782,11 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
 /obj/effect/landmark/zebra_interlock_point,
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
+	},
 /turf/open/floor/monotile/dark,
 /area/bridge{
 	name = "CIC"
@@ -53097,6 +53198,9 @@
 /obj/item/ship_weapon/ammunition/missile/missile_casing,
 /obj/item/ship_weapon/ammunition/missile/missile_casing,
 /obj/item/ship_weapon/ammunition/missile/missile_casing,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
 "xGt" = (
@@ -86972,7 +87076,7 @@ bTi
 caT
 gHw
 abG
-bmr
+fnN
 bFh
 bLa
 twU
@@ -87001,7 +87105,7 @@ acc
 acc
 acc
 acc
-acc
+nmN
 bse
 opK
 acc
@@ -89047,10 +89151,10 @@ bqV
 bqA
 bfK
 aci
-aOA
-aOA
-aOA
-aOA
+aci
+aci
+aci
+aci
 bha
 bIE
 bIE
@@ -89307,7 +89411,7 @@ aci
 aOE
 aOF
 cDF
-aOA
+aci
 bJH
 aNP
 mVt
@@ -89561,7 +89665,7 @@ bqg
 brp
 bsa
 bxA
-bJr
+bJx
 bJt
 bJx
 bJz
@@ -89818,10 +89922,10 @@ bqf
 bxE
 bqS
 aci
-bJs
+cDF
 bJu
-bJy
-bID
+cDF
+bIC
 aio
 bJC
 bJD
@@ -90074,14 +90178,14 @@ bcr
 gaR
 bqS
 iYd
-bIC
+vUD
 bID
-bID
-bgc
-bID
-bID
+pvj
+vUD
+vUD
 aij
 aij
+soJ
 aij
 aij
 bJH
@@ -90331,15 +90435,15 @@ bcr
 bqe
 bqc
 lzn
-bIC
-aaa
-bID
-nDD
 vUD
-bID
-aaa
-aaa
-aaa
+avD
+uir
+uir
+vUD
+lEE
+mPM
+rAy
+dzX
 aij
 wsH
 aih
@@ -90588,15 +90692,15 @@ bcr
 bqe
 bqc
 bqT
-bIC
-aaa
-bID
+vUD
+eno
 uir
-ddh
-bID
-aaa
-aaa
-aaa
+uir
+vUD
+ffp
+aim
+jrs
+aim
 aij
 bJH
 atf
@@ -90845,15 +90949,15 @@ bcr
 bqe
 bqc
 bqU
-bIC
-aaa
-bID
-bID
-uDu
-bID
-aaa
-aaa
-aaa
+vUD
+uir
+jkO
+uir
+vUD
+aim
+vQm
+ihA
+dzX
 aij
 bJH
 aim
@@ -91102,15 +91206,15 @@ bcs
 brb
 izj
 bnO
-bIC
-aaa
-aaa
-aaa
-bMo
-aaa
-aaa
-aaa
-aaa
+vUD
+vUD
+vUD
+vUD
+vUD
+aij
+aij
+aij
+aij
 aij
 bJH
 bjF
@@ -91570,7 +91674,7 @@ caX
 abk
 avi
 aqP
-ars
+mIL
 rXW
 acn
 amj
@@ -91599,7 +91703,7 @@ acn
 acn
 bkl
 acn
-acn
+lPA
 aPn
 aad
 adi
@@ -94631,7 +94735,7 @@ aaa
 moR
 iLl
 auV
-bFP
+aOA
 bFP
 bMb
 bMc

--- a/_maps/map_files/Tycoon/Tycoon2.dmm
+++ b/_maps/map_files/Tycoon/Tycoon2.dmm
@@ -37139,7 +37139,20 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/start/munitions_tech,
+/obj/machinery/ammo_sorter{
+	id = "atlas_missilebay";
+	name = "Missile Casings"
+	},
+/obj/item/ship_weapon/ammunition/missile/missile_casing,
+/obj/item/ship_weapon/ammunition/missile/missile_casing,
+/obj/item/ship_weapon/ammunition/missile/missile_casing,
+/obj/item/ship_weapon/ammunition/missile/missile_casing,
+/obj/item/ship_weapon/ammunition/missile/missile_casing,
+/obj/item/ship_weapon/ammunition/missile/missile_casing,
+/obj/item/ship_weapon/ammunition/missile/missile_casing,
+/obj/item/ship_weapon/ammunition/missile/missile_casing,
+/obj/item/ship_weapon/ammunition/missile/missile_casing,
+/obj/item/ship_weapon/ammunition/missile/missile_casing,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
 "bHv" = (
@@ -39174,22 +39187,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/ammo_sorter{
+/obj/machinery/conveyor/slow{
 	dir = 8;
-	id = "atlas_missilebay";
-	name = "Missile Casings"
+	id = "torp"
 	},
-/obj/item/ship_weapon/ammunition/missile/missile_casing,
-/obj/item/ship_weapon/ammunition/missile/missile_casing,
-/obj/item/ship_weapon/ammunition/missile/missile_casing,
-/obj/item/ship_weapon/ammunition/missile/missile_casing,
-/obj/item/ship_weapon/ammunition/missile/missile_casing,
-/obj/item/ship_weapon/ammunition/missile/missile_casing,
-/obj/item/ship_weapon/ammunition/missile/missile_casing,
-/obj/item/ship_weapon/ammunition/missile/missile_casing,
-/obj/item/ship_weapon/ammunition/missile/missile_casing,
-/obj/item/ship_weapon/ammunition/missile/missile_casing,
-/obj/item/ship_weapon/ammunition/missile/missile_casing,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
 "bXF" = (
@@ -45096,7 +45097,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/conveyor/slow{
-	dir = 1;
+	dir = 9;
 	id = "torp"
 	},
 /turf/open/floor/monotile/dark,

--- a/_maps/tycoon.json
+++ b/_maps/tycoon.json
@@ -10,8 +10,6 @@
 		"cargo": "cargo_hammerhead",
 		"ferry": "ferry_kilo",
 	    "emergency": "emergency_donut"},
-    "mine_file": "Rocinante.dmm",
-    "mine_path": "map_files/Mining/nsv13",
-	"ship_type": "/obj/structure/overmap/nanotrasen/battlecruiser/starter",
-	"mining_ship_type": "/obj/structure/overmap/nanotrasen/mining_cruiser/rocinante"
+    "mine_disable": 1,
+	"ship_type": "/obj/structure/overmap/nanotrasen/battlecruiser/starter"
 }


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Updates Tycoom with mining sabres and mining equipment setup room 

The old mining shuttle has been replaced with an elevator to the new launchsite 

![engi4](https://user-images.githubusercontent.com/22532898/153795652-7046f528-e23a-4b8f-85cc-85c3815dabe7.png)

## Why It's Good For The Game

Asteroid mining

Fixes #1796 
Fixes #1581 
Addresses 732 but doesn't mark it as fixed because it's a megaissue. https://github.com/BeeStation/NSV13/issues/732
Fixes #717 (this isn't actually an issue but I want it gone so w/e)

## Changelog
:cl:
del: Removed Rocinante from Tycoon
add: Added mining sabres to Tycoon
fix: Fixed disconnected pipes, duplicate APCs, missing air alarms in various areas 
fix: Fixed brig physician not having bare minimum access to access their medical station
fix: Fixed tycoon munitions factory not working most of the time 
fix: Fixed tycoon bots having no patrol routes 
fix: Fixed hangar bay APC not charging
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
