### PR TITLE
Fixes z move verb working inside object contents

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -486,8 +486,10 @@
 				return FALSE
 			if(T && is_station_level(T.z))//Multiz AI viewing of boardable ship is not currently supported.
 				AI.eyeobj.forceMove(T)
+				return TRUE
 			else
 				to_chat(AI, "<span class='warning'>You cannot move here</span>")
+		return FALSE
 
 	if(isturf(loc) && zMove(UP, TRUE)) // NSV13 - No moving Z while inside another object
 		to_chat(src, "<span class='notice'>You move upwards.</span>")
@@ -505,8 +507,10 @@
 				return FALSE
 			if(T && is_station_level(T.z))//Multiz AI viewing of boardable ship is not currently supported.
 				AI.eyeobj.forceMove(T)
+				return TRUE
 			else
 				to_chat(AI, "<span class='warning'>You cannot move here</span>")
+		return FALSE
 
 	if(isturf(loc) && zMove(DOWN, TRUE)) // NSV13 - No moving Z while inside another object
 		to_chat(src, "<span class='notice'>You move down.</span>")

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -489,7 +489,7 @@
 			else
 				to_chat(AI, "<span class='warning'>You cannot move here</span>")
 
-	if(zMove(UP, TRUE))
+	if(isturf(loc) && zMove(UP, TRUE)) // NSV13 - No moving Z while inside another object
 		to_chat(src, "<span class='notice'>You move upwards.</span>")
 
 ///Moves a mob down a z level
@@ -508,7 +508,7 @@
 			else
 				to_chat(AI, "<span class='warning'>You cannot move here</span>")
 
-	if(zMove(DOWN, TRUE))
+	if(isturf(loc) && zMove(DOWN, TRUE)) // NSV13 - No moving Z while inside another object
 		to_chat(src, "<span class='notice'>You move down.</span>")
 
 ///Move a mob between z levels, if it's valid to move z's on this turf


### PR DESCRIPTION
Fixes #2076

## About The Pull Request

Fixes a bug that allowed you to move outside another atom's loc by using the z movement verbs.
Fixes a bug that allowed the physical AI core to be moved by the z movement verbs under certain scenarios.

I'm unsure if maints wanted this verb to work with fighters for z movement control so I've just left that untouched for now

## Changelog
:cl:
fix: fixed z movement verbs working inside fighters and other containers
fix: fixed z movement verbs sometimes moving the physical AI core alongside the AI eye
/:cl:

