### PR TITLE
Fixes shield FX not deleting properly

### DIFF
--- a/nsv13/code/modules/overmap/shieldgen.dm
+++ b/nsv13/code/modules/overmap/shieldgen.dm
@@ -356,6 +356,7 @@
 
 /obj/effect/temp_visual/overmap_shield_hit/Destroy()
 	overmap?.vis_contents -= src
+	overmap = null
 	return ..()
 
 /obj/machinery/shield_generator/ui_act(action, params)

--- a/nsv13/code/modules/overmap/shieldgen.dm
+++ b/nsv13/code/modules/overmap/shieldgen.dm
@@ -352,14 +352,10 @@
 	desired.Scale(resize_x,resize_y)
 	desired.Turn(overmap.angle)
 	transform = desired
-	RegisterSignal(overmap, COMSIG_MOVABLE_MOVED, .proc/track)
-
-/obj/effect/temp_visual/overmap_shield_hit/proc/track(datum/source)
-	// SIGNAL_HANDLER -- we can't use the Signal handler because parallax updating (called later down the proc chain) uses callback datums which call admin proc wrapping (contains stoplag()) for some reason, uncomment the handler if this is ever fixed/changed
-	doMove(get_turf(source))
+	overmap.vis_contents += src
 
 /obj/effect/temp_visual/overmap_shield_hit/Destroy()
-	UnregisterSignal(overmap, COMSIG_MOVABLE_MOVED)
+	overmap?.vis_contents -= src
 	return ..()
 
 /obj/machinery/shield_generator/ui_act(action, params)

--- a/nsv13/code/modules/overmap/weapons/damage.dm
+++ b/nsv13/code/modules/overmap/weapons/damage.dm
@@ -15,22 +15,13 @@ Bullet reactions
 		if(M.client)
 			shake_with_inertia(M, severity, 1)
 
-/obj/structure/overmap/proc/e()
-	while(1)
-		stoplag(1)
-		add_overlay(new /obj/effect/temp_visual/overmap_shield_hit(get_turf(src), src))
-
-/obj/structure/overmap/proc/f()
-	add_overlay(new /obj/effect/temp_visual/overmap_shield_hit(get_turf(src), src))
-
-
 /obj/structure/overmap/bullet_act(obj/item/projectile/P)
 	if(istype(P, /obj/item/projectile/beam/overmap/aiming_beam))
 		return
 	if(shields && shields.absorb_hit(P.damage))
 		var/damage_sound = pick('nsv13/sound/effects/ship/damage/shield_hit.ogg', 'nsv13/sound/effects/ship/damage/shield_hit2.ogg')
 		if(!impact_sound_cooldown)
-			add_overlay(new /obj/effect/temp_visual/overmap_shield_hit(get_turf(src), src))
+			new /obj/effect/temp_visual/overmap_shield_hit(get_turf(src), src)
 			relay(damage_sound)
 			if(P.damage >= 15) //Flak begone
 				shake_everyone(5)


### PR DESCRIPTION
Fixes #1923

## About The Pull Request

The shield hit effect was not being deleted correctly when applied as an overlay. This bug was likely causing hard deletes too

## Changelog
:cl:
fix: fixed shield hit effect
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
