### PR TITLE
Fixes overmap and overmap-relayed piercing projectiles

### DIFF
--- a/nsv13/code/modules/munitions/ship_weapons/energy_weapons/bsa.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/energy_weapons/bsa.dm
@@ -203,7 +203,7 @@
 	muzzle_type = /obj/effect/projectile/muzzle/bsa
 	impact_type = /obj/effect/projectile/impact/bsa
 	movement_type = FLYING
-	projectile_phasing = ALL
+	projectile_piercing = ALL
 
 /obj/effect/projectile/muzzle/bsa
 	alpha = 0

--- a/nsv13/code/modules/overmap/weapons/projectiles_fx.dm
+++ b/nsv13/code/modules/overmap/weapons/projectiles_fx.dm
@@ -25,7 +25,7 @@ Misc projectile types, effects, think of this as the special FX file.
 	range = 255
 	speed = 1.85
 	movement_type = FLYING
-	projectile_phasing = ALL
+	projectile_piercing = ALL
 
 /obj/item/projectile/bullet/mac_round
 	icon = 'nsv13/icons/obj/projectiles_nsv.dmi'
@@ -47,7 +47,7 @@ Misc projectile types, effects, think of this as the special FX file.
 	if(isovermap(target))
 		var/obj/structure/overmap/OM = target
 		if(OM.mass <= MASS_TINY)
-			projectile_phasing = ALL
+			projectile_piercing = ALL
 		else
 			movement_type = base_movement_type
 	. = ..()
@@ -68,7 +68,7 @@ Misc projectile types, effects, think of this as the special FX file.
 	armour_penetration = 70
 	icon_state = "railgun_ap"
 	movement_type = FLYING
-	projectile_phasing = ALL //Railguns punch straight through your ship
+	projectile_piercing = ALL //Railguns punch straight through your ship
 
 /obj/item/projectile/bullet/mac_round/magneton
 	speed = 1.5
@@ -109,13 +109,14 @@ Misc projectile types, effects, think of this as the special FX file.
 	range = 255
 	speed = 1.85
 	movement_type = FLYING
-	projectile_phasing = ALL
+	projectile_piercing = ALL
 	damage = 45		//It's on a z now, lets not instakill people / objects this happens to hit.
 	var/penetration_fuze = 1	//Will pen through this many things considered valid for reducing this before arming. Can overpenetrate if it happens to pen through windows or other things with not enough resistance.
 
 /obj/item/projectile/bullet/delayed_prime/on_hit(atom/target, blocked)
 	. = ..()
 	penetration_fuze -= fuze_trigger_value(target)
+	message_admins("Hitting target [target] - reducing fuze by [fuze_trigger_value(target)] - remaining fuze = [penetration_fuze]")
 
 /obj/item/projectile/bullet/delayed_prime/proc/fuze_trigger_value(atom/target)
 	return 0

--- a/nsv13/code/modules/overmap/weapons/projectiles_fx.dm
+++ b/nsv13/code/modules/overmap/weapons/projectiles_fx.dm
@@ -41,7 +41,7 @@ Misc projectile types, effects, think of this as the special FX file.
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/torpedo
 	relay_projectile_type =  /obj/item/projectile/bullet/mac_relayed_round
 	var/homing_benefit_time = 0 SECONDS //NAC shells have a very slight homing effect.
-	var/base_movement_type	//Our base move type for when we gain unstoppability from hitting tiny ships.
+	var/base_piercing_type	//Our base move type for when we gain unstoppability from hitting tiny ships.
 
 /obj/item/projectile/bullet/mac_round/prehit_pierce(atom/target)
 	if(isovermap(target))
@@ -49,12 +49,12 @@ Misc projectile types, effects, think of this as the special FX file.
 		if(OM.mass <= MASS_TINY)
 			projectile_piercing = ALL
 		else
-			movement_type = base_movement_type
+			projectile_piercing = base_piercing_type
 	. = ..()
 
 /obj/item/projectile/bullet/mac_round/Initialize()
 	. = ..()
-	base_movement_type = movement_type
+	base_piercing_type = projectile_piercing
 	if(homing_benefit_time)
 		addtimer(CALLBACK(src, .proc/stop_homing), homing_benefit_time)
 	else

--- a/nsv13/code/modules/overmap/weapons/projectiles_fx.dm
+++ b/nsv13/code/modules/overmap/weapons/projectiles_fx.dm
@@ -116,7 +116,6 @@ Misc projectile types, effects, think of this as the special FX file.
 /obj/item/projectile/bullet/delayed_prime/on_hit(atom/target, blocked)
 	. = ..()
 	penetration_fuze -= fuze_trigger_value(target)
-	message_admins("Hitting target [target] - reducing fuze by [fuze_trigger_value(target)] - remaining fuze = [penetration_fuze]")
 
 /obj/item/projectile/bullet/delayed_prime/proc/fuze_trigger_value(atom/target)
 	return 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
#1859 changed a bunch of things about piercing projectiles, but made all NSV projectiles that go through stuff use phasing instead of piercing. This means they effectively were ghosts and didn't hit something, so MAC and simillar stuff just went through stuff shipside without dealing damage. It also made the BSA not do anything on hit, funnily enough.
This resolves that issue.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: overmap and overmap relayed projectiles which are piercing should no longer be intangible.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
