### PR TITLE
Fixes some bad reference stuff with player ships

### DIFF
--- a/nsv13/code/game/machinery/computer/helm.dm
+++ b/nsv13/code/game/machinery/computer/helm.dm
@@ -9,6 +9,10 @@
 /obj/machinery/computer/ship/helm/syndicate
 	req_one_access = list(ACCESS_SYNDICATE)
 
+/obj/machinery/computer/ship/helm/Destroy()
+	linked?.helm -= src
+	return ..()
+
 /obj/machinery/computer/ship/helm/set_position(obj/structure/overmap/OM)
 	OM.helm = src
 	return

--- a/nsv13/code/game/machinery/computer/helm.dm
+++ b/nsv13/code/game/machinery/computer/helm.dm
@@ -10,7 +10,7 @@
 	req_one_access = list(ACCESS_SYNDICATE)
 
 /obj/machinery/computer/ship/helm/Destroy()
-	linked?.helm -= src
+	linked?.helm = null
 	return ..()
 
 /obj/machinery/computer/ship/helm/set_position(obj/structure/overmap/OM)

--- a/nsv13/code/game/machinery/computer/tactical.dm
+++ b/nsv13/code/game/machinery/computer/tactical.dm
@@ -6,6 +6,10 @@
 	position = "gunner"
 	circuit = /obj/item/circuitboard/computer/ship/tactical_computer
 
+/obj/machinery/computer/ship/tactical/Destroy()
+	linked?.tactical -= src
+	return ..()
+
 /obj/machinery/computer/ship/tactical/ui_interact(mob/user, datum/tgui/ui)
 	if(isobserver(user))
 		return
@@ -91,7 +95,3 @@
 /obj/machinery/computer/ship/tactical/set_position(obj/structure/overmap/OM)
 	OM.tactical = src
 	return
-
-/obj/machinery/computer/ship/tactical/Destroy()
-	linked?.tactical -= src
-	return ..()

--- a/nsv13/code/game/machinery/computer/tactical.dm
+++ b/nsv13/code/game/machinery/computer/tactical.dm
@@ -91,3 +91,7 @@
 /obj/machinery/computer/ship/tactical/set_position(obj/structure/overmap/OM)
 	OM.tactical = src
 	return
+
+/obj/machinery/computer/ship/tactical/Destroy()
+	linked?.tactical -= src
+	return ..()

--- a/nsv13/code/game/machinery/computer/tactical.dm
+++ b/nsv13/code/game/machinery/computer/tactical.dm
@@ -7,7 +7,7 @@
 	circuit = /obj/item/circuitboard/computer/ship/tactical_computer
 
 /obj/machinery/computer/ship/tactical/Destroy()
-	linked?.tactical -= src
+	linked?.tactical = null
 	return ..()
 
 /obj/machinery/computer/ship/tactical/ui_interact(mob/user, datum/tgui/ui)

--- a/nsv13/code/modules/munitions/ship_weapons/_ship_weapon.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/_ship_weapon.dm
@@ -372,9 +372,9 @@
 /obj/machinery/ship_weapon/proc/update()
 	if(weapon_type) // Who would've thought creating a weapon with no weapon_type would break everything!
 		if(!safety && chambered)
-			LAZYOR(weapon_type.weapons["loaded"] , src) //OR to avoid duplicating refs
+			weapon_type.weapons["loaded"] |= src //OR to avoid duplicating refs
 		else
-			LAZYREMOVE(weapon_type.weapons["loaded"] , src)
+			weapon_type.weapons["loaded"] -= src
 
 /obj/machinery/ship_weapon/proc/lazyload()
 	if(magazine_type)

--- a/nsv13/code/modules/munitions/ship_weapons/_ship_weapon.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/_ship_weapon.dm
@@ -372,7 +372,7 @@
 /obj/machinery/ship_weapon/proc/update()
 	if(weapon_type) // Who would've thought creating a weapon with no weapon_type would break everything!
 		if(!safety && chambered)
-			LAZYADD(weapon_type.weapons["loaded"] , src)
+			LAZYOR(weapon_type.weapons["loaded"] , src) //OR to avoid duplicating refs
 		else
 			LAZYREMOVE(weapon_type.weapons["loaded"] , src)
 

--- a/nsv13/code/modules/overmap/weapons/ship_weapon.dm
+++ b/nsv13/code/modules/overmap/weapons/ship_weapon.dm
@@ -6,10 +6,6 @@
 		var/datum/ship_weapon/SW = weapon_types[weapon.fire_mode]
 		SW.add_weapon(weapon) //hand it over to the datum for sane things like adding it idk
 
-/obj/structure/overmap/proc/remove_weapon(obj/machinery/ship_weapon/weapon)
-	var/datum/ship_weapon/SW = weapon_types[weapon.fire_mode]
-	SW.weapons -= weapon
-
 /datum/ship_weapon
 	var/name = "Ship weapon"
 	var/default_projectile_type

--- a/nsv13/code/modules/overmap/weapons/ship_weapon.dm
+++ b/nsv13/code/modules/overmap/weapons/ship_weapon.dm
@@ -1,9 +1,14 @@
 #define FIRE_INTERCEPTED 2 //For special_fire()
 
+//These procs should *really* not be here
 /obj/structure/overmap/proc/add_weapon(obj/machinery/ship_weapon/weapon)
 	if(weapon_types[weapon.fire_mode])
 		var/datum/ship_weapon/SW = weapon_types[weapon.fire_mode]
 		SW.add_weapon(weapon) //hand it over to the datum for sane things like adding it idk
+
+/obj/structure/overmap/proc/remove_weapon(obj/machinery/ship_weapon/weapon)
+	var/datum/ship_weapon/SW = weapon_types[weapon.fire_mode]
+	SW.weapons -= weapon
 
 /datum/ship_weapon
 	var/name = "Ship weapon"


### PR DESCRIPTION
## About The Pull Request

Fixes some guns being added to the ship's weapon datums several thousands of times over and reference deletion for ship consoles.

## Why It's Good For The Game

Useless duplicate references are bad

## Changelog
:cl:
code: deleting ship consoles now dels their references properly.
code: stops ship weapons from filling the ship's loaded weapons list with their own refs.
/:cl:
