### PR TITLE
Hardsuit equip/strip delay.

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -175,7 +175,7 @@
 	var/image/item_overlay = image(holding)
 	item_overlay.alpha = 92
 
-	if(!user.can_equip(holding, slot_id, disable_warning = TRUE, bypass_equip_delay_self = TRUE)) //NSV13, fixes hover triggering of equip delay
+	if(!user.can_equip(holding, slot_id, disable_warning = TRUE, bypass_equip_delay_self = TRUE))
 		item_overlay.color = "#FF0000"
 	else
 		item_overlay.color = "#00ff00"

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -175,7 +175,7 @@
 	var/image/item_overlay = image(holding)
 	item_overlay.alpha = 92
 
-	if(!user.can_equip(holding, slot_id, TRUE))
+	if(!user.can_equip(holding, slot_id, disable_warning = TRUE, bypass_equip_delay_self = TRUE)) //NSV13, fixes hover triggering of equip delay
 		item_overlay.color = "#FF0000"
 	else
 		item_overlay.color = "#00ff00"

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -413,7 +413,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	if(throwing)
 		throwing.finalize(FALSE)
 	if(loc == user)
-		if(!allow_attack_hand_drop(user) || !user.temporarilyRemoveItemFromInventory(src))
+		if(!allow_attack_hand_drop(user) || !user.temporarilyRemoveItemFromInventory(src, bypass_strip_delay_other = FALSE)) //NSV13
 			return
 
 	remove_outline()
@@ -1038,7 +1038,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	return !HAS_TRAIT(src, TRAIT_NODROP)
 
 /obj/item/proc/doStrip(mob/stripper, mob/owner)
-	return owner.dropItemToGround(src)
+	return owner.dropItemToGround(src,)
 
 /obj/item/ex_act(severity, target)
 	if(resistance_flags & INDESTRUCTIBLE)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -413,7 +413,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	if(throwing)
 		throwing.finalize(FALSE)
 	if(loc == user)
-		if(!allow_attack_hand_drop(user) || !user.temporarilyRemoveItemFromInventory(src, bypass_strip_delay_other = FALSE)) //NSV13
+		if(!allow_attack_hand_drop(user) || !user.temporarilyRemoveItemFromInventory(src, bypass_delay = FALSE)) //NSV13
 			return
 
 	remove_outline()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1038,7 +1038,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	return !HAS_TRAIT(src, TRAIT_NODROP)
 
 /obj/item/proc/doStrip(mob/stripper, mob/owner)
-	return owner.dropItemToGround(src,)
+	return owner.dropItemToGround(src)
 
 /obj/item/ex_act(severity, target)
 	if(resistance_flags & INDESTRUCTIBLE)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -109,6 +109,8 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	var/equip_delay_other = 20
 	/// In deciseconds, how long an item takes to remove from another person
 	var/strip_delay = 40
+	/// NSV13 In deciseconds, how long an item takes to remove from another person
+	var/strip_delay_self = 0
 	/// In deciseconds, how long it takes to break out of an item by using resist. ex: handcuffs
 	var/breakouttime = 0
 

--- a/code/modules/antagonists/devil/true_devil/inventory.dm
+++ b/code/modules/antagonists/devil/true_devil/inventory.dm
@@ -1,4 +1,4 @@
-/mob/living/carbon/true_devil/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, was_thrown = FALSE, bypass_strip_delay_other = TRUE)
+/mob/living/carbon/true_devil/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, was_thrown = FALSE, bypass_strip_delay_other = TRUE) //NSV13
 	if(..())
 		update_inv_hands()
 		return TRUE

--- a/code/modules/antagonists/devil/true_devil/inventory.dm
+++ b/code/modules/antagonists/devil/true_devil/inventory.dm
@@ -1,4 +1,4 @@
-/mob/living/carbon/true_devil/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, was_thrown = FALSE, bypass_strip_delay_other = TRUE) //NSV13
+/mob/living/carbon/true_devil/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, was_thrown = FALSE, bypass_delay = TRUE) //NSV13
 	if(..())
 		update_inv_hands()
 		return TRUE

--- a/code/modules/antagonists/devil/true_devil/inventory.dm
+++ b/code/modules/antagonists/devil/true_devil/inventory.dm
@@ -1,4 +1,4 @@
-/mob/living/carbon/true_devil/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, was_thrown = FALSE)
+/mob/living/carbon/true_devil/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, was_thrown = FALSE, bypass_strip_delay_other = TRUE)
 	if(..())
 		update_inv_hands()
 		return TRUE

