### PR TITLE
Re-adds #967 - TG-style ethereal charge rates

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -359,7 +359,7 @@
 #define DOOR_CRUSH_DAMAGE	15	//! the amount of damage that airlocks deal when they crush you
 
 #define	HUNGER_FACTOR		0.1	//! factor at which mob nutrition decreases
-#define ETHEREAL_CHARGE_FACTOR	1.0 //! NSV13 - factor at which ethereal's charge decreases
+#define ETHEREAL_CHARGE_FACTOR	1.6 //! NSV13 - factor at which ethereal's charge decreases
 #define	HYGIENE_FACTOR  0.1	//! factor at which mob hygiene decreases
 #define	REAGENTS_METABOLISM 0.4	//! How many units of reagent are consumed per tick, by default.
 #define REAGENTS_EFFECT_MULTIPLIER (REAGENTS_METABOLISM / 0.4)	//! By defining the effect multiplier this way, it'll exactly adjust all effects according to how they originally were with the 0.4 metabolism

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -359,7 +359,7 @@
 #define DOOR_CRUSH_DAMAGE	15	//! the amount of damage that airlocks deal when they crush you
 
 #define	HUNGER_FACTOR		0.1	//! factor at which mob nutrition decreases
-#define ETHEREAL_CHARGE_FACTOR	1.6 //! NSV13 - factor at which ethereal's charge decreases
+#define ETHEREAL_CHARGE_FACTOR	2.0 //! NSV13 - factor at which ethereal's charge decreases
 #define	HYGIENE_FACTOR  0.1	//! factor at which mob hygiene decreases
 #define	REAGENTS_METABOLISM 0.4	//! How many units of reagent are consumed per tick, by default.
 #define REAGENTS_EFFECT_MULTIPLIER (REAGENTS_METABOLISM / 0.4)	//! By defining the effect multiplier this way, it'll exactly adjust all effects according to how they originally were with the 0.4 metabolism

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -229,12 +229,10 @@
 
 //NSV13 - TG style ethereal charge levels
 #define ETHEREAL_CHARGE_NONE 0
-#define ETHEREAL_CHARGE_LOWPOWER 400
-#define ETHEREAL_CHARGE_NORMAL 1000
-#define ETHEREAL_CHARGE_ALMOSTFULL 1500
-#define ETHEREAL_CHARGE_FULL 2000
-#define ETHEREAL_CHARGE_OVERLOAD 2500
-#define ETHEREAL_CHARGE_DANGEROUS 3000
+#define ETHEREAL_CHARGE_LOWPOWER 500
+#define ETHEREAL_CHARGE_NORMAL 1250
+#define ETHEREAL_CHARGE_ALMOSTFULL 1875
+#define ETHEREAL_CHARGE_FULL 2500
 
 //Base nutrition value used for newly initialized slimes
 #define SLIME_DEFAULT_NUTRITION 700
@@ -361,7 +359,7 @@
 #define DOOR_CRUSH_DAMAGE	15	//! the amount of damage that airlocks deal when they crush you
 
 #define	HUNGER_FACTOR		0.1	//! factor at which mob nutrition decreases
-#define ETHEREAL_CHARGE_FACTOR	1.6 //! NSV13 - factor at which ethereal's charge decreases
+#define ETHEREAL_CHARGE_FACTOR	0.5 //! NSV13 - factor at which ethereal's charge decreases
 #define	HYGIENE_FACTOR  0.1	//! factor at which mob hygiene decreases
 #define	REAGENTS_METABOLISM 0.4	//! How many units of reagent are consumed per tick, by default.
 #define REAGENTS_EFFECT_MULTIPLIER (REAGENTS_METABOLISM / 0.4)	//! By defining the effect multiplier this way, it'll exactly adjust all effects according to how they originally were with the 0.4 metabolism

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -359,7 +359,7 @@
 #define DOOR_CRUSH_DAMAGE	15	//! the amount of damage that airlocks deal when they crush you
 
 #define	HUNGER_FACTOR		0.1	//! factor at which mob nutrition decreases
