### PR TITLE
CE now spawns with their own jumpsuit and beret

### DIFF
--- a/code/modules/jobs/job_types/chief_engineer.dm
+++ b/code/modules/jobs/job_types/chief_engineer.dm
@@ -44,10 +44,10 @@
 	belt = /obj/item/storage/belt/utility/chief/full
 	l_pocket = /obj/item/pda/heads/ce
 	ears = /obj/item/radio/headset/heads/ce
-	uniform = /obj/item/clothing/under/ship/engineer
+	uniform = /obj/item/clothing/under/rank/engineering/chief_engineer
 	shoes = /obj/item/clothing/shoes/workboots
 	suit = /obj/item/clothing/suit/ship/engineer
-	head = /obj/item/clothing/head/beret/ship/engineer
+	head = /obj/item/clothing/head/beret/ce
 	gloves = /obj/item/clothing/gloves/color/black/ce
 	backpack_contents = list(/obj/item/melee/classic_baton/police/telescopic=1, /obj/item/modular_computer/tablet/preset/advanced=1)
 


### PR DESCRIPTION

## About The Pull Request

This small tweak makes CE spawn with their own green-white uniform and not just regular engie's one. That's it.

## Why It's Good For The Game

CE now don't have to waste 10 seconds of their time to change clothes. If they have ever wasted it.

## Changelog
:cl:

tweak: CE now spawns in their own outfit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
