### PR TITLE
Nerfs the alien infestation event

### DIFF
--- a/code/modules/events/alien_infestation.dm
+++ b/code/modules/events/alien_infestation.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/ghost_role/alien_infestation
 	weight = 5
 
-	min_players = 20
+	min_players = 20 //NSV13 - increased to 20
 
 	dynamic_should_hijack = TRUE
 	cannot_spawn_after_shuttlecall = TRUE

--- a/code/modules/events/alien_infestation.dm
+++ b/code/modules/events/alien_infestation.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/ghost_role/alien_infestation
 	weight = 5
 
-	min_players = 10
+	min_players = 20
 
 	dynamic_should_hijack = TRUE
 	cannot_spawn_after_shuttlecall = TRUE

--- a/code/modules/events/alien_infestation.dm
+++ b/code/modules/events/alien_infestation.dm
@@ -19,7 +19,7 @@
 			return FALSE
 
 /datum/round_event/ghost_role/alien_infestation
-	announceWhen	= 400
+	announceWhen	= 300 //NSV13 - changed from 400 to 300
 
 	minimum_required = 1
 	role_name = "alien larva"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The player requirement for alien infestation was 10 people. This doubles it.
It also reduces the number of iterations of the events system before announcing the threat.

## Why It's Good For The Game
Aliens are hard and 10 people aren't enough to deal with them, and the announcement comes well after they've gotten out of hand.

## Changelog
:cl:
balance: Increased pop requirement for midround alien infestation from 10 to 20
balance: Reduced minimum iterations before announcement from 400 to 300
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
