### PR TITLE
Fixes new aetherwhisp mining hangar blast door button access, and makes hangar plating airless

### DIFF
--- a/_maps/map_files/Aetherwhisp/Aetherwhisp2.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp2.dmm
@@ -4478,7 +4478,7 @@
 	name = "Hangar 1 exterior doors";
 	pixel_x = -26;
 	pixel_y = 26;
-	req_one_access_txt = "69"
+	req_one_access_txt = "48"
 	},
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2/port)

--- a/_maps/map_files/Aetherwhisp/Aetherwhisp2.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp2.dmm
@@ -2014,7 +2014,7 @@
 /obj/machinery/door/poddoor/ship{
 	id = "minerlaunch1"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/nsv/hanger/deck2/port)
 "bqX" = (
 /obj/structure/cable{
@@ -4323,7 +4323,7 @@
 	dir = 9
 	},
 /obj/machinery/computer/ship/viewscreen,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/nsv/hanger/deck2/port)
 "cYB" = (
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
@@ -4391,7 +4391,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/nsv/hanger/deck2/port)
 "dbe" = (
 /obj/structure/cable{
@@ -4480,7 +4480,7 @@
 	pixel_y = 26;
 	req_one_access_txt = "48"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/nsv/hanger/deck2/port)
 "dcQ" = (
 /obj/structure/table/glass,
@@ -5038,7 +5038,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/nsv/hanger/deck2/port)
 "dBw" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/visible,
@@ -6781,7 +6781,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/nsv/hanger/deck2/port)
 "eJj" = (
 /turf/open/floor/carpet/orange,
@@ -7167,7 +7167,7 @@
 "eXm" = (
 /obj/item/wallframe/airalarm,
 /obj/item/electronics/airalarm,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/nsv/hanger/deck2/port)
 "eXw" = (
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -8067,7 +8067,7 @@
 /area/crew_quarters/dorms)
 "fBj" = (
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/nsv/hanger/deck2/port)
 "fBU" = (
 /obj/structure/bookcase/random,
@@ -8116,7 +8116,7 @@
 /area/science/xenobiology)
 "fDg" = (
 /obj/machinery/light/floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/nsv/hanger/deck2/port)
 "fDm" = (
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
@@ -9668,7 +9668,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/nsv/hanger/deck2/port)
 "gCc" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
@@ -10293,7 +10293,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/nsv/hanger/deck2/port)
 "hbT" = (
 /obj/structure/lattice,
@@ -10560,7 +10560,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/nsv/hanger/deck2/port)
 "hlm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -11249,7 +11249,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/nsv/hanger/deck2/port)
 "hQz" = (
 /obj/machinery/suit_storage_unit/pilot,
@@ -13369,7 +13369,7 @@
 /area/bridge/secondary)
 "joM" = (
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/nsv/hanger/deck2/port)
 "jpO" = (
 /obj/structure/disposalpipe/segment{
@@ -13388,7 +13388,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/nsv/hanger/deck2/port)
 "jqk" = (
 /obj/machinery/ship_weapon/torpedo_launcher/cargo/east{
@@ -13599,7 +13599,7 @@
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/medical/genetics)
 "jvn" = (
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/nsv/hanger/deck2/port)
 "jvC" = (
 /obj/structure/cable{
@@ -14869,7 +14869,7 @@
 /area/bridge/showroom/corporate)
 "kxr" = (
 /obj/item/radio/intercom/directional/east,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/nsv/hanger/deck2/port)
 "kxM" = (
 /obj/structure/disposalpipe/trunk,
@@ -18571,7 +18571,7 @@
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/nsv/hanger/deck2/port)
 "nea" = (
 /obj/machinery/suit_storage_unit/pilot,
@@ -19162,7 +19162,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/nsv/hanger/deck2/port)
 "nzz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -21039,7 +21039,7 @@
 	},
 /obj/machinery/firealarm/directional/east,
 /obj/structure/ore_box,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/nsv/hanger/deck2/port)
 "oKP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -23027,7 +23027,7 @@
 	dir = 10
 	},
 /obj/structure/overmap/small_craft/transport/sabre/mining,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/nsv/hanger/deck2/port)
 "pZn" = (
 /obj/machinery/computer/mech_bay_power_console,
@@ -23040,7 +23040,7 @@
 	},
 /obj/structure/extinguisher_cabinet/east,
 /obj/structure/ore_box,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/nsv/hanger/deck2/port)
 "pZx" = (
 /turf/open/floor/engine,
@@ -24282,7 +24282,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/nsv/hanger/deck2/port)
 "qVA" = (
 /obj/item/pen,
@@ -26907,7 +26907,7 @@
 	dir = 10
 	},
 /obj/structure/overmap/small_craft/transport/sabre/mining,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/nsv/hanger/deck2/port)
 "swh" = (
 /obj/structure/window/reinforced{
@@ -27956,7 +27956,7 @@
 	},
 /obj/machinery/recharge_station,
 /obj/effect/landmark/start/cyborg,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/nsv/hanger/deck2/port)
 "toN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -28516,7 +28516,7 @@
 /obj/machinery/door/poddoor/ship{
 	id = "minerlaunch1"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/nsv/hanger/deck2/port)
 "tND" = (
 /obj/structure/disposalpipe/trunk,
@@ -28925,7 +28925,7 @@
 /area/quartermaster/lobby)
 "uaV" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/nsv/hanger/deck2/port)
 "uaY" = (
 /obj/machinery/space_heater,
@@ -29006,7 +29006,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/nsv/hanger/deck2/port)
 "ugt" = (
 /obj/machinery/light{
@@ -32809,7 +32809,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/nsv/hanger/deck2/port)
 "xba" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -34251,7 +34251,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/nsv/hanger/deck2/port)
 "xXE" = (
 /obj/machinery/rnd/production/techfab,
@@ -34506,7 +34506,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/nsv/hanger/deck2/port)
 "yiA" = (
 /obj/effect/landmark/start/shaft_miner,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes new aetherwhisp mining hangar blast door button access, and makes hangar plating airless

## Why It's Good For The Game

Fixes new aetherwhisp mining hangar blast door button access, and makes hangar plating airless

## Changelog
:cl:
fix: Fixes new aetherwhisp mining hangar blast door button access
fix: Fixes new aetherwhisp mining hangar dumping air into space 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
