### PR TITLE
add more channels to bridge staff encryption key

### DIFF
--- a/nsv13/code/game/objects/items/bridge_items.dm
+++ b/nsv13/code/game/objects/items/bridge_items.dm
@@ -7,4 +7,4 @@
 /obj/item/encryptionkey/bridge_staff
 	name = "bridge staff encryption key"
 	icon_state = "hop_cypherkey"
-	channels = list(RADIO_CHANNEL_COMMAND = 1)
+	channels = list(RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_MUNITIONS = 1, RADIO_CHANNEL_ATC = 1, RADIO_CHANNEL_SUPPLY = 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds Munitions, ATC and Supply (last one muted by default) channels to the Bridge Staff encryption key.

## Why It's Good For The Game

Bridge Staff benefit from knowing the state of and coordinating with their fighters and weapons in combat. They may need to coordinate with cargo for delivery missions if Captain and XO are busy. (Supply is muted by default because this is rather situational.) Giving them a direct line of communication is empowering for the Bridge Staff and gives Captain and XO more room to make important decision or roleplay.

## Changelog
:cl:
tweak: Bridge Staff have now have access to Munitions, ATC and Supply channels.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
