### PR TITLE
Lets biosuits hold large internal tanks

### DIFF
--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -21,7 +21,7 @@
 	clothing_flags = THICKMATERIAL | SHOWEROKAY
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	slowdown = 1
-	allowed = list(/obj/item/tank/internals, /obj/item/tank/internals/plasmaman, /obj/item/pen, /obj/item/flashlight/pen, /obj/item/reagent_containers/dropper, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/hypospray)
+	allowed = list(/obj/item/tank/internals, /obj/item/pen, /obj/item/flashlight/pen, /obj/item/reagent_containers/dropper, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/hypospray)
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 80, "fire" = 30, "acid" = 100, "stamina" = 0)
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	strip_delay = 70

--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -21,7 +21,7 @@
 	clothing_flags = THICKMATERIAL | SHOWEROKAY
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	slowdown = 1
-	allowed = list(/obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman, /obj/item/pen, /obj/item/flashlight/pen, /obj/item/reagent_containers/dropper, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/hypospray)
+	allowed = list(/obj/item/tank/internals, /obj/item/tank/internals/plasmaman, /obj/item/pen, /obj/item/flashlight/pen, /obj/item/reagent_containers/dropper, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/hypospray)
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 80, "fire" = 30, "acid" = 100, "stamina" = 0)
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	strip_delay = 70


### PR DESCRIPTION
## About The Pull Request

Small change, lets large internal tanks fit on Biosuits.

## Why It's Good For The Game

Biosuits come in sets when you find them in their locker, and part of that set is a large internals tank. Despite this, said tank doesn't fit, the whole set is kinda made useless unless you're willing to give up your bag. I don't see why you should be forced to give your bag up, when you already chose to accept the slowdown that comes with a biosuit.

This technically turned into a port since I added this to Beestation proper - https://github.com/BeeStation/BeeStation-Hornet/pull/7281

## Changelog
:cl:
balance: Biosuits can now hold large internal tanks.
/:cl: