### PR TITLE
Adds more fleets, makes points mission shorter, and a minor fix

### DIFF
--- a/nsv13/code/controllers/subsystem/starsystem.dm
+++ b/nsv13/code/controllers/subsystem/starsystem.dm
@@ -1,6 +1,5 @@
 GLOBAL_VAR_INIT(crew_transfer_risa, FALSE)
 
-#define FACTION_VICTORY_TICKETS 1000
 #define COMBAT_CYCLE_INTERVAL 180 SECONDS	//Time between each 'combat cycle' of starsystems. Every combat cycle, every system that has opposing fleets in it gets iterated through, with the fleets firing at eachother.
 
 #define THREAT_LEVEL_NONE 0
@@ -12,7 +11,7 @@ SUBSYSTEM_DEF(star_system)
 	name = "star_system"
 	wait = 10
 	init_order = INIT_ORDER_STARSYSTEM
-	//flags = SS_NO_INIT
+
 	var/last_combat_enter = 0 //Last time an AI controlled ship attacked the players
 	var/list/systems = list()
 	var/list/traders = list()
@@ -20,7 +19,6 @@ SUBSYSTEM_DEF(star_system)
 	var/list/enemy_types = list()
 	var/list/enemy_blacklist = list()
 	var/list/ships = list() //2-d array. Format: list("ship" = ship, "x" = 0, "y" = 0, "current_system" = null, "target_system" = null, "transit_time" = 0)
-	var/tickets_to_win = FACTION_VICTORY_TICKETS
 	//Starmap 2
 	var/list/factions = list() //List of all factions in play on this starmap, instantiated on init.
 	var/list/neutral_zone_systems = list()

--- a/nsv13/code/game/gamemodes/overmap/objectives/tickets.dm
+++ b/nsv13/code/game/gamemodes/overmap/objectives/tickets.dm
@@ -3,7 +3,7 @@
 	desc = "Acquire ticket_amount Tickets for assigned_faction"
 	binary = FALSE
 	target = 0
-	var/ticket_amount = 1000
+	var/ticket_amount = 700
 	var/assigned_faction = null
 
 /datum/overmap_objective/tickets/New()

--- a/nsv13/code/modules/overmap/ai-skynet.dm
+++ b/nsv13/code/modules/overmap/ai-skynet.dm
@@ -253,7 +253,8 @@ Adding tasks is easy! Just define a datum for it.
 			if(alignment != target.owner && !federation_check(target))
 				current_system.mission_sector = TRUE
 	if(!hide_movements && !current_system.hidden)
-		(alignment != "nanotrasen") && mini_announce("Typhoon drive signatures detected in [current_system]", "White Rapids EAS")
+		if((alignment == "syndicate") || (alignment == "pirate"))
+			mini_announce("Typhoon drive signatures detected in [current_system]", "White Rapids EAS")
 	for(var/obj/structure/overmap/OM in current_system.system_contents)
 		//Boarding ships don't want to go to brasil
 		if(OM.mobs_in_ship?.len && OM.reserved_z)

--- a/nsv13/code/modules/overmap/factions.dm
+++ b/nsv13/code/modules/overmap/factions.dm
@@ -17,7 +17,9 @@
 	var/list/fleet_types = list()
 	var/list/randomspawn_only_fleet_types = list()	//These fleets only get spawned randomly, not by say, missions.
 	var/next_fleet_spawn = 0 //Factions spawn fleets more frequently when they're doing well with tickets.
-	var/fleet_spawn_rate = 20 MINUTES //By default, 1 / 10 minutes.
+	var/fleet_spawn_rate = 10 MINUTES //By default, 1 / 5 minutes.
+	var/spawn_rate_jitter = 3 MINUTES
+	var/minimum_spawn_interval = 5 MINUTES
 
 /**
 Procs for handling factions winning / losing
@@ -59,17 +61,14 @@ Set up relationships.
 	for(var/datum/faction/F in relationships)
 		if(relationships[F] <= RELATIONSHIP_ENEMIES)
 			F.gain_influence(value)
-	//SSstar_system.check_completion()
 
 /datum/faction/proc/gain_influence(value)
 	tickets += value
-	//SSstar_system.check_completion()
 
 /datum/faction/proc/send_fleet(datum/star_system/override=null, custom_difficulty=null, force=FALSE)
-	 //if(SSstar_system.check_completion() || !fleet_types || !force && (world.time < next_fleet_spawn)) - Why are we checking completion this here?
 	if(!fleet_types || !force && (world.time < next_fleet_spawn))
 		return
-	next_fleet_spawn = world.time + fleet_spawn_rate
+	next_fleet_spawn = world.time + max(fleet_spawn_rate + rand(-spawn_rate_jitter, spawn_rate_jitter), minimum_spawn_interval)
 	var/datum/star_system/current_system //Dont spawn enemies where theyre currently at
 	for(var/obj/structure/overmap/OM in GLOB.overmap_objects) //The ship doesnt start with a system assigned by default
 		if(OM.role != MAIN_OVERMAP)
@@ -102,9 +101,9 @@ Set up relationships.
 	F.assemble(starsys)
 	if(!F.hide_movements && !starsys.hidden)
 		if(F.alignment == "nanotrasen")
-			mini_announce("A White Rapids fleet has been assigned to [current_system]", "White Rapids Fleet Command")
+			mini_announce("A White Rapids fleet has been assigned to [starsys]", "White Rapids Fleet Command")
 		else
-			mini_announce("Typhoon drive signatures detected in [current_system]", "White Rapids EAS")
+			mini_announce("Typhoon drive signatures detected in [starsys]", "White Rapids EAS")
 	F.faction = src
 	if(!force && id == FACTION_ID_SYNDICATE && !SSstar_system.neutral_zone_systems.Find(F.current_system))	//If it isn't forced, it got spawned by the midround processing. If we didn't already spawn in the neutral zone, we head to a random system there and occupy it.
 		var/list/possible_occupation_targets = list()

--- a/nsv13/code/modules/overmap/factions.dm
+++ b/nsv13/code/modules/overmap/factions.dm
@@ -100,7 +100,7 @@ Set up relationships.
 		F.size = custom_difficulty
 	F.assemble(starsys)
 	if(!F.hide_movements && !starsys.hidden)
-		if(F.alignment == "nanotrasen")
+		if((F.alignment == "nanotrasen") || (F.alignment == "solgov"))
 			mini_announce("A White Rapids fleet has been assigned to [starsys]", "White Rapids Fleet Command")
 		else
 			mini_announce("Typhoon drive signatures detected in [starsys]", "White Rapids EAS")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Reduces number of faction points needed by 30%
- Doubles default fleet spawn rate and adds some jitter
- Fixes one of the typhoon drive announcements always announcing the main ship's location

## Why It's Good For The Game
- Gives the crew more opportunities to encounter other fleets
- Makes points mission not go on as long
- Fix is fix

## Changelog
:cl:
tweak: Reduced faction point requirement to 700
tweak: Increased fleet spawn rates
fix: Fixed fleet movement announcement location
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
