### PR TITLE
Some fixes for projectiles

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -354,7 +354,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	if(!canPassSelf)	//Even if mover is unstoppable they need to bump us.
 		firstbump = src
 	if(firstbump)
-		if(mover.Bump(firstbump)==FALSE)
+		if(mover.Bump(firstbump) == 2)
 			return TRUE
 		return (mover.movement_type & PHASING)
 	return TRUE

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -354,7 +354,8 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	if(!canPassSelf)	//Even if mover is unstoppable they need to bump us.
 		firstbump = src
 	if(firstbump)
-		mover.Bump(firstbump)
+		if(mover.Bump(firstbump)==FALSE)
+			return TRUE
 		return (mover.movement_type & PHASING)
 	return TRUE
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -324,7 +324,7 @@
 /obj/item/projectile/Bump(atom/A)
 	SEND_SIGNAL(src, COMSIG_MOVABLE_BUMP, A)
 	if(!can_hit_target(A, A == original, TRUE, TRUE))
-		return FALSE
+		return 2
 	Impact(A)
 
 /**

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -324,7 +324,7 @@
 /obj/item/projectile/Bump(atom/A)
 	SEND_SIGNAL(src, COMSIG_MOVABLE_BUMP, A)
 	if(!can_hit_target(A, A == original, TRUE, TRUE))
-		return
+		return FALSE
 	Impact(A)
 
 /**

--- a/nsv13/code/game/objects/structures/barricade.dm
+++ b/nsv13/code/game/objects/structures/barricade.dm
@@ -131,21 +131,7 @@
 	if(closed || !anchored)
 		return 0
 	if(istype(leaving, /obj/item/projectile))
-		var/obj/item/projectile/S = leaving
-		if(get_turf(S.firer) == get_turf(src)) //This is a pretty safe bet to say that they're allowed to shoot through us.
-			return 0
-		if(!(direction in GLOB.cardinals)) //Sometimes shit can come in from odd angles, so we need to strip out diagonals
-			switch(direction)
-				if(NORTHEAST)
-					direction = EAST
-				if(NORTHWEST)
-					direction = WEST
-				if(SOUTHEAST)
-					direction = EAST
-				if(SOUTHWEST)
-					direction = WEST
-		if(!(dir & direction)) //This means they're not shooting the direction we're facing
-			return COMPONENT_ATOM_BLOCK_EXIT
+		return 0 //who cares lol
 
 	if(leaving.throwing)
 		if(is_wired && iscarbon(leaving)) //Leaping mob against barbed wire fails

--- a/nsv13/code/modules/projectiles/projectile.dm
+++ b/nsv13/code/modules/projectiles/projectile.dm
@@ -8,9 +8,6 @@ GLOBAL_LIST_INIT(projectile_hitbox, list(new /datum/vector2d(-2,16),\
 	var/datum/component/physics2d/physics2d = null
 	var/obj/structure/overmap/overmap_firer = null
 
-/obj/item/projectile/forceMove(atom/destination)
-	return doMove(destination)
-
 /obj/item/projectile/proc/setup_collider()
 	physics2d = AddComponent(/datum/component/physics2d)
 	physics2d.setup(GLOB.projectile_hitbox, Angle)


### PR DESCRIPTION
## About The Pull Request
* fixes projectiles flying across the map when forcemove()'d, like when they hit the edge of the looping overmap
* fixes barricades causing projectiles to get stuck on them
* fixes projectiles getting stuck on the ships that fired them
## Why It's Good For The Game
fixmangud
## Changelog
:cl:
fix: projectiles edgewarp properly again
fix: projectiles no longer get stuck on barricades
fix: projectiles no longer get stuck on ships
/:cl: