### PR TITLE
Renaming station engineers to engineers

### DIFF
--- a/SQL/ban_conversion_2018-10-28.py
+++ b/SQL/ban_conversion_2018-10-28.py
@@ -62,7 +62,7 @@ def parse_role(bantype, job):
         role = "Server"
     else:
         #TG: Some legacy jobbans are missing the last character from their job string.
-        job_name_fixes = {"A":"AI", "Captai":"Captain", "Cargo Technicia":"Cargo Technician", "Chaplai":"Chaplain", "Che":"Chef", "Chemis":"Chemist", "Chief Enginee":"Chief Engineer", "Chief Medical Office":"Chief Medical Officer", "Cybor":"Cyborg", "Detectiv":"Detective", "Head of Personne":"Head of Personnel", "Head of Securit":"Head of Security", "Mim":"Mime", "pA":"pAI", "Quartermaste":"Quartermaster", "Research Directo":"Research Director", "Scientis":"Scientist", "Security Office":"Military Police", "Station Enginee":"Station Engineer", "Enginee":"Engineer", "Syndicat":"Syndicate", "Warde":"Warden"}
+        job_name_fixes = {"A":"AI", "Captai":"Captain", "Cargo Technicia":"Cargo Technician", "Chaplai":"Chaplain", "Che":"Chef", "Chemis":"Chemist", "Chief Enginee":"Chief Engineer", "Chief Medical Office":"Chief Medical Officer", "Cybor":"Cyborg", "Detectiv":"Detective", "Head of Personne":"Head of Personnel", "Head of Securit":"Head of Security", "Mim":"Mime", "pA":"pAI", "Quartermaste":"Quartermaster", "Research Directo":"Research Director", "Scientis":"Scientist", "Security Office":"Military Police", "Station Enginee":"Engineer", "Enginee":"Engineer", "Syndicat":"Syndicate", "Warde":"Warden"}
         keep_job_names = ("AI", "Head of Personnel", "Head of Security", "OOC", "pAI")
         if job in job_name_fixes:
             role = job_name_fixes[job]

--- a/SQL/ban_conversion_2018-10-28.py
+++ b/SQL/ban_conversion_2018-10-28.py
@@ -62,7 +62,7 @@ def parse_role(bantype, job):
         role = "Server"
     else:
         #TG: Some legacy jobbans are missing the last character from their job string.
-        job_name_fixes = {"A":"AI", "Captai":"Captain", "Cargo Technicia":"Cargo Technician", "Chaplai":"Chaplain", "Che":"Chef", "Chemis":"Chemist", "Chief Enginee":"Chief Engineer", "Chief Medical Office":"Chief Medical Officer", "Cybor":"Cyborg", "Detectiv":"Detective", "Head of Personne":"Head of Personnel", "Head of Securit":"Head of Security", "Mim":"Mime", "pA":"pAI", "Quartermaste":"Quartermaster", "Research Directo":"Research Director", "Scientis":"Scientist", "Security Office":"Military Police", "Station Enginee":"Station Engineer", "Syndicat":"Syndicate", "Warde":"Warden"}
+        job_name_fixes = {"A":"AI", "Captai":"Captain", "Cargo Technicia":"Cargo Technician", "Chaplai":"Chaplain", "Che":"Chef", "Chemis":"Chemist", "Chief Enginee":"Chief Engineer", "Chief Medical Office":"Chief Medical Officer", "Cybor":"Cyborg", "Detectiv":"Detective", "Head of Personne":"Head of Personnel", "Head of Securit":"Head of Security", "Mim":"Mime", "pA":"pAI", "Quartermaste":"Quartermaster", "Research Directo":"Research Director", "Scientis":"Scientist", "Security Office":"Military Police", "Station Enginee":"Station Engineer", "Enginee":"Engineer", "Syndicat":"Syndicate", "Warde":"Warden"}
         keep_job_names = ("AI", "Head of Personnel", "Head of Security", "OOC", "pAI")
         if job in job_name_fixes:
             role = job_name_fixes[job]

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -340,7 +340,7 @@ SUBSYSTEM_DEF(job)
 
 	//NSV13 - fill some other high priority jobs
 	JobDebug("DO, Running Critical Jobs Check")
-	FillPosition("Station Engineer")
+	FillPosition("Engineer")
 	FillPosition("Munitions Technician")
 	FillPosition("Bridge Staff")
 	FillPosition("Shaft Miner")

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -177,7 +177,7 @@
 			//Engineering
 			if("Chief Engineer")
 				heirloom_type = pick(/obj/item/clothing/head/hardhat/white, /obj/item/screwdriver, /obj/item/wrench, /obj/item/weldingtool, /obj/item/crowbar, /obj/item/wirecutters)
-			if("Station Engineer")
+			if("Engineer") //nsv13 station engineer -> engineer
 				heirloom_type = pick(/obj/item/clothing/head/hardhat, /obj/item/screwdriver, /obj/item/wrench, /obj/item/weldingtool, /obj/item/crowbar, /obj/item/wirecutters)
 			if("Atmospheric Technician")
 				heirloom_type = pick(/obj/item/lighter, /obj/item/lighter/greyscale, /obj/item/storage/box/matches)

--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -119,7 +119,7 @@
 	name = "28 moles of plasma (full tank). Be sure to fill up the tank with additional plasma since it doesn't start full!"
 	targetitem = /obj/item/tank
 	difficulty = 3
-	excludefromjob = list("Chief Engineer","Research Director","Station Engineer","Scientist","Atmospheric Technician")
+	excludefromjob = list("Chief Engineer","Research Director","Engineer","Scientist","Atmospheric Technician") //nsv13 station engineer -> engineer
 
 /datum/objective_item/steal/plasma/check_special_completion(obj/item/tank/T)
 	var/target_amount = text2num(name)
@@ -170,7 +170,7 @@
 	name = "the blackbox."
 	targetitem = /obj/item/blackbox
 	difficulty = 10
-	excludefromjob = list("Chief Engineer","Station Engineer","Atmospheric Technician")
+	excludefromjob = list("Chief Engineer","Engineer","Atmospheric Technician") //nsv13 station engineer -> engineer
 
 //Unique Objectives
 /datum/objective_item/unique/docs_red

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -49,7 +49,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 	jobs["Roboticist"] = 32
 	jobs["Exploration Crew"] = 33
 	jobs["Chief Engineer"] = 40
-	jobs["Station Engineer"] = 41
+	jobs["Engineer"] = 41 //nsv13 station engineer -> engineer
 	jobs["Atmospheric Technician"] = 42
 	jobs["Quartermaster"] = 51
 	jobs["Shaft Miner"] = 52

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -146,7 +146,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark)
 	icon_state = "Lawyer"
 
 /obj/effect/landmark/start/station_engineer
-	name = "Station Engineer"
+	name = "Engineer" //nsv13 station engineer -> engineer
 	icon_state = "Station Engineer"
 
 /obj/effect/landmark/start/medical_doctor

--- a/code/game/objects/items/religion.dm
+++ b/code/game/objects/items/religion.dm
@@ -176,7 +176,7 @@
 	item_state = "banner_engineering"
 	lefthand_file = 'icons/mob/inhands/equipment/banners_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/banners_righthand.dmi'
-	job_loyalties = list("Station Engineer", "Atmospheric Technician", "Chief Engineer")
+	job_loyalties = list("Engineer", "Atmospheric Technician", "Chief Engineer") //nsv13 station engineer -> engineer
 	warcry = "All hail lord Singuloth!!"
 
 /obj/item/banner/engineering/mundane

--- a/code/modules/client/loadout/loadout_hat.dm
+++ b/code/modules/client/loadout/loadout_hat.dm
@@ -10,7 +10,7 @@
 /datum/gear/hat/hhat_yellow
 	display_name = "hardhat, yellow"
 	path = /obj/item/clothing/head/hardhat
-	allowed_roles = list("Chief Engineer", "Station Engineer", "Atmospheric Technician")
+	allowed_roles = list("Chief Engineer", "Engineer", "Atmospheric Technician") //nsv13 station engineer -> engineer
 	cost = 2500
 
 /datum/gear/hat/hhat_orange

--- a/code/modules/client/loadout/loadout_hat.dm
+++ b/code/modules/client/loadout/loadout_hat.dm
@@ -16,13 +16,13 @@
 /datum/gear/hat/hhat_orange
 	display_name = "hardhat, orange"
 	path = /obj/item/clothing/head/hardhat/orange
-	allowed_roles = list("Chief Engineer", "Station Engineer", "Atmospheric Technician")
+	allowed_roles = list("Chief Engineer", "Engineer", "Atmospheric Technician") //nsv13 station engineer -> engineer
 	cost = 2500
 
 /datum/gear/hat/hhat_blue
 	display_name = "hardhat, blue"
 	path = /obj/item/clothing/head/hardhat/dblue
-	allowed_roles = list("Chief Engineer", "Station Engineer", "Atmospheric Technician")
+	allowed_roles = list("Chief Engineer", "Engineer", "Atmospheric Technician") //nsv13 station engineer -> engineer
 	cost = 2500
 
 //CIVILIAN HATS & MISC

--- a/code/modules/client/loadout/loadout_suit.dm
+++ b/code/modules/client/loadout/loadout_suit.dm
@@ -57,7 +57,7 @@
 /datum/gear/suit/wintercoat/engineering
 	display_name = "engineering winter coat"
 	path = /obj/item/clothing/suit/hooded/wintercoat/engineering
-	allowed_roles = list("Chief Engineer", "Station Engineer", "Atmospheric Technician")
+	allowed_roles = list("Chief Engineer", "Engineer", "Atmospheric Technician") //nsv13 station engineer -> engineer
 
 /datum/gear/suit/wintercoat/hydro
 	display_name = "hydroponics winter coat"

--- a/code/modules/client/loadout/loadout_uniform.dm
+++ b/code/modules/client/loadout/loadout_uniform.dm
@@ -333,7 +333,7 @@
 
 /datum/gear/uniform/rank/engineering
 	subtype_path = /datum/gear/uniform/rank/engineering
-	allowed_roles = list("Chief Engineer", "Station Engineer", "Atmospheric Technician")
+	allowed_roles = list("Chief Engineer", "Engineer", "Atmospheric Technician") //nsv13 station engineer -> engineer
 
 /datum/gear/uniform/rank/engineering/hazard
 	display_name = "engineering jumpsuit, hazard"

--- a/code/modules/events/wizard/departmentrevolt.dm
+++ b/code/modules/events/wizard/departmentrevolt.dm
@@ -21,7 +21,7 @@
 			jobs_to_revolt = list("Chief Medical Officer", "Medical Doctor", "Chemist", "Geneticist", "Virologist", "Paramedic")
 			nation_name = pick("Mede", "Healtha", "Recova", "Chemi", "Geneti", "Viro", "Psych")
 		if("yellow")
-			jobs_to_revolt = list("Chief Engineer", "Station Engineer", "Atmospheric Technician")
+			jobs_to_revolt = list("Chief Engineer", "Engineer", "Atmospheric Technician") //nsv13 station engineer -> engineer
 			nation_name = pick("Atomo", "Engino", "Power", "Teleco")
 		if("purple")
 			jobs_to_revolt = list("Research Director","Scientist", "Roboticist")

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -394,7 +394,7 @@
 				// Cargo
 				"Quartermaster", "Cargo Technician","Shaft Miner",
 				// Engineering
-				"Chief Engineer", "Station Engineer", "Atmospheric Technician",
+				"Chief Engineer", "Engineer", "Atmospheric Technician", //nsv13 station engineer -> engineer
 				// NSV13 - munitions
 				"Air Traffic Controller", "Pilot", "Munitions Technician", "Deck Technician", "Master At Arms", "Bridge Staff",
 				// R&D

