### PR TITLE
Knpc pathfinding pass (and a bit of normal pathfinding)

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -168,6 +168,16 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define KNPC_IS_DOOR_BASHER 1<<4		//Does the KNPC kick the door off its hinges if it doesn't have a valid ID?
 #define KNPC_IS_DOOR_HACKER 1<<5		//Does the KNPC hack the door open if it doesn't have a valid ID?
 
+//Knpc pathfinding return values
+#define KNPC_PATHFIND_SUCCESS 0 //Path successfully generated
+#define KNPC_PATHFIND_SKIP 1 //Regenerating of path isn't needed, incapable of moving, etc
+#define KNPC_PATHFIND_TIMEOUT 2 //Pathfinding is currently in timeout due to having failed previously.
+#define KNPC_PATHFIND_FAIL 3 //No path found
+
+//Knpc pathfinding timeout defines
+#define KNPC_TIMEOUT_BASE (3 SECONDS) //The base timeout applied if an knpc's pathfinding fails.
+#define KNPC_TIMEOUT_STACK_CAP 9 //Every consecutive pathfinding fail adds a stacks; Timeout applied uses them as multiplier up to a cap of this value.
+
 //Starsystem Traits
 #define STARSYSTEM_NO_ANOMALIES 1<<0	//Prevents Anomalies Spawning
 #define STARSYSTEM_NO_ASTEROIDS 1<<1	//Prevents Asteroids Spawning

--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -168,16 +168,6 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define KNPC_IS_DOOR_BASHER 1<<4		//Does the KNPC kick the door off its hinges if it doesn't have a valid ID?
 #define KNPC_IS_DOOR_HACKER 1<<5		//Does the KNPC hack the door open if it doesn't have a valid ID?
 
