### PR TITLE
Fixes sabres being able to bring all overmap objects into a system

### DIFF
--- a/nsv13/code/modules/overmap/ftl.dm
+++ b/nsv13/code/modules/overmap/ftl.dm
@@ -279,6 +279,8 @@
 			continue
 		if(SOM == src)
 			continue
+		if(!SOM.z)
+			continue
 		LAZYADD(pulled, SOM)
 	target_system.add_ship(src) //Get the system to transfer us to its location.
 	for(var/obj/structure/overmap/SOM in pulled)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
After some reserved Z fixes, if a sabre tried to enter a system with a reserved z of 0 and nothing occupying that system, all the overmap objects would come out of storage but not be moving.

## Why It's Good For The Game
This bug is bad.

## Changelog
:cl:
fix: Fixed sabre undocking importing all the objects from nullspace
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
