### PR TITLE
Refactors overmap keybindings

### DIFF
--- a/code/datums/keybinding/_defines.dm
+++ b/code/datums/keybinding/_defines.dm
@@ -4,6 +4,7 @@
 #define CATEGORY_HUMAN "HUMAN"
 #define CATEGORY_MISC "MISC"
 #define CATEGORY_ROBOT "ROBOT"
+#define CATEGORY_OVERMAP "OVERMAP" //NSV13 - overmap controls
 
 #define WEIGHT_HIGHEST 0
 #define WEIGHT_CLIENT 10
@@ -12,4 +13,5 @@
 #define WEIGHT_LIVING 40
 #define WEIGHT_DEAD 50
 #define WEIGHT_ROBOT 60
+#define WEIGHT_OVERMAP 65 //NSV13 - overmap controls override some of the other controls, don't ask me why highest and lowest are named like this
 #define WEIGHT_LOWEST 999

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -5,7 +5,7 @@
 //	You do not need to raise this if you are adding new values that have sane defaults.
 //	Only raise this value when changing the meaning/format/name/layout of an existing value
 //	where you would want the updater procs below to run
-#define SAVEFILE_VERSION_MAX	35
+#define SAVEFILE_VERSION_MAX	36
 
 /*
 SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Carn
@@ -145,6 +145,9 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	if(current_version < 27)
 		if (!(underwear in GLOB.underwear_list))
 			underwear = "Nude"
+	if(current_version < 36) //NSV13 - added some keybinds
+		key_bindings = deepCopyList(GLOB.keybinding_list_by_key)
+		WRITE_FILE(S["key_bindings"], key_bindings)
 
 /datum/preferences/proc/load_path(ckey,filename="preferences.sav")
 	if(!ckey)

--- a/nsv13.dme
+++ b/nsv13.dme
@@ -3491,6 +3491,7 @@
 #include "nsv13\code\datums\freight_type\single\reagent\drinking_glass.dm"
 #include "nsv13\code\datums\freight_type\single\reagent\pill_patch.dm"
 #include "nsv13\code\datums\components\crafting\recipes.dm"
+#include "nsv13\code\datums\keybinding\overmap.dm"
 #include "nsv13\code\datums\looping_sounds\_looping_sound.dm"
 #include "nsv13\code\datums\mood_events\nsv_events.dm"
 #include "nsv13\code\datums\traits\negative.dm"

--- a/nsv13/code/datums/keybinding/overmap.dm
+++ b/nsv13/code/datums/keybinding/overmap.dm
@@ -3,7 +3,7 @@
 		weight = WEIGHT_OVERMAP
 
 
-// Basically just blocks the other Q and E bindings since held keys are handled in keyLoop
+// Strafing AND turning? It's more likely than you think!
 /datum/keybinding/overmap/rotate_left
 	key = "Q"
 	name = "rotate_left"
@@ -18,6 +18,7 @@
 
 	if(M != OM.pilot) return
 	if(!OM.use_QE_turning()) return
+	OM.keyboard_delta_angle = OM.keyboard_delta_angle - 15
 	return TRUE
 
 /datum/keybinding/overmap/rotate_left/up(client/user)
@@ -28,6 +29,7 @@
 
 	if(M != OM.pilot) return
 	if(!OM.use_QE_turning()) return
+	OM.keyboard_delta_angle = OM.keyboard_delta_angle + 15
 	return TRUE
 
 /datum/keybinding/overmap/rotate_right
@@ -44,6 +46,7 @@
 
 	if(M != OM.pilot) return
 	if(!OM.use_QE_turning()) return
+	OM.keyboard_delta_angle = OM.keyboard_delta_angle + 15
 	return TRUE
 
 /datum/keybinding/overmap/rotate_right/up(client/user)
@@ -54,6 +57,7 @@
 
 	if(M != OM.pilot) return
 	if(!OM.use_QE_turning()) return
+	OM.keyboard_delta_angle = OM.keyboard_delta_angle - 15
 	return TRUE
 
 // Keys that are held down in other binding modes need both a down and an up to override correctly

--- a/nsv13/code/datums/keybinding/overmap.dm
+++ b/nsv13/code/datums/keybinding/overmap.dm
@@ -13,7 +13,7 @@
 /datum/keybinding/overmap/rotate_left/down(client/user)
 	if(!user.mob) return
 	var/mob/M = user.mob
-	var/obj/structure/overmap/OM = M.get_overmap()
+	var/obj/structure/overmap/OM = M.overmap_ship
 	if(!OM) return
 
 	if(M != OM.pilot) return
@@ -23,7 +23,7 @@
 /datum/keybinding/overmap/rotate_left/up(client/user)
 	if(!user.mob) return
 	var/mob/M = user.mob
-	var/obj/structure/overmap/OM = M.get_overmap()
+	var/obj/structure/overmap/OM = M.overmap_ship
 	if(!OM) return
 
 	if(M != OM.pilot) return
@@ -39,7 +39,7 @@
 /datum/keybinding/overmap/rotate_right/down(client/user)
 	if(!user.mob) return
 	var/mob/M = user.mob
-	var/obj/structure/overmap/OM = M.get_overmap()
+	var/obj/structure/overmap/OM = M.overmap_ship
 	if(!OM) return
 
 	if(M != OM.pilot) return
@@ -49,7 +49,7 @@
 /datum/keybinding/overmap/rotate_right/up(client/user)
 	if(!user.mob) return
 	var/mob/M = user.mob
-	var/obj/structure/overmap/OM = M.get_overmap()
+	var/obj/structure/overmap/OM = M.overmap_ship
 	if(!OM) return
 
 	if(M != OM.pilot) return
@@ -66,7 +66,7 @@
 /datum/keybinding/overmap/boost/down(client/user)
 	if(!user.mob) return
 	var/mob/M = user.mob
-	var/obj/structure/overmap/OM = M.get_overmap()
+	var/obj/structure/overmap/OM = M.overmap_ship
 	if(!OM) return
 
 	if(M != OM.pilot) return
@@ -76,7 +76,7 @@
 /datum/keybinding/overmap/boost/up(client/user)
 	if(!user.mob) return
 	var/mob/M = user.mob
-	var/obj/structure/overmap/OM = M.get_overmap()
+	var/obj/structure/overmap/OM = M.overmap_ship
 	if(!OM) return
 
 	if(M != OM.pilot) return
@@ -91,7 +91,7 @@
 /datum/keybinding/overmap/toggle_brakes/down(client/user)
 	if(!user.mob) return
 	var/mob/M = user.mob
-	var/obj/structure/overmap/OM = M.get_overmap()
+	var/obj/structure/overmap/OM = M.overmap_ship
 	if(!OM) return
 
 	if(M != OM.pilot) return
@@ -104,7 +104,7 @@
 /datum/keybinding/overmap/toggle_brakes/up(client/user)
 	if(!user.mob) return
 	var/mob/M = user.mob
-	var/obj/structure/overmap/OM = M.get_overmap()
+	var/obj/structure/overmap/OM = M.overmap_ship
 	if(!OM) return
 
 	if(M != OM.pilot) return
@@ -120,7 +120,7 @@
 /datum/keybinding/overmap/toggle_inertia/down(client/user)
 	if(!user.mob) return
 	var/mob/M = user.mob
-	var/obj/structure/overmap/OM = M.get_overmap()
+	var/obj/structure/overmap/OM = M.overmap_ship
 	if(!OM) return
 
 	if(M != OM.pilot) return
@@ -139,7 +139,7 @@
 /datum/keybinding/overmap/toggle_move_mode/down(client/user)
 	if(!user.mob) return
 	var/mob/M = user.mob
-	var/obj/structure/overmap/OM = M.get_overmap()
+	var/obj/structure/overmap/OM = M.overmap_ship
 	if(!OM) return
 
 	if(M != OM.pilot) return
@@ -158,7 +158,7 @@
 /datum/keybinding/overmap/cycle_firemode/down(client/user)
 	if(!user.mob) return
 	var/mob/M = user.mob
-	var/obj/structure/overmap/OM = M.get_overmap()
+	var/obj/structure/overmap/OM = M.overmap_ship
 	if(!OM) return
 
 	if(M != OM.gunner) return
@@ -179,7 +179,7 @@
 /datum/keybinding/overmap/deploy_countermeasure/down(client/user)
 	if(!user.mob) return
 	var/mob/M = user.mob
-	var/obj/structure/overmap/small_craft/OM = M.get_overmap()
+	var/obj/structure/overmap/small_craft/OM = M.overmap_ship
 	if(!istype(OM)) return
 
 	if(M != OM.pilot) return
@@ -195,7 +195,7 @@
 /datum/keybinding/overmap/toggle_safety/down(client/user)
 	if(!user.mob) return
 	var/mob/M = user.mob
-	var/obj/structure/overmap/small_craft/OM = M.get_overmap()
+	var/obj/structure/overmap/small_craft/OM = M.overmap_ship
 	if(!istype(OM)) return
 
 	if(M != OM.gunner) return
@@ -215,7 +215,7 @@
 /datum/keybinding/overmap/weapon_1/down(client/user)
 	if(!user.mob) return
 	var/mob/M = user.mob
-	var/obj/structure/overmap/OM = M.get_overmap()
+	var/obj/structure/overmap/OM = M.overmap_ship
 	if(!OM) return
 
 	if(M != OM.gunner) return
@@ -231,7 +231,7 @@
 /datum/keybinding/overmap/weapon_2/down(client/user)
 	if(!user.mob) return
 	var/mob/M = user.mob
-	var/obj/structure/overmap/OM = M.get_overmap()
+	var/obj/structure/overmap/OM = M.overmap_ship
 	if(!OM) return
 
 	if(M != OM.gunner) return
@@ -247,7 +247,7 @@
 /datum/keybinding/overmap/weapon_3/down(client/user)
 	if(!user.mob) return
 	var/mob/M = user.mob
-	var/obj/structure/overmap/OM = M.get_overmap()
+	var/obj/structure/overmap/OM = M.overmap_ship
 	if(!OM) return
 
 	if(M != OM.gunner) return
@@ -263,25 +263,9 @@
 /datum/keybinding/overmap/weapon_4/down(client/user)
 	if(!user.mob) return
 	var/mob/M = user.mob
-	var/obj/structure/overmap/OM = M.get_overmap()
+	var/obj/structure/overmap/OM = M.overmap_ship
 	if(!OM) return
 
 	if(M != OM.gunner) return
 	OM.select_weapon(4)
-	return TRUE
-
-/datum/keybinding/overmap/weapon_5
-	key = "5"
-	name = "weapon_5"
-	full_name = "Weapon 5"
-	description = ""
-
-/datum/keybinding/overmap/weapon_5/down(client/user)
-	if(!user.mob) return
-	var/mob/M = user.mob
-	var/obj/structure/overmap/OM = M.get_overmap()
-	if(!OM) return
-
-	if(M != OM.gunner) return
-	OM.select_weapon(5)
 	return TRUE

--- a/nsv13/code/datums/keybinding/overmap.dm
+++ b/nsv13/code/datums/keybinding/overmap.dm
@@ -59,7 +59,7 @@
 		playsound(OM.tactical, sound, 100, 1)
 	return TRUE
 
-// Strafing AND turning? At the same time? It's more likely than you think!
+// Basically just blocks the other Q and E bindings since held keys are handled in keyLoop
 /datum/keybinding/overmap/rotate_left
 	key = "Q"
 	name = "rotate_left"
@@ -74,7 +74,6 @@
 
 	if(M != OM.pilot) return
 	if(OM.mass >= MASS_SMALL) return
-	OM.applied_turn_rate = OM.applied_turn_rate - 15
 	return TRUE
 
 /datum/keybinding/overmap/rotate_left/up(client/user)
@@ -85,7 +84,6 @@
 
 	if(M != OM.pilot) return
 	if(OM.mass >= MASS_SMALL) return
-	OM.applied_turn_rate = OM.applied_turn_rate + 15
 	return TRUE
 
 /datum/keybinding/overmap/rotate_right

--- a/nsv13/code/datums/keybinding/overmap.dm
+++ b/nsv13/code/datums/keybinding/overmap.dm
@@ -73,7 +73,7 @@
 	if(!OM) return
 
 	if(M != OM.pilot) return
-	if(OM.mass >= MASS_SMALL) return
+	if(!OM.use_QE_turning()) return
 	return TRUE
 
 /datum/keybinding/overmap/rotate_left/up(client/user)
@@ -83,7 +83,7 @@
 	if(!OM) return
 
 	if(M != OM.pilot) return
-	if(OM.mass >= MASS_SMALL) return
+	if(!OM.use_QE_turning()) return
 	return TRUE
 
 /datum/keybinding/overmap/rotate_right
@@ -99,8 +99,7 @@
 	if(!OM) return
 
 	if(M != OM.pilot) return
-	if(OM.mass >= MASS_SMALL) return
-	OM.applied_turn_rate = OM.applied_turn_rate + 15
+	if(!OM.use_QE_turning()) return
 	return TRUE
 
 /datum/keybinding/overmap/rotate_right/up(client/user)
@@ -110,8 +109,7 @@
 	if(!OM) return
 
 	if(M != OM.pilot) return
-	if(OM.mass >= MASS_SMALL) return
-	OM.applied_turn_rate = OM.applied_turn_rate - 15
+	if(!OM.use_QE_turning()) return
 	return TRUE
 
 // Small craft - safeties and countermeasures

--- a/nsv13/code/datums/keybinding/overmap.dm
+++ b/nsv13/code/datums/keybinding/overmap.dm
@@ -17,7 +17,7 @@
 	if(!OM) return
 
 	if(M != OM.pilot) return
-	if(!OM.use_QE_turning()) return
+	if(OM.move_by_mouse) return
 	OM.keyboard_delta_angle_left = -15
 	return TRUE
 
@@ -28,7 +28,7 @@
 	if(!OM) return
 
 	if(M != OM.pilot) return
-	if(!OM.use_QE_turning()) return
+	if(OM.move_by_mouse) return
 	OM.keyboard_delta_angle_left = 0
 	return TRUE
 
@@ -45,7 +45,7 @@
 	if(!OM) return
 
 	if(M != OM.pilot) return
-	if(!OM.use_QE_turning()) return
+	if(OM.move_by_mouse) return
 	OM.keyboard_delta_angle_right = 15
 	return TRUE
 
@@ -56,7 +56,7 @@
 	if(!OM) return
 
 	if(M != OM.pilot) return
-	if(!OM.use_QE_turning()) return
+	if(OM.move_by_mouse) return
 	OM.keyboard_delta_angle_right = 0
 	return TRUE
 

--- a/nsv13/code/datums/keybinding/overmap.dm
+++ b/nsv13/code/datums/keybinding/overmap.dm
@@ -2,62 +2,6 @@
 		category = CATEGORY_OVERMAP
 		weight = WEIGHT_OVERMAP
 
-/datum/keybinding/overmap/toggle_inertia
-	key = "X"
-	name = "toggle_inertia"
-	full_name = "Toggle Inertia"
-	description = ""
-
-/datum/keybinding/overmap/toggle_inertia/down(client/user)
-	if(!user.mob) return
-	var/mob/M = user.mob
-	var/obj/structure/overmap/OM = M.get_overmap()
-	if(!OM) return
-
-	if(M != OM.pilot) return
-	OM.toggle_inertia()
-	if(OM.helm && prob(80))
-		var/sound = pick(GLOB.computer_beeps)
-		playsound(OM.helm, sound, 100, 1)
-	return TRUE
-
-/datum/keybinding/overmap/toggle_move_mode
-	key = "C"
-	name = "toggle_move_mode"
-	full_name = "Toggle Movement Mode"
-	description = ""
-
-/datum/keybinding/overmap/toggle_move_mode/down(client/user)
-	if(!user.mob) return
-	var/mob/M = user.mob
-	var/obj/structure/overmap/OM = M.get_overmap()
-	if(!OM) return
-
-	if(M != OM.pilot) return
-	OM.toggle_move_mode()
-	if(OM.helm && prob(80))
-		var/sound = pick(GLOB.computer_beeps)
-		playsound(OM.helm, sound, 100, 1)
-	return TRUE
-
-/datum/keybinding/overmap/cycle_firemode
-	key = "Space"
-	name = "cycle_firemode"
-	full_name = "Cycle Firemode"
-	description = ""
-
-/datum/keybinding/overmap/cycle_firemode/down(client/user)
-	if(!user.mob) return
-	var/mob/M = user.mob
-	var/obj/structure/overmap/OM = M.get_overmap()
-	if(!OM) return
-
-	if(M != OM.gunner) return
-	OM.cycle_firemode()
-	if(OM.tactical && prob(80))
-		var/sound = pick(GLOB.computer_beeps)
-		playsound(OM.tactical, sound, 100, 1)
-	return TRUE
 
 // Basically just blocks the other Q and E bindings since held keys are handled in keyLoop
 /datum/keybinding/overmap/rotate_left
@@ -112,42 +56,6 @@
 	if(!OM.use_QE_turning()) return
 	return TRUE
 
-// Small craft - safeties and countermeasures
-/datum/keybinding/overmap/toggle_safety
-	key = "Capslock"
-	name = "toggle_safety"
-	full_name = "Toggle Safeties"
-	description = ""
-
-/datum/keybinding/overmap/toggle_safety/down(client/user)
-	if(!user.mob) return
-	var/mob/M = user.mob
-	var/obj/structure/overmap/small_craft/OM = M.get_overmap()
-	if(!istype(OM)) return
-
-	if(M != OM.gunner) return
-	OM.toggle_safety()
-	if(OM.helm && prob(80))
-		var/sound = pick(GLOB.computer_beeps)
-		playsound(OM.helm, sound, 100, 1)
-	return TRUE
-
-/datum/keybinding/overmap/deploy_countermeasure
-	key = "5"
-	name = "deploy_countermeasure"
-	full_name = "Deploy Countermeasure"
-	description = ""
-
-/datum/keybinding/overmap/deploy_countermeasure/down(client/user)
-	if(!user.mob) return
-	var/mob/M = user.mob
-	var/obj/structure/overmap/small_craft/OM = M.get_overmap()
-	if(!istype(OM)) return
-
-	if(M != OM.pilot) return
-	OM.countermeasure()
-	return TRUE
-
 // Keys that are held down in other binding modes need both a down and an up to override correctly
 /datum/keybinding/overmap/boost
 	key = "Shift"
@@ -200,4 +108,180 @@
 	if(!OM) return
 
 	if(M != OM.pilot) return
+	return TRUE
+
+// Other ship controls
+/datum/keybinding/overmap/toggle_inertia
+	key = "X"
+	name = "toggle_inertia"
+	full_name = "Toggle Inertial Assistance"
+	description = ""
+
+/datum/keybinding/overmap/toggle_inertia/down(client/user)
+	if(!user.mob) return
+	var/mob/M = user.mob
+	var/obj/structure/overmap/OM = M.get_overmap()
+	if(!OM) return
+
+	if(M != OM.pilot) return
+	OM.toggle_inertia()
+	if(OM.helm && prob(80))
+		var/sound = pick(GLOB.computer_beeps)
+		playsound(OM.helm, sound, 100, 1)
+	return TRUE
+
+/datum/keybinding/overmap/toggle_move_mode
+	key = "C"
+	name = "toggle_move_mode"
+	full_name = "Toggle Mouse Movement"
+	description = ""
+
+/datum/keybinding/overmap/toggle_move_mode/down(client/user)
+	if(!user.mob) return
+	var/mob/M = user.mob
+	var/obj/structure/overmap/OM = M.get_overmap()
+	if(!OM) return
+
+	if(M != OM.pilot) return
+	OM.toggle_move_mode()
+	if(OM.helm && prob(80))
+		var/sound = pick(GLOB.computer_beeps)
+		playsound(OM.helm, sound, 100, 1)
+	return TRUE
+
+/datum/keybinding/overmap/cycle_firemode
+	key = "Space"
+	name = "cycle_firemode"
+	full_name = "Cycle Firemode"
+	description = ""
+
+/datum/keybinding/overmap/cycle_firemode/down(client/user)
+	if(!user.mob) return
+	var/mob/M = user.mob
+	var/obj/structure/overmap/OM = M.get_overmap()
+	if(!OM) return
+
+	if(M != OM.gunner) return
+	OM.cycle_firemode()
+	if(OM.tactical && prob(80))
+		var/sound = pick(GLOB.computer_beeps)
+		playsound(OM.tactical, sound, 100, 1)
+	return TRUE
+
+// Small craft - safeties and countermeasures
+
+/datum/keybinding/overmap/deploy_countermeasure
+	key = "5"
+	name = "deploy_countermeasure"
+	full_name = "Deploy Countermeasure"
+	description = ""
+
+/datum/keybinding/overmap/deploy_countermeasure/down(client/user)
+	if(!user.mob) return
+	var/mob/M = user.mob
+	var/obj/structure/overmap/small_craft/OM = M.get_overmap()
+	if(!istype(OM)) return
+
+	if(M != OM.pilot) return
+	OM.countermeasure()
+	return TRUE
+
+/datum/keybinding/overmap/toggle_safety
+	key = "Capslock"
+	name = "toggle_safety"
+	full_name = "Toggle Safeties"
+	description = ""
+
+/datum/keybinding/overmap/toggle_safety/down(client/user)
+	if(!user.mob) return
+	var/mob/M = user.mob
+	var/obj/structure/overmap/small_craft/OM = M.get_overmap()
+	if(!istype(OM)) return
+
+	if(M != OM.gunner) return
+	OM.toggle_safety()
+	if(OM.helm && prob(80))
+		var/sound = pick(GLOB.computer_beeps)
+		playsound(OM.helm, sound, 100, 1)
+	return TRUE
+
+// Weapon selection - this is overly complicated but probably useful as a proof of concept
+/datum/keybinding/overmap/weapon_1
+	key = "1"
+	name = "weapon_1"
+	full_name = "Weapon 1"
+	description = ""
+
+/datum/keybinding/overmap/weapon_1/down(client/user)
+	if(!user.mob) return
+	var/mob/M = user.mob
+	var/obj/structure/overmap/OM = M.get_overmap()
+	if(!OM) return
+
+	if(M != OM.gunner) return
+	OM.select_weapon(1)
+	return TRUE
+
+/datum/keybinding/overmap/weapon_2
+	key = "2"
+	name = "weapon_2"
+	full_name = "Weapon 2"
+	description = ""
+
+/datum/keybinding/overmap/weapon_2/down(client/user)
+	if(!user.mob) return
+	var/mob/M = user.mob
+	var/obj/structure/overmap/OM = M.get_overmap()
+	if(!OM) return
+
+	if(M != OM.gunner) return
+	OM.select_weapon(2)
+	return TRUE
+
+/datum/keybinding/overmap/weapon_3
+	key = "3"
+	name = "weapon_3"
+	full_name = "Weapon 3"
+	description = ""
+
+/datum/keybinding/overmap/weapon_3/down(client/user)
+	if(!user.mob) return
+	var/mob/M = user.mob
+	var/obj/structure/overmap/OM = M.get_overmap()
+	if(!OM) return
+
+	if(M != OM.gunner) return
+	OM.select_weapon(3)
+	return TRUE
+
+/datum/keybinding/overmap/weapon_4
+	key = "4"
+	name = "weapon_4"
+	full_name = "Weapon 4"
+	description = ""
+
+/datum/keybinding/overmap/weapon_4/down(client/user)
+	if(!user.mob) return
+	var/mob/M = user.mob
+	var/obj/structure/overmap/OM = M.get_overmap()
+	if(!OM) return
+
+	if(M != OM.gunner) return
+	OM.select_weapon(4)
+	return TRUE
+
+/datum/keybinding/overmap/weapon_5
+	key = "5"
+	name = "weapon_5"
+	full_name = "Weapon 5"
+	description = ""
+
+/datum/keybinding/overmap/weapon_5/down(client/user)
+	if(!user.mob) return
+	var/mob/M = user.mob
+	var/obj/structure/overmap/OM = M.get_overmap()
+	if(!OM) return
+
+	if(M != OM.gunner) return
+	OM.select_weapon(5)
 	return TRUE

--- a/nsv13/code/datums/keybinding/overmap.dm
+++ b/nsv13/code/datums/keybinding/overmap.dm
@@ -59,19 +59,61 @@
 		playsound(OM.tactical, sound, 100, 1)
 	return TRUE
 
-/datum/keybinding/overmap/suppress_drop
+// Strafing AND turning? At the same time? It's more likely than you think!
+/datum/keybinding/overmap/rotate_left
 	key = "Q"
-	name = "suppress_drop"
-	full_name = "Suppress Drop"
-	description = "Intercepts the drop action"
+	name = "rotate_left"
+	full_name = "Rotate Left"
+	description = ""
 
-/datum/keybinding/overmap/suppress_drop/down(client/user)
+/datum/keybinding/overmap/rotate_left/down(client/user)
 	if(!user.mob) return
 	var/mob/M = user.mob
 	var/obj/structure/overmap/OM = M.get_overmap()
 	if(!OM) return
 
 	if(M != OM.pilot) return
+	if(OM.mass >= MASS_SMALL) return
+	OM.applied_turn_rate = OM.applied_turn_rate - 15
+	return TRUE
+
+/datum/keybinding/overmap/rotate_left/up(client/user)
+	if(!user.mob) return
+	var/mob/M = user.mob
+	var/obj/structure/overmap/OM = M.get_overmap()
+	if(!OM) return
+
+	if(M != OM.pilot) return
+	if(OM.mass >= MASS_SMALL) return
+	OM.applied_turn_rate = OM.applied_turn_rate + 15
+	return TRUE
+
+/datum/keybinding/overmap/rotate_right
+	key = "E"
+	name = "rotate_right"
+	full_name = "Rotate Right"
+	description = ""
+
+/datum/keybinding/overmap/rotate_right/down(client/user)
+	if(!user.mob) return
+	var/mob/M = user.mob
+	var/obj/structure/overmap/OM = M.get_overmap()
+	if(!OM) return
+
+	if(M != OM.pilot) return
+	if(OM.mass >= MASS_SMALL) return
+	OM.applied_turn_rate = OM.applied_turn_rate + 15
+	return TRUE
+
+/datum/keybinding/overmap/rotate_right/up(client/user)
+	if(!user.mob) return
+	var/mob/M = user.mob
+	var/obj/structure/overmap/OM = M.get_overmap()
+	if(!OM) return
+
+	if(M != OM.pilot) return
+	if(OM.mass >= MASS_SMALL) return
+	OM.applied_turn_rate = OM.applied_turn_rate - 15
 	return TRUE
 
 // Small craft - safeties and countermeasures

--- a/nsv13/code/datums/keybinding/overmap.dm
+++ b/nsv13/code/datums/keybinding/overmap.dm
@@ -1,0 +1,165 @@
+/datum/keybinding/overmap
+		category = CATEGORY_OVERMAP
+		weight = WEIGHT_OVERMAP
+
+/datum/keybinding/overmap/toggle_inertia
+	key = "X"
+	name = "toggle_inertia"
+	full_name = "Toggle Inertia"
+	description = ""
+
+/datum/keybinding/overmap/toggle_inertia/down(client/user)
+	if(!user.mob) return
+	var/mob/M = user.mob
+	var/obj/structure/overmap/OM = M.get_overmap()
+	if(!OM) return
+
+	if(M != OM.pilot) return
+	OM.toggle_inertia()
+	if(OM.helm && prob(80))
+		var/sound = pick(GLOB.computer_beeps)
+		playsound(OM.helm, sound, 100, 1)
+	return TRUE
+
+/datum/keybinding/overmap/toggle_move_mode
+	key = "C"
+	name = "toggle_move_mode"
+	full_name = "Toggle Movement Mode"
+	description = ""
+
+/datum/keybinding/overmap/toggle_move_mode/down(client/user)
+	if(!user.mob) return
+	var/mob/M = user.mob
+	var/obj/structure/overmap/OM = M.get_overmap()
+	if(!OM) return
+
+	if(M != OM.pilot) return
+	OM.toggle_move_mode()
+	if(OM.helm && prob(80))
+		var/sound = pick(GLOB.computer_beeps)
+		playsound(OM.helm, sound, 100, 1)
+	return TRUE
+
+/datum/keybinding/overmap/cycle_firemode
+	key = "Space"
+	name = "cycle_firemode"
+	full_name = "Cycle Firemode"
+	description = ""
+
+/datum/keybinding/overmap/cycle_firemode/down(client/user)
+	if(!user.mob) return
+	var/mob/M = user.mob
+	var/obj/structure/overmap/OM = M.get_overmap()
+	if(!OM) return
+
+	if(M != OM.gunner) return
+	OM.cycle_firemode()
+	if(OM.tactical && prob(80))
+		var/sound = pick(GLOB.computer_beeps)
+		playsound(OM.tactical, sound, 100, 1)
+	return TRUE
+
+/datum/keybinding/overmap/suppress_drop
+	key = "Q"
+	name = "suppress_drop"
+	full_name = "Suppress Drop"
+	description = "Intercepts the drop action"
+
+/datum/keybinding/overmap/suppress_drop/down(client/user)
+	if(!user.mob) return
+	var/mob/M = user.mob
+	var/obj/structure/overmap/OM = M.get_overmap()
+	if(!OM) return
+
+	if(M != OM.pilot) return
+	return TRUE
+
+// Small craft - safeties and countermeasures
+/datum/keybinding/overmap/toggle_safety
+	key = "Capslock"
+	name = "toggle_safety"
+	full_name = "Toggle Safeties"
+	description = ""
+
+/datum/keybinding/overmap/toggle_safety/down(client/user)
+	if(!user.mob) return
+	var/mob/M = user.mob
+	var/obj/structure/overmap/small_craft/OM = M.get_overmap()
+	if(!istype(OM)) return
+
+	if(M != OM.gunner) return
+	OM.toggle_safety()
+	if(OM.helm && prob(80))
+		var/sound = pick(GLOB.computer_beeps)
+		playsound(OM.helm, sound, 100, 1)
+	return TRUE
+
+/datum/keybinding/overmap/deploy_countermeasure
+	key = "5"
+	name = "deploy_countermeasure"
+	full_name = "Deploy Countermeasure"
+	description = ""
+
+/datum/keybinding/overmap/deploy_countermeasure/down(client/user)
+	if(!user.mob) return
+	var/mob/M = user.mob
+	var/obj/structure/overmap/small_craft/OM = M.get_overmap()
+	if(!istype(OM)) return
+
+	if(M != OM.pilot) return
+	OM.countermeasure()
+	return TRUE
+
+// Keys that are held down in other binding modes need both a down and an up to override correctly
+/datum/keybinding/overmap/boost
+	key = "Shift"
+	name = "boost"
+	full_name = "Boost"
+	description = ""
+
+/datum/keybinding/overmap/boost/down(client/user)
+	if(!user.mob) return
+	var/mob/M = user.mob
+	var/obj/structure/overmap/OM = M.get_overmap()
+	if(!OM) return
+
+	if(M != OM.pilot) return
+	OM.boost(NORTH)
+	return TRUE
+
+/datum/keybinding/overmap/boost/up(client/user)
+	if(!user.mob) return
+	var/mob/M = user.mob
+	var/obj/structure/overmap/OM = M.get_overmap()
+	if(!OM) return
+
+	if(M != OM.pilot) return
+	return TRUE
+
+/datum/keybinding/overmap/toggle_brakes
+	key = "Alt"
+	name = "toggle_brakes"
+	full_name = "Toggle Brakes"
+	description = ""
+
+/datum/keybinding/overmap/toggle_brakes/down(client/user)
+	if(!user.mob) return
+	var/mob/M = user.mob
+	var/obj/structure/overmap/OM = M.get_overmap()
+	if(!OM) return
+
+	if(M != OM.pilot) return
+	OM.toggle_brakes()
+	if(OM.helm && prob(80))
+		var/sound = pick(GLOB.computer_beeps)
+		playsound(OM.helm, sound, 100, 1)
+	return TRUE
+
+/datum/keybinding/overmap/toggle_brakes/up(client/user)
+	if(!user.mob) return
+	var/mob/M = user.mob
+	var/obj/structure/overmap/OM = M.get_overmap()
+	if(!OM) return
+
+	if(M != OM.pilot) return
+	return TRUE

--- a/nsv13/code/datums/keybinding/overmap.dm
+++ b/nsv13/code/datums/keybinding/overmap.dm
@@ -18,7 +18,7 @@
 
 	if(M != OM.pilot) return
 	if(!OM.use_QE_turning()) return
-	OM.keyboard_delta_angle = OM.keyboard_delta_angle - 15
+	OM.keyboard_delta_angle_left = 15
 	return TRUE
 
 /datum/keybinding/overmap/rotate_left/up(client/user)
@@ -29,7 +29,7 @@
 
 	if(M != OM.pilot) return
 	if(!OM.use_QE_turning()) return
-	OM.keyboard_delta_angle = OM.keyboard_delta_angle + 15
+	OM.keyboard_delta_angle_left = 0
 	return TRUE
 
 /datum/keybinding/overmap/rotate_right
@@ -46,7 +46,7 @@
 
 	if(M != OM.pilot) return
 	if(!OM.use_QE_turning()) return
-	OM.keyboard_delta_angle = OM.keyboard_delta_angle + 15
+	OM.keyboard_delta_angle_right = 15
 	return TRUE
 
 /datum/keybinding/overmap/rotate_right/up(client/user)
@@ -57,7 +57,7 @@
 
 	if(M != OM.pilot) return
 	if(!OM.use_QE_turning()) return
-	OM.keyboard_delta_angle = OM.keyboard_delta_angle - 15
+	OM.keyboard_delta_angle_right = 0
 	return TRUE
 
 // Keys that are held down in other binding modes need both a down and an up to override correctly

--- a/nsv13/code/datums/keybinding/overmap.dm
+++ b/nsv13/code/datums/keybinding/overmap.dm
@@ -18,7 +18,7 @@
 
 	if(M != OM.pilot) return
 	if(!OM.use_QE_turning()) return
-	OM.keyboard_delta_angle_left = 15
+	OM.keyboard_delta_angle_left = -15
 	return TRUE
 
 /datum/keybinding/overmap/rotate_left/up(client/user)

--- a/nsv13/code/modules/overmap/camera.dm
+++ b/nsv13/code/modules/overmap/camera.dm
@@ -62,6 +62,8 @@
 	if(pilot && M == pilot)
 		LAZYREMOVE(M.mousemove_intercept_objects, src)
 		pilot = null
+		keyboard_delta_angle_left = 0
+		keyboard_delta_angle_right = 0
 		if(helm)
 			playsound(helm, 'nsv13/sound/effects/computer/hum.ogg', 100, 1)
 	if(gunner && M == gunner)

--- a/nsv13/code/modules/overmap/fighters/_fighters.dm
+++ b/nsv13/code/modules/overmap/fighters/_fighters.dm
@@ -81,19 +81,6 @@ Been a mess since 2018, we'll fix it someday (probably)
 		playsound(helm, 'sound/machines/buzz-sigh.ogg', 75, 1)
 		return
 	. = ..()
-	var/mob/themob = user.mob
-	switch(key)
-		if("Capslock")
-			if(themob == pilot)
-				toggle_safety()
-			if(helm && prob(80))
-				var/sound = pick(GLOB.computer_beeps)
-				playsound(helm, sound, 100, 1)
-			return TRUE
-		if("5")
-			if(themob == pilot)
-				countermeasure()
-			return TRUE
 
 /obj/structure/overmap/small_craft/ui_state(mob/user)
 	return GLOB.contained_state

--- a/nsv13/code/modules/overmap/overmap.dm
+++ b/nsv13/code/modules/overmap/overmap.dm
@@ -69,6 +69,7 @@
 	var/offset_x = 0 // like pixel_x/y but in tiles
 	var/offset_y = 0
 	var/angle = 0 // degrees, clockwise
+	var/keyboard_delta_angle = 0 // Set by use of turning keys
 	var/desired_angle = null // set by pilot moving his mouse
 	var/angular_velocity = 0 // degrees per second
 	var/max_angular_acceleration = 180 // in degrees per second per second
@@ -564,16 +565,6 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 
 /obj/structure/overmap/proc/use_QE_turning()
 	return (!move_by_mouse && (mass < MASS_SMALL))
-
-/obj/structure/overmap/keyLoop(client/user)
-	. = ..()
-	if(use_QE_turning())
-		for(var/_key in user.keys_held)
-			switch(_key)
-				if("Q", "q")
-					desired_angle = angle - 15
-				if("W", "w")
-					desired_angle = angle + 15
 
 /obj/structure/overmap/proc/start_lockon(atom/target)
 	if(!istype(target, /obj/structure/overmap))

--- a/nsv13/code/modules/overmap/overmap.dm
+++ b/nsv13/code/modules/overmap/overmap.dm
@@ -114,6 +114,7 @@
 
 	// Ship weapons
 	var/list/weapon_types[MAX_POSSIBLE_FIREMODE]
+	var/list/weapon_numkeys_map = list() // I hate this
 
 	var/fire_mode = FIRE_MODE_TORPEDO //What gun do we want to fire? Defaults to railgun, with PDCs there for flak
 	var/weapon_safety = FALSE //Like a gun safety. Entirely un-used except for fighters to stop brainlets from shooting people on the ship unintentionally :)
@@ -411,6 +412,11 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 			post_load_interior()
 
 	apply_weapons()
+	//We have a lot of types but not that many weapons per ship, so let's just worry about the ones we do have
+	for(var/firemode = 1; firemode <= MAX_POSSIBLE_FIREMODE; firemode++)
+		var/datum/ship_weapon/SW = weapon_types[firemode]
+		if(istype(SW) && SW.selectable)
+			weapon_numkeys_map += firemode
 
 //Method to apply weapon types to a ship. Override to your liking, this just handles generic rules and behaviours
 /obj/structure/overmap/proc/apply_weapons()

--- a/nsv13/code/modules/overmap/overmap.dm
+++ b/nsv13/code/modules/overmap/overmap.dm
@@ -79,7 +79,6 @@
 	var/should_open_doors = FALSE //Should we open airlocks? This is off by default because it was HORRIBLE.
 	var/inertial_dampeners = TRUE
 
-	var/applied_turn_rate = 0
 	var/user_thrust_dir = 0
 
 	//Movement speed variables
@@ -556,6 +555,16 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 		return TRUE
 	fire(target)
 	return TRUE
+
+/obj/structure/overmap/keyLoop(client/user)
+	. = ..()
+	if(!move_by_mouse && mass < MASS_SMALL)
+		for(var/_key in user.keys_held)
+			switch(_key)
+				if("Q", "q")
+					desired_angle = angle - 15
+				if("W", "w")
+					desired_angle = angle + 15
 
 /obj/structure/overmap/proc/start_lockon(atom/target)
 	if(!istype(target, /obj/structure/overmap))

--- a/nsv13/code/modules/overmap/overmap.dm
+++ b/nsv13/code/modules/overmap/overmap.dm
@@ -556,6 +556,9 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 	fire(target)
 	return TRUE
 
+/obj/structure/overmap/proc/use_QE_turning()
+	return (!move_by_mouse && (mass < MASS_SMALL))
+
 /obj/structure/overmap/keyLoop(client/user)
 	. = ..()
 	if(!move_by_mouse && mass < MASS_SMALL)
@@ -623,7 +626,7 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 	if(user != pilot || pilot.incapacitated())
 		return
 
-	if(mass < MASS_SMALL) //Small craft can "strafe"
+	if(use_QE_turning()) //Small craft can "strafe"
 		user_thrust_dir = direction
 
 	else //Everything else cannot

--- a/nsv13/code/modules/overmap/overmap.dm
+++ b/nsv13/code/modules/overmap/overmap.dm
@@ -620,8 +620,15 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 /obj/structure/overmap/relaymove(mob/user, direction)
 	if(user != pilot || pilot.incapacitated())
 		return
-
 	user_thrust_dir = direction
+	// Since they can't strafe with IAS on, they can also turn with A and D
+	if(inertial_dampeners)
+		if(direction & WEST)
+			desired_angle = angle - 15
+			user_thrust_dir = direction - WEST
+		else if(direction & EAST)
+			desired_angle = angle + 15
+			user_thrust_dir = direction - EAST
 
 //relay('nsv13/sound/effects/ship/rcs.ogg')
 

--- a/nsv13/code/modules/overmap/overmap.dm
+++ b/nsv13/code/modules/overmap/overmap.dm
@@ -711,41 +711,6 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 					continue
 			ship.relay(S,message)
 
-/obj/structure/overmap/key_down(key, client/user)
-	var/mob/themob = user.mob
-	switch(key)
-		if("Shift")
-			if(themob == pilot)
-				boost(NORTH)
-		if("X")
-			if(themob == pilot)
-				toggle_inertia()
-			if(helm && prob(80))
-				var/sound = pick(GLOB.computer_beeps)
-				playsound(helm, sound, 100, 1)
-			return TRUE
-		if("C" || "c")
-			if(themob == pilot)
-				toggle_move_mode()
-			if(helm && prob(80))
-				var/sound = pick(GLOB.computer_beeps)
-				playsound(helm, sound, 100, 1)
-			return TRUE
-		if("Alt")
-			if(themob == pilot)
-				toggle_brakes()
-			if(helm && prob(80))
-				var/sound = pick(GLOB.computer_beeps)
-				playsound(helm, sound, 100, 1)
-			return TRUE
-		if("Space")
-			if(themob == gunner)
-				cycle_firemode()
-				if(tactical && prob(80))
-					var/sound = pick(GLOB.computer_beeps)
-					playsound(tactical, sound, 100, 1)
-			return TRUE
-
 /obj/structure/overmap/proc/boost(direction)
 	if(world.time < next_maneuvre)
 		to_chat(pilot, "<span class='notice'>Engines on cooldown to prevent overheat</span>")

--- a/nsv13/code/modules/overmap/overmap.dm
+++ b/nsv13/code/modules/overmap/overmap.dm
@@ -624,7 +624,7 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 	if(user != pilot || pilot.incapacitated())
 		return
 
-	if(use_QE_turning()) //Small craft can "strafe"
+	if(mass < MASS_SMALL) //Small craft can "strafe"
 		user_thrust_dir = direction
 
 	else //Everything else cannot

--- a/nsv13/code/modules/overmap/overmap.dm
+++ b/nsv13/code/modules/overmap/overmap.dm
@@ -69,8 +69,9 @@
 	var/offset_x = 0 // like pixel_x/y but in tiles
 	var/offset_y = 0
 	var/angle = 0 // degrees, clockwise
-	var/keyboard_delta_angle = 0 // Set by use of turning keys
-	var/desired_angle = null // set by pilot moving his mouse
+	var/keyboard_delta_angle_left = 0 // Set by use of turning key
+	var/keyboard_delta_angle_right = 0 // Set by use of turning key
+	var/desired_angle = null // set by pilot moving his mouse or by keyboard steering
 	var/angular_velocity = 0 // degrees per second
 	var/max_angular_acceleration = 180 // in degrees per second per second
 	var/speed_limit = 3.5 //Stops ships from going too damn fast. This can be overridden by things like fighters launching from tubes, so it's not a const.

--- a/nsv13/code/modules/overmap/overmap.dm
+++ b/nsv13/code/modules/overmap/overmap.dm
@@ -79,6 +79,7 @@
 	var/should_open_doors = FALSE //Should we open airlocks? This is off by default because it was HORRIBLE.
 	var/inertial_dampeners = TRUE
 
+	var/applied_turn_rate = 0
 	var/user_thrust_dir = 0
 
 	//Movement speed variables

--- a/nsv13/code/modules/overmap/overmap.dm
+++ b/nsv13/code/modules/overmap/overmap.dm
@@ -561,7 +561,7 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 
 /obj/structure/overmap/keyLoop(client/user)
 	. = ..()
-	if(!move_by_mouse && mass < MASS_SMALL)
+	if(use_QE_turning())
 		for(var/_key in user.keys_held)
 			switch(_key)
 				if("Q", "q")

--- a/nsv13/code/modules/overmap/overmap.dm
+++ b/nsv13/code/modules/overmap/overmap.dm
@@ -564,9 +564,6 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 	fire(target)
 	return TRUE
 
-/obj/structure/overmap/proc/use_QE_turning()
-	return (!move_by_mouse && (mass < MASS_SMALL))
-
 /obj/structure/overmap/proc/start_lockon(atom/target)
 	if(!istype(target, /obj/structure/overmap))
 		return FALSE
@@ -624,20 +621,7 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 	if(user != pilot || pilot.incapacitated())
 		return
 
-	if(mass < MASS_SMALL) //Small craft can "strafe"
-		user_thrust_dir = direction
-
-	else //Everything else cannot
-		if(direction & WEST)
-			desired_angle = angle - 15
-			user_thrust_dir = direction - WEST
-
-		else if(direction & EAST)
-			desired_angle = angle + 15
-			user_thrust_dir = direction - EAST
-
-		else
-			user_thrust_dir = direction
+	user_thrust_dir = direction
 
 //relay('nsv13/sound/effects/ship/rcs.ogg')
 

--- a/nsv13/code/modules/overmap/physics.dm
+++ b/nsv13/code/modules/overmap/physics.dm
@@ -164,7 +164,7 @@ This proc is to be used when someone gets stuck in an overmap ship, gauss, WHATE
 	last_offset.copy(offset)
 	var/last_angle = angle
 	if(use_QE_turning())
-		desired_angle = angle + keyboard_delta_angle
+		desired_angle = angle + keyboard_delta_angle_left + keyboard_delta_angle_right
 	var/desired_angular_velocity = 0
 	if(isnum(desired_angle))
 		// do some finagling to make sure that our angles end up rotating the short way

--- a/nsv13/code/modules/overmap/physics.dm
+++ b/nsv13/code/modules/overmap/physics.dm
@@ -163,6 +163,9 @@ This proc is to be used when someone gets stuck in an overmap ship, gauss, WHATE
 		slowprocess()
 	last_offset.copy(offset)
 	var/last_angle = angle
+
+	if(!move_by_mouse && mass < MASS_SMALL)
+		desired_angle = angle + applied_turn_rate
 	var/desired_angular_velocity = 0
 	if(isnum(desired_angle))
 		// do some finagling to make sure that our angles end up rotating the short way

--- a/nsv13/code/modules/overmap/physics.dm
+++ b/nsv13/code/modules/overmap/physics.dm
@@ -163,6 +163,8 @@ This proc is to be used when someone gets stuck in an overmap ship, gauss, WHATE
 		slowprocess()
 	last_offset.copy(offset)
 	var/last_angle = angle
+	if(use_QE_turning())
+		desired_angle = angle + keyboard_delta_angle
 	var/desired_angular_velocity = 0
 	if(isnum(desired_angle))
 		// do some finagling to make sure that our angles end up rotating the short way

--- a/nsv13/code/modules/overmap/physics.dm
+++ b/nsv13/code/modules/overmap/physics.dm
@@ -163,7 +163,7 @@ This proc is to be used when someone gets stuck in an overmap ship, gauss, WHATE
 		slowprocess()
 	last_offset.copy(offset)
 	var/last_angle = angle
-	if(use_QE_turning())
+	if(!move_by_mouse)
 		desired_angle = angle + keyboard_delta_angle_left + keyboard_delta_angle_right
 	var/desired_angular_velocity = 0
 	if(isnum(desired_angle))

--- a/nsv13/code/modules/overmap/physics.dm
+++ b/nsv13/code/modules/overmap/physics.dm
@@ -163,7 +163,7 @@ This proc is to be used when someone gets stuck in an overmap ship, gauss, WHATE
 		slowprocess()
 	last_offset.copy(offset)
 	var/last_angle = angle
-	if(!move_by_mouse)
+	if(!move_by_mouse && !ai_controlled)
 		desired_angle = angle + keyboard_delta_angle_left + keyboard_delta_angle_right
 	var/desired_angular_velocity = 0
 	if(isnum(desired_angle))

--- a/nsv13/code/modules/overmap/physics.dm
+++ b/nsv13/code/modules/overmap/physics.dm
@@ -164,8 +164,6 @@ This proc is to be used when someone gets stuck in an overmap ship, gauss, WHATE
 	last_offset.copy(offset)
 	var/last_angle = angle
 
-	if(!move_by_mouse && mass < MASS_SMALL)
-		desired_angle = angle + applied_turn_rate
 	var/desired_angular_velocity = 0
 	if(isnum(desired_angle))
 		// do some finagling to make sure that our angles end up rotating the short way

--- a/nsv13/code/modules/overmap/physics.dm
+++ b/nsv13/code/modules/overmap/physics.dm
@@ -163,7 +163,6 @@ This proc is to be used when someone gets stuck in an overmap ship, gauss, WHATE
 		slowprocess()
 	last_offset.copy(offset)
 	var/last_angle = angle
-
 	var/desired_angular_velocity = 0
 	if(isnum(desired_angle))
 		// do some finagling to make sure that our angles end up rotating the short way

--- a/nsv13/code/modules/overmap/weapons/weapons.dm
+++ b/nsv13/code/modules/overmap/weapons/weapons.dm
@@ -65,6 +65,11 @@
 		return FIRE_MODE_TORPEDO
 	return FIRE_MODE_MAC
 
+/obj/structure/overmap/proc/select_weapon(number)
+	if(number > 0 && number <= length(weapon_numkeys_map))
+		swap_to(weapon_numkeys_map[number])
+		return TRUE
+
 /obj/structure/overmap/proc/swap_to(what=FIRE_MODE_ANTI_AIR)
 	if(!weapon_types[what])
 		return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Moves key handling for most things into keybinding datums. Adds keybindings for the first 4 selectable weapons.
It's a secret tool that will help us later.

Before merging:
- [x] AI no longer flies in straight lines all the time
- [ ] Eclipse and Atlas don't fly backwards when brakes are applied

## Why It's Good For The Game
Doing it this way helps us not have to worry about key conflicts as much, and the weapon thing is probably useful even though it may wind up different per ship

## Changelog
:cl:
add: Top row numbers 1-4 can be used to select weapons while gunning
refactor: Moved overmap key handling into the keybind system
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