-#define ETHEREAL_CHARGE_FACTOR	0.5 //! NSV13 - factor at which ethereal's charge decreases
+#define ETHEREAL_CHARGE_FACTOR	1.0 //! NSV13 - factor at which ethereal's charge decreases
 #define	HYGIENE_FACTOR  0.1	//! factor at which mob hygiene decreases
 #define	REAGENTS_METABOLISM 0.4	//! How many units of reagent are consumed per tick, by default.
 #define REAGENTS_EFFECT_MULTIPLIER (REAGENTS_METABOLISM / 0.4)	//! By defining the effect multiplier this way, it'll exactly adjust all effects according to how they originally were with the 0.4 metabolism

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -227,6 +227,15 @@
 //Used as an upper limit for species that continuously gain nutriment
 #define NUTRITION_LEVEL_ALMOST_FULL 535
 
+//NSV13 - TG style ethereal charge levels
+#define ETHEREAL_CHARGE_NONE 0
+#define ETHEREAL_CHARGE_LOWPOWER 400
+#define ETHEREAL_CHARGE_NORMAL 1000
+#define ETHEREAL_CHARGE_ALMOSTFULL 1500
+#define ETHEREAL_CHARGE_FULL 2000
+#define ETHEREAL_CHARGE_OVERLOAD 2500
+#define ETHEREAL_CHARGE_DANGEROUS 3000
+
 //Base nutrition value used for newly initialized slimes
 #define SLIME_DEFAULT_NUTRITION 700
 
@@ -352,6 +361,7 @@
 #define DOOR_CRUSH_DAMAGE	15	//! the amount of damage that airlocks deal when they crush you
 
 #define	HUNGER_FACTOR		0.1	//! factor at which mob nutrition decreases
+#define ETHEREAL_CHARGE_FACTOR	1.6 //! NSV13 - factor at which ethereal's charge decreases
 #define	HYGIENE_FACTOR  0.1	//! factor at which mob hygiene decreases
 #define	REAGENTS_METABOLISM 0.4	//! How many units of reagent are consumed per tick, by default.
 #define REAGENTS_EFFECT_MULTIPLIER (REAGENTS_METABOLISM / 0.4)	//! By defining the effect multiplier this way, it'll exactly adjust all effects according to how they originally were with the 0.4 metabolism

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -39,7 +39,7 @@
 #define APC_FULLY_CHARGED 2
 
 //NSV13 added ethereal power drain defines
-#define APC_DRAIN_TIME 75
+#define APC_DRAIN_TIME 80
 #define APC_POWER_GAIN 200
 
 // the Area Power Controller (APC), formerly Power Distribution Unit (PDU)
@@ -893,9 +893,9 @@
 				to_chat(H, "<span class='warning'>The APC doesn't have much power, you probably shouldn't drain anymore.</span>")
 				return
 
-			E.drain_time = world.time + 80
+			E.drain_time = world.time + APC_DRAIN_TIME
 			to_chat(H, "<span class='notice'>You start channeling some power through the APC into your body.</span>")
-			while(do_after(user, 75, target = src))
+			while(do_after(user, APC_DRAIN_TIME, target = src))
 				if(!istype(stomach))
 					to_chat(H, "<span class='warning'>You can't receive charge!</span>")
 					return
@@ -903,10 +903,10 @@
 					to_chat(H, "<span class='warning'>The APC doesn't have much power, you probably shouldn't drain anymore.</span>")
 					E.drain_time = 0
 					return
-				E.drain_time = world.time + 80
+				E.drain_time = world.time + APC_DRAIN_TIME
 				if(cell.charge > cell.maxcharge/4 + 250)
-					stomach.adjust_charge(250)
-					cell.charge -= 250
+					stomach.adjust_charge(APC_POWER_GAIN)
+					cell.charge -= APC_POWER_GAIN
 					to_chat(H, "<span class='notice'>You receive some charge from the APC.</span>")
 				else
 					stomach.adjust_charge(cell.charge - cell.maxcharge/4)
@@ -925,17 +925,17 @@
 			if(!istype(stomach))
 				to_chat(H, "<span class='warning'>You can't transfer charge!</span>")
 				return
-			E.drain_time = world.time + 80
+			E.drain_time = world.time + APC_DRAIN_TIME
 			to_chat(H, "<span class='notice'>You start channeling power through your body into the APC.</span>")
 			while(do_after(user, 75, target = src))
 				if(!istype(stomach))
 					to_chat(H, "<span class='warning'>You can't transfer charge!</span>")
 					return
