### PR TITLE
Fixes fighter fuel hoses

### DIFF
--- a/nsv13/code/modules/overmap/fighters/fuel_tank.dm
+++ b/nsv13/code/modules/overmap/fighters/fuel_tank.dm
@@ -99,7 +99,7 @@
 			return
 		to_chat(user, "<span class='warning'>You grab [src]'s refuelling hose.</span>")
 		RegisterSignal(user, COMSIG_MOVABLE_MOVED, .proc/check_distance)
-		toggle_nozzle(FALSE)
+		set_nozzle(TRUE)
 		ui_interact(user)
 	else
 		ui_interact(user)
@@ -109,9 +109,9 @@
 	name = "fuel hose"
 	layer = LYING_MOB_LAYER
 
-/obj/structure/reagent_dispensers/fueltank/cryogenic_fuel/proc/toggle_nozzle(state) //@param state: are you adding or removing the nozzle. True = adding, false = removing
-	if(state)
-		var/mob/user = get_current_user() //If they let the hose snap back in, unregister this way
+/obj/structure/reagent_dispensers/fueltank/cryogenic_fuel/proc/set_nozzle(state) //@param state: are you adding or removing the nozzle. True = adding, false = removing
+	var/mob/living/user = get_current_user()
+	if(!state) //If they let the hose snap back in, unregister this way
 		if(user)
 			UnregisterSignal(user, COMSIG_MOVABLE_MOVED)
 		add_overlay("cryofuel_nozzle")
@@ -122,7 +122,7 @@
 		fuel_target = null
 	else
 		cut_overlay("cryofuel_nozzle")
-		current_beam = new(get_current_user(),src,beam_icon='nsv13/icons/effects/beam.dmi',time=INFINITY,maxdistance = INFINITY,beam_icon_state="hose",btype=/obj/effect/ebeam/fuel_hose)
+		current_beam = new(user, src, beam_icon='nsv13/icons/effects/beam.dmi',time=INFINITY,maxdistance = INFINITY,beam_icon_state="hose",btype=/obj/effect/ebeam/fuel_hose)
 		INVOKE_ASYNC(current_beam, /datum/beam.proc/Start)
 
 /obj/structure/reagent_dispensers/fueltank/cryogenic_fuel/attackby(obj/item/I, mob/user, params)
@@ -130,7 +130,7 @@
 		to_chat(user, "<span class='warning'>You slot the fuel hose back into [src]</span>")
 		UnregisterSignal(user, COMSIG_MOVABLE_MOVED) //Otherwise unregister the signal here because they put it back cleanly
 		nozzle.forceMove(src)
-		toggle_nozzle(TRUE)
+		set_nozzle(FALSE)
 	if(allow_refuel)
 		if(istype(I, /obj/item/reagent_containers))
 			to_chat(user, "<span class='warning'>You transfer some of [I]'s contents to [src].</span>") //Put anything other than cryogenic fuel in here at your own risk of having to flush out the tank and possibly wreck your fighter :)
@@ -146,9 +146,10 @@
 	START_PROCESSING(SSobj, src)
 
 /obj/structure/reagent_dispensers/fueltank/cryogenic_fuel/proc/check_distance()
-	if(get_dist(get_current_user(), src) > max_range)// because nozzle, when in storage, will actually be in nullspace.
-		toggle_nozzle(TRUE)
-		STOP_PROCESSING(SSobj,src)
+	var/mob/living/user = get_current_user()
+	if(user.z != z || get_dist(user, src) > max_range)
+		set_nozzle(FALSE)
+		STOP_PROCESSING(SSobj, src)
 		return FALSE
 	return TRUE
 


### PR DESCRIPTION
Fixes #2093

## About The Pull Request

Fighter cryo fuel lines would break if you entered another container or changed z level. 

Additionally, refueling code contained some incorrect documentation for parameters (bool parameter claimed to do the complete opposite of each state's actual outcome)

## Changelog
:cl:
fix: fixed fighter fuel hoses not disappearing when changing z
code: corrected some code documentation/behavior in fuel_tank.dm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
