### PR TITLE
Reduces use of global overmap list

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -457,7 +457,7 @@
 			for(var/obj/structure/blob/B in view(scan_range, T))
 				targets += B
 	//Nsv13 start
-	for(var/A in GLOB.overmap_objects)
+	for(var/A in GLOB.overmap_objects) //Has to go through global list due to occuring on a ship's z, not the overmap.
 		var/obj/structure/overmap/target = A
 		if((get_dist(A, base) < scan_range) && can_see(base, A, scan_range) && istype(A, /obj/structure/overmap) && target.z == z)
 			if(target.pilot && !in_faction(target.pilot)) //If there is a user and they're not in our faction

--- a/nsv13/code/controllers/subsystem/starsystem.dm
+++ b/nsv13/code/controllers/subsystem/starsystem.dm
@@ -568,7 +568,7 @@ Returns a faction datum by its name (case insensitive!)
 		research_points = 0
 		scanned = TRUE
 		minor_announce("Successfully received probe telemetry. Full astrological survey of [name] complete.", "WAYFARER subsystem")
-		for(var/obj/structure/overmap/OM in GLOB.overmap_objects)
+		for(var/obj/structure/overmap/OM in GLOB.overmap_objects) //Has to go through global overmaps due to anomalies not referencing their system - probably something to change one day.
 			if(OM && OM.z == z)
 				OM.relay('nsv13/sound/effects/ship/FTL.ogg')
 		qdel(AM)
@@ -610,7 +610,7 @@ Returns a faction datum by its name (case insensitive!)
 			for(var/obj/structure/overmap/OM in affecting)
 				stop_affecting(OM)
 		return
-	for(var/obj/structure/overmap/OM as() in GLOB.overmap_objects)
+	for(var/obj/structure/overmap/OM as() in GLOB.overmap_objects) //Has to go through global overmaps due to anomalies not referencing their system - probably something to change one day.
 		if(LAZYFIND(affecting, OM))
 			continue
 		if(get_dist(src, OM) <= influence_range && OM.z == z)

--- a/nsv13/code/game/machinery/computer/salvage.dm
+++ b/nsv13/code/game/machinery/computer/salvage.dm
@@ -49,7 +49,10 @@
 	data["salvage_target_integrity"] = (linked.active_boarding_target) ? linked.active_boarding_target.obj_integrity  : 0
 	data["salvage_target_max_integrity"] = (linked.active_boarding_target) ? linked.active_boarding_target.max_integrity  : 100
 	var/list/ships = list()
-	for(var/obj/structure/overmap/OM in GLOB.overmap_objects)
+	if(!linked?.current_system)
+		data["ships"] = ships
+		return data
+	for(var/obj/structure/overmap/OM in linked.current_system.system_contents)
 		if(OM.z != linked?.z || OM.interior_mode != INTERIOR_EXCLUSIVE || OM.is_sensor_visible(linked) <= SENSOR_VISIBILITY_FAINT || OM == linked.active_boarding_target)
 			continue
 		ships[++ships.len] = list("name"=OM.name, "desc"=OM.desc, "id"="\ref[OM]")

--- a/nsv13/code/game/machinery/computer/tactical.dm
+++ b/nsv13/code/game/machinery/computer/tactical.dm
@@ -51,7 +51,9 @@
 			linked.target_lock = null
 		if("target_ship")
 			var/target_name = params["target"]
-			for(var/obj/structure/overmap/OM in GLOB.overmap_objects)
+			if(!linked?.current_system)
+				return
+			for(var/obj/structure/overmap/OM in linked.current_system.system_contents)
 				if(OM.name == target_name)
 					linked.start_lockon(OM)
 					break
@@ -85,7 +87,9 @@
 			ammo += SW.get_ammo()
 		data["weapons"] += list(list("name" = thename, "ammo" = ammo, "maxammo" = max_ammo))
 	data["ships"] = list()