--- a/code/modules/jobs/job_types/station_engineer.dm
+++ b/code/modules/jobs/job_types/station_engineer.dm
@@ -1,5 +1,5 @@
 /datum/job/engineer
-	title = "Station Engineer"
+	title = "Engineer" //nsv13 station engineer -> engineer
 	flag = ENGINEER
 	department_head = list("Chief Engineer")
 	department_flag = ENGSEC
@@ -30,7 +30,7 @@
 	)
 
 /datum/outfit/job/engineer
-	name = "Station Engineer"
+	name = "Engineer" //nsv13 station engineer -> engineer
 	jobtype = /datum/job/engineer
 
 	id = /obj/item/card/id/job/engi
@@ -51,11 +51,11 @@
 	backpack_contents = list(/obj/item/modular_computer/tablet/preset/advanced=1)
 
 /datum/outfit/job/engineer/gloved
-	name = "Station Engineer (Gloves)"
+	name = "Engineer (Gloves)" //nsv13 station engineer -> engineer
 	gloves = /obj/item/clothing/gloves/color/yellow
 
 /datum/outfit/job/engineer/gloved/rig
-	name = "Station Engineer (Hardsuit)"
+	name = "Engineer (Hardsuit)" //nsv13 station engineer -> engineer
 	mask = /obj/item/clothing/mask/breath
 	suit = /obj/item/clothing/suit/space/hardsuit/engine
 	suit_store = /obj/item/tank/internals/oxygen

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -149,7 +149,7 @@ GLOBAL_PROTECT(exp_specialmap)
 	job = ce_expand.Replace(job, "chief engineer")
 	job = qm_expand.Replace(job, "quartermaster")
 	job = sec_expand.Replace(job, "security officer")
