### PR TITLE
Improves Peacekeeper Barricade code

### DIFF
--- a/nsv13/code/game/objects/structures/barricade.dm
+++ b/nsv13/code/game/objects/structures/barricade.dm
@@ -415,11 +415,6 @@
 
 /obj/structure/peacekeeper_barricade/AltClick(mob/user)
 	. = ..()
-	if(!isliving(user))
-		return
-	var/mob/living/living_user
-	if(!Adjacent(living_user) || living_user.incapacitated())
-		return
 	revrotate()
 
 /obj/structure/peacekeeper_barricade/verb/rotate()
@@ -427,6 +422,11 @@
 	set category = "Object"
 	set src in oview(1)
 
+	if(!isliving(usr))
+		return FALSE
+	var/mob/living/living_user = usr
+	if(!Adjacent(living_user) || living_user.incapacitated())
+		return FALSE
 	if(anchored)
 		to_chat(usr, "<span class='warning'>It is fastened to the floor, you can't rotate it!</span>")
 		return FALSE
@@ -439,6 +439,11 @@
 	set category = "Object"
 	set src in oview(1)
 
+	if(!isliving(usr))
+		return FALSE
+	var/mob/living/living_user = usr
+	if(!Adjacent(living_user) || living_user.incapacitated())
+		return FALSE
 	if(anchored)
 		to_chat(usr, "<span class='warning'>It is fastened to the floor, you can't rotate it!</span>")
 		return FALSE

--- a/nsv13/code/game/objects/structures/barricade.dm
+++ b/nsv13/code/game/objects/structures/barricade.dm
@@ -221,17 +221,15 @@
 	//	climbable = FALSE
 		return FALSE
 
-	if(istype(I, /obj/item/wirecutters))
+	if(I.tool_behaviour == TOOL_WIRECUTTER)
 		if(!is_wired)
 			return
 
 		user.visible_message("<span class='notice'>[user] starts to remove the barbed wire on [src].</span>",
 		"<span class='notice'>You begin removing the barbed wire on [src].</span>")
-
-		if(!do_after(user, 20, target=src))
+		if(!I.use_tool(src, user, 20, volume=25))
 			return
 
-		playsound(loc, 'sound/items/wirecutter.ogg', 25, 1)
 		user.visible_message("<span class='notice'>[user] removes the barbed wire on [src].</span>",
 		"<span class='notice'>You remove the barbed wire on [src].</span>")
 		overlays -= wired_overlay
@@ -243,8 +241,7 @@
 		climbable = TRUE
 		new /obj/item/stack/barbed_wire(loc)
 
-	if(istype(I, /obj/item/weldingtool))
-		var/obj/item/weldingtool/WT = I
+	if(I.tool_behaviour == TOOL_WELDER)
 		if(obj_integrity <= max_integrity * 0.3)
 			to_chat(user, "<span class='warning'>[src] has sustained too much structural damage to be repaired.</span>")
 			return
@@ -253,30 +250,24 @@
 			to_chat(user, "<span class='warning'>[src] doesn't need repairs.</span>")
 			return
 
-		if(!WT.use())
+		if(!I.tool_start_check(user, 1))
 			return
 
 		user.visible_message("<span class='notice'>[user] begins repairing damage to [src].</span>",
 		"<span class='notice'>You begin repairing the damage to [src].</span>")
-		playsound(loc, 'sound/items/welder2.ogg', 25, 1)
 
-		var/old_loc = loc
-		if(!do_after(user, 50, target=src) || old_loc != loc)
+		if(!I.use_tool(src, user, 50, 1, volume=25))
 			return
 
 		user.visible_message("<span class='notice'>[user] repairs some damage on [src].</span>",
 		"<span class='notice'>You repair [src].</span>")
 		obj_integrity += 150
 		update_health()
-		playsound(loc, 'sound/items/welder2.ogg', 25, 1)
 
 	switch(build_state)
 		if(2) //Fully constructed step. Use screwdriver to remove the protection panels to reveal the bolts
