### PR TITLE
Status Displays for the atlas

### DIFF
--- a/_maps/map_files/Atlas/atlas.dmm
+++ b/_maps/map_files/Atlas/atlas.dmm
@@ -959,6 +959,14 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons)
+"du" = (
+/obj/structure/closet/secure_closet/security/sec,
+/obj/item/book/granter/martial/jujitsu,
+/obj/machinery/status_display/evac/north{
+	pixel_y = 26
+	},
+/turf/open/floor/monotile/steel,
+/area/security/brig)
 "dv" = (
 /obj/structure/lattice/catwalk/over/ship,
 /turf/open/floor/monotile/dark,
@@ -1719,6 +1727,7 @@
 "fP" = (
 /obj/effect/turf_decal/pool,
 /obj/machinery/suit_storage_unit/engine,
+/obj/machinery/status_display/evac/east,
 /turf/open/floor/monotile/dark,
 /area/engine/engine_room)
 "fS" = (
@@ -4445,6 +4454,9 @@
 /area/science)
 "om" = (
 /obj/machinery/vending/engivend,
+/obj/machinery/status_display/ai/north{
+	pixel_y = 26
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/engine_room)
 "oo" = (
@@ -7440,6 +7452,21 @@
 /obj/machinery/light,
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons)
+"xU" = (
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/status_display/evac/north{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck2/primary)
 "xX" = (
 /obj/structure/reagent_dispensers/fueltank/cryogenic_fuel,
 /obj/item/radio/intercom/directional/north,
@@ -7840,6 +7867,27 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
+"zw" = (
+/obj/structure/rack,
+/obj/item/powder_bag{
+	pixel_y = -10
+	},
+/obj/item/powder_bag{
+	pixel_y = -10
+	},
+/obj/item/powder_bag,
+/obj/item/powder_bag,
+/obj/item/powder_bag{
+	pixel_y = 8
+	},
+/obj/item/powder_bag{
+	pixel_y = 8
+	},
+/obj/machinery/status_display/evac/north{
+	pixel_y = 26
+	},
+/turf/open/floor/monotile/dark,
+/area/nsv/weapons)
 "zy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -8574,6 +8622,11 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
+"Cx" = (
+/obj/structure/chair,
+/obj/machinery/status_display/evac/west,
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/primary)
 "Cz" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/stripes/line,
@@ -8935,6 +8988,7 @@
 /obj/effect/turf_decal/tile/ship/green{
 	dir = 1
 	},
+/obj/machinery/status_display/evac/west,
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/primary)
 "Ef" = (
@@ -9207,6 +9261,9 @@
 	},
 /obj/item/ship_weapon/ammunition/missile{
 	pixel_y = 10
+	},
+/obj/machinery/status_display/ai/north{
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel/techmaint{
 	initial_gas_mix = "TEMP=2.7"
@@ -11953,6 +12010,18 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/security/armory)
+"OR" = (
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 1
+	},
+/obj/machinery/status_display/evac/north{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck2/primary)
 "OV" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
@@ -12346,6 +12415,14 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/science)
+"Qr" = (
+/obj/machinery/status_display/evac/north{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/techmaint{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/nsv/hanger/notkmcstupidhanger)
 "Qs" = (
 /obj/machinery/advanced_airlock_controller/directional/east{
 	pixel_y = 24
@@ -13259,6 +13336,21 @@
 "Tm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/primary)
+"Tn" = (
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/status_display/ai/north{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/primary)
 "To" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -47178,7 +47270,7 @@ hL
 Oo
 ir
 wd
-rf
+OR
 un
 Ef
 RN
@@ -47192,7 +47284,7 @@ Oy
 jh
 BR
 RN
-Jz
+xU
 un
 Ef
 qI
@@ -48220,7 +48312,7 @@ GB
 jh
 lD
 RN
-Jz
+Tn
 un
 ql
 yX
@@ -48488,7 +48580,7 @@ IW
 uX
 Jk
 ew
-tN
+Cx
 qG
 cH
 AS
@@ -49999,7 +50091,7 @@ NV
 FT
 dI
 WN
-mg
+du
 KE
 SW
 iy
@@ -53863,7 +53955,7 @@ fj
 Ql
 zU
 eY
-lf
+zw
 dH
 mP
 qq
@@ -59002,7 +59094,7 @@ Nh
 Nh
 jx
 jx
-Jc
+Qr
 Jc
 wX
 UB

--- a/_maps/map_files/Atlas/atlas2.dmm
+++ b/_maps/map_files/Atlas/atlas2.dmm
@@ -34,6 +34,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/status_display/evac/south,
 /turf/open/floor/plasteel/grid/lino,
 /area/medical/medbay)
 "ae" = (
@@ -2220,6 +2221,17 @@
 /obj/machinery/vending/clothing,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
+"kp" = (
+/obj/effect/turf_decal/tile/ship/green,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 4
+	},
+/obj/structure/sign/ship/nosmoking{
+	dir = 8;
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck1/hallway)
 "ku" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
@@ -2380,14 +2392,14 @@
 /turf/open/floor/wood,
 /area/security/detectives_office)
 "lb" = (
-/obj/machinery/status_display/evac{
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/tile/ship/green{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
 	dir = 1
+	},
+/obj/machinery/status_display/ai/north{
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/hallway)
@@ -2886,6 +2898,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/status_display/evac/south,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
 "nH" = (
@@ -3222,16 +3235,13 @@
 /obj/effect/turf_decal/tile/ship/half/green{
 	dir = 4
 	},
-/obj/structure/sign/ship/nosmoking{
-	dir = 8;
-	pixel_x = 32
-	},
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
+/obj/machinery/status_display/evac/east,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "ps" = (
@@ -3824,13 +3834,15 @@
 	location = "right"
 	},
 /obj/machinery/camera/autoname,
-/obj/structure/extinguisher_cabinet/north,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /obj/effect/landmark/patrol_node{
 	id = "deck1_bridge";
 	next_id = "deck1_medical"
+	},
+/obj/machinery/status_display/evac/north{
+	pixel_y = 26
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
@@ -6574,6 +6586,15 @@
 "Fy" = (
 /turf/open/floor/wood,
 /area/crew_quarters/bar/mess_hall)
+"Fz" = (
+/obj/effect/turf_decal/tile/ship/half/green{
+	dir = 1
+	},
+/obj/machinery/status_display/evac/north{
+	pixel_y = 26
+	},
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck1/hallway)
 "FA" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/structure/railing/corner{
@@ -9868,6 +9889,15 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
+"UM" = (
+/obj/effect/turf_decal/tile/ship/half/green{
+	dir = 1
+	},
+/obj/machinery/status_display/ai/north{
+	pixel_y = 26
+	},
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck1/hallway)
 "UN" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -39970,7 +40000,7 @@ pl
 Db
 Zr
 Zr
-Zr
+kp
 NL
 gR
 wu
@@ -40472,7 +40502,7 @@ HI
 Wf
 sd
 Pk
-MQ
+lb
 wu
 tQ
 gq
@@ -43556,7 +43586,7 @@ HI
 cm
 LL
 HG
-rb
+Fz
 wu
 YC
 Tc
@@ -43570,7 +43600,7 @@ ha
 ir
 tY
 Tc
-rb
+UM
 wu
 YC
 MS
@@ -46654,7 +46684,7 @@ PE
 Ka
 xd
 at
-lb
+cX
 pe
 ol
 LK


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Did you know that the atlas only has a single status display, right near the bridge?
This adds more around the ship. Most are either in departments or in common areas like hallways.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Status displays good, Now the AI can put funny faces on our walls again.
And the captain can tell us what flavour of bad we got this shift.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added more status displays to atlas
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
