### PR TITLE
make gauss guns require no power

### DIFF
--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/gauss_gun.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/gauss_gun.dm
@@ -31,6 +31,8 @@
 	var/BeingLoaded //Used for gunner load
 	var/list/gauss_verbs = list(.verb/show_computer, .verb/show_view, .verb/swap_firemode)
 	circuit = /obj/item/circuitboard/machine/gauss_turret
+	//INTERACT_MACHINE_OFFLINE added because gauss guns are usually unpowered because they're usually in near space
+	interaction_flags_machine = INTERACT_MACHINE_OFFLINE | INTERACT_MACHINE_WIRES_IF_OPEN | INTERACT_MACHINE_ALLOW_SILICON | INTERACT_MACHINE_OPEN_SILICON | INTERACT_MACHINE_SET_MACHINE
 
 /obj/machinery/ship_weapon/gauss_gun/MouseDrop_T(obj/structure/A, mob/user)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gauss guns currently require power in the turret's room to operate. Prebuilt turrets seem to be powered by default but rebuilt turrets are usually unpowered because they're in an area without APC. Making them require no power is an easier fix than making new powered areas in space for each gauss battery.

## Why It's Good For The Game

bugfix without much side effects (Fixes #1855)

## Changelog
:cl:
fix: rebuilt gauss guns should now always be usable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