-	job = engi_expand.Replace(job, "station engineer")
+	job = engi_expand.Replace(job, "engineer") //nsv13 station engineer -> engineer
 	job = atmos_expand.Replace(job, "atmospheric technician")
 	job = doc_expand.Replace(job, "medical doctor")
 	job = mine_expand.Replace(job, "shaft miner")

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -12,7 +12,7 @@ GLOBAL_LIST_INIT(command_positions, list(
 
 GLOBAL_LIST_INIT(engineering_positions, list(
 	"Chief Engineer",
-	"Station Engineer",
+	"Engineer", //nsv13 station engineer -> engineer
 	"Atmospheric Technician"))
 
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -657,7 +657,7 @@
 
 
 	if(mind)
-		if((mind.assigned_role == "Station Engineer") || (mind.assigned_role == "Chief Engineer") )
+		if((mind.assigned_role == "Engineer") || (mind.assigned_role == "Chief Engineer") ) //nsv13 station engineer -> engineer
 			gain = 100
 		if(mind.assigned_role == "Clown")
 			gain = rand(-1000, 1000)

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -529,7 +529,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "A simple, yet superb mixture of Vodka and orange juice. Just the thing for the tired engineer."
 
 /datum/reagent/consumable/ethanol/screwdrivercocktail/on_mob_life(mob/living/carbon/M)
-	if(M.mind && (M.mind.assigned_role in list("Station Engineer", "Atmospheric Technician", "Chief Engineer"))) //Engineers lose radiation poisoning at a massive rate.
+	if(M.mind && (M.mind.assigned_role in list("Engineer", "Atmospheric Technician", "Chief Engineer"))) //Engineers lose radiation poisoning at a massive rate.
 		M.radiation = max(M.radiation - 25, 0)
 	return ..()
 

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -529,7 +529,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "A simple, yet superb mixture of Vodka and orange juice. Just the thing for the tired engineer."
 
 /datum/reagent/consumable/ethanol/screwdrivercocktail/on_mob_life(mob/living/carbon/M)
-	if(M.mind && (M.mind.assigned_role in list("Engineer", "Atmospheric Technician", "Chief Engineer"))) //Engineers lose radiation poisoning at a massive rate.
+	if(M.mind && (M.mind.assigned_role in list("Engineer", "Atmospheric Technician", "Chief Engineer"))) //Engineers lose radiation poisoning at a massive rate. //nsv13 station engineer -> engineer
 		M.radiation = max(M.radiation - 25, 0)
 	return ..()
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1987,7 +1987,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A pair of extra-strength magboots that crush anyone you walk over."
 	cost = 7
 	item = /obj/item/clothing/shoes/magboots/crushing
-	restricted_roles = list("Chief Engineer", "Station Engineer", "Atmospheric Technician")
+	restricted_roles = list("Chief Engineer", "Engineer", "Atmospheric Technician") //nsv13 station engineer -> engineer
 
 /datum/uplink_item/role_restricted/gorillacubes
 	name = "Box of Gorilla Cubes"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2309,7 +2309,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A plasma cored control rod designed for sabotaging Stormdrive reactors."
 	cost = 10
 	item = /obj/item/control_rod/plasma
-	restricted_roles = list("Chief Engineer", "Station Engineer", "Atmospheric Technician")
+	restricted_roles = list("Chief Engineer", "Engineer", "Atmospheric Technician") //nsv13 station engineer -> engineer
 
 // Pointless
 /datum/uplink_item/badass

--- a/config/jobs.txt
+++ b/config/jobs.txt
@@ -28,7 +28,7 @@ Lawyer=2,2
 
 Chaplain=1,1
 
-Station Engineer=7,5
+Engineer=7,5 //nsv13 station engineer -> engineer
 Atmospheric Technician=4,2
 
 Medical Doctor=8,6

--- a/config/jobs.txt
+++ b/config/jobs.txt
@@ -28,7 +28,7 @@ Lawyer=2,2
 
 Chaplain=1,1
 
-Engineer=7,5 //nsv13 station engineer -> engineer
+Engineer=7,5 #nsv13 station engineer -> engineer
 Atmospheric Technician=4,2
 
 Medical Doctor=8,6

--- a/config/ranks/corporate.txt
+++ b/config/ranks/corporate.txt
@@ -27,7 +27,7 @@ Lawyer=WS
 
 Chaplain=WS
 
-Engineer=WS //nsv13 station engineer -> engineer
+Engineer=WS #nsv13 station engineer -> engineer
 Atmospheric Technician=WS
 
 Medical Doctor=WS

--- a/config/ranks/corporate.txt
+++ b/config/ranks/corporate.txt
@@ -27,7 +27,7 @@ Lawyer=WS
 
 Chaplain=WS
 
-Station Engineer=WS
+Engineer=WS //nsv13 station engineer -> engineer
 Atmospheric Technician=WS
 
 Medical Doctor=WS

--- a/config/ranks/military.txt
+++ b/config/ranks/military.txt
@@ -27,7 +27,7 @@ Lawyer=CRW
 
 Chaplain=CRW
 
-Engineer=LCPL //nsv13 station engineer -> engineer
+Engineer=LCPL #nsv13 station engineer -> engineer
 Atmospheric Technician=LCPL
 
 Medical Doctor=CPL

--- a/config/ranks/military.txt
+++ b/config/ranks/military.txt
@@ -27,7 +27,7 @@ Lawyer=CRW
 
 Chaplain=CRW
 
-Station Engineer=LCPL
+Engineer=LCPL //nsv13 station engineer -> engineer
 Atmospheric Technician=LCPL
 
 Medical Doctor=CPL

--- a/config/ranks/royal_navy.txt
+++ b/config/ranks/royal_navy.txt
@@ -27,7 +27,7 @@ Lawyer=CIV
 
 Chaplain=SLT
 
-Engineer=SLT //nsv13 station engineer -> engineer
+Engineer=SLT #nsv13 station engineer -> engineer
 Atmospheric Technician=SPC
 
 Medical Doctor=SLT

--- a/config/ranks/royal_navy.txt
+++ b/config/ranks/royal_navy.txt
@@ -27,7 +27,7 @@ Lawyer=CIV
 
 Chaplain=SLT
 
-Station Engineer=SLT
+Engineer=SLT //nsv13 station engineer -> engineer
 Atmospheric Technician=SPC
 
 Medical Doctor=SLT

--- a/config/ranks/sharpe.txt
+++ b/config/ranks/sharpe.txt
@@ -30,7 +30,7 @@ Lawyer=SPM
 
 Chaplain=CPL
 
-Station Engineer=ENS
+Engineer=ENS //nsv13 station engineer -> engineer
 Atmospheric Technician=ENS
 
 Medical Doctor=ENS

--- a/config/ranks/sharpe.txt
+++ b/config/ranks/sharpe.txt
@@ -30,7 +30,7 @@ Lawyer=SPM
 
 Chaplain=CPL
 
-Engineer=ENS //nsv13 station engineer -> engineer
+Engineer=ENS #nsv13 station engineer -> engineer
 Atmospheric Technician=ENS
 
 Medical Doctor=ENS

--- a/nsv13/code/modules/power/reactor/rbmk.dm
+++ b/nsv13/code/modules/power/reactor/rbmk.dm
@@ -496,7 +496,7 @@ The reactor CHEWS through moderator. It does not do this slowly. Be very careful
 	for(var/client/C in GLOB.clients)
 		if(CONFIG_GET(flag/allow_crew_objectives))
 			var/mob/M = C.mob
-			if(M?.mind?.current && LAZYLEN(M.mind.crew_objectives) && (M.job == "Station Engineer" || M.job == "Chief Engineer" || M.job == "Atmospheric Technician"))
+			if(M?.mind?.current && LAZYLEN(M.mind.crew_objectives) && (M.job == "Engineer" || M.job == "Chief Engineer" || M.job == "Atmospheric Technician")) //nsv13 station engineer -> engineer
 				for(var/datum/objective/crew/meltdown/MO in M.mind.crew_objectives)
 					MO.meltdown = TRUE
 

--- a/nsv13/code/modules/power/stormdrive.dm
+++ b/nsv13/code/modules/power/stormdrive.dm
@@ -1145,7 +1145,7 @@ Control Rods
 		if(C)
 			if(CONFIG_GET(flag/allow_crew_objectives))
 				var/mob/M = C.mob
-				if(M?.mind?.current && LAZYLEN(M.mind.crew_objectives) && (M.job == "Station Engineer" || M.job == "Chief Engineer" || M.job == "Atmospheric Technician"))
+				if(M?.mind?.current && LAZYLEN(M.mind.crew_objectives) && (M.job == "Engineer" || M.job == "Chief Engineer" || M.job == "Atmospheric Technician")) //nsv13 station engineer -> engineer
 					for(var/datum/objective/crew/meltdown/MO in M.mind.crew_objectives)
 						MO.meltdown = TRUE
 

--- a/strings/ion_laws.json
+++ b/strings/ion_laws.json
@@ -447,7 +447,7 @@
         "DETECTIVES",
         "LAWYERS",
         "CHIEF ENGINEERS",
-        "STATION ENGINEERS",
+        "ENGINEERS",
         "ATMOSPHERIC TECHNICIANS",
         "JANITORS",
         "QUARTERMASTERS",


### PR DESCRIPTION

## About The Pull Request

This PR renames several (alomost all of there except where it doesn't have sense) instances of Engineer's being called "Station Engineer". No job path changed. No icon state changed. 

Technically this should not affect anything game-wise since everything that uses a job name as a pointer is renamed too. The most biggest concerns with such thing are (of course) upstream computability and ban preservation, since I doubt that every engineer ban would be saved, but this is not something that I can fix or reproduce to be 100% sure about. Keep this in mind. Don't recommend until decision about this is made.   

## Why It's Good For The Game

Can you see a station somewhere around here? Yeah, I too.
I guess you can call it "Engineer gaming"

## Changelog
:cl:
add: Station Engineer is killed
del: Long live the Engineer!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->