### PR TITLE
Fixes PDSR graphs

### DIFF
--- a/tgui/packages/tgui/interfaces/PDSRMainframe.js
+++ b/tgui/packages/tgui/interfaces/PDSRMainframe.js
@@ -37,7 +37,7 @@ export const PDSRMainframe = (props, context) => {
           <Section title="Reactor Containment Statistics">
             <Flex spacing={1}>
               <Flex.Item grow={1}>
-                <Section position="relative" height="100%">
+                <Section fill position="relative" height="100%">
                   <Chart.Line
                     fillPositionedParent
                     data={r_reaction_polarityData}


### PR DESCRIPTION
Fixes #1941

## About The Pull Request

The PDSR UI's graph section was not scaling properly due to exclusively using relative positions without filling, resulting in it being compressed at the top of the panel. 
The same issue has previously been encountered in the AGCNR UI (fixed in #1776)

## Changelog
:cl:
fix: fixed the PDSR graph
/:cl:
