### PR TITLE
Time to pump it up! Default gamemode is now set to DYNAMIC

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -89,7 +89,7 @@ ALERT_DELTA DANGER: DANGER: The automatic destruct sequence is now activated. Th
 ## GAME MODES ###
 
 #Set the Master (Default) Game Mode.
-MASTER_MODE secret_extended
+MASTER_MODE dynamic
 
 ## Uncomment to not send a roundstart intercept report. Gamemodes may override this.
 NO_INTERCEPT_REPORT


### PR DESCRIPTION


## About The Pull Request

Simply changes the master gamemode to "Dynamic"

## Why It's Good For The Game

As of late, NSV13's shipside aspect has been slightly neglected, as most of the focus
is shifted onto the overmap, this especially applies to security officers, as they usually have
no threat to take care of (and even if theres one, they'll probably take care of it quickly), making sec play very dull. Overall, if you arent involved with overmap business, you dont have much to do. This is a test to see lf this type of gameplay style suits NSV13 and could potentially make shipside less dull.

## Changelog
:cl:
config: Default gamemode is now DYNAMIC!
/:cl:


