### PR TITLE
Adds the design disk for railgun ammo to the prototype fighter

### DIFF
--- a/nsv13/code/modules/overmap/traders.dm
+++ b/nsv13/code/modules/overmap/traders.dm
@@ -195,7 +195,7 @@
 	desc = "Corporate approved aftermarket shipyard."
 	shortname = "MHE"
 	faction_type = FACTION_ID_NT
-	sold_items = list(/datum/trader_item/ship_repair/tier2, /datum/trader_item/flak,/datum/trader_item/fighter/light,/datum/trader_item/fighter/heavy,/datum/trader_item/fighter/utility, /datum/trader_item/fighter/judgement, /datum/trader_item/fighter/prototype)
+	sold_items = list(/datum/trader_item/ship_repair/tier2, /datum/trader_item/flak,/datum/trader_item/fighter/light,/datum/trader_item/fighter/heavy,/datum/trader_item/fighter/utility, /datum/trader_item/fighter/judgement, /datum/trader_item/fighter/prototype, /datum/trader_item/railgun_disk)
 	station_type = /obj/structure/overmap/trader/shipyard
 
 // HIM

--- a/nsv13/code/modules/overmap/traders_items.dm
+++ b/nsv13/code/modules/overmap/traders_items.dm
@@ -273,7 +273,7 @@
 
 /datum/trader_item/fighter/prototype
 	name = "SU-148 Chelyabinsk Superiority Fighter"
-	desc = "A highly experimental fighter prototype outfitted with a railgun. This absolute powerhouse balances speed, power and stealth in a package guaranteed to outclass anything the Syndicate can throw at you."
+	desc = "A highly experimental fighter prototype outfitted with a railgun. This absolute powerhouse balances speed, power and stealth in a package guaranteed to outclass anything the Syndicate can throw at you. Ammo blueprints sold seperately!"
 	price = 50000
 	stock = 1
 	unlock_path = /obj/structure/overmap/small_craft/combat/light/prototype
@@ -293,8 +293,14 @@
 						/obj/item/fighter_component/canopy/tier2,
 						/obj/item/fighter_component/docking_computer,
 						/obj/item/fighter_component/battery/tier2,
-						/obj/item/fighter_component/primary/cannon/heavy,
-						/obj/item/disk/design_disk/hybrid_rail_slugs)
+						/obj/item/fighter_component/primary/cannon/heavy)
+
+/datum/trader_item/railgun_disk
+	name = "Outdated Railgun Slug Design Disk"
+	desc = "A disk containing railgun slug blueprints."
+	price = 5000
+	stock = 1
+	unlock_path = /obj/item/disk/design_disk/hybrid_rail_slugs
 
 /datum/trader_item/fighter/syndicate
 	name = "AV-41 'Corvid' Syndicate Light Fighter"

--- a/nsv13/code/modules/overmap/traders_items.dm
+++ b/nsv13/code/modules/overmap/traders_items.dm
@@ -293,7 +293,8 @@
 						/obj/item/fighter_component/canopy/tier2,
 						/obj/item/fighter_component/docking_computer,
 						/obj/item/fighter_component/battery/tier2,
-						/obj/item/fighter_component/primary/cannon/heavy)
+						/obj/item/fighter_component/primary/cannon/heavy,
+						/obj/item/disk/design_disk/hybrid_rail_slugs)
 
 /datum/trader_item/fighter/syndicate
 	name = "AV-41 'Corvid' Syndicate Light Fighter"


### PR DESCRIPTION
## About The Pull Request
Does what it says


## Why It's Good For The Game
Being able to make ammo for your gun makes it a lot more useful.

## Changelog
:cl:
balance: Prototype fighters now come with railgun ammo blueprints
/:cl:
