### PR TITLE
Makes it so A and D still steer in inertial mode

### DIFF
--- a/nsv13/code/modules/overmap/overmap.dm
+++ b/nsv13/code/modules/overmap/overmap.dm
@@ -71,6 +71,7 @@
 	var/angle = 0 // degrees, clockwise
 	var/keyboard_delta_angle_left = 0 // Set by use of turning key
 	var/keyboard_delta_angle_right = 0 // Set by use of turning key
+	var/movekey_delta_angle = 0 // A&D support
 	var/desired_angle = null // set by pilot moving his mouse or by keyboard steering
 	var/angular_velocity = 0 // degrees per second
 	var/max_angular_acceleration = 180 // in degrees per second per second
@@ -624,10 +625,10 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 	// Since they can't strafe with IAS on, they can also turn with A and D
 	if(inertial_dampeners)
 		if(direction & WEST)
-			desired_angle = angle - 15
+			movekey_delta_angle = -15
 			user_thrust_dir = direction - WEST
 		else if(direction & EAST)
-			desired_angle = angle + 15
+			movekey_delta_angle = 15
 			user_thrust_dir = direction - EAST
 
 //relay('nsv13/sound/effects/ship/rcs.ogg')

--- a/nsv13/code/modules/overmap/physics.dm
+++ b/nsv13/code/modules/overmap/physics.dm
@@ -163,7 +163,7 @@ This proc is to be used when someone gets stuck in an overmap ship, gauss, WHATE
 		slowprocess()
 	last_offset.copy(offset)
 	var/last_angle = angle
-	if(!move_by_mouse && !ai_controlled)
+	if(!move_by_mouse && !ai_controlled && !inertial_dampeners)
 		desired_angle = angle + keyboard_delta_angle_left + keyboard_delta_angle_right
 	var/desired_angular_velocity = 0
 	if(isnum(desired_angle))

--- a/nsv13/code/modules/overmap/physics.dm
+++ b/nsv13/code/modules/overmap/physics.dm
@@ -163,8 +163,9 @@ This proc is to be used when someone gets stuck in an overmap ship, gauss, WHATE
 		slowprocess()
 	last_offset.copy(offset)
 	var/last_angle = angle
-	if(!move_by_mouse && !ai_controlled && !inertial_dampeners)
-		desired_angle = angle + keyboard_delta_angle_left + keyboard_delta_angle_right
+	if(!move_by_mouse && !ai_controlled)
+		desired_angle = angle + keyboard_delta_angle_left + keyboard_delta_angle_right + movekey_delta_angle
+		movekey_delta_angle = 0
 	var/desired_angular_velocity = 0
 	if(isnum(desired_angle))
 		// do some finagling to make sure that our angles end up rotating the short way


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This will enable A and D turning when using inertial assistance

## Why It's Good For The Game
It was supposed to already do this but was being overridden

## Changelog
:cl:
fix: Makes A & D steering work correctly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