--- a/code/modules/clothing/spacesuits/_spacesuits.dm
+++ b/code/modules/clothing/spacesuits/_spacesuits.dm
@@ -42,4 +42,6 @@
 	max_heat_protection_temperature = SPACE_SUIT_MAX_TEMP_PROTECT
 	strip_delay = 80
 	equip_delay_other = 80
+	equip_delay_self = 25
+	strip_delay_self = 25
 	resistance_flags = NONE

--- a/code/modules/clothing/spacesuits/_spacesuits.dm
+++ b/code/modules/clothing/spacesuits/_spacesuits.dm
@@ -42,6 +42,6 @@
 	max_heat_protection_temperature = SPACE_SUIT_MAX_TEMP_PROTECT
 	strip_delay = 80
 	equip_delay_other = 80
-	equip_delay_self = 40 //NSV13
-	strip_delay_self = 40 //NSV13
+	equip_delay_self = 55 //NSV13
+	strip_delay_self = 55 //NSV13
 	resistance_flags = NONE

--- a/code/modules/clothing/spacesuits/_spacesuits.dm
+++ b/code/modules/clothing/spacesuits/_spacesuits.dm
@@ -42,6 +42,6 @@
 	max_heat_protection_temperature = SPACE_SUIT_MAX_TEMP_PROTECT
 	strip_delay = 80
 	equip_delay_other = 80
-	equip_delay_self = 55 //NSV13
-	strip_delay_self = 55 //NSV13
+	equip_delay_self = 53 //NSV13
+	strip_delay_self = 53 //NSV13
 	resistance_flags = NONE

--- a/code/modules/clothing/spacesuits/_spacesuits.dm
+++ b/code/modules/clothing/spacesuits/_spacesuits.dm
@@ -42,6 +42,6 @@
 	max_heat_protection_temperature = SPACE_SUIT_MAX_TEMP_PROTECT
 	strip_delay = 80
 	equip_delay_other = 80
-	equip_delay_self = 40
-	strip_delay_self = 40
+	equip_delay_self = 40 //NSV13
+	strip_delay_self = 40 //NSV13
 	resistance_flags = NONE

--- a/code/modules/clothing/spacesuits/_spacesuits.dm
+++ b/code/modules/clothing/spacesuits/_spacesuits.dm
@@ -42,6 +42,6 @@
 	max_heat_protection_temperature = SPACE_SUIT_MAX_TEMP_PROTECT
 	strip_delay = 80
 	equip_delay_other = 80
-	equip_delay_self = 25
-	strip_delay_self = 25
+	equip_delay_self = 40
+	strip_delay_self = 40
 	resistance_flags = NONE

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -306,7 +306,7 @@
 //DO NOT CALL THIS PROC
 //use one of the above 3 helper procs
 //you may override it, but do not modify the args
-/mob/proc/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, was_thrown = FALSE, bypass_strip_delay_other = TRUE) //NSV13 Force overrides TRAIT_NODROP for things like wizarditis and admin undress.
+/mob/proc/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, was_thrown = FALSE, bypass_strip_delay_other = TRUE) //Force overrides TRAIT_NODROP for things like wizarditis and admin undress. //NSV13 strip delay bypass
 													//Use no_move if the item is just gonna be immediately moved afterward
 													//Invdrop is used to prevent stuff in pockets dropping. only set to false if it's going to immediately be replaced
 	if(!I) //If there's nothing to drop, the drop is automatically succesfull. If(unEquip) should generally be used to check for TRAIT_NODROP.

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -291,22 +291,22 @@
 
 //for when you want the item to end up on the ground
 //will force move the item to the ground and call the turf's Entered
-/mob/proc/dropItemToGround(obj/item/I, force = FALSE, thrown = FALSE)
-	return doUnEquip(I, force, drop_location(), FALSE, was_thrown = thrown)
+/mob/proc/dropItemToGround(obj/item/I, force = FALSE, thrown = FALSE, bypass_strip_delay_other)//NSV13
+	return doUnEquip(I, force, drop_location(), FALSE, was_thrown = thrown, bypass_strip_delay_other = bypass_strip_delay_other)//NSV13
 
 //for when the item will be immediately placed in a loc other than the ground
