### PR TITLE
Makes the title screen fit... on the screen

### DIFF
--- a/code/game/turfs/closed/_closed.dm
+++ b/code/game/turfs/closed/_closed.dm
@@ -60,6 +60,7 @@
 	icon_state = ""
 	layer = FLY_LAYER
 	bullet_bounce_sound = null
+	pixel_w = -32 //NSV13 fitting the widescreen-sized image on to the screen
 
 /turf/closed/indestructible/splashscreen/New()
 	SStitle.splash_turf = src


### PR DESCRIPTION
## About The Pull Request

The title screen's icon is always off to the right by one tile because we have widescreen enabled, this moves it to the left one tile.

## Why It's Good For The Game

It makes it not look like crap

## Changelog
:cl:
fix: fixed the title screen being aligned wrong
/:cl: