### PR TITLE
Fixes issues with the naked outfit

### DIFF
--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -109,6 +109,8 @@
 	glasses = /obj/item/clothing/glasses/eyepatch
 
 /datum/outfit/pirate/space
+	name = "Space Pirate - Space Suit" //NSV13 - prevent overwriting of space pirate outfit in admin equip
+
 	suit = /obj/item/clothing/suit/space/pirate
 	head = /obj/item/clothing/head/helmet/space/pirate/bandana
 	mask = /obj/item/clothing/mask/breath
@@ -117,6 +119,8 @@
 	id = /obj/item/card/id
 
 /datum/outfit/pirate/space/captain
+	name = "Space Pirate - Captain" //NSV13 - prevent overwriting of space pirate outfit in admin equip
+
 	head = /obj/item/clothing/head/helmet/space/pirate
 
 /datum/outfit/pirate/post_equip(mob/living/carbon/human/H)

--- a/nsv13/code/modules/clothing/custom_outfits.dm
+++ b/nsv13/code/modules/clothing/custom_outfits.dm
@@ -24,6 +24,7 @@
 	id = /obj/item/card/id/prisoner
 
 /datum/outfit/syndicate/odst
+	name = "Syndicate Boarder - Base"
 	suit = /obj/item/clothing/suit/space/syndicate/odst
 	head = /obj/item/clothing/head/helmet/space/syndicate/odst
 	belt = /obj/item/storage/belt/utility/syndicate
@@ -35,23 +36,28 @@
 	internals_slot = ITEM_SLOT_SUITSTORE
 	r_pocket = /obj/item/gun/ballistic/automatic/pistol/APS
 	tc = 0
+	can_be_admin_equipped = FALSE // Base should not be equippable, only derivitaves
 
 /datum/outfit/syndicate/odst/smg
 	name = "Syndicate Boarder - SMG Kit"
 	back = /obj/item/storage/backpack/duffelbag/syndie/c20rbundle
 	backpack_contents = list(/obj/item/storage/box/syndie=1,/obj/item/kitchen/knife/combat/survival=1, /obj/item/ammo_box/magazine/smgm45=1)
+	can_be_admin_equipped = TRUE
 
 /datum/outfit/syndicate/odst/shotgun
 	name = "Syndicate Boarder - Shotgun Kit"
 	back = /obj/item/storage/backpack/duffelbag/syndie/bulldogbundle
 	backpack_contents = list(/obj/item/storage/box/syndie=1,/obj/item/kitchen/knife/combat/survival=1, /obj/item/grenade/flashbang=1)
+	can_be_admin_equipped = TRUE
 
 /datum/outfit/syndicate/odst/medic
 	name = "Syndicate Boarder - Medic Kit"
 	back = /obj/item/storage/backpack/duffelbag/syndie/med/medicalbundle
 	backpack_contents = list(/obj/item/storage/box/syndie=1,/obj/item/kitchen/knife/combat/survival=1, /obj/item/ammo_box/magazine/pistolm9mm=1)
+	can_be_admin_equipped = TRUE
 
 /datum/outfit/pirate/space/boarding
+	name = "Space Pirate Boarder - Base"
 	suit = /obj/item/clothing/suit/space/pirate/boarder
 	head = /obj/item/clothing/head/helmet/space/pirate/bandana/boarder
 	mask = /obj/item/clothing/mask/breath
@@ -62,6 +68,7 @@
 	ears = /obj/item/radio/headset/pirate
 	id = /obj/item/card/id
 	r_pocket = /obj/item/gps
+	can_be_admin_equipped = FALSE // Base should not be equippable, only derivitaves
 
 /datum/outfit/pirate/space/boarding/lead
 	name = "Space Pirate Boarder - Lead Kit"
@@ -69,17 +76,20 @@
 	head = /obj/item/clothing/head/helmet/space/pirate/boarder
 	l_pocket = /obj/item/melee/transforming/energy/sword/pirate
 	backpack_contents = list(/obj/item/gun/ballistic/automatic/pistol/glock/makarov=1, /obj/item/ammo_box/magazine/pistolm9mm/glock=3, /obj/item/storage/firstaid/regular=1, /obj/item/loot_locator=1)
+	can_be_admin_equipped = TRUE
 
 /datum/outfit/pirate/space/boarding/sapper
 	name = "Space Pirate Boarder - Sapper Kit"
 	l_pocket = /obj/item/kitchen/knife
 	backpack_contents = list(/obj/item/gun/ballistic/automatic/pistol/glock/makarov=1, /obj/item/ammo_box/magazine/pistolm9mm/glock=2, /obj/item/grenade/smokebomb=2, /obj/item/grenade/plastic/x4=2)
+	can_be_admin_equipped = TRUE
 
 /datum/outfit/pirate/space/boarding/gunner
 	name = "Space Pirate Boarder - Gunner Kit"
 	r_hand = /obj/item/gun/ballistic/rifle/boltaction
 	l_pocket = /obj/item/kitchen/knife/combat/survival
 	backpack_contents = list(/obj/item/ammo_box/a762=4)
