### PR TITLE
Replacing "fleet/nanotrasen/earth" with "fleet/solgov/earth"

### DIFF
--- a/config/starmap/README.md
+++ b/config/starmap/README.md
@@ -36,7 +36,7 @@ An example system would be:
 An example (Invalid) map setup COULD be:
 
 ```
-{"name":"Staging","desc":"Used for round initialisation and admin event staging","threat_level":0,"alignment":"unaligned","hidden":1,"system_type":"null","system_traits":7,"is_capital":0,"adjacency_list":"[]","wormhole_connections":"[]","fleet_type":null,"x":0,"y":0,"parallax_property":null,"visitable":0,"sector":1,"is_hypergate":0,"preset_trader":null,"audio_cues":"null"},{"name":"Sol","desc":null,"threat_level":0,"alignment":"nanotrasen","hidden":0,"system_type":"{\"tag\":\"planet_earth\",\"label\":\"Planetary system\"}","system_traits":5,"is_capital":1,"adjacency_list":"[\"Alpha Centauri\",\"Outpost 45\",\"Ross 154\"]","wormhole_connections":"[]","fleet_type":"/datum/fleet/solgov/earth","x":70,"y":50,"parallax_property":null,"visitable":0,"sector":1,"is_hypergate":0,"preset_trader":null,"audio_cues":"null"}
+{"name":"Staging","desc":"Used for round initialisation and admin event staging","threat_level":0,"alignment":"unaligned","hidden":1,"system_type":"null","system_traits":7,"is_capital":0,"adjacency_list":"[]","wormhole_connections":"[]","fleet_type":null,"x":0,"y":0,"parallax_property":null,"visitable":0,"sector":1,"is_hypergate":0,"preset_trader":null,"audio_cues":"null"},{"name":"Sol","desc":null,"threat_level":0,"alignment":"solgov","hidden":0,"system_type":"{\"tag\":\"planet_earth\",\"label\":\"Planetary system\"}","system_traits":5,"is_capital":1,"adjacency_list":"[\"Alpha Centauri\",\"Outpost 45\",\"Ross 154\"]","wormhole_connections":"[]","fleet_type":"/datum/fleet/solgov/earth","x":70,"y":50,"parallax_property":null,"visitable":0,"sector":1,"is_hypergate":0,"preset_trader":null,"audio_cues":"null"}
 ```
 
 ## Props:

--- a/config/starmap/README.md
+++ b/config/starmap/README.md
@@ -30,13 +30,13 @@ Each individual list element is directly serialized into a starsystem object.
 An example system would be:
 
 ```
-{"name":"Sol","desc":null,"threat_level":0,"alignment":"nanotrasen","hidden":0,"system_type":"{\"tag\":\"planet_earth\",\"label\":\"Planetary system\"}","system_traits":5,"is_capital":1,"adjacency_list":"[\"Alpha Centauri\",\"Outpost 45\",\"Ross 154\"]","wormhole_connections":"[]","fleet_type":"/datum/fleet/nanotrasen/earth","x":70,"y":50,"parallax_property":null,"visitable":0,"sector":1,"is_hypergate":0,"preset_trader":null,"audio_cues":"null"}
+{"name":"Sol","desc":null,"threat_level":0,"alignment":"nanotrasen","hidden":0,"system_type":"{\"tag\":\"planet_earth\",\"label\":\"Planetary system\"}","system_traits":5,"is_capital":1,"adjacency_list":"[\"Alpha Centauri\",\"Outpost 45\",\"Ross 154\"]","wormhole_connections":"[]","fleet_type":"/datum/fleet/solgov/earth","x":70,"y":50,"parallax_property":null,"visitable":0,"sector":1,"is_hypergate":0,"preset_trader":null,"audio_cues":"null"}
 ```
 
 An example (Invalid) map setup COULD be:
 
 ```
-{"name":"Staging","desc":"Used for round initialisation and admin event staging","threat_level":0,"alignment":"unaligned","hidden":1,"system_type":"null","system_traits":7,"is_capital":0,"adjacency_list":"[]","wormhole_connections":"[]","fleet_type":null,"x":0,"y":0,"parallax_property":null,"visitable":0,"sector":1,"is_hypergate":0,"preset_trader":null,"audio_cues":"null"},{"name":"Sol","desc":null,"threat_level":0,"alignment":"nanotrasen","hidden":0,"system_type":"{\"tag\":\"planet_earth\",\"label\":\"Planetary system\"}","system_traits":5,"is_capital":1,"adjacency_list":"[\"Alpha Centauri\",\"Outpost 45\",\"Ross 154\"]","wormhole_connections":"[]","fleet_type":"/datum/fleet/nanotrasen/earth","x":70,"y":50,"parallax_property":null,"visitable":0,"sector":1,"is_hypergate":0,"preset_trader":null,"audio_cues":"null"}
+{"name":"Staging","desc":"Used for round initialisation and admin event staging","threat_level":0,"alignment":"unaligned","hidden":1,"system_type":"null","system_traits":7,"is_capital":0,"adjacency_list":"[]","wormhole_connections":"[]","fleet_type":null,"x":0,"y":0,"parallax_property":null,"visitable":0,"sector":1,"is_hypergate":0,"preset_trader":null,"audio_cues":"null"},{"name":"Sol","desc":null,"threat_level":0,"alignment":"nanotrasen","hidden":0,"system_type":"{\"tag\":\"planet_earth\",\"label\":\"Planetary system\"}","system_traits":5,"is_capital":1,"adjacency_list":"[\"Alpha Centauri\",\"Outpost 45\",\"Ross 154\"]","wormhole_connections":"[]","fleet_type":"/datum/fleet/solgov/earth","x":70,"y":50,"parallax_property":null,"visitable":0,"sector":1,"is_hypergate":0,"preset_trader":null,"audio_cues":"null"}
 ```
 
 ## Props:

--- a/config/starmap/README.md
+++ b/config/starmap/README.md
@@ -30,7 +30,7 @@ Each individual list element is directly serialized into a starsystem object.
 An example system would be:
 
 ```
-{"name":"Sol","desc":null,"threat_level":0,"alignment":"nanotrasen","hidden":0,"system_type":"{\"tag\":\"planet_earth\",\"label\":\"Planetary system\"}","system_traits":5,"is_capital":1,"adjacency_list":"[\"Alpha Centauri\",\"Outpost 45\",\"Ross 154\"]","wormhole_connections":"[]","fleet_type":"/datum/fleet/solgov/earth","x":70,"y":50,"parallax_property":null,"visitable":0,"sector":1,"is_hypergate":0,"preset_trader":null,"audio_cues":"null"}
+{"name":"Sol","desc":null,"threat_level":0,"alignment":"solgov","hidden":0,"system_type":"{\"tag\":\"planet_earth\",\"label\":\"Planetary system\"}","system_traits":5,"is_capital":1,"adjacency_list":"[\"Alpha Centauri\",\"Outpost 45\",\"Ross 154\"]","wormhole_connections":"[]","fleet_type":"/datum/fleet/solgov/earth","x":70,"y":50,"parallax_property":null,"visitable":0,"sector":1,"is_hypergate":0,"preset_trader":null,"audio_cues":"null"}
 ```
 
 An example (Invalid) map setup COULD be:

--- a/config/starmap/starmap_default.json
+++ b/config/starmap/starmap_default.json
@@ -34,7 +34,7 @@
 	  "is_capital": 1,
 	  "adjacency_list": "[\"Alpha Centauri\",\"Outpost 45\",\"Ross 154\"]",
 	  "wormhole_connections": "[]",
-	  "fleet_type": "/datum/fleet/nanotrasen/earth",
+	  "fleet_type": "/datum/fleet/solgov/earth",
 	  "x": 70,
 	  "y": 50,
 	  "parallax_property": null,

--- a/nsv13/code/controllers/subsystem/starsystem.dm
+++ b/nsv13/code/controllers/subsystem/starsystem.dm
@@ -830,7 +830,7 @@ Returns a faction datum by its name (case insensitive!)
 	is_capital = TRUE
 	x = 70
 	y = 50
-	fleet_type = /datum/fleet/nanotrasen/earth
+	fleet_type = /datum/fleet/solgov/earth
 	alignment = "nanotrasen"
 	system_type = list(
 		tag = "planet_earth",

--- a/nsv13/code/controllers/subsystem/starsystem.dm
+++ b/nsv13/code/controllers/subsystem/starsystem.dm
@@ -831,7 +831,7 @@ Returns a faction datum by its name (case insensitive!)
 	x = 70
 	y = 50
 	fleet_type = /datum/fleet/solgov/earth
-	alignment = "nanotrasen"
+	alignment = "solgov"
 	system_type = list(
 		tag = "planet_earth",
 		label = "Planetary system",

--- a/nsv13/code/modules/overmap/ai-skynet.dm
+++ b/nsv13/code/modules/overmap/ai-skynet.dm
@@ -337,7 +337,7 @@ Adding tasks is easy! Just define a datum for it.
 			SSovermap_mode.modify_threat_elevation(TE_FLEET_THREAT_DYNAMIC ? (TE_FLEET_KILL_THREAT * applied_size ) : TE_FLEET_KILL_THREAT)
 	QDEL_NULL(src)
 
-/datum/fleet/nanotrasen/earth/defeat()
+/datum/fleet/solgov/earth/defeat()
 	. = ..() //If you lose sol...game over man, game over.
 	priority_announce("SolGov command do you read?! Requesting immediate assistance, we have a foothold situation, repeat, a foothold sit##----///", "White Rapids Fleet Command")
 	SSticker.mode.check_finished(TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Why It's Good For The Game

Are you tired when your "last hope fleet on Sol" does suicide attack on Rubicon, reports it's own death and ends the round?
I am tired. So here we are!

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## About The Pull Request

nanotrasen/earth fleet is not described, so it has no overriden traits like "FLEET_DIFFICULTY_HARD" or "FLEET_TRAIT_DEFENSE"
So after game start it moves from Sol to it's destiny.
Actually to just die in combat
A-a-and because it's has special round-end trigger it's pretty sad

But we have solgov/earth fleet with all those traits. But it's unused. Ugh.

How that mistake was even made?!

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Earth Defense Force admiral was replaced for his suicidal attacks on Rubicon. So it should remain calm in Sol now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