-	for(var/obj/structure/overmap/OM in GLOB.overmap_objects)
+	if(!linked?.current_system)
+		return data
+	for(var/obj/structure/overmap/OM in linked.current_system.system_contents)
 		if(OM.z == linked.z && OM.faction != linked.faction && get_dist(linked, OM) <= scan_range && OM.is_sensor_visible(linked) >= SENSOR_VISIBILITY_TARGETABLE)
 			data["ships"] += list(list("name" = OM.name, "integrity" = OM.obj_integrity, "max_integrity" = OM.max_integrity, "faction" = OM.faction, \
 				"quadrant_fs_armour_current" = OM.armour_quadrants["forward_starboard"]["current_armour"], \
@@ -172,7 +176,9 @@
 	data["target_name"] = (linked.target_lock) ? linked.target_lock.name : "none"
 	var/scan_range = (linked?.dradis) ? linked.dradis.sensor_range : 45 //hide targets that are outside of sensor range to avoid cheese.
 	data["ships"] = list()
-	for(var/obj/structure/overmap/OM in GLOB.overmap_objects)
+	if(!linked?.current_system)
+		return data
+	for(var/obj/structure/overmap/OM in linked.current_system.system_contents)
 		if(OM.z == linked.z && OM.faction != linked.faction && get_dist(linked, OM) <= scan_range && OM.is_sensor_visible(linked) >= SENSOR_VISIBILITY_TARGETABLE)
 			data["ships"] += list(list("name" = OM.name, "integrity" = OM.obj_integrity, "max_integrity" = OM.max_integrity, "faction" = OM.faction, \
 				"quadrant_fs_armour_current" = OM.armour_quadrants["forward_starboard"]["current_armour"], \

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/vls.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/vls.dm
@@ -290,6 +290,8 @@
 		spawn(150)
 			light_shots_left = initial(light_shots_left) // make them reload like real people, sort of
 		return FALSE
+	if(!current_system)
+		return
 	var/datum/ship_weapon/SW = weapon_types[FIRE_MODE_FLAK]
 	var/flak_left = flak_battery_amount //Multi-flak batteries!
 	if(!ai_controlled)
@@ -300,7 +302,7 @@
 			flak_left --
 			if(flak_left <= 0)
 				return
-	for(var/obj/structure/overmap/ship in GLOB.overmap_objects)
+	for(var/obj/structure/overmap/ship in current_system.system_contents)
 		if(!ship || !istype(ship))
 			continue
 		if(ship == src || ship == last_target || ship.faction == faction || ship.z != z) //No friendly fire, don't blow up wrecks that the crew may wish to loot. For AIs, do not target our active target, and risk blowing up our precious torpedoes / missiles.
@@ -344,7 +346,7 @@
 					break
 
 	//Not currently used, but may as well keep it for reference...
-	if(flak_battery_amount > 0)
+	if(flak_battery_amount > 0 && current_system)
 		var/datum/ship_weapon/SW = weapon_types[FIRE_MODE_FLAK]
 		var/flak_left = flak_battery_amount //Multi-flak batteries!
 		if(!ai_controlled)
@@ -355,7 +357,7 @@
 				flak_left --
 				if(flak_left <= 0)
 					return
-		for(var/obj/structure/overmap/ship in GLOB.overmap_objects)
+		for(var/obj/structure/overmap/ship in current_system.system_contents)
 			if(!ship || !istype(ship))
 				continue
 			if(ship == src || ship == last_target || ship.faction == faction || ship.z != z) //No friendly fire, don't blow up wrecks that the crew may wish to loot. For AIs, do not target our active target, and risk blowing up our precious torpedoes / missiles.

--- a/nsv13/code/modules/overmap/factions.dm
+++ b/nsv13/code/modules/overmap/factions.dm
@@ -71,10 +71,9 @@ Set up relationships.
 		return
 	next_fleet_spawn = world.time + fleet_spawn_rate
 	var/datum/star_system/current_system //Dont spawn enemies where theyre currently at
-	for(var/obj/structure/overmap/OM in GLOB.overmap_objects) //The ship doesnt start with a system assigned by default
-		if(OM.role != MAIN_OVERMAP)
-			continue
-		current_system = SSstar_system.ships[OM]["current_system"]
+	var/obj/structure/overmap/main_ship = SSstar_system.find_main_overmap()
+	if(main_ship)
+		current_system = SSstar_system.ships[main_ship]["current_system"]
 	var/list/possible_spawns = list()
 	for(var/datum/star_system/starsys in SSstar_system.systems)
 		if(starsys != current_system && !starsys.hidden && (lowertext(starsys.alignment) == lowertext(src.name) || starsys.alignment == "unaligned")) //Find one of our base systems and try to send a fleet out from there.

--- a/nsv13/code/modules/overmap/fighters/control_console.dm
+++ b/nsv13/code/modules/overmap/fighters/control_console.dm
@@ -22,7 +22,7 @@
 	var/list/data = list()
 	data["fighters"] = list()
 	var/desired_trait = is_station_level(src.z) ? ZTRAIT_STATION : ZTRAIT_BOARDABLE
-	for(var/obj/structure/overmap/small_craft/OM in GLOB.overmap_objects)
+	for(var/obj/structure/overmap/small_craft/OM in GLOB.overmap_objects) //Needs to go through global list due to having to access fighters on a ship map.
 		if(!locate(OM.z) in SSmapping.levels_by_trait(desired_trait))
 			continue
 		if(LAZYFIND(current_filters, "Only Occupied Ship") && !OM.operators.len)
@@ -69,7 +69,7 @@
 				return
 			message_admins("[key_name(ui.user)] ([(ui.user.mind && ui.user.mind.antag_datums) ? "<b>Antagonist</b>" : "Non-Antagonist"]) has force-ejected every pilot from their fighter.")
 		var/desired_trait = is_station_level(src.z) ? ZTRAIT_STATION : ZTRAIT_BOARDABLE
-		for(var/obj/structure/overmap/small_craft/OM in GLOB.overmap_objects)
+		for(var/obj/structure/overmap/small_craft/OM in GLOB.overmap_objects) //Needs to go through global list due to interacting with fighters on the ship z.
 			if(!locate(OM.z) in SSmapping.levels_by_trait(desired_trait))
 				continue
 			if(action == "global_toggle")

--- a/nsv13/code/modules/overmap/fighters/vv_docking.dm
+++ b/nsv13/code/modules/overmap/fighters/vv_docking.dm
@@ -19,7 +19,7 @@
 			if("Main Ship")
 				target = SSstar_system.find_main_overmap()
 			if("Choose")
-				target = input(usr, "Select target ship:", "Select Target") as null|anything in GLOB.overmap_objects
+				target = input(usr, "Select target ship:", "Select Target") as null|anything in GLOB.overmap_objects //Needs to go through global list due to requiring access to any overmap.
 
 		var/obj/item/fighter_component/docking_computer/DC = loadout.get_slot(HARDPOINT_SLOT_DOCKING)
 		if(!DC)

--- a/nsv13/code/modules/overmap/ftl.dm
+++ b/nsv13/code/modules/overmap/ftl.dm
@@ -273,7 +273,7 @@
 	relay(ftl_drive.ftl_exit, "<span class='warning'>You feel the ship lurch to a halt</span>", loop=FALSE, channel = CHANNEL_SHIP_ALERT)
 
 	var/list/pulled = list()
-	for(var/obj/structure/overmap/SOM in GLOB.overmap_objects)
+	for(var/obj/structure/overmap/SOM in GLOB.overmap_objects) //Needs to go through global objects due to being in jumpspace not a system.
 		if(SOM.z != reserved_z)
 			continue
 		if(SOM == src)
@@ -459,7 +459,7 @@ Preset classes of FTL drive with pre-programmed behaviours
 
 /obj/machinery/computer/ship/ftl_computer/syndicate/LateInitialize()
 	. = ..()
-	for(var/obj/structure/overmap/OM in GLOB.overmap_objects)
+	for(var/obj/structure/overmap/OM in GLOB.overmap_objects) //Needs to go through global list due to filtering for any ship with importants not just the one main ship.
 		if(OM.role > NORMAL_OVERMAP && OM.faction != faction)
 			start_monitoring(OM)
 

--- a/nsv13/code/modules/overmap/knpc.dm
+++ b/nsv13/code/modules/overmap/knpc.dm
@@ -264,7 +264,7 @@ GLOBAL_LIST_EMPTY(knpcs)
 				continue
 			if(OM.occupant && !H.faction_check_mob(OM.occupant))
 				. += OM.occupant
-	for(var/obj/structure/overmap/OM as() in GLOB.overmap_objects)
+	for(var/obj/structure/overmap/OM as() in GLOB.overmap_objects) //Has to go through global objects due to happening on a ship's z level.
 		if(OM.z != H.z)
 			continue
 		if(get_dist(H, OM) > HA.view_range || !can_see(H, OM, HA.view_range))

--- a/nsv13/code/modules/overmap/overmap.dm
+++ b/nsv13/code/modules/overmap/overmap.dm
@@ -708,10 +708,12 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 		M.stop_sound_channel(channel)
 
 /obj/structure/overmap/proc/relay_to_nearby(S, message, ignore_self=FALSE, sound_range=20, faction_check=FALSE) //Sends a sound + text message to nearby ships
-	for(var/obj/structure/overmap/ship as() in GLOB.overmap_objects)
+	for(var/obj/structure/overmap/ship as() in GLOB.overmap_objects) //Might be called in hyperspace or by fighters, so shouldn't use a system check.
 		if(ignore_self)
 			if(ship == src)
 				continue
+		if(z != ship.z)	//If we aren't on the same z level this shouldn't be happening.
+			continue
 		if(get_dist(src, ship) <= sound_range) //Sound doesnt really travel in space, but space combat with no kaboom is LAME
 			if(faction_check)
 				if(src.faction == ship.faction)

--- a/nsv13/code/modules/overmap/radar.dm
+++ b/nsv13/code/modules/overmap/radar.dm
@@ -355,7 +355,7 @@ Called by add_sensor_profile_penalty if remove_in is used.
 	for(var/obj/effect/overmap_anomaly/OA in linked?.current_system?.system_contents)
 		if(OA && istype(OA) && OA.z == linked?.z)
 			blips.Add(list(list("x" = OA.x, "y" = OA.y, "colour" = "#eb9534", "name" = "[(OA.scanned) ? OA.name : "anomaly"]", opacity=showAnomalies*0.01, alignment = "uncharted")))
-	for(var/obj/structure/overmap/OM in GLOB.overmap_objects) //Iterate through overmaps in the world!
+	for(var/obj/structure/overmap/OM in GLOB.overmap_objects) //Iterate through overmaps in the world! - Needs to go through global overmaps since it may be on a ship's z level or in hyperspace.
 		var/sensor_visible = (OM != linked && OM.faction != linked.faction) ? ((overmap_dist(linked, OM) > max(sensor_range * 2, OM.sensor_profile)) ? 0 : OM.is_sensor_visible(linked)) : SENSOR_VISIBILITY_FULL //You can always see your own ship, or allied, cloaked ships.
 		if(OM.z == linked.z && sensor_visible >= SENSOR_VISIBILITY_FAINT)
 			var/inRange = (overmap_dist(linked, OM) <= max(sensor_range,OM.sensor_profile)) || OM.faction == linked.faction	//Allies broadcast encrypted IFF so we can see them anywhere.

--- a/nsv13/code/modules/power/reactor/rbmk.dm
+++ b/nsv13/code/modules/power/reactor/rbmk.dm
@@ -70,7 +70,7 @@ The reactor CHEWS through moderator. It does not do this slowly. Be very careful
 		return FALSE
 	ambient_buzz = sound
 	var/list/affecting = list() //Which mobs are we about to transmit to?
-	for(var/obj/structure/overmap/OM in GLOB.overmap_objects)
+	for(var/obj/structure/overmap/OM in GLOB.overmap_objects) //Currently needs to go through global objects due to areas not having a loc. Could probably be changed into get_overmap() for a objects within the area, although this is safer.
 		if(OM.linked_areas?.len)
 			if(src in OM.linked_areas)
 				affecting = OM.mobs_in_ship


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. This goes through all the uses of GLOB.overmap_objects(which is a large list) and swaps uses to system_contents whereever possible due to that list being much smaller than that of every single overmap objects. Additionally comments onm every place that can't have it switched out at the moment.
Also probably fixes an issue that caused nearby sound / message relaying to affect ships in different systems at times.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: Many places iterating through overmap objects should now use a smaller list where applicable.
fix: Some sounds and messages being relayed by a ship towards nearby objects should no longer work across systems.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