+	can_be_admin_equipped = TRUE
 
 /obj/item/storage/box/hug/clown_uniform
 	name = "Clown's formal attire"
@@ -249,6 +259,7 @@ For when the marines are being irritating.
 ///// KNPC OUTFITS /////
 //Syndicate
 /datum/outfit/syndicate/knpc_pistol
+	name = "Syndicate Boarder - Pistol (KNPC)"
 	l_pocket = /obj/item/reagent_containers/hypospray/medipen/survival
 	r_pocket = /obj/item/gun/ballistic/automatic/pistol
 	belt = /obj/item/storage/belt/utility/syndicate
@@ -260,8 +271,10 @@ For when the marines are being irritating.
 	back = /obj/item/storage/backpack/duffelbag/syndie
 	backpack_contents = list(/obj/item/storage/box/syndie=1, /obj/item/gun/ballistic/automatic/pistol=1,  /obj/item/ammo_box/magazine/m10mm=5)
 	tc = 0
+	can_be_admin_equipped = FALSE // This presents problems
 
 /datum/outfit/syndicate/knpc_smg
+	name = "Syndicate Boarder - SMG (KNPC)"
 	l_pocket = /obj/item/reagent_containers/hypospray/medipen/survival
 	r_pocket = /obj/item/gun/ballistic/automatic/pistol
 	belt = /obj/item/storage/belt/utility/syndicate
@@ -273,8 +286,10 @@ For when the marines are being irritating.
 	back = /obj/item/storage/backpack/duffelbag/syndie
 	backpack_contents = list(/obj/item/storage/box/syndie=1, /obj/item/gun/ballistic/automatic/c20r=1,  /obj/item/ammo_box/magazine/smgm45=5)
 	tc = 0
+	can_be_admin_equipped = FALSE // This presents problems
 
 /datum/outfit/syndicate/knpc_shotgun
+	name = "Syndicate Boarder - Shotgun (KNPC)"
 	l_pocket = /obj/item/reagent_containers/hypospray/medipen/survival
 	r_pocket = /obj/item/gun/ballistic/automatic/pistol
 	belt = /obj/item/storage/belt/utility/syndicate
@@ -286,9 +301,11 @@ For when the marines are being irritating.
 	back = /obj/item/storage/backpack/duffelbag/syndie
 	backpack_contents = list(/obj/item/storage/box/syndie=1, /obj/item/gun/ballistic/shotgun/bulldog=1,  /obj/item/ammo_box/magazine/m12g=5)
 	tc = 0
+	can_be_admin_equipped = FALSE // This presents problems
 
 //Space Pirate - TEMP UNTIL REWORK
 /datum/outfit/space_pirate/knpc_pistol
+	name = "Space Pirate Boarder - Pistol (KNPC)"
 	uniform = /obj/item/clothing/under/costume/pirate
 	shoes = /obj/item/clothing/shoes/sneakers/brown
 	gloves = /obj/item/clothing/gloves/color/brown
@@ -304,8 +321,10 @@ For when the marines are being irritating.
 	r_pocket = /obj/item/gun/ballistic/automatic/pistol/glock/makarov/lethal
 	back = /obj/item/storage/backpack/satchel
 	backpack_contents = list(/obj/item/gun/ballistic/automatic/pistol/glock/makarov/lethal=1, /obj/item/ammo_box/magazine/pistolm9mm/glock/lethal=5)
+	can_be_admin_equipped = FALSE // This presents problems
 
 /datum/outfit/space_pirate/knpc_auto_pistol
+	name = "Space Pirate Boarder - Auto Pistol (KNPC)"
 	uniform = /obj/item/clothing/under/costume/pirate
 	shoes = /obj/item/clothing/shoes/sneakers/brown
 	gloves = /obj/item/clothing/gloves/color/brown
@@ -321,6 +340,7 @@ For when the marines are being irritating.
 	r_pocket = /obj/item/gun/ballistic/automatic/pistol/glock/makarov/lethal
 	back = /obj/item/storage/backpack/satchel
 	backpack_contents = list(/obj/item/gun/ballistic/automatic/pistol/APS=1, /obj/item/ammo_box/magazine/pistolm9mm=5)
+	can_be_admin_equipped = FALSE // This presents problems
 
 /datum/outfit/boarding_droid
 	name = "Boarding Droid Loadout"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gives names to certain outfits (boarders) to prevent them from overwriting the naked outfit, as they were using the default outfit name, which happened to be naked

Also prevents some outfits ovewriting eachother

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

allows admins to set people as naked, and have them actually be naked, and not a space pirate, fixes #1897 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Gives names to boarder outfits
admin: Prevents outfits from overriding the naked outfit in the Set outfit dialogue
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