-			if(istype(I, /obj/item/screwdriver))
-
-				playsound(loc, 'sound/items/screwdriver.ogg', 25, 1)
-
-				if(!do_after(user, 10, src))
+			if(I.tool_behaviour == TOOL_SCREWDRIVER)
+				if(!I.use_tool(src, user, 10, volume=25))
 					return
 
 				user.visible_message("<span class='notice'>[user] removes [src]'s protection panel.</span>",
@@ -284,10 +275,8 @@
 				build_state = 1
 				return FALSE
 		if(1) //Protection panel removed step. Screwdriver to put the panel back, wrench to unsecure the anchor bolts
-			if(istype(I, /obj/item/screwdriver))
-
-				playsound(loc, 'sound/items/screwdriver.ogg', 25, 1)
-				if(!do_after(user, 10, target=src))
+			if(I.tool_behaviour == TOOL_SCREWDRIVER)
+				if(!I.use_tool(src, user, 10, volume=25))
 					return
 
 				user.visible_message("<span class='notice'>[user] set [src]'s protection panel back.</span>",
@@ -295,10 +284,8 @@
 				build_state = 2
 				return FALSE
 
-			else if(istype(I, /obj/item/wrench))
-
-				playsound(loc, 'sound/items/ratchet.ogg', 25, 1)
-				if(!do_after(user, 10, src))
+			else if(I.tool_behaviour == TOOL_WRENCH)
+				if(!I.use_tool(src, user, 10, volume=25))
 					return
 
 				user.visible_message("<span class='notice'>[user] loosens [src]'s anchor bolts.</span>",
@@ -308,14 +295,13 @@
 				update_icon() //unanchored changes layer
 				return FALSE
 		if(0) //Anchor bolts loosened step. Apply crowbar to unseat the panel and take apart the whole thing. Apply wrench to resecure anchor bolts
-			if(istype(I, /obj/item/wrench))
+			if(I.tool_behaviour == TOOL_WRENCH)
 				for(var/obj/structure/peacekeeper_barricade/B in loc)
 					if(B != src && B.dir == dir)
 						to_chat(user, "<span class='warning'>There's already a barricade here.</span>")
 						return
 
-				playsound(loc, 'sound/items/ratchet.ogg', 25, 1)
-				if(!do_after(user, 10, src))
+				if(!I.use_tool(src, user, 10, volume=25))
 					return
 
 				user.visible_message("<span class='notice'>[user] secures [src]'s anchor bolts.</span>",
@@ -325,18 +311,16 @@
 				update_icon() //unanchored changes layer
 				return FALSE
 
-			else if(istype(I, /obj/item/crowbar))
+			else if(I.tool_behaviour == TOOL_CROWBAR)
 
 				user.visible_message("<span class='notice'>[user] starts unseating [src]'s panels.</span>",
 				"<span class='notice'>You start unseating [src]'s panels.</span>")
 
-				playsound(loc, 'sound/items/crowbar.ogg', 25, 1)
-				if(!do_after(user, 50, src))
+				if(!I.use_tool(src, user, 50, volume=25))
 					return
 
 				user.visible_message("<span class='notice'>[user] takes [src]'s panels apart.</span>",
 				"<span class='notice'>You take [src]'s panels apart.</span>")
-				playsound(loc, 'sound/items/deconstruct.ogg', 25, 1)
 				destroy_structure(TRUE) //Note : Handles deconstruction too !
 				return FALSE
 	. = ..()
@@ -431,6 +415,11 @@
 
 /obj/structure/peacekeeper_barricade/AltClick(mob/user)
 	. = ..()
+	if(!isliving(user))
+		return
+	var/mob/living/living_user
+	if(!Adjacent(living_user) || living_user.incapacitated())
+		return
 	revrotate()
 
 /obj/structure/peacekeeper_barricade/verb/rotate()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Peacekeeper barricades were not using proper tool handling and also could be turned when not supposed to be able to. This improves the handling of both.

Fixes #1731 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Peacekeeper barricades now use proper tool checks.
fix: Peacekeeper barricades can no longer be rotated by nonliving things like cameras.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
