### PR TITLE
The felinid disease now only requires either of its cures, not both

### DIFF
--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -340,14 +340,14 @@
 	spread_text = "Acute"
 	disease_flags = CURABLE|CAN_CARRY|CAN_RESIST
 	cures = list(/datum/reagent/consumable/cocoa, /datum/reagent/consumable/cocoa/hot_cocoa) //kills all the tiny cats that infected your organism
-	needs_all_cures = 0 //NSV13 - only needs hot choco or chocolate, not both.
+	needs_all_cures = FALSE //NSV13 - only needs hot choco or chocolate, not both.
 	cure_chance = 25
 	stage_prob = 3
 	agent = "Nano-feline Toxoplasmosis"
 	desc = "A lot of tiny cats in the blood that slowly turn you into a big cat."
 	is_mutagenic = TRUE //So that it won't be autocured after stage 5
 	danger = DISEASE_BIOHAZARD
-	visibility_flags = FALSE
+	visibility_flags = 0
 	stage1	= list("You feel scratching fom within.", "You hear a faint miaow somewhere really close.")
 	stage2	= list("<span class='danger'>You suppress the urge to lick yourself.</span>")
 	stage3	= list("<span class='danger'>You feel the need to cough out something fluffy.</span>", "<span class='danger'>You feel the need to scratch your neck with your foot.</span>", "<span class='danger'>You think you should adopt a cat.</span>")

--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -347,7 +347,7 @@
 	desc = "A lot of tiny cats in the blood that slowly turn you into a big cat."
 	is_mutagenic = TRUE //So that it won't be autocured after stage 5
 	danger = DISEASE_BIOHAZARD
-	visibility_flags = 0
+	visibility_flags = FALSE
 	stage1	= list("You feel scratching fom within.", "You hear a faint miaow somewhere really close.")
 	stage2	= list("<span class='danger'>You suppress the urge to lick yourself.</span>")
 	stage3	= list("<span class='danger'>You feel the need to cough out something fluffy.</span>", "<span class='danger'>You feel the need to scratch your neck with your foot.</span>", "<span class='danger'>You think you should adopt a cat.</span>")

--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -340,6 +340,7 @@
 	spread_text = "Acute"
 	disease_flags = CURABLE|CAN_CARRY|CAN_RESIST
 	cures = list(/datum/reagent/consumable/cocoa, /datum/reagent/consumable/cocoa/hot_cocoa) //kills all the tiny cats that infected your organism
+	needs_all_cures = 0 //NSV13 - only needs hot choco or chocolate, not both.
 	cure_chance = 25
 	stage_prob = 3
 	agent = "Nano-feline Toxoplasmosis"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. The disease states it needs "something that'd kill the tiny cats" and does have hot chocolate or actual chocolate as cures, but it also still has needs_all_cures as true, which, one thing that kills the tiny cats should be enough.
This'd be good to have rectified for the next time *someone* decides to hand it to a traitor.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
One chocolate-based cure should be enough to cure this disease according to its cure hint, needing both is counterintuitive.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: The felinid disease only needs either hot choco or choco powder, not both.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
