### PR TITLE
Probably fixes some stuff about dynamic map entrypoints

### DIFF
--- a/nsv13/code/modules/overmap/boarding/interiors.dm
+++ b/nsv13/code/modules/overmap/boarding/interiors.dm
@@ -39,6 +39,9 @@ Attempt to "board" an AI ship. You can only do this when they're low on health t
 				for(var/turf/T as () in boarding_interior.get_affected_turfs(target)) //nuke
 					T.empty()
 					CHECK_TICK
+				for(var/entry as() in interior_entry_points)
+					docking_points -= entry
+				QDEL_LIST(interior_entry_points)
 			//Free the reservation.
 			QDEL_NULL(roomReservation)
 			boarding_interior = null

--- a/nsv13/code/modules/overmap/boarding/interiors.dm
+++ b/nsv13/code/modules/overmap/boarding/interiors.dm
@@ -155,6 +155,14 @@ The meat of this file. This will instance the dropship's interior in reserved sp
 /obj/structure/overmap/proc/add_entrypoints(area/target_area)
 	for(var/obj/effect/landmark/dropship_entry/entryway in GLOB.landmarks_list)
 		if(!entryway.linked && get_area(entryway) == target_area)
+			// Please fix asteroids
+			if(roomReservation && \
+				((entryway.z != roomReservation.bottom_left_coords[3]) || \
+				(entryway.x < roomReservation.bottom_left_coords[1]) || \
+				(entryway.y < roomReservation.bottom_left_coords[2]) || \
+				(entryway.x > roomReservation.top_right_coords[1]) || \
+				(entryway.y > roomReservation.top_right_coords[2])))
+				continue
 			interior_entry_points += entryway
 			entryway.linked = src
 	if(!length(interior_entry_points))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The landmarks used for entry weren't getting deleted when the overmap was, so they could be claimed by another overmap later if they were the right type.
Fixes #2021

## Why It's Good For The Game
Stops you from ending up in the void or the husk of a destroyed sabre

## Changelog
:cl:
fix: Fixes entrypoints from dead overmaps being reused by accident
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
