### PR TITLE
delete Astrometrics Computer's radio on destruction

### DIFF
--- a/nsv13/code/modules/research/astrometrics.dm
+++ b/nsv13/code/modules/research/astrometrics.dm
@@ -139,3 +139,7 @@ Clean override of the navigation computer to provide scan functionality.
 				OA.scanned = TRUE
 			scan_target = null
 			scan_progress = 0
+
+/obj/machinery/computer/ship/navigation/astrometrics/Destroy()
+	QDEL_NULL(radio)
+	return ..()


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

On construction, the Astrometrics Computer creates a radio in its contents.
All contents get droped on destruction by default. Because the radio
wasn't added in construction this creates it from thin air from the
players perspective. This fix is in line how the same thing is handled for the
SM crystal.
Fixes  #1925

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bugfix

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Astrometrics Computer no longer creates radio from thin air on destruction
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