-//Knpc pathfinding return values
-#define KNPC_PATHFIND_SUCCESS 0 //Path successfully generated
-#define KNPC_PATHFIND_SKIP 1 //Regenerating of path isn't needed, incapable of moving, etc
-#define KNPC_PATHFIND_TIMEOUT 2 //Pathfinding is currently in timeout due to having failed previously.
-#define KNPC_PATHFIND_FAIL 3 //No path found
-
-//Knpc pathfinding timeout defines
-#define KNPC_TIMEOUT_BASE (3 SECONDS) //The base timeout applied if an knpc's pathfinding fails.
-#define KNPC_TIMEOUT_STACK_CAP 9 //Every consecutive pathfinding fail adds a stacks; Timeout applied uses them as multiplier up to a cap of this value.
-
 //Starsystem Traits
 #define STARSYSTEM_NO_ANOMALIES 1<<0	//Prevents Anomalies Spawning
 #define STARSYSTEM_NO_ASTEROIDS 1<<1	//Prevents Asteroids Spawning

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -59,6 +59,10 @@ GLOBAL_LIST_INIT(turfs_without_ground, typecacheof(list(
 
 #define ishuman(A) (istype(A, /mob/living/carbon/human))
 
+//NSV13 - knpc helper
+#define isknpc(A) (istype(A, /mob/living/carbon/human/ai_boarder))
+//NSV13 end
+
 //Human sub-species
 #define isabductor(A) (is_species(A, /datum/species/abductor))
 #define isgolem(A) (is_species(A, /datum/species/golem))

--- a/code/__HELPERS/path.dm
+++ b/code/__HELPERS/path.dm
@@ -44,7 +44,7 @@
  * Note that this can only be used inside the [datum/pathfind][pathfind datum] since it uses variables from said datum.
  * If you really want to optimize things, optimize this, cuz this gets called a lot.
  */
-#define CAN_STEP(cur_turf, next) (next && !next.density && cur_turf.Adjacent(next) && !(simulated_only && SSpathfinder.space_type_cache[next.type]) && !cur_turf.LinkBlockedWithAccess(next,caller, id) && (next != avoid))
+#define CAN_STEP(cur_turf, next) (next && !next.density && cur_turf.Adjacent(next, ignore_objects = TRUE) && !(simulated_only && SSpathfinder.space_type_cache[next.type]) && !cur_turf.LinkBlockedWithAccess(next,caller, id) && (next != avoid))
 /// Another helper macro for JPS, for telling when a node has forced neighbors that need expanding
 #define STEP_NOT_HERE_BUT_THERE(cur_turf, dirA, dirB) ((!CAN_STEP(cur_turf, get_step(cur_turf, dirA)) && CAN_STEP(cur_turf, get_step(cur_turf, dirB))))
 

--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -24,8 +24,9 @@
 	* If you are vertically/horizontally adjacent, ensure there are no border objects
 	* If you are diagonally adjacent, ensure you can pass through at least one of the mutually adjacent square.
 		* Passing through in this case ignores anything with the LETPASSTHROW pass flag, such as tables, racks, and morgue trays.
+	* * NSV13 additionally adds an ignore_objects arg which determines if the click cross checks are skipped.
 */
-/turf/Adjacent(atom/neighbor, atom/target = null, atom/movable/mover = null)
+/turf/Adjacent(atom/neighbor, atom/target = null, atom/movable/mover = null, ignore_objects) //NS13 - ignore objects arg
 	var/turf/T0 = get_turf(neighbor)
 
 	if(T0 == src) //same turf
@@ -34,6 +35,8 @@
 	if(get_dist(src, T0) > 1 || z != T0.z) //too far
 		return FALSE
 
+	if(ignore_objects) //NSV13 - ignore_objects skips clickcross checks
+		return TRUE
 	// Non diagonal case
 	if(T0.x == x || T0.y == y)
 		// Check for border blockages

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -508,6 +508,32 @@
 	else
 		return TRUE
 
+//NSV13 - knpcs can into firelock
+/obj/machinery/door/firedoor/border_only/CanAStarPass(obj/item/card/id/ID, to_dir, atom/movable/caller)
+	if(istype(caller) && (caller.pass_flags & pass_flags_self))
+		return TRUE
+	if(!density)
+		return TRUE
+	if(!(dir in dir_to_cardinal_dirs(to_dir)))
+		return TRUE
+	if(welded)
+		return FALSE
+	if(!hasPower())
+		return isknpc(caller)
+	return TRUE
+
+/obj/machinery/door/firedoor/CanAStarPass(obj/item/card/id/ID, to_dir, atom/movable/caller)
+	if(istype(caller) && (caller.pass_flags & pass_flags_self))
+		return TRUE
+	if(!density)
+		return TRUE
+	if(welded)
+		return FALSE
+	if(!hasPower())
+		return isknpc(caller)
+	return TRUE
+//NSV13 end
+
 /obj/machinery/door/firedoor/heavy
 	name = "heavy firelock"
 	icon = 'icons/obj/doors/doorfire.dmi'

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -127,3 +127,15 @@
 	air_update_turf(1)
 	ini_dir = dir
 	add_fingerprint(user)
+
+//NSV13 - railings don't completely block the turf for A* purposes
+/obj/structure/railing/CanAStarPass(obj/item/card/id/ID, to_dir, atom/movable/caller)
+	. = ..()
+	if(.)
+		return
+	if(!(dir in dir_to_cardinal_dirs(to_dir)))
+		return TRUE
+	if(isknpc(caller))	//They can climb
+		return TRUE
+	return FALSE
+//NSV13 end

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -118,6 +118,8 @@
 
 /obj/structure/table/CanAStarPass(obj/item/card/id/ID, to_dir, atom/movable/caller)
 	. = !density
+	if(isknpc(caller)) //NSV13 - Knpcs can climb tables.
+		return TRUE
 	if(istype(caller))
 		. = . || (caller.pass_flags & PASSTABLE)
 

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -116,12 +116,26 @@
 	if(locate(/obj/structure/table) in get_turf(mover))
 		return TRUE
 
+//NSV13 - minor changes to support knpcs climbing tables.
 /obj/structure/table/CanAStarPass(obj/item/card/id/ID, to_dir, atom/movable/caller)
 	. = !density
-	if(isknpc(caller)) //NSV13 - Knpcs can climb tables.
+	if(isknpc(caller))
 		return TRUE
 	if(istype(caller))
 		. = . || (caller.pass_flags & PASSTABLE)
+
+/obj/structure/table/glass/CanAStarPass(obj/item/card/id/ID, to_dir, atom/movable/caller)
+	. = !density
+	if(istype(caller))
+		. = . || (caller.pass_flags & PASSTABLE)
+
+/obj/structure/table/glass/plasma/CanAStarPass(obj/item/card/id/ID, to_dir, atom/movable/caller) //Unfortunately this is needed because of subtypes.
+	. = !density
+	if(isknpc(caller))
+		return TRUE
+	if(istype(caller))
+		. = . || (caller.pass_flags & PASSTABLE)
+//NSV13 end
 
 /obj/structure/table/proc/tableplace(mob/living/user, mob/living/pushed_mob)
 	pushed_mob.forceMove(loc)

--- a/nsv13.dme
+++ b/nsv13.dme
@@ -3463,6 +3463,7 @@
 #include "nsv13\code\__DEFINES\localisation\_localisation.dm"
 #include "nsv13\code\__HELPERS\maths.dm"
 #include "nsv13\code\__HELPERS\matrices.dm"
+#include "nsv13\code\__HELPERS\misc.dm"
 #include "nsv13\code\__HELPERS\names.dm"
 #include "nsv13\code\__HELPERS\overmap.dm"
 #include "nsv13\code\__HELPERS\priority_announce.dm"

--- a/nsv13.dme
+++ b/nsv13.dme
@@ -3450,6 +3450,7 @@
 #include "interface\skin.dmf"
 #include "nsv13\code\__DEFINES\components.dm"
 #include "nsv13\code\__DEFINES\fleets.dm"
+#include "nsv13\code\__DEFINES\knpc.dm"
 #include "nsv13\code\__DEFINES\medal.dm"
 #include "nsv13\code\__DEFINES\missions.dm"
 #include "nsv13\code\__DEFINES\overmap.dm"

--- a/nsv13/code/__DEFINES/knpc.dm
+++ b/nsv13/code/__DEFINES/knpc.dm
@@ -1,0 +1,9 @@
+//Knpc pathfinding return values
+#define KNPC_PATHFIND_SUCCESS 0 //Path successfully generated
+#define KNPC_PATHFIND_SKIP 1 //Regenerating of path isn't needed, incapable of moving, etc
+#define KNPC_PATHFIND_TIMEOUT 2 //Pathfinding is currently in timeout due to having failed previously.
+#define KNPC_PATHFIND_FAIL 3 //No path found
+
+//Knpc pathfinding timeout defines
+#define KNPC_TIMEOUT_BASE (3 SECONDS) //The base timeout applied if an knpc's pathfinding fails.
+#define KNPC_TIMEOUT_STACK_CAP 9 //Every consecutive pathfinding fail adds a stacks; Timeout applied uses them as multiplier up to a cap of this value.

--- a/nsv13/code/__HELPERS/misc.dm
+++ b/nsv13/code/__HELPERS/misc.dm
@@ -1,0 +1,13 @@
+///This proc takes a dir and turns it into a list of its cardinal dirs. Useful for, say, handling things on multiple cardinals, and only cardinals, in case of diagonal positioning.
+/proc/dir_to_cardinal_dirs(input_dir)
+	if(input_dir in list(NORTH, EAST, SOUTH, WEST))
+		return list(input_dir)
+	switch(input_dir)
+		if(NORTHEAST)
+			return list(NORTH, EAST)
+		if(NORTHWEST)
+			return list(NORTH, WEST)
+		if(SOUTHEAST)
+			return list(SOUTH, EAST)
+		if(SOUTHWEST)
+			return list(SOUTH, WEST)

--- a/nsv13/code/__HELPERS/overmap.dm
+++ b/nsv13/code/__HELPERS/overmap.dm
@@ -1,4 +1,4 @@
-/atom/proc/get_overmap() //Helper proc to get the overmap ship representing a given area.
+/atom/proc/get_overmap(failsafe = FALSE) //Helper proc to get the overmap ship representing a given area.
 	RETURN_TYPE(/obj/structure/overmap)
 	if(isovermap(loc))
 		return loc
@@ -6,6 +6,10 @@
 		if(!loc) // Or not...
 			return FALSE
 		return loc.get_overmap() // Begin recursion!
+	if(!SSmapping.z_list) //Being called by pre-mapping init call
+		if(!failsafe) //Only retry once
+			addtimer(CALLBACK(src, .proc/get_overmap, TRUE), 30 SECONDS)
+		return FALSE
 	var/datum/space_level/SL = SSmapping.z_list[z] // Overmaps linked to Zs, like the main ship
 	if(SL?.linked_overmap)
 		return SL.linked_overmap
@@ -28,7 +32,8 @@ Helper method to get what ship an observer belongs to for stuff like parallax.
 	if(last_overmap)
 		last_overmap.mobs_in_ship -= src
 	last_overmap = OM
-	OM?.mobs_in_ship += src
+	if(OM)
+		OM.mobs_in_ship += src
 	SEND_SIGNAL(src, COMSIG_MOB_OVERMAP_CHANGE, src, OM)
 
 /// Finds a turf outside of the overmap

--- a/nsv13/code/_onclick/adjacent.dm
+++ b/nsv13/code/_onclick/adjacent.dm
@@ -5,7 +5,7 @@
 	* If you are diagonally adjacent, ensure you can pass through at least one of the mutually adjacent square.
 		* Passing through in this case ignores anything with the LETPASSTHROW pass flag, such as tables, racks, and morgue trays.
 */
-/turf/Adjacent(atom/neighbor, atom/target = null, atom/movable/mover = null)
+/turf/Adjacent(atom/neighbor, atom/target = null, atom/movable/mover = null, ignore_objects)
 	if(neighbor == src)
 		return TRUE //don't be retarded!!
 

--- a/nsv13/code/modules/overmap/knpc.dm
+++ b/nsv13/code/modules/overmap/knpc.dm
@@ -147,23 +147,23 @@ GLOBAL_LIST_EMPTY(knpcs)
 		else
 			H.m_intent = MOVE_INTENT_RUN
 
-		for(var/obj/machinery/door/firedoor/fuckingMonsterMos in next_turf)
-			if((fuckingMonsterMos.flags_1 & ON_BORDER_1) && !(fuckingMonsterMos.dir in dir_to_cardinal_dirs(get_dir(next_turf, this_turf))))
+		for(var/obj/machinery/door/firedoor/blocking_firelock in next_turf)
+			if((blocking_firelock.flags_1 & ON_BORDER_1) && !(blocking_firelock.dir in dir_to_cardinal_dirs(get_dir(next_turf, this_turf))))
 				continue
-			if(!fuckingMonsterMos.density || fuckingMonsterMos.operating)
+			if(!blocking_firelock.density || blocking_firelock.operating)
 				continue
-			if(fuckingMonsterMos.welded)
+			if(blocking_firelock.welded)
 				break	//If at least one firedoor in our way is welded shut, welp!
-			fuckingMonsterMos.open()	//Open one firelock per tile per try.
+			blocking_firelock.open()	//Open one firelock per tile per try.
 			break
-		for(var/obj/machinery/door/firedoor/fuckingMonsterMos in this_turf)
-			if(!((fuckingMonsterMos.flags_1 & ON_BORDER_1) && (fuckingMonsterMos.dir in dir_to_cardinal_dirs(get_dir(this_turf, next_turf))))) //Here, only firelocks on the border matter since fulltile firelocks let you exit.
+		for(var/obj/machinery/door/firedoor/blocking_firelock in this_turf)
+			if(!((blocking_firelock.flags_1 & ON_BORDER_1) && (blocking_firelock.dir in dir_to_cardinal_dirs(get_dir(this_turf, next_turf))))) //Here, only firelocks on the border matter since fulltile firelocks let you exit.
 				continue
-			if(!fuckingMonsterMos.density || fuckingMonsterMos.operating)
+			if(!blocking_firelock.density || blocking_firelock.operating)
 				continue
-			if(fuckingMonsterMos.welded)
+			if(blocking_firelock.welded)
 				break	//If at least one firedoor in our way is welded shut, welp!
-			fuckingMonsterMos.open()	//Open one firelock per tile per try.
+			blocking_firelock.open()	//Open one firelock per tile per try.
 			break
 		for(var/obj/structure/possible_barrier in next_turf) //If we're stuck
 			if(!climbable.Find(possible_barrier.type))

--- a/nsv13/code/modules/overmap/knpc.dm
+++ b/nsv13/code/modules/overmap/knpc.dm
@@ -19,6 +19,10 @@ GLOBAL_LIST_EMPTY(knpcs)
 	var/stealing_id = FALSE
 	var/next_internals_attempt = 0
 	var/static/list/climbable = typecacheof(list(/obj/structure/table, /obj/structure/railing)) // climbable structures
+	///If pathfinding fails, it is püt in timeout for a while to avoid spamming the server with pathfinding calls.
+	var/pathfind_timeout = 0
+	///Consecutive pathfind fails add additional delay stacks to further counteract the effects of knpcs in unreachable locations.
+	var/timeout_stacks = 0
 
 /mob/living/carbon/human/ai_boarder
 	faction = list("Neutral")
@@ -83,28 +87,28 @@ GLOBAL_LIST_EMPTY(knpcs)
 	return ..()
 
 /datum/component/knpc/proc/pathfind_to(atom/target, turf/avoid)
+	if(pathfind_timeout > 0)
+		return KNPC_PATHFIND_TIMEOUT
 	var/mob/living/carbon/human/ai_boarder/H = parent
-	if(dest && dest == get_turf(target) || H.incapacitated())
-		return FALSE //No need to recalculate this path.
+	if(target == null)
+		path = list()
+		dest = null
+		return KNPC_PATHFIND_SKIP
+	if((dest && dest == get_turf(target) && length(path)) || H.incapacitated())
+		return KNPC_PATHFIND_SKIP //No need to recalculate this path.
 	path = list()
 	dest = null
 	var/obj/item/card/id/access_card = H.wear_id
 	if(target)
 		dest = get_turf(target)
 		path = get_path_to(H, dest, 120, 0, access_card, !(H.wear_suit?.clothing_flags & STOPSPRESSUREDAMAGE && H.head?.clothing_flags & STOPSPRESSUREDAMAGE), avoid)
-
-		var/obj/structure/dense_object = locate() in get_step(H, H.dir) //If we're stuck
-		if(climbable[dense_object.type])
-			H.forceMove(get_turf(dense_object))
-			H.visible_message("<span class='warning'>[H] climbs onto [dense_object]!</span>")
-			H.Stun(2 SECONDS) //Table.
-		var/obj/machinery/door/firedoor/border_only/fuckingMonsterMos = locate() in get_step(H, H.dir)
-		if(fuckingMonsterMos)
-			fuckingMonsterMos.open()
 	//There's no valid path, try run against the wall.
 	if(!length(path) && !H.incapacitated())
-		return FALSE
-	return TRUE
+		pathfind_timeout += KNPC_TIMEOUT_BASE * (1 + timeout_stacks)
+		timeout_stacks = min(timeout_stacks+1, KNPC_TIMEOUT_STACK_CAP)
+		return KNPC_PATHFIND_FAIL
+	timeout_stacks = 0
+	return KNPC_PATHFIND_SUCCESS
 
 /datum/component/knpc/proc/next_path_step()
 	if(world.time < next_move)
@@ -112,6 +116,10 @@ GLOBAL_LIST_EMPTY(knpcs)
 	var/mob/living/carbon/human/ai_boarder/H = parent
 	next_move = world.time + H.move_delay
 	if(H.incapacitated() || H.stat == DEAD)
+		return FALSE
+	if(pathfind_timeout > 0) //Pathfinding in timeout, move around aimlessly
+		H.set_resting(FALSE, FALSE)
+		H.Move(get_step(H,pick(GLOB.cardinals)))
 		return FALSE
 	if(!path)
 		return FALSE
@@ -131,13 +139,41 @@ GLOBAL_LIST_EMPTY(knpcs)
 		last_node = null //Reset pathfinding fully.
 		return FALSE
 	if(length(path) > 1)
-		var/turf/T = path[1]
+		var/turf/next_turf = get_step_towards(H, path[1])
+		var/turf/this_turf = get_turf(H)	
 		//Walk when you see a wet floor
-		if(T.GetComponent(/datum/component/wet_floor))
+		if(next_turf.GetComponent(/datum/component/wet_floor))
 			H.m_intent = MOVE_INTENT_WALK
 		else
 			H.m_intent = MOVE_INTENT_RUN
 
+		for(var/obj/machinery/door/firedoor/fuckingMonsterMos in next_turf)
+			if((fuckingMonsterMos.flags_1 & ON_BORDER_1) && !(fuckingMonsterMos.dir in dir_to_cardinal_dirs(get_dir(next_turf, this_turf))))
+				continue
+			if(!fuckingMonsterMos.density || fuckingMonsterMos.operating)
+				continue
+			if(fuckingMonsterMos.welded)
+				break	//If at least one firedoor in our way is welded shut, welp!
+			fuckingMonsterMos.open()	//Open one firelock per tile per try.
+			break
+		for(var/obj/machinery/door/firedoor/fuckingMonsterMos in this_turf)
+			if(!((fuckingMonsterMos.flags_1 & ON_BORDER_1) && (fuckingMonsterMos.dir in dir_to_cardinal_dirs(get_dir(this_turf, next_turf))))) //Here, only firelocks on the border matter since fulltile firelocks let you exit.
+				continue
+			if(!fuckingMonsterMos.density || fuckingMonsterMos.operating)
+				continue
+			if(fuckingMonsterMos.welded)
+				break	//If at least one firedoor in our way is welded shut, welp!
+			fuckingMonsterMos.open()	//Open one firelock per tile per try.
+			break
+		for(var/obj/structure/possible_barrier in next_turf) //If we're stuck
+			if(!climbable.Find(possible_barrier.type))
+				continue
+			H.forceMove(next_turf)
+			H.visible_message("<span class='warning'>[H] climbs onto [possible_barrier]!</span>")
+			H.Stun(2 SECONDS) //Table.
+			if(get_turf(H) == path[1])
+				increment_path()
+			return TRUE
 		step_towards(H, path[1])
 		if(get_turf(H) == path[1]) //Successful move
 			increment_path()
@@ -213,6 +249,7 @@ GLOBAL_LIST_EMPTY(knpcs)
 		path = list()
 		last_node = null
 		current_goal?.get_next_patrol_node(src)
+	pathfind_timeout = max(0, pathfind_timeout - 1)
 
 /datum/ai_goal/human
 	name = "Placeholder goal" //Please keep these human readable for debugging!
@@ -319,7 +356,6 @@ This is to account for sec Ju-Jitsuing boarding commandos.
 /datum/ai_goal/human/acquire_weapon/action(datum/component/knpc/HA)
 	if(!can_action(HA))
 		return
-	HA.last_node = null //Reset their pathfinding
 	var/mob/living/carbon/human/H = HA.parent
 	var/obj/item/storage/S = H.back
 	var/obj/item/gun/target_item = null
@@ -536,7 +572,7 @@ This is to account for sec Ju-Jitsuing boarding commandos.
 	H.say(support_text)
 
 	// Call for other intelligent AIs
-	for(var/datum/component/knpc/HH as() in GLOB.knpcs - H)
+	for(var/datum/component/knpc/HH as() in GLOB.knpcs - HA)
 		var/mob/living/carbon/human/ai_boarder/other = HH.parent
 		var/obj/item/radio/headset/other_radio = other.ears
 		if(other.z != H.z || !other.can_hear() || other.incapacitated())

--- a/nsv13/code/modules/overmap/overmap.dm
+++ b/nsv13/code/modules/overmap/overmap.dm
@@ -502,7 +502,7 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 	return ..()
 
 /obj/structure/overmap/forceMove(atom/destination)
-	if(!SSmapping.level_trait(destination.z, ZTRAIT_OVERMAP))
+	if(destination && !SSmapping.level_trait(destination.z, ZTRAIT_OVERMAP))
 		return //No :)
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
At the moment, knpcs have some issues with their pathfinding and some lag generation. Additionally, normal non-knpc mobs are unable to use firelocks, even if powered.
This PR aims to improve both of these somewhat, namely, bots should be able to pass firelocks (provided they are powered), while knpcs can just generally pass any firelock that isn't sealed.
Knpcs additionally should have some minor improvements towards them, namely actually accounting for tables as things they can pass aswell as not resetting their patrol node when picking up weaponry (since, they might drop theirs quite sometimes when patrolling which would cause them to just return to their old node if such a table is close)
Additionally, knpcs now gain an increasing level of "timeout" if they find themselves unable to pathfind at all, which should serve to prevent them severely hampering processing (pathfinding through the full tree ten times a second is uh, not the best processing wise). This might lead to them behaving slightly dumber in some few cases, but should work better in general.
They also shouldn't ask themselves for assistance anymore, which led to a runtime.
Additionally fixes a few random runtimes that showed up while debugging.

Someone may want to look this over or do their own investigating because this is mild suffering:tm:
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
uhhhhhhhhhh
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: Improved some knpc pathfinding stuff.. Probably.
tweak: Things that pathfind can now pass firelocks.
fix: Knpcs no longer call themselves for backup.
fix: Fixed some random runtimes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