-				E.drain_time = world.time + 80
-				if(stomach.charge > 250)
+				E.drain_time = world.time + APC_DRAIN_TIME
+				if(stomach.charge > APC_POWER_GAIN)
 					to_chat(H, "<span class='notice'>You transfer some power to the APC.</span>")
-					stomach.adjust_charge(-250)
-					cell.charge = min(cell.charge + 250, cell.maxcharge)
+					stomach.adjust_charge(-APC_POWER_GAIN)
+					cell.charge = min(cell.charge + APC_POWER_GAIN, cell.maxcharge)
 				else
 					to_chat(H, "<span class='notice'>You transfer the last of your charge to the APC.</span>")
 					cell.charge = min(cell.charge + stomach.charge, cell.maxcharge)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -40,7 +40,7 @@
 
 //NSV13 added ethereal power drain defines
 #define APC_DRAIN_TIME 80
-#define APC_POWER_GAIN 200
+#define APC_POWER_GAIN 250
 
 // the Area Power Controller (APC), formerly Power Distribution Unit (PDU)
 // one per area, needs wire connection to power network through a terminal

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -1,7 +1,7 @@
 //NSV13 added defines for ethereal cell interactions
-#define CELL_DRAIN_TIME 35
-#define CELL_POWER_GAIN 60
-#define CELL_POWER_DRAIN 750
+#define CELL_DRAIN_TIME 25
+#define CELL_POWER_GAIN 75
+#define CELL_POWER_DRAIN 300
 
 /obj/item/stock_parts/cell
 	name = "power cell"

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -169,15 +169,15 @@
 			return
 
 		to_chat(H, "<span class='notice'>You clumsily channel power through the [src] and into your body, wasting some in the process.</span>")
-		E.drain_time = world.time + 25
-		while(do_after(user, 20, target = src))
+		E.drain_time = world.time + CELL_DRAIN_TIME
+		while(do_after(user, CELL_DRAIN_TIME, target = src))
 			if(!istype(stomach))
 				to_chat(H, "<span class='warning'>You can't receive charge!</span>")
 				return
-			E.drain_time = world.time + 25
-			if(charge > 300)
-				stomach.adjust_charge(75)
-				charge -= 300 //you waste way more than you receive, so that ethereals cant just steal one cell and forget about hunger
+			E.drain_time = world.time + CELL_DRAIN_TIME
+			if(charge > CELL_POWER_DRAIN)
+				stomach.adjust_charge(CELL_POWER_GAIN)
+				charge -= CELL_POWER_DRAIN //you waste way more than you receive, so that ethereals cant just steal one cell and forget about hunger
 				to_chat(H, "<span class='notice'>You receive some charge from the [src].</span>")
 			else
 				stomach.adjust_charge(charge/4)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -13,8 +13,8 @@
 #define BROKEN_SPARKS_MAX (90 SECONDS)
 
 //NSV13 added ethereal light interaction defines
-#define LIGHT_DRAIN_TIME 25
-#define LIGHT_POWER_GAIN 35
+#define LIGHT_DRAIN_TIME 35
+#define LIGHT_POWER_GAIN 50
 
 /obj/item/wallframe/light_fixture
 	name = "light fixture frame"

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -681,15 +681,15 @@
 					return
 
 				to_chat(H, "<span class='notice'>You start channeling some power through the [fitting] into your body.</span>")
-				E.drain_time = world.time + 35
-				while(do_after(user, 30, target = src))
-					E.drain_time = world.time + 35
+				E.drain_time = world.time + LIGHT_DRAIN_TIME
+				while(do_after(user, LIGHT_DRAIN_TIME, target = src))
+					E.drain_time = world.time + LIGHT_DRAIN_TIME
 					if(!istype(stomach))
 						to_chat(H, "<span class='warning'>You can't receive charge!</span>")
 						return
 					to_chat(H, "<span class='notice'>You receive some charge from the [fitting].</span>")
-					stomach.adjust_charge(50)
-					use_power(50)
+					stomach.adjust_charge(LIGHT_POWER_GAIN)
+					use_power(LIGHT_POWER_GAIN)
 					if(stomach.charge >= stomach.max_charge)
 						to_chat(H, "<span class='notice'>You are now fully charged.</span>")
 						E.drain_time = 0

