### PR TITLE
Allows Brig Physician to access Galactica Brig Infirmary

### DIFF
--- a/_maps/map_files/Galactica/Galactica2.dmm
+++ b/_maps/map_files/Galactica/Galactica2.dmm
@@ -4471,7 +4471,7 @@
 "crU" = (
 /obj/machinery/door/airlock/ship/security/glass{
 	name = "Brig Infirmary";
-	req_one_access_txt = "2"
+	req_one_access_txt = list(2,34)
 	},
 /turf/open/floor/monotile/dark,
 /area/security/prison)
@@ -27942,7 +27942,7 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/airlock/ship/security/glass{
 	name = "Brig Infirmary";
-	req_one_access_txt = "2"
+	req_one_access_txt = list(2,34)
 	},
 /turf/open/floor/monotile/dark,
 /area/security/prison)
@@ -35810,7 +35810,7 @@
 	},
 /obj/machinery/door/airlock/ship/security/glass{
 	name = "Security Equipment";
-	req_one_access_txt = "2"
+	req_one_access_txt = "63"
 	},
 /turf/open/floor/monotile/dark,
 /area/security/brig)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes access on a couple of Galactica brig airlocks, allowing brig physicians to enter the brig infirmary

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Brig physicians should be able to enter their room

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Brig Physicians can now enter the Galactica brig infirmary 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