-/mob/proc/transferItemToLoc(obj/item/I, newloc = null, force = FALSE)
-	return doUnEquip(I, force, newloc, FALSE)
+/mob/proc/transferItemToLoc(obj/item/I, newloc = null, force = FALSE, bypass_strip_delay_other)//NSV13
+	return doUnEquip(I, force, newloc, FALSE, bypass_strip_delay_other = bypass_strip_delay_other)//NSV13
 
 //visibly unequips I but it is NOT MOVED AND REMAINS IN SRC
 //item MUST BE FORCEMOVE'D OR QDEL'D
-/mob/proc/temporarilyRemoveItemFromInventory(obj/item/I, force = FALSE, idrop = TRUE)
-	return doUnEquip(I, force, null, TRUE, idrop)
+/mob/proc/temporarilyRemoveItemFromInventory(obj/item/I, force = FALSE, idrop = TRUE, bypass_strip_delay_other)//NSV13
+	return doUnEquip(I, force, null, TRUE, idrop, bypass_strip_delay_other = bypass_strip_delay_other)//NSV13
 
 //DO NOT CALL THIS PROC
 //use one of the above 3 helper procs
 //you may override it, but do not modify the args
-/mob/proc/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, was_thrown = FALSE) //Force overrides TRAIT_NODROP for things like wizarditis and admin undress.
+/mob/proc/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, was_thrown = FALSE, bypass_strip_delay_other = TRUE) //NSV13 Force overrides TRAIT_NODROP for things like wizarditis and admin undress.
 													//Use no_move if the item is just gonna be immediately moved afterward
 													//Invdrop is used to prevent stuff in pockets dropping. only set to false if it's going to immediately be replaced
 	if(!I) //If there's nothing to drop, the drop is automatically succesfull. If(unEquip) should generally be used to check for TRAIT_NODROP.

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -291,22 +291,22 @@
 
 //for when you want the item to end up on the ground
 //will force move the item to the ground and call the turf's Entered
-/mob/proc/dropItemToGround(obj/item/I, force = FALSE, thrown = FALSE, bypass_strip_delay_other)//NSV13
-	return doUnEquip(I, force, drop_location(), FALSE, was_thrown = thrown, bypass_strip_delay_other = bypass_strip_delay_other)//NSV13
+/mob/proc/dropItemToGround(obj/item/I, force = FALSE, thrown = FALSE, bypass_delay)//NSV13
+	return doUnEquip(I, force, drop_location(), FALSE, was_thrown = thrown, bypass_delay = bypass_delay)//NSV13
 
 //for when the item will be immediately placed in a loc other than the ground
-/mob/proc/transferItemToLoc(obj/item/I, newloc = null, force = FALSE, bypass_strip_delay_other)//NSV13
-	return doUnEquip(I, force, newloc, FALSE, bypass_strip_delay_other = bypass_strip_delay_other)//NSV13
+/mob/proc/transferItemToLoc(obj/item/I, newloc = null, force = FALSE, bypass_delay)//NSV13
+	return doUnEquip(I, force, newloc, FALSE, bypass_delay = bypass_delay)//NSV13
 
 //visibly unequips I but it is NOT MOVED AND REMAINS IN SRC
 //item MUST BE FORCEMOVE'D OR QDEL'D
-/mob/proc/temporarilyRemoveItemFromInventory(obj/item/I, force = FALSE, idrop = TRUE, bypass_strip_delay_other)//NSV13
-	return doUnEquip(I, force, null, TRUE, idrop, bypass_strip_delay_other = bypass_strip_delay_other)//NSV13
+/mob/proc/temporarilyRemoveItemFromInventory(obj/item/I, force = FALSE, idrop = TRUE, bypass_delay)//NSV13
+	return doUnEquip(I, force, null, TRUE, idrop, bypass_delay = bypass_delay)//NSV13
 
 //DO NOT CALL THIS PROC
 //use one of the above 3 helper procs
 //you may override it, but do not modify the args
-/mob/proc/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, was_thrown = FALSE, bypass_strip_delay_other = TRUE) //Force overrides TRAIT_NODROP for things like wizarditis and admin undress. //NSV13 strip delay bypass
+/mob/proc/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, was_thrown = FALSE, bypass_delay = TRUE) //Force overrides TRAIT_NODROP for things like wizarditis and admin undress. //NSV13 strip delay bypass
 													//Use no_move if the item is just gonna be immediately moved afterward
 													//Invdrop is used to prevent stuff in pockets dropping. only set to false if it's going to immediately be replaced
 	if(!I) //If there's nothing to drop, the drop is automatically succesfull. If(unEquip) should generally be used to check for TRAIT_NODROP.

--- a/code/modules/mob/living/carbon/alien/humanoid/inventory.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/inventory.dm
@@ -1,4 +1,4 @@
-/mob/living/carbon/alien/humanoid/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, was_thrown = FALSE)
+/mob/living/carbon/alien/humanoid/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, was_thrown = FALSE, bypass_strip_delay_other = TRUE)
 	. = ..()
 	if(!. || !I)
 		return

--- a/code/modules/mob/living/carbon/alien/humanoid/inventory.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/inventory.dm
@@ -1,4 +1,4 @@
-/mob/living/carbon/alien/humanoid/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, was_thrown = FALSE, bypass_strip_delay_other = TRUE)
+/mob/living/carbon/alien/humanoid/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, was_thrown = FALSE, bypass_strip_delay_other = TRUE)//NSV13
 	. = ..()
 	if(!. || !I)
 		return

--- a/code/modules/mob/living/carbon/alien/humanoid/inventory.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/inventory.dm
@@ -1,4 +1,4 @@
-/mob/living/carbon/alien/humanoid/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, was_thrown = FALSE, bypass_strip_delay_other = TRUE)//NSV13
+/mob/living/carbon/alien/humanoid/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, was_thrown = FALSE, bypass_delay = TRUE)//NSV13
 	. = ..()
 	if(!. || !I)
 		return

--- a/code/modules/mob/living/carbon/alien/larva/inventory.dm
+++ b/code/modules/mob/living/carbon/alien/larva/inventory.dm
@@ -1,3 +1,3 @@
 //can't unequip since it can't equip anything
-/mob/living/carbon/alien/larva/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, was_thrown = FALSE, bypass_strip_delay_other = TRUE)
+/mob/living/carbon/alien/larva/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, was_thrown = FALSE, bypass_strip_delay_other = TRUE)//NSV13
 	return

--- a/code/modules/mob/living/carbon/alien/larva/inventory.dm
+++ b/code/modules/mob/living/carbon/alien/larva/inventory.dm
@@ -1,3 +1,3 @@
 //can't unequip since it can't equip anything
-/mob/living/carbon/alien/larva/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, was_thrown = FALSE, bypass_strip_delay_other = TRUE)//NSV13
+/mob/living/carbon/alien/larva/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, was_thrown = FALSE, bypass_delay = TRUE)//NSV13
 	return

--- a/code/modules/mob/living/carbon/alien/larva/inventory.dm
+++ b/code/modules/mob/living/carbon/alien/larva/inventory.dm
@@ -1,3 +1,3 @@
 //can't unequip since it can't equip anything
-/mob/living/carbon/alien/larva/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, was_thrown = FALSE)
+/mob/living/carbon/alien/larva/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, was_thrown = FALSE, bypass_strip_delay_other = TRUE)
 	return

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -144,12 +144,12 @@
 	return not_handled //For future deeper overrides
 
 //NSV13 lots of changes below in this proc, all related to strip delays
-/mob/living/carbon/human/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, silent = FALSE, was_thrown = FALSE, bypass_strip_delay_other = TRUE)
+/mob/living/carbon/human/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, silent = FALSE, was_thrown = FALSE, bypass_delay = TRUE)
 	var/index = get_held_index_of_item(I)
 	if(index && !QDELETED(src) && dna.species.mutanthands) //hand freed, fill with claws, skip if we're getting deleted.
 		put_in_hand(new dna.species.mutanthands(), index)
 	if(I == wear_suit)
-		if (I.strip_delay_self && !bypass_strip_delay_other)
+		if (I.strip_delay_self && !bypass_delay)
 			var/mob/living/carbon/human/H = src
 			if(!(I in held_items))
 				H.visible_message("<span class='notice'>[H] starts unequipping [I]...</span>", "<span class='notice'>You start unequipping [I]...</span>")

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -143,19 +143,21 @@
 
 	return not_handled //For future deeper overrides
 
-/mob/living/carbon/human/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, silent = FALSE, was_thrown = FALSE)
+//NSV13 lots of changes below in this proc, all related to strip delays
+/mob/living/carbon/human/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, silent = FALSE, was_thrown = FALSE, bypass_strip_delay_other = TRUE)
 	var/index = get_held_index_of_item(I)
 	if(index && !QDELETED(src) && dna.species.mutanthands) //hand freed, fill with claws, skip if we're getting deleted.
 		put_in_hand(new dna.species.mutanthands(), index)
 	if(I == wear_suit)
