### PR TITLE
Asteroids no longer get FTL-dragged just because someone is on them

### DIFF
--- a/nsv13/code/__DEFINES/overmap.dm
+++ b/nsv13/code/__DEFINES/overmap.dm
@@ -48,6 +48,7 @@
 #define AI_GUARD 4
 
 #define isovermap(A) (istype(A, /obj/structure/overmap))
+#define isasteroid(A) (istype(A, /obj/structure/overmap/asteroid))
 
 //Assigning player ships goes here
 

--- a/nsv13/code/modules/overmap/ftl.dm
+++ b/nsv13/code/modules/overmap/ftl.dm
@@ -149,6 +149,8 @@
 		//Ships that have a Z reserved are on the active FTL plane.
 		if(OM.reserved_z)
 			continue
+		if(isasteroid(OM))
+			continue
 		if((!length(OM.operators) && !length(OM.mobs_in_ship)) || OM.ai_controlled)	//AI ships / ships without a pilot just get put in stasis.
 			continue
 		if(same_faction_only && jumping.faction != OM.faction)	//We don't pull all small craft in the system unless we were the last ship here.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Asteroids are currently getting FTL-dragged because when people are on them they fit into the conditions checking for dragging when unloading systems to avoid sending fighters to nullspace. However, since sabres can project their own reality bubble so this isn't needed nor should asteroids be dragged in general.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Asteroids no longer get FTL-dragged.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
