### PR TITLE
Adds cross-server news reports for NSV specific round ends

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -314,11 +314,13 @@ GLOBAL_LIST_INIT(pda_styles, sortList(list(MONO, VT, ORBITRON, SHARE)))
 #define CLOCK_SILICONS 22
 #define CLOCK_PROSELYTIZATION 23
 #define SHUTTLE_HIJACK 24
-//Nsv13 - Galactic conquest
+//NSV13
 #define PVP_SYNDIE_WIN 25
 #define PVP_SYNDIE_LOSS 26
 #define PVP_SYNDIE_PIRATE_WIN 27
-// /Nsv
+#define SHIP_VICTORY 28
+#define SHIP_DESTROYED 29
+//NSV13
 
 #define FIELD_TURF 1
 #define FIELD_EDGE 2

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -640,12 +640,16 @@ SUBSYSTEM_DEF(ticker)
 			news_message = "The burst of energy released near [station_name()] has been confirmed as merely a test of a new weapon. However, due to an unexpected mechanical error, their communications system has been knocked offline."
 		if(SHUTTLE_HIJACK)
 			news_message = "During routine evacuation procedures, the emergency shuttle of [station_name()] had its navigation protocols corrupted and went off course, but was recovered shortly after."
+		if(SHIP_VICTORY) //NSV13 start - news reports for nsv round ends
+			news_message = "[station_name()] has successfully completed their mission and has returned to Outpost 45 for resupply and crew transfer."
+		if(SHIP_DESTROYED)
+			news_message = "[station_name()] has been defeated in combat while attempting to complete their mission."
 		if(PVP_SYNDIE_WIN)
 			news_message = "The crew of [station_name()] have been cloned and subsequently court-martialled after losing a border skirmish to the SSV Nebuchadnezzar and her crew. VICKER media would like to remind all employees to do better than that crew!"
 		if(PVP_SYNDIE_LOSS)
 			news_message = "The crew of [station_name()] successfully repelled an attempted invasion by the SSV Nebuchadnezzar and have strengthened Nanotrasen's position in the Sol sector!"
 		if(PVP_SYNDIE_PIRATE_WIN)
-			news_message = "The sol sector has fallen into anarchistic piracy, as the Tortuga raiders used the chaos of a surprise attack by Syndicate forces to seize a large amount of territory unanswered."
+			news_message = "The sol sector has fallen into anarchistic piracy, as the Tortuga raiders used the chaos of a surprise attack by Syndicate forces to seize a large amount of territory unanswered." //NSV13 end
 
 	if(news_message)
 		SStopic.crosscomms_send("news_report", news_message, news_source)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -649,7 +649,7 @@ SUBSYSTEM_DEF(ticker)
 		if(PVP_SYNDIE_LOSS)
 			news_message = "The crew of [station_name()] successfully repelled an attempted invasion by the SSV Nebuchadnezzar and have strengthened Nanotrasen's position in the Sol sector!"
 		if(PVP_SYNDIE_PIRATE_WIN)
-			news_message = "The sol sector has fallen into anarchistic piracy, as the Tortuga raiders used the chaos of a surprise attack by Syndicate forces to seize a large amount of territory unanswered." //NSV13 end
+			news_message = "The Sol sector has fallen into anarchistic piracy, as the Tortuga raiders used the chaos of a surprise attack by Syndicate forces to seize a large amount of territory unanswered." //NSV13 end
 
 	if(news_message)
 		SStopic.crosscomms_send("news_report", news_message, news_source)

--- a/nsv13/code/modules/overmap/ftl.dm
+++ b/nsv13/code/modules/overmap/ftl.dm
@@ -53,6 +53,7 @@
 			priority_announce("[station_name()] has successfully returned to [src] for resupply and crew transfer, excellent work crew.", "Naval Command")
 			GLOB.crew_transfer_risa = TRUE
 			SSticker.mode.check_finished()
+			SSticker.news_report = SHIP_VICTORY
 	if(!audio_cues?.len)
 		return FALSE
 	for(var/datum/fleet/F in fleets)

--- a/nsv13/code/modules/overmap/overmap.dm
+++ b/nsv13/code/modules/overmap/overmap.dm
@@ -478,6 +478,7 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 		priority_announce("WARNING: ([rand(10,100)]) Attempts to establish DRADIS uplink with [station_name()] have failed. Unable to ascertain operational status. Presumed status: TERMINATED","Central Intelligence Unit", 'nsv13/sound/effects/ship/reactor/explode.ogg')
 		Cinematic(CINEMATIC_NSV_SHIP_KABOOM,world)
 		SSticker.mode.check_finished(TRUE)
+		SSticker.news_report = SHIP_DESTROYED
 		SSticker.force_ending = 1
 	SEND_SIGNAL(src,COMSIG_SHIP_KILLED)
 	QDEL_LIST(current_tracers)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds cross-server news reports for returning to Outpost 45 and for the main ship exploding

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
News reports are supposed to be sent at round ends, however, NSV currently doesn't have news reports for returning to Outpost 45 and the main ship being destroyed so no news report is sent. This PR allows news reports of our victory and defeat to be sent.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Adds cross-server news reports for NSV specific round ends
spellcheck: Capitalizes Sol in a PVP news report
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
