### PR TITLE
add minimum population requirement for kill objectives to changeling and wizzard

### DIFF
--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -443,7 +443,7 @@
 					identity_theft.update_explanation_text()
 					objectives += identity_theft
 					log_objective(owner, identity_theft.explanation_text)
-					escape_objective_possible = FALSE
+					escape_objective_possible = FALSE //nsv13 end
 
 	if (!(locate(/datum/objective/escape) in objectives) && escape_objective_possible)
 		//nsv13 - No (almost neccessarily) kill objectives on low pop

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -416,36 +416,38 @@
 		objectives += destroy_objective
 		log_objective(owner, destroy_objective.explanation_text)
 	else
-		if(prob(70))
-			var/datum/objective/assassinate/kill_objective = new
-			kill_objective.owner = owner
-			if(team_mode) //No backstabbing while in a team
-				kill_objective.find_target_by_role(role = ROLE_CHANGELING, role_type = TRUE, invert = TRUE)
+		if(GLOB.joined_player_list.len >= CONFIG_GET(number/min_pop_kill_objectives)) //nsv13 - No kill objectives on low pop
+			if(prob(70))
+				var/datum/objective/assassinate/kill_objective = new
+				kill_objective.owner = owner
+				if(team_mode) //No backstabbing while in a team
+					kill_objective.find_target_by_role(role = ROLE_CHANGELING, role_type = TRUE, invert = TRUE)
+				else
+					kill_objective.find_target()
+				objectives += kill_objective
+				log_objective(owner, kill_objective.explanation_text)
 			else
-				kill_objective.find_target()
-			objectives += kill_objective
-			log_objective(owner, kill_objective.explanation_text)
-		else
-			var/datum/objective/maroon/maroon_objective = new
-			maroon_objective.owner = owner
-			if(team_mode)
-				maroon_objective.find_target_by_role(role = ROLE_CHANGELING, role_type = TRUE, invert = TRUE)
-			else
-				maroon_objective.find_target()
-			objectives += maroon_objective
-			log_objective(owner, maroon_objective.explanation_text)
+				var/datum/objective/maroon/maroon_objective = new
+				maroon_objective.owner = owner
+				if(team_mode)
+					maroon_objective.find_target_by_role(role = ROLE_CHANGELING, role_type = TRUE, invert = TRUE)
+				else
+					maroon_objective.find_target()
+				objectives += maroon_objective
+				log_objective(owner, maroon_objective.explanation_text)
 
-			if (!(locate(/datum/objective/escape) in objectives) && escape_objective_possible)
-				var/datum/objective/escape/escape_with_identity/identity_theft = new
-				identity_theft.owner = owner
-				identity_theft.target = maroon_objective.target
-				identity_theft.update_explanation_text()
-				objectives += identity_theft
-				log_objective(owner, identity_theft.explanation_text)
-				escape_objective_possible = FALSE
+				if (!(locate(/datum/objective/escape) in objectives) && escape_objective_possible)
+					var/datum/objective/escape/escape_with_identity/identity_theft = new
+					identity_theft.owner = owner
+					identity_theft.target = maroon_objective.target
+					identity_theft.update_explanation_text()
+					objectives += identity_theft
+					log_objective(owner, identity_theft.explanation_text)
+					escape_objective_possible = FALSE
 
 	if (!(locate(/datum/objective/escape) in objectives) && escape_objective_possible)
-		if(prob(50))
+		//nsv13 - No (almost neccessarily) kill objectives on low pop
+		if(prob(50) || (GLOB.joined_player_list.len <= CONFIG_GET(number/min_pop_kill_objectives)))
 			var/datum/objective/escape/escape_objective = new
 			escape_objective.owner = owner
 			objectives += escape_objective

--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -63,6 +63,22 @@
 /datum/antagonist/wizard/proc/create_objectives()
 	if(!give_objectives)
 		return
+
+	//nsv13 - On lowpop, only create one steal and escape objective and then return
+	if(GLOB.joined_player_list.len < CONFIG_GET(number/min_pop_kill_objectives))
+		var/datum/objective/steal/steal_objective = new
+		steal_objective.owner = owner
+		steal_objective.find_target()
+		objectives += steal_objective
+		log_objective(owner, steal_objective.explanation_text)
+
+		if (!(locate(/datum/objective/escape) in objectives))
+			var/datum/objective/escape/escape_objective = new
+			escape_objective.owner = owner
+			objectives += escape_objective
+			log_objective(owner, escape_objective.explanation_text)
+		return //nsv13 end
+
 	switch(rand(1,100))
 		if(1 to 30)
 			var/datum/objective/assassinate/kill_objective = new


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Only give kill objectives to wizards and changelings if the population is above MIN_POP_KILL_OBJECTIVES from config\game_options.txt
Fixes #1884
 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Brings wizards and changelings in line with traitors. Consistency is good because people get upset about inconsistencies. Also, lowpop murder is lame.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: No longer give kill objectives to wizards and changelings on low pop.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
