### PR TITLE
Adds Ration Packs to Sustenance Vendors

### DIFF
--- a/code/modules/vending/sustenance.dm
+++ b/code/modules/vending/sustenance.dm
@@ -1,7 +1,7 @@
 /obj/machinery/vending/sustenance
 	name = "\improper Sustenance Vendor"
 	desc = "A vending machine which vends food, as required by section 47-C of the NT's Prisoner Ethical Treatment Agreement."
-	product_slogans = "Enjoy your meal.;Enough calories to support strenuous labor."
+	product_slogans = "Enjoy your meal.;Enough calories to support strenuous labor.;Sufficiently healthy.;Efficiently produced tofu!;Mmm! So good!;Have a meal.;You need food to live!;Have some more candy corn!;Try our new ice cups!;Rememver: Ration packs save lifes, soldier!;Don't believe the lies about ration packs.; Ration packs: custom tailored to the Spaceman's taste!"
 	product_ads = "Sufficiently healthy.;Efficiently produced tofu!;Mmm! So good!;Have a meal.;You need food to live!;Have some more candy corn!;Try our new ice cups!;Rememver: Ration packs save lifes, soldier!;Don't believe the lies about ration packs.; Ration packs: custom tailored to the Spaceman's taste!"
 	icon_state = "sustenance"
 	light_color = LIGHT_COLOR_BLUEGREEN

--- a/code/modules/vending/sustenance.dm
+++ b/code/modules/vending/sustenance.dm
@@ -5,8 +5,8 @@
 	product_ads = "Sufficiently healthy.;Efficiently produced tofu!;Mmm! So good!;Have a meal.;You need food to live!;Have some more candy corn!;Try our new ice cups!;Remember: Ration packs save lifes, soldier!;Don't believe the lies about ration packs.; Ration packs: custom tailored to the Spaceman's taste!" //NSV13 added lines referencing ration packs
 	icon_state = "sustenance"
 	light_color = LIGHT_COLOR_BLUEGREEN
-	products = list(/obj/item/reagent_containers/food/snacks/tofu/prison = 12,
-					/obj/item/reagent_containers/food/snacks/rationpack = 12,
+	products = list(/obj/item/reagent_containers/food/snacks/tofu/prison = 12, //NSV13 halved available tofu
+					/obj/item/reagent_containers/food/snacks/rationpack = 12, //NSV13 added ration packs
 					/obj/item/reagent_containers/food/drinks/ice/prison = 12,
 					/obj/item/reagent_containers/food/snacks/candy_corn/prison = 6)
 	contraband = list(/obj/item/kitchen/knife = 6,

--- a/code/modules/vending/sustenance.dm
+++ b/code/modules/vending/sustenance.dm
@@ -2,10 +2,11 @@
 	name = "\improper Sustenance Vendor"
 	desc = "A vending machine which vends food, as required by section 47-C of the NT's Prisoner Ethical Treatment Agreement."
 	product_slogans = "Enjoy your meal.;Enough calories to support strenuous labor."
-	product_ads = "Sufficiently healthy.;Efficiently produced tofu!;Mmm! So good!;Have a meal.;You need food to live!;Have some more candy corn!;Try our new ice cups!"
+	product_ads = "Sufficiently healthy.;Efficiently produced tofu!;Mmm! So good!;Have a meal.;You need food to live!;Have some more candy corn!;Try our new ice cups!;Rememver: Ration packs save lifes, soldier!;Don't believe the lies about ration packs.; Ration packs: custom tailored to the Spaceman's taste!"
 	icon_state = "sustenance"
 	light_color = LIGHT_COLOR_BLUEGREEN
-	products = list(/obj/item/reagent_containers/food/snacks/tofu/prison = 24,
+	products = list(/obj/item/reagent_containers/food/snacks/tofu/prison = 12,
+					/obj/item/reagent_containers/food/snacks/rationpack = 12,
 					/obj/item/reagent_containers/food/drinks/ice/prison = 12,
 					/obj/item/reagent_containers/food/snacks/candy_corn/prison = 6)
 	contraband = list(/obj/item/kitchen/knife = 6,

--- a/code/modules/vending/sustenance.dm
+++ b/code/modules/vending/sustenance.dm
@@ -1,8 +1,8 @@
 /obj/machinery/vending/sustenance
 	name = "\improper Sustenance Vendor"
 	desc = "A vending machine which vends food, as required by section 47-C of the NT's Prisoner Ethical Treatment Agreement."
-	product_slogans = "Enjoy your meal.;Enough calories to support strenuous labor.;Sufficiently healthy.;Efficiently produced tofu!;Mmm! So good!;Have a meal.;You need food to live!;Have some more candy corn!;Try our new ice cups!;Rememver: Ration packs save lifes, soldier!;Don't believe the lies about ration packs.; Ration packs: custom tailored to the Spaceman's taste!"
-	product_ads = "Sufficiently healthy.;Efficiently produced tofu!;Mmm! So good!;Have a meal.;You need food to live!;Have some more candy corn!;Try our new ice cups!;Rememver: Ration packs save lifes, soldier!;Don't believe the lies about ration packs.; Ration packs: custom tailored to the Spaceman's taste!"
+	product_slogans = "Enjoy your meal.;Enough calories to support strenuous labor.;Sufficiently healthy.;Efficiently produced tofu!;Mmm! So good!;Have a meal.;You need food to live!;Have some more candy corn!;Try our new ice cups!;Rememver: Ration packs save lifes, soldier!;Don't believe the lies about ration packs.; Ration packs: custom tailored to the Spaceman's taste!" //NSV13 added lines referencing ration packs
+	product_ads = "Sufficiently healthy.;Efficiently produced tofu!;Mmm! So good!;Have a meal.;You need food to live!;Have some more candy corn!;Try our new ice cups!;Remember: Ration packs save lifes, soldier!;Don't believe the lies about ration packs.; Ration packs: custom tailored to the Spaceman's taste!" //NSV13 added lines referencing ration packs
 	icon_state = "sustenance"
 	light_color = LIGHT_COLOR_BLUEGREEN
 	products = list(/obj/item/reagent_containers/food/snacks/tofu/prison = 12,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds 12 ration packs to the list of available items in the sustenance vendor and at the same time reduces the number of available soggy tofu bars by the same amount. Whether that's necessary and whether soggy tofu even needs to remain in the vendor is up for discussion.

Adds fitting text to product_slogans (the ads that the machine occasionally speaks). Also moves some text from product_adds to product_slogans so that the machine speaks those. I don't think product_adds works any more anyway.

In the future, the sustenance vendor's description should probably be changed to reflect that it's not just for prisoners, considering it's in a public space on the Aetherwhisp. Maybe a subtype for public places would be good. Or we just change the description to something more neutral, not mentioning prisoners.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Ration packs are the thing that militaries feed to their soldiers if there isn't the capacity to make actual food. We're kind of a military server, so it makes sense to have them. The atlas even has them on the mess hall tables. The Aetherwhisp has a sustenance vendor in its dining area and this seems like the perfect place to me to distribute those rations.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added ration packs to sustenance vendors
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
