### PR TITLE
prevent the SD from burning out lights

### DIFF
--- a/nsv13/code/modules/power/stormdrive.dm
+++ b/nsv13/code/modules/power/stormdrive.dm
@@ -989,10 +989,7 @@ Control Rods
 							L.flicker()
 			if(prob(1))
 				for(var/obj/machinery/light/L in orange(10, src))
-					if(prob(25))
-						L.burn_out()
-					else
-						L.flicker()
+					L.flicker()
 			if(prob(0.01))
 				for(var/obj/machinery/power/grounding_rod/R in orange(5, src))
 					R.take_damage(rand(25, 50))
@@ -1003,9 +1000,6 @@ Control Rods
 				for(var/obj/machinery/light/L in GLOB.machines)
 					if(prob(50) && shares_overmap(src, L))
 						L.flicker()
-			if(prob(5))
-				for(var/obj/machinery/light/L in orange(12, src))
-					L.burn_out() //If there are even any left by this stage
 			if(prob(0.1))
 				for(var/obj/machinery/power/grounding_rod/R in orange(8, src))
 					R.take_damage(rand(25, 75))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Prevents the Stormdrive from burning out lights, as discussed on discord

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The current meta is to have a high powered stormdrive to produce enough power for the entire ship and have spare, some ships like the aetherwhisp requires the stormdrive to be very high powered in order to power everything it needs, however this often leads to lights burning out around the ship, and plunging the whole engineering department (and sometimes the entire ship) into darkness
Replacing these lights leads to more burnouts

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: stops the stormdrive from burning out lights
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
