### PR TITLE
Moves the Atlas ladder, you know the one

### DIFF
--- a/_maps/map_files/Atlas/atlas.dmm
+++ b/_maps/map_files/Atlas/atlas.dmm
@@ -1722,8 +1722,11 @@
 /turf/open/floor/monotile/dark,
 /area/engine/engine_room)
 "fS" = (
-/obj/structure/ladder,
-/turf/open/floor/monotile/steel,
+/obj/structure/sign/directions/supply{
+	pixel_y = -6
+	},
+/obj/structure/sign/directions/science,
+/turf/closed/wall/r_wall,
 /area/engine/atmos)
 "fU" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -5226,24 +5229,6 @@
 /obj/machinery/ship_weapon/vls,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
-"qs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/requests_console{
-	department = "Deck 2 Primary Hallway";
-	departmentType = 2;
-	name = "Deck 2 Primary Hallway RC";
-	pixel_y = 26
-	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck2/primary)
 "qt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11001,6 +10986,12 @@
 /obj/effect/turf_decal/tile/ship/half/yellow{
 	dir = 1
 	},
+/obj/machinery/requests_console{
+	department = "Deck 2 Primary Hallway";
+	departmentType = 2;
+	name = "Deck 2 Primary Hallway RC";
+	pixel_y = 26
+	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "LC" = (
@@ -13026,12 +13017,9 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/space/nearstation)
 "Sn" = (
-/obj/structure/sign/directions/science,
-/obj/structure/sign/directions/supply{
-	pixel_y = -6
-	},
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
+/obj/structure/ladder,
+/turf/open/floor/monotile/dark,
+/area/nsv/weapons)
 "So" = (
 /obj/structure/ladder,
 /obj/effect/turf_decal/tile/ship/half/green{
@@ -48232,7 +48220,7 @@ GB
 jh
 lD
 RN
-qs
+Jz
 un
 ql
 yX
@@ -49259,7 +49247,7 @@ hH
 Se
 pH
 EB
-Sn
+RN
 LA
 un
 ny
@@ -52858,7 +52846,7 @@ rX
 TX
 nw
 mP
-mP
+Sn
 ff
 eY
 Mi

--- a/_maps/map_files/Atlas/atlas.dmm
+++ b/_maps/map_files/Atlas/atlas.dmm
@@ -1722,11 +1722,8 @@
 /turf/open/floor/monotile/dark,
 /area/engine/engine_room)
 "fS" = (
-/obj/structure/sign/directions/supply{
-	pixel_y = -6
-	},
-/obj/structure/sign/directions/science,
-/turf/closed/wall/r_wall,
+/obj/structure/ladder,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "fU" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -5229,6 +5226,24 @@
 /obj/machinery/ship_weapon/vls,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
+"qs" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/requests_console{
+	department = "Deck 2 Primary Hallway";
+	departmentType = 2;
+	name = "Deck 2 Primary Hallway RC";
+	pixel_y = 26
+	},
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 4
+	},
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/primary)
 "qt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10986,12 +11001,6 @@
 /obj/effect/turf_decal/tile/ship/half/yellow{
 	dir = 1
 	},
-/obj/machinery/requests_console{
-	department = "Deck 2 Primary Hallway";
-	departmentType = 2;
-	name = "Deck 2 Primary Hallway RC";
-	pixel_y = 26
-	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "LC" = (
@@ -13017,9 +13026,12 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/space/nearstation)
 "Sn" = (
-/obj/structure/ladder,
-/turf/open/floor/monotile/dark,
-/area/nsv/weapons)
+/obj/structure/sign/directions/science,
+/obj/structure/sign/directions/supply{
+	pixel_y = -6
+	},
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "So" = (
 /obj/structure/ladder,
 /obj/effect/turf_decal/tile/ship/half/green{
@@ -48220,7 +48232,7 @@ GB
 jh
 lD
 RN
-Jz
+qs
 un
 ql
 yX
@@ -49247,7 +49259,7 @@ hH
 Se
 pH
 EB
-RN
+Sn
 LA
 un
 ny
@@ -52846,7 +52858,7 @@ rX
 TX
 nw
 mP
-Sn
+mP
 ff
 eY
 Mi

--- a/_maps/map_files/Atlas/atlas.dmm
+++ b/_maps/map_files/Atlas/atlas.dmm
@@ -381,9 +381,13 @@
 /turf/open/floor/monotile/steel,
 /area/science)
 "bn" = (
-/obj/structure/chair,
-/obj/machinery/computer/ship/viewscreen,
-/turf/open/floor/monotile/steel,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/primary)
 "bo" = (
 /obj/structure/cable{
@@ -601,16 +605,22 @@
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos)
 "cj" = (
+/obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/ship/techfloor{
-	dir = 8
+	dir = 9
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
+/obj/structure/chair/stool,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/landmark/start/janitor,
+/obj/structure/chair/noose,
+/obj/effect/decal/remains/human{
+	name = "Joe Czanek"
 	},
-/obj/item/cigbutt/roach,
-/mob/living/simple_animal/kalo{
-	name = "Comrade"
+/obj/machinery/requests_console{
+	department = "Custodial Closet";
+	departmentType = 2;
+	name = "Custodial RC";
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel/grid/lino,
 /area/janitor)
@@ -1950,22 +1960,12 @@
 /turf/open/floor/engine/n2,
 /area/engine/atmos)
 "gv" = (
-/obj/structure/closet/l3closet/janitor,
-/obj/machinery/camera/autoname,
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/effect/turf_decal/tile/ship/green,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/north,
-/obj/effect/turf_decal/ship/techfloor{
-	dir = 5
-	},
-/obj/item/poster/random_contraband{
-	desc = "No memes in general!";
-	name = "discord moderation textbook"
-	},
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/plasteel/grid/lino,
-/area/janitor)
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck2/primary)
 "gx" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden/layer1{
 	dir = 4
@@ -2337,24 +2337,11 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "hC" = (
-/obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/ship/techfloor{
-	dir = 9
+/obj/effect/turf_decal/tile/ship/half/green,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 1
 	},
-/obj/structure/chair/stool,
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/landmark/start/janitor,
-/obj/structure/chair/noose,
-/obj/effect/decal/remains/human{
-	name = "Joe Czanek"
-	},
-/obj/machinery/requests_console{
-	department = "Custodial Closet";
-	departmentType = 2;
-	name = "Custodial RC";
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/grid/lino,
+/turf/open/floor/plasteel/grid/mono,
 /area/janitor)
 "hE" = (
 /obj/structure/cable{
@@ -3393,10 +3380,10 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "kT" = (
-/obj/vehicle/ridden/janicart,
-/obj/item/key/janitor,
-/obj/effect/turf_decal/ship/techfloor,
-/obj/machinery/light/small/broken,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/grid/lino,
 /area/janitor)
 "kU" = (
@@ -5679,10 +5666,16 @@
 	},
 /area/maintenance/nsv/deck2/starboard)
 "rU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
-/obj/effect/turf_decal/box,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/ship/techfloor{
+	dir = 1
+	},
 /turf/open/floor/plasteel/grid/lino,
 /area/janitor)
 "rV" = (
@@ -6205,9 +6198,13 @@
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "tN" = (
-/obj/structure/chair,
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck2/primary)
+/obj/effect/turf_decal/tile/ship/half/green,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 4
+	},
+/obj/structure/ladder,
+/turf/open/floor/plasteel/grid/mono,
+/area/janitor)
 "tP" = (
 /turf/closed/wall/r_wall,
 /area/quartermaster/storage)
@@ -6591,11 +6588,13 @@
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons/gauss/battery/deck2/port)
 "uX" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-32"
+/obj/structure/janitorialcart,
+/obj/item/mop,
+/obj/effect/turf_decal/ship/techfloor{
+	dir = 10
 	},
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck2/primary)
+/turf/open/floor/plasteel/grid/lino,
+/area/janitor)
 "uY" = (
 /obj/machinery/deck_turret/autoelevator,
 /obj/effect/turf_decal/stripes/line,
@@ -6833,6 +6832,18 @@
 /obj/effect/turf_decal/tile/ship/orange,
 /obj/effect/turf_decal/tile/ship/orange{
 	dir = 4
+	},
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/primary)
+"vS" = (
+/obj/machinery/door/airlock/ship/security/glass{
+	name = "Prisoner Transfer";
+	req_one_access_txt = "2"
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
@@ -7075,23 +7086,20 @@
 /turf/open/floor/carpet/orange,
 /area/engine/engine_room)
 "wN" = (
+/obj/structure/closet/l3closet/janitor,
+/obj/machinery/camera/autoname,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/auto_name/north,
 /obj/effect/turf_decal/ship/techfloor{
-	dir = 4
+	dir = 5
 	},
-/obj/item/cigbutt,
-/obj/item/cigbutt{
-	pixel_x = 5;
-	pixel_y = -3
+/obj/item/poster/random_contraband{
+	desc = "No memes in general!";
+	name = "discord moderation textbook"
 	},
-/obj/item/cigbutt{
-	pixel_x = 12;
-	pixel_y = 6
-	},
-/obj/item/storage/fancy/cigarettes{
-	desc = "These taste terrible, but they'll help you manage a community.";
-	name = "\improper Community Manager's Cigarettes"
-	},
-/obj/machinery/light_switch/east,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/plasteel/grid/lino,
 /area/janitor)
 "wO" = (
@@ -8590,17 +8598,20 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "CD" = (
+/obj/machinery/door/airlock/ship/public{
+	name = "Custodial Garage";
+	req_one_access_txt = "26"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/ship/techfloor{
-	dir = 1
-	},
-/turf/open/floor/plasteel/grid/lino,
+/turf/open/floor/monotile/steel,
 /area/janitor)
 "CE" = (
 /turf/closed/wall/r_wall,
@@ -10314,10 +10325,16 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "Jt" = (
-/obj/structure/janitorialcart,
-/obj/item/mop,
 /obj/effect/turf_decal/ship/techfloor{
-	dir = 10
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/obj/item/cigbutt/roach,
+/mob/living/simple_animal/kalo{
+	name = "Comrade"
 	},
 /turf/open/floor/plasteel/grid/lino,
 /area/janitor)
@@ -10489,10 +10506,23 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "JW" = (
-/obj/machinery/vending/wardrobe/jani_wardrobe,
 /obj/effect/turf_decal/ship/techfloor{
-	dir = 6
+	dir = 4
 	},
+/obj/item/cigbutt,
+/obj/item/cigbutt{
+	pixel_x = 5;
+	pixel_y = -3
+	},
+/obj/item/cigbutt{
+	pixel_x = 12;
+	pixel_y = 6
+	},
+/obj/item/storage/fancy/cigarettes{
+	desc = "These taste terrible, but they'll help you manage a community.";
+	name = "\improper Community Manager's Cigarettes"
+	},
+/obj/machinery/light_switch/east,
 /turf/open/floor/plasteel/grid/lino,
 /area/janitor)
 "JX" = (
@@ -11147,6 +11177,7 @@
 	name = "Munitions requests console";
 	pixel_y = -32
 	},
+/obj/structure/ladder,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "Me" = (
@@ -12163,19 +12194,12 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "PH" = (
-/obj/machinery/door/airlock/ship/public{
-	name = "Custodial Garage";
-	req_one_access_txt = "26"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/tile/ship/half/green,
 /turf/open/floor/monotile/steel,
 /area/janitor)
 "PJ" = (
@@ -12855,17 +12879,12 @@
 /turf/open/floor/carpet/red,
 /area/nsv/weapons)
 "RR" = (
-/obj/machinery/door/airlock/ship/security/glass{
-	name = "Prisoner Transfer";
-	req_one_access_txt = "2"
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck2/primary)
+/obj/vehicle/ridden/janicart,
+/obj/item/key/janitor,
+/obj/effect/turf_decal/ship/techfloor,
+/obj/machinery/light/small/broken,
+/turf/open/floor/plasteel/grid/lino,
+/area/janitor)
 "RS" = (
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -13017,9 +13036,12 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/space/nearstation)
 "Sn" = (
-/obj/structure/ladder,
-/turf/open/floor/monotile/dark,
-/area/nsv/weapons)
+/obj/machinery/vending/wardrobe/jani_wardrobe,
+/obj/effect/turf_decal/ship/techfloor{
+	dir = 6
+	},
+/turf/open/floor/plasteel/grid/lino,
+/area/janitor)
 "So" = (
 /obj/structure/ladder,
 /obj/effect/turf_decal/tile/ship/half/green{
@@ -13303,6 +13325,11 @@
 /obj/item/toy/beach_ball/holoball,
 /turf/open/floor/plasteel/techmaint,
 /area/security/prison)
+"Tv" = (
+/obj/structure/chair,
+/obj/machinery/computer/ship/viewscreen,
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/primary)
 "Tw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -13651,9 +13678,9 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
 "UA" = (
-/obj/structure/chair,
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/camera/autoname,
+/obj/item/kirbyplants{
+	icon_state = "plant-32"
+	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "UB" = (
@@ -13959,6 +13986,12 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
+"VA" = (
+/obj/structure/chair,
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/camera/autoname,
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/primary)
 "VC" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only,
@@ -48479,16 +48512,16 @@ RN
 nk
 Jz
 un
-Ef
-IW
+bn
 hC
+IW
 cj
 Jt
-IW
 uX
+qI
+UA
 Jk
 ew
-tN
 qG
 cH
 AS
@@ -48741,11 +48774,11 @@ PH
 CD
 rU
 kT
-IW
-bn
-Jk
 RR
+qI
+Tv
 Jk
+vS
 Yw
 aw
 Yw
@@ -48993,16 +49026,16 @@ SK
 RN
 sR
 un
-Ef
-IW
 gv
+tN
+IW
 wN
 JW
-IW
-UA
+Sn
+qI
+VA
 Jk
 ew
-tN
 Yw
 em
 ei
@@ -49256,7 +49289,7 @@ IW
 IW
 IW
 IW
-ew
+qI
 ew
 Rm
 qI
@@ -52846,7 +52879,7 @@ rX
 TX
 nw
 mP
-Sn
+mP
 ff
 eY
 Mi

--- a/_maps/map_files/Atlas/atlas2.dmm
+++ b/_maps/map_files/Atlas/atlas2.dmm
@@ -2530,11 +2530,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/squad_vendor{
-	density = 0;
-	pixel_x = -32
-	},
-/turf/open/floor/monotile/steel,
+/obj/machinery/squad_vendor,
+/turf/closed/wall/steel,
 /area/bridge/cic)
 "lF" = (
 /obj/machinery/door/airlock/ship/public{
@@ -6089,17 +6086,9 @@
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/hallway)
 "Dv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/structure/ladder,
 /turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck1/hallway)
+/area/bridge/cic)
 "Dx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -7876,11 +7865,18 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "Lt" = (
-/obj/structure/ladder,
-/obj/machinery/door/window{
-	req_one_access_txt = "69"
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
-/turf/open/floor/engine,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/turf_decal/ship/delivery/yellow,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/structure/sign/nanotrasen{
+	pixel_y = 26
+	},
+/turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "Lw" = (
 /obj/effect/turf_decal/stripes/line{
@@ -8183,15 +8179,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/aisat)
-"MO" = (
-/obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1
-	},
-/obj/structure/sign/nanotrasen{
-	pixel_y = 26
-	},
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck1/hallway)
 "MQ" = (
 /obj/effect/turf_decal/tile/ship/green{
 	dir = 4
@@ -44855,7 +44842,7 @@ Tc
 FP
 Tc
 Tc
-cD
+Lt
 sf
 cD
 cH
@@ -45111,8 +45098,8 @@ Vg
 Yn
 wW
 Tc
-Tc
-MO
+Dv
+rb
 wu
 iJ
 cH
@@ -48453,8 +48440,8 @@ mK
 mK
 lx
 Am
-Lt
-Dv
+Am
+ST
 Em
 qP
 Em

--- a/_maps/map_files/Atlas/atlas2.dmm
+++ b/_maps/map_files/Atlas/atlas2.dmm
@@ -1639,6 +1639,20 @@
 "hJ" = (
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/bar/mess_hall)
+"hM" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/turf_decal/ship/delivery/yellow,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck1/hallway)
 "hN" = (
 /turf/closed/wall/r_wall,
 /area/medical/morgue)
@@ -3825,9 +3839,6 @@
 	},
 /obj/machinery/camera/autoname,
 /obj/structure/extinguisher_cabinet/north,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /obj/effect/landmark/patrol_node{
 	id = "deck1_bridge";
 	next_id = "deck1_medical"
@@ -5619,9 +5630,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
 "Bi" = (
@@ -5883,9 +5891,16 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/captain)
 "CF" = (
-/obj/structure/railing,
 /obj/effect/decal/cleanable/cobweb,
-/turf/open/openspace,
+/obj/item/toy/plush/carpplushie{
+	name = "carptain plasmasalt"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/item/clothing/head/pirate{
+	pixel_x = -1;
+	pixel_y = -8
+	},
+/turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
 "CI" = (
 /obj/structure/lattice/catwalk/over/ship,
@@ -6089,17 +6104,10 @@
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/hallway)
 "Dv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck1/hallway)
+/obj/structure/hull_plate,
+/obj/structure/ladder,
+/turf/open/floor/engine/airless,
+/area/space/nearstation)
 "Dx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -7876,11 +7884,12 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "Lt" = (
-/obj/structure/ladder,
-/obj/machinery/door/window{
-	req_one_access_txt = "69"
+/obj/effect/turf_decal/tile/ship/green,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 8
 	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/hallway)
 "Lw" = (
 /obj/effect/turf_decal/stripes/line{
@@ -9073,6 +9082,14 @@
 /obj/machinery/chem_master/condimaster,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
+"QR" = (
+/obj/effect/turf_decal/tile/ship/green,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck1/hallway)
 "QS" = (
 /obj/effect/turf_decal/tile/ship/green{
 	dir = 4
@@ -10436,6 +10453,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
+"Yc" = (
+/obj/structure/ladder,
+/turf/open/floor/monotile/steel,
+/area/medical/medbay)
 "Yj" = (
 /turf/open/floor/monotile/dark,
 /area/hydroponics)
@@ -44343,9 +44364,9 @@ ke
 Tc
 ay
 Af
-Sc
+Lt
 pB
-Ed
+pB
 Ou
 kR
 FX
@@ -44600,8 +44621,8 @@ Tc
 Tc
 MU
 wu
-Sc
-cH
+QR
+Yc
 WJ
 WJ
 WJ
@@ -44857,7 +44878,7 @@ Tc
 Tc
 cD
 sf
-cD
+hM
 cH
 iH
 Gp
@@ -48453,8 +48474,8 @@ mK
 mK
 lx
 Am
-Lt
-Dv
+Am
+ST
 Em
 qP
 Em
@@ -49223,7 +49244,7 @@ Bp
 Bp
 mK
 mK
-mK
+Dv
 Am
 EM
 FU

--- a/_maps/map_files/Atlas/atlas2.dmm
+++ b/_maps/map_files/Atlas/atlas2.dmm
@@ -2530,8 +2530,11 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/squad_vendor,
-/turf/closed/wall/steel,
+/obj/machinery/squad_vendor{
+	density = 0;
+	pixel_x = -32
+	},
+/turf/open/floor/monotile/steel,
 /area/bridge/cic)
 "lF" = (
 /obj/machinery/door/airlock/ship/public{
@@ -6086,9 +6089,17 @@
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/hallway)
 "Dv" = (
-/obj/structure/ladder,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/monotile/steel,
-/area/bridge/cic)
+/area/hallway/nsv/deck1/hallway)
 "Dx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -7865,18 +7876,11 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "Lt" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
+/obj/structure/ladder,
+/obj/machinery/door/window{
+	req_one_access_txt = "69"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/effect/turf_decal/ship/delivery/yellow,
-/obj/effect/landmark/zebra_interlock_point,
-/obj/structure/sign/nanotrasen{
-	pixel_y = 26
-	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/engine,
 /area/hallway/nsv/deck1/hallway)
 "Lw" = (
 /obj/effect/turf_decal/stripes/line{
@@ -8179,6 +8183,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/aisat)
+"MO" = (
+/obj/effect/turf_decal/tile/ship/half/green{
+	dir = 1
+	},
+/obj/structure/sign/nanotrasen{
+	pixel_y = 26
+	},
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck1/hallway)
 "MQ" = (
 /obj/effect/turf_decal/tile/ship/green{
 	dir = 4
@@ -44842,7 +44855,7 @@ Tc
 FP
 Tc
 Tc
-Lt
+cD
 sf
 cD
 cH
@@ -45098,8 +45111,8 @@ Vg
 Yn
 wW
 Tc
-Dv
-rb
+Tc
+MO
 wu
 iJ
 cH
@@ -48440,8 +48453,8 @@ mK
 mK
 lx
 Am
-Am
-ST
+Lt
+Dv
 Em
 qP
 Em


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Moves the munitions ladder into the hallway

## Why It's Good For The Game
Makes munitions more likely to maintain access control instead of being used as a hallway

## Changelog
:cl:
tweak: Moved the ladder inside Atlas munitions to the hallway near atmos/bridge.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