-		if (I.strip_delay_self)
+		if (I.strip_delay_self && !bypass_strip_delay_other)
 			var/mob/living/carbon/human/H = src
 			if(!(I in held_items))
 				H.visible_message("<span class='notice'>[H] starts unequipping [I]...</span>", "<span class='notice'>You start unequipping [I]...</span>")
 				if(!do_after(H, I.strip_delay_self, TRUE, H))
 					if(s_store && invdrop)
 						return FALSE
-			dropItemToGround(s_store, TRUE) //It makes no sense for your suit storage to stay on you if you drop your suit.
+		message_admins("/mob/living/carbon/human/doUnEquip was called on [I], [src] with bypass [bypass_strip_delay_other]")
+		dropItemToGround(s_store, TRUE) //It makes no sense for your suit storage to stay on you if you drop your suit.
 		if(wear_suit.breakouttime) //when unequipping a straightjacket
 			drop_all_held_items() //suit is restraining
 			update_action_buttons_icon() //certain action buttons may be usable again.

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -145,13 +145,16 @@
 
 /mob/living/carbon/human/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, silent = FALSE, was_thrown = FALSE)
 	var/index = get_held_index_of_item(I)
-	. = ..(I, force, newloc, no_move, invdrop, was_thrown) //See mob.dm for an explanation on this and some rage about people copypasting instead of calling ..() like they should.
-	if(!. || !I)
-		return
 	if(index && !QDELETED(src) && dna.species.mutanthands) //hand freed, fill with claws, skip if we're getting deleted.
 		put_in_hand(new dna.species.mutanthands(), index)
 	if(I == wear_suit)
-		if(s_store && invdrop)
+		if (I.strip_delay_self)
+			var/mob/living/carbon/human/H = src
+			if(!(I in held_items))
+				H.visible_message("<span class='notice'>[H] starts unequipping [I]...</span>", "<span class='notice'>You start unequipping [I]...</span>")
+				if(!do_after(H, I.strip_delay_self, TRUE, H))
+					if(s_store && invdrop)
+						return FALSE
 			dropItemToGround(s_store, TRUE) //It makes no sense for your suit storage to stay on you if you drop your suit.
 		if(wear_suit.breakouttime) //when unequipping a straightjacket
 			drop_all_held_items() //suit is restraining
@@ -222,6 +225,9 @@
 		s_store = null
 		if(!QDELETED(src))
 			update_inv_s_store()
+	. = ..(I, force, newloc, no_move, invdrop, was_thrown) //See mob.dm for an explanation on this and some rage about people copypasting instead of calling ..() like they should.
+	if(!. || !I)
+		return
 
 /mob/living/carbon/human/wear_mask_update(obj/item/I, toggle_off = 1)
 	if((I.flags_inv & (HIDEHAIR|HIDEFACIALHAIR)) || (initial(I.flags_inv) & (HIDEHAIR|HIDEFACIALHAIR)))

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -156,7 +156,6 @@
 				if(!do_after(H, I.strip_delay_self, TRUE, H))
 					if(s_store && invdrop)
 						return FALSE
-		message_admins("/mob/living/carbon/human/doUnEquip was called on [I], [src] with bypass [bypass_strip_delay_other]")
 		dropItemToGround(s_store, TRUE) //It makes no sense for your suit storage to stay on you if you drop your suit.
 		if(wear_suit.breakouttime) //when unequipping a straightjacket
 			drop_all_held_items() //suit is restraining

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -85,7 +85,7 @@
 
 	return not_handled
 
-/mob/living/carbon/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, was_thrown = FALSE)
+/mob/living/carbon/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, was_thrown = FALSE, bypass_strip_delay_other = TRUE) //NSV13
 	. = ..() //Sets the default return value to what the parent returns.
 	if(!. || !I) //We don't want to set anything to null if the parent returned 0.
 		return

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -85,7 +85,7 @@
 
 	return not_handled
 
-/mob/living/carbon/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, was_thrown = FALSE, bypass_strip_delay_other = TRUE) //NSV13
+/mob/living/carbon/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, was_thrown = FALSE, bypass_delay = TRUE) //NSV13
 	. = ..() //Sets the default return value to what the parent returns.
 	if(!. || !I) //We don't want to set anything to null if the parent returned 0.
 		return

--- a/code/modules/mob/living/simple_animal/friendly/drone/inventory.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/inventory.dm
@@ -6,7 +6,7 @@
 //Drone hands
 
 //Does nobody read the comments telling you to not touch shit you souldn't?
