### PR TITLE
Alicorn 2: The Great Smoothmove boogaloo

### DIFF
--- a/nsv13/code/datums/weapon_types.dm
+++ b/nsv13/code/datums/weapon_types.dm
@@ -378,11 +378,10 @@
 	name = "Prototype Bluespace Artillery"
 	default_projectile_type = /obj/item/projectile/bullet/prototype_bsa
 	burst_size = 1
-	fire_delay = 32 SECONDS
+	fire_delay = 22 SECONDS
 	range_modifier = 200
 	overmap_firing_sounds = list('nsv13/sound/weapons/bsa_fire.ogg')
 	overmap_select_sound = 'nsv13/sound/weapons/bsa_select.ogg'
 	ai_fire_delay = 32 SECONDS
-	lateral = TRUE
 
 

--- a/nsv13/code/modules/overmap/ai-skynet.dm
+++ b/nsv13/code/modules/overmap/ai-skynet.dm
@@ -906,7 +906,7 @@ Adding tasks is easy! Just define a datum for it.
 	allow_difficulty_scaling = FALSE
 	fighter_types = list(/obj/structure/overmap/hostile/ai/fighter)
 	supply_types = list(/obj/structure/overmap/hostile/ai/alicorn)
-	taunts = list("Ahaha... A powerful ship, a powerful gun, powerful ammunition. The graceful slaughter of a billion lives to save billions more!")
+	taunts = list("A powerful ship, a powerful gun, powerful ammunition. The graceful slaughter of a billion lives to save billions more, you'll be the first of many.")
 	fleet_trait = FLEET_TRAIT_DEFENSE
 
 

--- a/nsv13/code/modules/overmap/types/syndicate.dm
+++ b/nsv13/code/modules/overmap/types/syndicate.dm
@@ -524,12 +524,12 @@
 	ai_controlled = TRUE
 	armor = list("overmap_light" = 99, "overmap_medium" = 70, "overmap_heavy" = 65)
 	can_resupply = TRUE
-	ai_flags = AI_FLAG_DESTROYER | AI_FLAG_ELITE
+	ai_flags = AI_FLAG_BATTLESHIP | AI_FLAG_ELITE
 	combat_dice_type = /datum/combat_dice/carrier
 	ai_can_launch_fighters = TRUE
 	ai_fighter_type = list(/obj/structure/overmap/hostile/ai/fighter)
 	torpedo_type = /obj/item/projectile/guided_munition/torpedo/hellfire
-	flak_battery_amount = 2
+	flak_battery_amount = 3
 
 /obj/structure/overmap/hostile/ai/alicorn/Initialize()
 	. = ..()

--- a/nsv13/code/modules/overmap/types/syndicate.dm
+++ b/nsv13/code/modules/overmap/types/syndicate.dm
@@ -61,6 +61,10 @@
 /obj/structure/overmap/syndicate/ai/Initialize()
 	. = ..()
 	name = "[name] ([rand(0,999)])"
+	
+/obj/structure/overmap/hostile/ai/fighter/Initialize()
+	. = ..()
+	name = "[name] ([rand(0,999)])"
 
 /obj/structure/overmap/syndicate/ai/Destroy()
 	SSstar_system.bounty_pool += bounty //Adding payment for services rendered
@@ -501,16 +505,16 @@
 	weapon_types[FIRE_MODE_MISSILE] = new /datum/ship_weapon/missile_launcher(src)
 	
 /obj/structure/overmap/hostile/ai/alicorn
-	name = "The Alicorn"
+	name = "SGV Alicorn"
 	desc = "One Billion Lives!"
 	icon = 'nsv13/icons/overmap/alicorn.dmi'
 	icon_state = "alicorn"
 	faction = "hostile"
 	mass = MASS_LARGE
-	sprite_size = 96
+	sprite_size = 128
 	damage_states = FALSE
-	bound_width = 112
-	bound_height = 112
+	bound_width = 128
+	bound_height = 128
 	obj_integrity = 4750
 	max_integrity = 4750
 	integrity_failure = 4750
@@ -539,7 +543,7 @@
 	weapon_types[FIRE_MODE_FLAK] = new /datum/ship_weapon/flak(src)
 
 /obj/structure/overmap/hostile/ai/fighter
-	name = "Rattlesnake class fighter-bomber"
+	name = "Rattlesnake Strike fighter"
 	icon = 'nsv13/icons/overmap/alicorn.dmi'
 	icon_state = "alifighter"
 	damage_states = FALSE

--- a/nsv13/code/modules/overmap/weapons/projectiles_fx.dm
+++ b/nsv13/code/modules/overmap/weapons/projectiles_fx.dm
@@ -304,10 +304,10 @@ Misc projectile types, effects, think of this as the special FX file.
 	icon_state = "proto_bsa"
 	name = "Prototype BSA Round"
 	icon = 'nsv13/icons/obj/projectiles_nsv.dmi'
-	speed = 0.3
-	damage = 400
+	speed = 0.7
+	damage = 325
 	spread = 1
-	armour_penetration = 35
+	armour_penetration = 30
 	flag = "overmap_heavy"
 
 /obj/item/projectile/guided_munition


### PR DESCRIPTION

## About The Pull Request

As it turns out, having a ship sprite size that is not divisable by 32 breaks smooth movement for _**SOME**_ godforsaken reason. This fixes it, as well as slaps a few bugs that came up in testing.

## Why It's Good For The Game

The Alicorn no longer breaks features that it has nothing to do with, yay. In layman's terms, we can actually use it now.
Fix man good.

## Changelog
:cl:

tweak: tweaked the taunt the Alicorn says when it enters the system
tweak: tweaked the naming routine of the Alicorn's fighter squadron to be shorter and have random numbers assigned.
tweak: the Alicorn will now use Battleship AI instead of destroyer, hopefully meaning it'll peruse it's target a bit more ruthlessly.
balance: rebalanced the special weapon and round of the Alicorn to hopefully be a bit easier to avoid.
fix: fixed the alicorn destroying smooth movement when it so much as dares to exist.

/:cl:
