### PR TITLE
Fixes mapdiff check action

### DIFF
--- a/_maps/map_files/Galactica/Galactica2.dmm
+++ b/_maps/map_files/Galactica/Galactica2.dmm
@@ -93194,7 +93194,7 @@ xTO
 ebc
 wjA
 dPw
-bAn
+fZw
 rdS
 lPs
 lPs

--- a/_maps/map_files/Galactica/Galactica2.dmm
+++ b/_maps/map_files/Galactica/Galactica2.dmm
@@ -93194,7 +93194,7 @@ xTO
 ebc
 wjA
 dPw
-fZw
+bAn
 rdS
 lPs
 lPs

--- a/_maps/map_files/Galactica/Galactica2.dmm
+++ b/_maps/map_files/Galactica/Galactica2.dmm
@@ -199,7 +199,7 @@
 /obj/effect/turf_decal/ship/techfloor,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1;
-	filter_types = list(GAS_NUCLEIUM);
+	filter_types = list("nucleium");
 	name = "Nucleium Scrubber"
 	},
 /turf/open/floor/plasteel/ridged/steel,
@@ -569,7 +569,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4;
-	filter_types = list(GAS_NUCLEIUM);
+	filter_types = list("nucleium");
 	name = "Nucleium Scrubber"
 	},
 /turf/open/floor/plasteel/grid/techfloor/grid,
@@ -1297,7 +1297,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	filter_types = list(GAS_NUCLEIUM);
+	filter_types = list("nucleium");
 	name = "Nucleium Scrubber"
 	},
 /turf/open/floor/plasteel/grid/techfloor/grid,
@@ -5999,7 +5999,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8;
-	filter_types = list(GAS_NUCLEIUM);
+	filter_types = list("nucleium");
 	name = "Nucleium Scrubber"
 	},
 /turf/open/floor/plasteel/ridged/steel,
@@ -14026,7 +14026,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	filter_types = list(GAS_NUCLEIUM);
+	filter_types = list("nucleium");
 	name = "Nucleium Scrubber"
 	},
 /turf/open/floor/plasteel/ridged/steel,
@@ -17151,7 +17151,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4;
-	filter_types = list(GAS_NUCLEIUM);
+	filter_types = list("nucleium");
 	name = "Nucleium Scrubber"
 	},
 /turf/open/floor/plasteel/ridged/steel,
@@ -31662,7 +31662,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8;
-	filter_types = list(GAS_NUCLEIUM);
+	filter_types = list("nucleium");
 	name = "Nucleium Scrubber"
 	},
 /turf/open/floor/plasteel/grid/techfloor/grid,
@@ -31948,7 +31948,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1;
-	filter_types = list(GAS_NUCLEIUM);
+	filter_types = list("nucleium");
 	name = "Nucleium Scrubber"
 	},
 /turf/open/floor/plasteel/grid/techfloor/grid,

--- a/_maps/map_files/Gladius/Gladius2.dmm
+++ b/_maps/map_files/Gladius/Gladius2.dmm
@@ -6325,7 +6325,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 4;
-	filter_types = list(GAS_NUCLEIUM);
+	filter_types = list("nucleium");
 	name = "Nucleium Scrubber"
 	},
 /turf/open/floor/plasteel/ridged/steel,
@@ -14460,7 +14460,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 8;
-	filter_types = list(GAS_NUCLEIUM);
+	filter_types = list("nucleium");
 	name = "Nucleium Scrubber"
 	},
 /turf/open/floor/plasteel/ridged/steel,
@@ -20473,7 +20473,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 1;
-	filter_types = list(GAS_NUCLEIUM);
+	filter_types = list("nucleium");
 	name = "Nucleium Scrubber"
 	},
 /turf/open/floor/plasteel/ridged/steel,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Galactic was trying to use the nucleium define inside the map file for some reason, this wasn't detected by the old mapdiff bot but now every new PR fails for this reason

## Changelog
:cl:
fix: fixes galactica nucleium scrubbers/filters
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
