### PR TITLE
AI ships no longer try to predict shots when using hitscan weapons

### DIFF
--- a/nsv13/code/modules/overmap/physics.dm
+++ b/nsv13/code/modules/overmap/physics.dm
@@ -567,7 +567,7 @@ This proc is to be used when someone gets stuck in an overmap ship, gauss, WHATE
 /obj/structure/overmap/proc/fire_projectile(proj_type, atom/target, homing = FALSE, speed=null, user_override=null, lateral=FALSE, ai_aim = FALSE, miss_chance=5, max_miss_distance=5) //Fire one shot. Used for big, hyper accelerated shots rather than PDCs
 	var/turf/T = get_center()
 	var/obj/item/projectile/proj = new proj_type(T)
-	if(ai_aim && !homing)
+	if(ai_aim && !homing && !proj.hitscan)
 		target = calculate_intercept(target, proj, miss_chance=miss_chance, max_miss_distance=max_miss_distance)
 	proj.starting = T
 	proj.firer = (!user_override && gunner) ? gunner : user_override


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. Effectively, AI ships with hitscan weaponry currently have stormtrooper aim, as they'll try predicting the ship's movement, and subsequently almost always miss because well, the projectile is instant and the ship isn't.
This should make them as scary are they should be.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Hitscan weapons don't need any trajectory prediction as they're hitscan.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: AI hitscan weapons aim dead center instead of trying to predict trajectory (and missing)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
