### PR TITLE
Kills the asteroid chasm (maybe this time for real)

### DIFF
--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -4,7 +4,7 @@
 	desc = "Shallow water."
 	icon = 'icons/turf/floors.dmi'
 	icon_state = "riverwater_motion"
-	baseturfs = /turf/open/chasm/lavaland
+	baseturfs = /turf/open/floor/plating/asteroid/airless //NSV 13 - rocks don't have chasms and no cases currently exist where they'd make sense.
 	initial_gas_mix = OPENTURF_LOW_PRESSURE
 	planetary_atmos = TRUE
 	slowdown = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The rivers on that one asteroid ruin have chasms as basetype, which means if a rock spawns ontop of them and then is destroyed, there'll now be a chasm. Needless to say, chasms shouldn't be existing on asteroids.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Water turfs no longer turn into chasms if a rock spawns ontop them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
