### PR TITLE
Adds selling boarder gear for cash with cargo

### DIFF
--- a/nsv13.dme
+++ b/nsv13.dme
@@ -3608,6 +3608,7 @@
 #include "nsv13\code\modules\cargo\objective_cargo.dm"
 #include "nsv13\code\modules\cargo\packs.dm"
 #include "nsv13\code\modules\cargo\exports\engineering.dm"
+#include "nsv13\code\modules\cargo\exports\syndie.dm"
 #include "nsv13\code\modules\client\zoom.dm"
 #include "nsv13\code\modules\client\loadout\loadout_donator.dm"
 #include "nsv13\code\modules\clothing\custom_clothes.dm"

--- a/nsv13/code/modules/cargo/exports/syndie.dm
+++ b/nsv13/code/modules/cargo/exports/syndie.dm
@@ -1,3 +1,5 @@
+
+//TODO: Seperate Syndicate ship exports from NT ship exports to prevent them selling their own kit for profit
 //Exports (selling stuff)
 /datum/export/gear/space/syndiehelmet/odst
 	cost = 300
@@ -33,7 +35,7 @@
 //Bounties
 /datum/bounty/item/syndicate_gear
 	name = "Syndicate Drop Trooper Equipment"
-	desc = "The scientists back home are very interested in Syndicate technology and kit. Send them a full set of drop trooper equipment and we'll compensate you for your effort."
+	description = "The scientists back home are very interested in Syndicate technology and kit. Send them a full set of drop trooper equipment and we'll compensate you for your effort."
 	reward = 5000
-	required_count = 5
-	wanted_types = list(/obj/item/clothing/head/helmet/space/syndicate/odst, /obj/item/clothing/suit/space/syndicate/odst, /obj/item/storage/backpack/duffelbag/syndie, /obj/item/gun/ballistic/automatic/c20r, obj/item/encryptionkey/syndicate)
+	required_count = 5 //Currently the combination of items isn't a requirement. Something to add later...
+	wanted_types = list(/obj/item/clothing/head/helmet/space/syndicate/odst, /obj/item/clothing/suit/space/syndicate/odst, /obj/item/storage/backpack/duffelbag/syndie, /obj/item/gun/ballistic/automatic/c20r, /obj/item/encryptionkey/syndicate)

--- a/nsv13/code/modules/cargo/exports/syndie.dm
+++ b/nsv13/code/modules/cargo/exports/syndie.dm
@@ -1,0 +1,39 @@
+//Exports (selling stuff)
+/datum/export/gear/space/syndiehelmet/odst
+	cost = 300
+	unit_name = "\improper Syndicate drop trooper space suit helmet"
+	export_types = list(/obj/item/clothing/head/helmet/space/syndicate/odst)
+
+/datum/export/gear/space/syndiesuit/odst
+	cost = 700
+	unit_name = "\improper Syndicate drop trooper space suit"
+	export_types = list(/obj/item/clothing/suit/space/syndicate/odst)
+
+/datum/export/gear/syndie_duffel
+	cost = 200
+	unit_name = "\improper Syndicate duffelbag"
+	export_types = list(/obj/item/storage/backpack/duffelbag/syndie)
+
+/datum/export/weapon/pistol
+	cost = 250
+	unit_name = "Stechkin pistol"
+	export_types = list(/obj/item/gun/ballistic/automatic/pistol)
+	include_subtypes = FALSE
+
+/datum/export/weapon/c20r
+	cost = 500
+	unit_name = "\improper C-20R SMG"
+	export_types = list(/obj/item/gun/ballistic/automatic/c20r)
+
+/datum/export/gear/syndie_headset
+	cost = 500
+	unit_name = "\improper Syndicate Headset"
+	export_types = list(/obj/item/encryptionkey/syndicate) //we're actually only interested in the encryption key
+
+//Bounties
+/datum/bounty/item/syndicate_gear
+	name = "Syndicate Drop Trooper Equipment"
+	desc = "The scientists back home are very interested in Syndicate technology and kit. Send them a full set of drop trooper equipment and we'll compensate you for your effort."
+	reward = 5000
+	required_count = 5
+	wanted_types = list(/obj/item/clothing/head/helmet/space/syndicate/odst, /obj/item/clothing/suit/space/syndicate/odst, /obj/item/storage/backpack/duffelbag/syndie, /obj/item/gun/ballistic/automatic/c20r, obj/item/encryptionkey/syndicate)


### PR DESCRIPTION
## About The Pull Request

This PR lets you sell boarder space suits, guns, headsets and duffel bags in cargo for a bit of extra cash.

## Why It's Good For The Game

Adding an incentive for players to get rid of boarders' equipment should help with the disposal of the equipment after the boarders are taken out. This also makes the equipment a bit more useful for the NT crew.

## Changelog
:cl:
add: Added the ability to sell the equipment of Syndicate boarders through cargo
add: Added a bounty for Syndicate boarder equipment to the cargo bounty console
/:cl:
