### PR TITLE
Ammo sorter features

### DIFF
--- a/nsv13/code/game/machinery/computer/helm.dm
+++ b/nsv13/code/game/machinery/computer/helm.dm
@@ -30,9 +30,10 @@
 		playsound(src, 'nsv13/sound/effects/computer/startup.ogg', 75, 1)
 		to_chat(user, "<span class='warning'>Autopilot [linked.ai_controlled ? "Enabled" : "Disengaged"].</span>")
 	..()
+	return TRUE
 
-// Helm and tactical in one console, useful for debugging 
-// This console should not be made available for the player ship, looking at you mappers 
+// Helm and tactical in one console, useful for debugging
+// This console should not be made available for the player ship, looking at you mappers
 /obj/machinery/computer/ship/helm/allinone
 	name = "debug ship"
 	desc = "You shouldn't be seeing this"

--- a/nsv13/code/game/objects/items/nsv_circuitboards.dm
+++ b/nsv13/code/game/objects/items/nsv_circuitboards.dm
@@ -209,6 +209,7 @@
 		/obj/item/stack/sheet/mineral/titanium = 10,
 		/obj/item/stack/cable_coil = 5)
 	build_path = /obj/machinery/deck_turret
+	needs_anchored = FALSE
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
 
 /obj/item/circuitboard/machine/deck_gun/Destroy(force=FALSE)
@@ -273,6 +274,8 @@
 /obj/item/circuitboard/machine/missile_builder
 	name = "Seegson model 'Ford' robotic autowrench (board)"
 	build_path = /obj/machinery/missile_builder
+	req_components = list()
+	needs_anchored = FALSE
 
 /obj/item/circuitboard/machine/missile_builder/wirer
 	name = "Seegson model 'Ford' robotic autowirer (board)"

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/50Cal.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/50Cal.dm
@@ -143,7 +143,8 @@
 	return attack_hand(user)
 
 /obj/machinery/computer/anti_air/multitool_act(mob/living/user, obj/item/multitool/I)
-	. = ..()
+	..()
+	. = TRUE
 	turret = locate(/obj/machinery/ship_weapon/anti_air) in SSmapping.get_turf_above(src)
 	if ( turret )
 		to_chat(user, "<span class='warning'>Successfully linked [src] to [turret].")

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
@@ -240,8 +240,9 @@
 	return ..()
 
 /obj/machinery/deck_turret/multitool_act(mob/living/user, obj/item/I)
-	. = ..()
+	..()
 	update_parts()
+	return TRUE
 
 /obj/machinery/deck_turret/attackby(obj/item/I, mob/user, params)
 	if(default_unfasten_wrench(user, I))

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/automation.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/automation.dm
@@ -235,7 +235,8 @@
 
 /obj/machinery/computer/ammo_sorter/Initialize(mapload, obj/item/circuitboard/C)
 	..()
-	return INITIALIZE_HINT_LATELOAD
+	if(mapload)
+		return INITIALIZE_HINT_LATELOAD
 
 /obj/machinery/computer/ammo_sorter/LateInitialize()
 	. = ..()

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/automation.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/automation.dm
@@ -21,9 +21,17 @@
 
 /obj/machinery/missile_builder/examine(mob/user)
 	. = ..()
-	. += "<span class='notice'>It currently holds...</span>"
-	for(var/atom/movable/X in held_components)
-		. += "<span class='notice'>-[X]</span>"
+	if(held_components.len)
+		. += "<span class='notice'>It currently holds...</span>"
+		var/listofitems = list()
+		for(var/obj/item/C in held_components)
+			var/path = C.type
+			if (listofitems[path])
+				listofitems[path]["amount"]++
+			else
+				listofitems[path] = list("name" = C.name, "amount" = 1)
+		for(var/i in listofitems)
+			. += "<span class='notice'>[listofitems[i]["name"]] x[listofitems[i]["amount"]]</span>"
 
 /obj/machinery/missile_builder/attackby(obj/item/I, mob/user, params)
 	if(default_unfasten_wrench(user, I))

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/automation.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/automation.dm
@@ -31,6 +31,8 @@
 	if(default_deconstruction_screwdriver(user, icon_state, icon_state, I))
 		update_icon()
 		return
+	if(default_deconstruction_crowbar(I))
+		return
 	. = ..()
 
 /obj/item/stack/conveyor/slow
@@ -214,6 +216,7 @@
 	name = "ammo sorter (circuitboard)"
 	req_components = list(/obj/item/stock_parts/matter_bin = 3)
 	build_path = /obj/machinery/ammo_sorter
+	needs_anchored = FALSE
 
 /obj/machinery/computer/ammo_sorter
 	name = "ammo rack control console"
@@ -320,6 +323,8 @@
 		return
 	if(default_deconstruction_screwdriver(user, icon_state, icon_state, I))
 		update_icon()
