### PR TITLE
Fixes fighter fueling at any distance

### DIFF
--- a/nsv13/code/modules/overmap/fighters/fuel_tank.dm
+++ b/nsv13/code/modules/overmap/fighters/fuel_tank.dm
@@ -191,6 +191,8 @@
 
 /obj/item/cryofuel_nozzle/afterattack(atom/target, mob/user, proximity)
 	. = ..()
+	if(!proximity)
+		return
 	if(istype(target, /obj/structure/overmap/small_craft))
 		var/obj/structure/overmap/small_craft/f16 = target
 		var/obj/item/fighter_component/fuel_tank/sft = f16.loadout.get_slot(HARDPOINT_SLOT_FUEL)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fuel nozzles will now only fuel fighters when you are next to them.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #2036 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fighters can no longer be fueled at any distance
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
