### PR TITLE
Fixes invisible bullets for Glocks and pulse rifles

### DIFF
--- a/nsv13/code/game/objects/items/custom_guns.dm
+++ b/nsv13/code/game/objects/items/custom_guns.dm
@@ -38,6 +38,7 @@
 	name = "6mm tungsten round"
 	damage = 10 //Hopefully making it bias towards armorpen should make it less likely to kill people straight out.
 	armour_penetration = 30
+	icon = 'nsv13/icons/obj/projectiles_nsv.dmi'
 	icon_state = "pdc"
 
 /obj/item/projectile/bullet/peacekeeper/stun

--- a/nsv13/code/modules/jobs/security/weapons.dm
+++ b/nsv13/code/modules/jobs/security/weapons.dm
@@ -98,7 +98,7 @@
 /obj/item/ammo_box/magazine/glock/update_icon()
     ..()
     icon_state = "[initial(icon_state)][ammo_count() ? "" : "-0"]"
-	
+
 /obj/item/ammo_casing/c9mm/rubber
 	name = "9mm rubber bullet casing"
 	desc = "A 9mm rubber bullet casing."
@@ -115,6 +115,7 @@
 	name = "9mm bullet"
 	damage = 20
 	damage_type = STAMINA
+	icon = 'nsv13/icons/obj/projectiles_nsv.dmi'
 	icon_state = "pdc"
 
 /obj/item/ammo_box/magazine/tazer_cartridge


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Gives rubber Glock and pulse rifle rounds its icon back.
An old beebase moved nsv-specific sprites to a custom folder, but these rounds are currently trying to find their sprite in the old folder. This causes the bullets to be invisible. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bullets shouldn't be invisible
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Projectiles for rubber Glock and pulse rifle bullets are no longer invisible
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
