### PR TITLE
Fixes Gauss turret deafening

### DIFF
--- a/nsv13/code/modules/munitions/ship_weapons/_ship_weapon.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/_ship_weapon.dm
@@ -51,8 +51,6 @@
 	var/maintainable = TRUE //Does the weapon require maintenance?
 	var/bang = TRUE //Is firing loud?
 	var/bang_range = 8
-	var/last_bang = 0 // performance reasons, rapid range/hearers checking is terrible
-	var/bang_list // :flushed:
 	var/auto_load = FALSE //Does the weapon feed and chamber the round once we load it?
 	var/semi_auto = FALSE //Does the weapon re-chamber for us after firing?
 
@@ -517,7 +515,7 @@
 	if(firing_sound)
 		playsound(src, firing_sound, 100, 1)
 	if(bang)
-		for(var/mob/living/M in hearers(bang_range, src)) //Burst unprotected eardrums
+		for(var/mob/living/M in get_hearers_in_view(bang_range, src)) //Burst unprotected eardrums
 			if(M.stat != DEAD && M.get_ear_protection() < 1) //checks for protection - why was this not here before???
 				M.soundbang_act(1,200,10,15)
 


### PR DESCRIPTION
Fixes #2084

## About The Pull Request

It appears I broke ship weapon deafening a while ago in an optimization pass, accidentally removing the recursive check for hearers

## Changelog
:cl:
fix: fixed ship weapon deafening not working for operators
/:cl:

