### PR TITLE
Ammo fix

### DIFF
--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
@@ -673,11 +673,12 @@
 	if(loading)
 		to_chat(user, "<span class='notice'>[src] is already being loaded...</span>")
 		return FALSE
-	if(ammo_type && istype(A, ammo_type))
-		if(get_dist(A, src) > 1)
-			load_delay = 10.4 SECONDS
-		load(A, user)
-		load_delay = 7.2 SECONDS
+	if(!ammo_type || !istype(A, ammo_type))
+		return FALSE
+	if(get_dist(A, src) > 1)
+		load_delay = 10.4 SECONDS
+	load(A, user)
+	load_delay = 7.2 SECONDS
 
 /obj/machinery/deck_turret/payload_gate/proc/load(obj/item/A, mob/user)
 	var/temp = load_delay
@@ -697,13 +698,20 @@
 			playsound(src.loc, 'nsv13/sound/effects/ship/mac_load.ogg', 100, 1)
 	loading = FALSE
 
+///Updates state if the moved out obj was the loaded shell
+/obj/machinery/deck_turret/payload_gate/Exited(src)
+	. = ..()
+	if(src == shell)
+		icon_state = initial(icon_state)
+		loaded = FALSE
+		shell = null
+
+///Shorthand for moving shell to turf
 /obj/machinery/deck_turret/payload_gate/proc/unload()
-	icon_state = initial(icon_state)
-	loaded = FALSE
 	if(!shell)
-		return
-	shell.forceMove(get_turf(src))
-	shell = null
+		return FALSE
+	//Will call payload_gate.Exited which handles the actual unloading
+	return shell.forceMove(get_turf(src))
 
 /obj/machinery/deck_turret/payload_gate/proc/feed()
 	if(!shell)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes two similar bugs where objects could be kind of loaded into multiple payload gates or munitions trolleys respectively.

Fixes #1907: The same NAC shell could be loaded into multiple payload gates at once. Players were
able to feed it into both cannons at once. When a shell is loaded into one payload
gate and during that into another, it already got moved to the last gate but remained
in the old gate's shell variable. Some code for adjusting payload gate state was
moved to Exited() to make sure the state is correctly adjusted after the shell
gets removed in any way, fixing this bug.

Same item could be loaded onto multiple munitions trolleys at once. When it got loaded onto the second one it got removed from the first's contents but not from its vis_contents and the variables for the stacking overlay weren't adjusted, making the item still apear to be on the trolley and taking up space. This fix makes sure that unload_munition gets called by calling it from the Exited proc.

Also includes a tiny refactor of munitions_trolley MouseDrop_T code.

## Why It's Good For The Game

less bugs = good

## Changelog
:cl:
fix: fixed duplicate loading into payload gates and onto munitions trolleys
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