--- a/code/modules/surgery/organs/stomach.dm
+++ b/code/modules/surgery/organs/stomach.dm
@@ -182,6 +182,10 @@
 	UnregisterSignal(owner, COMSIG_LIVING_ELECTROCUTE_ACT)
 	..()
 
+/obj/item/organ/stomach/battery/ethereal/charge(datum/source, amount, repairs)
+	SIGNAL_HANDLER
+	adjust_charge(amount * 20)
+
 /obj/item/organ/stomach/battery/ethereal/proc/on_electrocute(datum/source, shock_damage, shock_source, siemens_coeff = 1, safety = 0, tesla_shock = 0, illusion = 0, stun = TRUE)
 	SIGNAL_HANDLER
 

--- a/code/modules/surgery/organs/stomach.dm
+++ b/code/modules/surgery/organs/stomach.dm
@@ -184,7 +184,7 @@
 
 /obj/item/organ/stomach/battery/ethereal/charge(datum/source, amount, repairs)
 	SIGNAL_HANDLER
-	adjust_charge(amount * 20)
+	adjust_charge(amount / 3.5) //NSV13 - divide by 3.5
 
 /obj/item/organ/stomach/battery/ethereal/proc/on_electrocute(datum/source, shock_damage, shock_source, siemens_coeff = 1, safety = 0, tesla_shock = 0, illusion = 0, stun = TRUE)
 	SIGNAL_HANDLER

--- a/code/modules/surgery/organs/stomach.dm
+++ b/code/modules/surgery/organs/stomach.dm
@@ -187,7 +187,6 @@
 	adjust_charge((ETHEREAL_CHARGE_FACTOR/HUNGER_FACTOR)*amount*max_charge/NUTRITION_LEVEL_FULL)
 
 /obj/item/organ/stomach/battery/ethereal/charge(datum/source, amount, repairs)
-	SIGNAL_HANDLER
 	adjust_charge(amount / 3.5) //NSV13 - divide by 3.5
 
 /obj/item/organ/stomach/battery/ethereal/proc/on_electrocute(datum/source, shock_damage, shock_source, siemens_coeff = 1, safety = 0, tesla_shock = 0, illusion = 0, stun = TRUE)

--- a/code/modules/surgery/organs/stomach.dm
+++ b/code/modules/surgery/organs/stomach.dm
@@ -182,6 +182,10 @@
 	UnregisterSignal(owner, COMSIG_LIVING_ELECTROCUTE_ACT)
 	..()
 
+//NSV13 - more hunger
+/obj/item/organ/stomach/battery/ethereal/adjust_charge_scaled(amount)
+	adjust_charge((ETHEREAL_CHARGE_FACTOR/HUNGER_FACTOR)*amount*max_charge/NUTRITION_LEVEL_FULL)
+
 /obj/item/organ/stomach/battery/ethereal/charge(datum/source, amount, repairs)
 	SIGNAL_HANDLER
 	adjust_charge(amount / 3.5) //NSV13 - divide by 3.5

--- a/code/modules/surgery/organs/stomach.dm
+++ b/code/modules/surgery/organs/stomach.dm
@@ -182,9 +182,9 @@
 	UnregisterSignal(owner, COMSIG_LIVING_ELECTROCUTE_ACT)
 	..()
 
-//NSV13 - more hunger
+//NSV13 - uses ETHEREAL_CHARGE_FACTOR
 /obj/item/organ/stomach/battery/ethereal/adjust_charge_scaled(amount)
-	adjust_charge((ETHEREAL_CHARGE_FACTOR/HUNGER_FACTOR)*amount*max_charge/NUTRITION_LEVEL_FULL)
+	adjust_charge(ETHEREAL_CHARGE_FACTOR*amount*max_charge/NUTRITION_LEVEL_FULL)
 
 /obj/item/organ/stomach/battery/ethereal/charge(datum/source, amount, repairs)
 	adjust_charge(amount / 3.5) //NSV13 - divide by 3.5


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The changes from https://github.com/BeeStation/NSV13/pull/967 got lost in the Beebase due to the rework of electrical species.
Some of these numbers are probably a bit off, but hopefully it's close.
Also this may have unintended side effects for IPCs.
Please do the feedback whenever we test merge this

## Why It's Good For The Game
This wasn't actually supposed to go away

## Changelog
:cl: MacBlaze1
add: Re-added ethereal high-demand high-compensation dynamic
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
