### PR TITLE
Removes shambling corpse courier mob type forever (Ready to merge)

### DIFF
--- a/nsv13/code/game/gamemodes/overmap/objectives/cargo/transfer/specimen.dm
+++ b/nsv13/code/game/gamemodes/overmap/objectives/cargo/transfer/specimen.dm
@@ -1,18 +1,18 @@
-/datum/overmap_objective/cargo/transfer/specimen 
+/datum/overmap_objective/cargo/transfer/specimen
 	name = "Deliver a specimen"
 	desc = "Deliver a specific specimen provided by the objective"
 	crate_name = "Secure Specimen Transfer"
-	
-/datum/overmap_objective/cargo/transfer/specimen/New() 
+
+/datum/overmap_objective/cargo/transfer/specimen/New()
 	var/picked = pick( list (
-		// Dangerous specimens 
+		// Dangerous specimens
 		/mob/living/simple_animal/slime/random,
-		/mob/living/simple_animal/hostile/zombie/hugbox,
+		// /mob/living/simple_animal/hostile/zombie/hugbox,
 		/mob/living/simple_animal/hostile/alien,
 		/mob/living/simple_animal/hostile/swarmer,
 		/mob/living/simple_animal/hostile/carp,
-		
-		// Benign specimens 
+
+		// Benign specimens
 		/mob/living/simple_animal/hostile/lizard,
 		/mob/living/simple_animal/pet/dog/corgi,
 		/mob/living/simple_animal/pet/dog/bullterrier,
@@ -29,6 +29,6 @@
 
 	var/datum/freight_type/specimen/C = new /datum/freight_type/specimen( picked )
 	C.send_prepackaged_item = TRUE
-	C.allow_replacements = FALSE // Once a packaged specimen gets out it may be too large to fit in a crate, or it may get killed. Prevents gamemode softlocks from incomplete objectives 
+	C.allow_replacements = FALSE // Once a packaged specimen gets out it may be too large to fit in a crate, or it may get killed. Prevents gamemode softlocks from incomplete objectives
 	C.overmap_objective = src
 	freight_types += C

--- a/nsv13/code/game/gamemodes/overmap/objectives/cargo/transfer/specimen.dm
+++ b/nsv13/code/game/gamemodes/overmap/objectives/cargo/transfer/specimen.dm
@@ -7,7 +7,6 @@
 	var/picked = pick( list (
 		// Dangerous specimens
 		/mob/living/simple_animal/slime/random,
-		// /mob/living/simple_animal/hostile/zombie/hugbox,
 		/mob/living/simple_animal/hostile/alien,
 		/mob/living/simple_animal/hostile/swarmer,
 		/mob/living/simple_animal/hostile/carp,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

~~Hotfix for the freight torpedo launcher rejecting this type of mob when trying to ship it to a mission target~~

~~It should be testmerged but probably not merge merged until I fix the actual issue~~

Fun fact, shambling corpses have an effect inside their contents that drops a corpse when the shambling corpse dies. And that's what the shuttle checker was rejecting.

Anyways instead of adding 40 lines of code to check all objectives for wildcard contents inside intended objective targets inside the freight torp, I'm just not gonna use shambling corpses 

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