+		return
+	if(default_deconstruction_crowbar(I))
 		return
 	if(panel_open && istype(I, /obj/item/reagent_containers))
 		if(!jammed)

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/automation.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/automation.dm
@@ -301,10 +301,12 @@
 /obj/machinery/computer/ammo_sorter/proc/linkSorter(var/obj/machinery/ammo_sorter/AS)
 	linked_sorters += AS
 	AS.linked_consoles += src
+	ui_update()
 
 /obj/machinery/computer/ammo_sorter/proc/unlinkSorter(var/obj/machinery/ammo_sorter/AS)
 	linked_sorters -= AS
 	AS.linked_consoles -= src
+	ui_update()
 
 /obj/machinery/computer/ammo_sorter/ui_data(mob/user)
 	. = ..()
@@ -428,12 +430,13 @@
 /obj/machinery/ammo_sorter/Destroy()
 	for(var/obj/machinery/computer/ammo_sorter/AS as() in linked_consoles)
 		AS.linked_sorters -= src
+		AS.ui_update()
 	. = ..()
 
 /obj/machinery/ammo_sorter/examine(mob/user)
 	. = ..()
 	if(panel_open)
-		. += "<span class='notice'>It's maintenance panel is open, you could probably add some oil to lubricate it.</span>" //it didnt tell the players if this was the case before.
+		. += "<span class='notice'>Its maintenance panel is open, you could probably add some oil to lubricate it.</span>" //it didnt tell the players if this was the case before.
 	if(jammed)
 		. += "<span class='notice'>It's jammed shut.</span>"	//if it's jammed, don't show durability. only thing they need to know is that it's jammed.
 	else
@@ -516,6 +519,8 @@
 			loading = FALSE
 			loaded += A
 			weardown()
+			for(var/obj/machinery/computer/ammo_sorter/AS as() in linked_consoles)
+				AS.ui_update()
 			return TRUE
 		else
 			loading = FALSE

--- a/nsv13/code/modules/munitions/ship_weapons/energy_weapons/bsa.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/energy_weapons/bsa.dm
@@ -76,10 +76,11 @@
 			break
 
 /obj/machinery/computer/sts_bsa_control/multitool_act(mob/living/user, obj/item/I)
-	. = ..()
+	..()
+	. = TRUE
 	var/obj/item/multitool/M = I
 	if(!M.buffer || !istype(M.buffer, /obj/machinery/ship_weapon/energy/beam/bsa))
-		return FALSE
+		return
 	cannon = M.buffer
 	to_chat(user, "<span class='warning'>Successfully linked to [M.buffer]...</span>")
 

--- a/nsv13/code/modules/munitions/ship_weapons/hybrid_weapons/hybrid_railgun.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/hybrid_weapons/hybrid_railgun.dm
@@ -187,6 +187,7 @@
 		"<span class='italics'>You hear a heavy electrical crack.</span>")
 
 /obj/machinery/ship_weapon/hybrid_rail/multitool_act(mob/living/user, obj/item/I)
+	. = TRUE
 	if(maint_state < 2)
 		to_chat(user, "<span class='notice'>You must first open the maintenance panel before realigning the magnetic coils.</span>")
 	else

--- a/nsv13/code/modules/overmap/armour/nano_pump.dm
+++ b/nsv13/code/modules/overmap/armour/nano_pump.dm
@@ -122,7 +122,7 @@
 				apnw = W
 
 /obj/machinery/armour_plating_nanorepair_pump/multitool_act(mob/user, obj/item/tool)
-	. = FALSE
+	. = TRUE
 	if(!multitool_check_buffer(user, tool))
 		return
 	var/obj/item/multitool/M = tool

--- a/nsv13/code/modules/overmap/radar.dm
+++ b/nsv13/code/modules/overmap/radar.dm
@@ -119,7 +119,7 @@ Called by add_sensor_profile_penalty if remove_in is used.
 /obj/machinery/computer/ship/dradis/multitool_act(mob/living/user, obj/item/I)
 	usingBeacon = !usingBeacon
 	to_chat(user, "<span class='sciradio'>You switch [src]'s trader delivery location to [usingBeacon ? "target supply beacons" : "target the default landing location on your ship"]</span>")
-	return FALSE
+	return TRUE
 
 /obj/machinery/computer/ship/dradis/minor //Secondary dradis consoles usable by people who arent on the bridge. All secondary dradis consoles should be a subtype of this
 	name = "air traffic control console"

--- a/tgui/packages/tgui/interfaces/AmmoSorter.js
+++ b/tgui/packages/tgui/interfaces/AmmoSorter.js
@@ -5,6 +5,7 @@ import { Window } from '../layouts';
 
 export const AmmoSorter = (props, context) => {
   const { act, data } = useBackend(context);
+  const [settingsVisible, setSettingsVisible] = useLocalState(context, 'settings', false);
   return (
     <Window resizable theme="hackerman">
       <Window.Content scrollable>
@@ -15,20 +16,38 @@ export const AmmoSorter = (props, context) => {
               <Fragment key={key}>
                 <Section title={`${value.name}`} buttons={
                   <Fragment>
-                    <Button
-                      content="Rename"
-                      icon="pen"
-                      onClick={() => act('rename', { id: value.id })} />
-                    <Button
-                      content="Unlink"
-                      icon="times"
-                      color="bad"
-                      onClick={() => act('unlink', { id: value.id })} />
+                    {(key == 0) && (
+                      <Button
+                        icon={settingsVisible ? 'times' : 'cog'}
+                        selected={settingsVisible}
+                        onClick={() => setSettingsVisible(!settingsVisible)} />
+                    )}
+                    {!!settingsVisible && (
+                      <Fragment>
+                        <Button
+                          content="Rename"
+                          icon="pen"
+                          onClick={() => act('rename', { id: value.id })} />
+                        <Button
+                          content="Unlink"
+                          icon="trash-alt"
+                          color="bad"
+                          onClick={() => act('unlink', { id: value.id })} />
+                        <Button
+                          icon="arrow-up"
+                          disabled={(key == 0)}
+                          onClick={() => act('moveup', { id: value.id })} />
+                        <Button
+                          icon="arrow-down"
+                          disabled={(key == data.racks_info.length - 1)}
+                          onClick={() => act('movedown', { id: value.id })} />
+                      </Fragment>
+                    )}
                   </Fragment>
                 }>
                   <Button
                     content={`Unload ${value.top}`}
-                    icon="arrow-right"
+                    icon="sign-out-alt"
                     disabled={!value.has_loaded}
                     onClick={() => act('unload', { id: value.id })} />
                 </Section>

--- a/tgui/packages/tgui/interfaces/AmmoSorter.js
+++ b/tgui/packages/tgui/interfaces/AmmoSorter.js
@@ -16,7 +16,7 @@ export const AmmoSorter = (props, context) => {
               <Fragment key={key}>
                 <Section title={`${value.name}`} buttons={
                   <Fragment>
-                    {(key == 0) && (
+                    {(key === "0") && (
                       <Button
                         icon={settingsVisible ? 'times' : 'cog'}
                         selected={settingsVisible}
@@ -35,11 +35,11 @@ export const AmmoSorter = (props, context) => {
                           onClick={() => act('unlink', { id: value.id })} />
                         <Button
                           icon="arrow-up"
-                          disabled={(key == 0)}
+                          disabled={(key === "0")}
                           onClick={() => act('moveup', { id: value.id })} />
                         <Button
                           icon="arrow-down"
-                          disabled={(key == data.racks_info.length - 1)}
+                          disabled={(key === `${data.racks_info.length - 1}`)}
                           onClick={() => act('movedown', { id: value.id })} />
                       </Fragment>
                     )}


### PR DESCRIPTION
## About The Pull Request
* Changes the way you link sorters to a console, now you select the console first and just hit all the sorters you want to connect.
* Shrinks the examine text on full sorters by an order of magnitude, and now it shows the amount it can hold.
  * also missile assemblers
* Changes some icons on the sorter console UI
* Adds a collapsing options button to the sorter console UI
* Adds buttons to the sorter console UI to change the order of them in the list
* The multitool no longer bonks any NSV13 machinery that actually has a multitool_act()
* Sorters and assemblers can be disassembled
* NSV13 machinery that can be unanchored can now also be assembled in an unanchored state
* Sorter consoles UI now updates when sorters die, and when they are loaded
## Why It's Good For The Game
nice to haves are nice to have
also you just should not be able to bash a computer to death (eventually) by using a multitool on it.
## Changelog
:cl:
add: You can change the order of ammo racks in the console
add: The options for renaming/removing ammo racks are hidden by default
tweak: The examine text for ammo racks groups items of the same type together
tweak: Ammo rack console linking is a bit easier
fix: Teaches spacemen that they don't need to hit things so hard with their multitools to make them work
/:cl:

<details>

![image](https://user-images.githubusercontent.com/23534908/177051768-2e3abf74-278b-49d0-a4ed-f7d64ee5f373.png)
![image](https://user-images.githubusercontent.com/23534908/177051821-f91de0c6-4742-44ed-91af-4a843691da6d.png)
![image](https://user-images.githubusercontent.com/23534908/177051846-8354ca03-9a25-43f8-8896-2e32ad474204.png)
![image](https://user-images.githubusercontent.com/23534908/177051854-dda706fc-15b0-4528-8769-f9ef9df1c902.png)

</details>