-/mob/living/simple_animal/drone/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, was_thrown = FALSE)
+/mob/living/simple_animal/drone/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, was_thrown = FALSE, bypass_strip_delay_other = TRUE) //NSV13
 	if(..())
 		update_inv_hands()
 		if(I == head)

--- a/code/modules/mob/living/simple_animal/friendly/drone/inventory.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/inventory.dm
@@ -6,7 +6,7 @@
 //Drone hands
 
 //Does nobody read the comments telling you to not touch shit you souldn't?
-/mob/living/simple_animal/drone/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, was_thrown = FALSE, bypass_strip_delay_other = TRUE) //NSV13
+/mob/living/simple_animal/drone/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, was_thrown = FALSE, bypass_delay = TRUE) //NSV13
 	if(..())
 		update_inv_hands()
 		if(I == head)

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -283,7 +283,7 @@
 			Feedon(Food)
 	return ..()
 
-/mob/living/simple_animal/slime/doUnEquip(obj/item/W, was_thrown = FALSE)
+/mob/living/simple_animal/slime/doUnEquip(obj/item/W, was_thrown = FALSE, bypass_strip_delay_other = TRUE )//NSV13
 	return
 
 /mob/living/simple_animal/slime/start_pulling(atom/movable/AM, state, force = move_force, supress_message = FALSE)

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -283,7 +283,7 @@
 			Feedon(Food)
 	return ..()
 
-/mob/living/simple_animal/slime/doUnEquip(obj/item/W, was_thrown = FALSE, bypass_strip_delay_other = TRUE )//NSV13
+/mob/living/simple_animal/slime/doUnEquip(obj/item/W, was_thrown = FALSE, bypass_delay = TRUE )//NSV13
 	return
 
 /mob/living/simple_animal/slime/start_pulling(atom/movable/AM, state, force = move_force, supress_message = FALSE)

--- a/nsv13/code/modules/clothing/custom_clothes.dm
+++ b/nsv13/code/modules/clothing/custom_clothes.dm
@@ -763,8 +763,8 @@
 	heat_protection = NONE
 	max_heat_protection_temperature = 100
 	var/rolled_up = TRUE
-	equip_delay_self = 15
-	strip_delay_self = 15
+	equip_delay_self = 13
+	strip_delay_self = 13
 
 /obj/item/clothing/suit/space/skinsuit/mob_can_equip(mob/M, mob/living/equipper, slot)
 	if(rolled_up && slot == ITEM_SLOT_OCLOTHING)

--- a/nsv13/code/modules/clothing/custom_clothes.dm
+++ b/nsv13/code/modules/clothing/custom_clothes.dm
@@ -763,6 +763,8 @@
 	heat_protection = NONE
 	max_heat_protection_temperature = 100
 	var/rolled_up = TRUE
+	equip_delay_self = 15
+	strip_delay_self = 15
 
 /obj/item/clothing/suit/space/skinsuit/mob_can_equip(mob/M, mob/living/equipper, slot)
 	if(rolled_up && slot == ITEM_SLOT_OCLOTHING)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This adds an equip/strip delay to the act of donning/doffing a hardsuit.
It also adds the strip delay system which can be somewhat easily adapted to any other piece of equipment.
It also fixes an UI bug that has gone unnoticed for some time, related to the inbuilt equip delay triggering on mouse hover over the suit slot.

In Effect:
Spacesuits take around 5 seconds to put on/strip off.
They take longer if you're dressing someone else(as it always was, this takes 8 seconds)
Skinsuits are able to be equipped in only ~1 second.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Hardsuits slow you down, an intentional debuff to counteract the protection they offer.
A debuff which can be entirely ignored by simply taking it off and keeping it in your hand while running, and quickly putting it back on whenever you need to.
This is bad.
This delay increases immersion, makes it impossible for people to don/doff hardsuits while running, and while It still doesn't take as long as I'd like(30 secs), It still reinforces the fact that this is supposed to be a tradeoff.
Using a Hardsuit is a choice to be made, one that should have tangible up and downsides, a choice you shouldn't just be able to go back on 10 times a second.
If you're gonna complain about engineers being affected, tell me a time when they ever get out of their suits.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added strip delay system
add: Added equip delay to spacesuits
tweak: tweaked equip&strip delay of spacesuits to 5.5 seconds
fix: fixed an UI bug related to equip delays
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
