### PR TITLE
Tweaks ammo sorter repairs and fighter armor repairs

### DIFF
--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/automation.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/automation.dm
@@ -334,53 +334,68 @@
 	var/list/loaded = list() //What's loaded in?
 	var/max_capacity = 12	//Max cap for holding.
 	var/loading = FALSE
-	var/durability = 100 //max durability: 100.
+	var/durability = 100
+	var/max_durability = 100
+	var/repair_multiplier = 10 // How many points of durability we repair per unit of oil
 	var/jammed = FALSE //if at 0 durability, jam it, handled in weardown().
 	var/jamchance = 0 //probability to jam every weardown
+	var/busy = FALSE
 
 /obj/machinery/ammo_sorter/attackby(obj/item/I, mob/user, params)
 	if(default_unfasten_wrench(user, I))
 		return
 	if(default_deconstruction_screwdriver(user, icon_state, icon_state, I))
+		busy = FALSE // Just in case it gets stuck somehow, you can reset it
 		update_icon()
 		return
 	if(default_deconstruction_crowbar(I))
 		return
+	if(busy)
+		to_chat(user, "<span class='warning'>Someone's already working on [src]!</span>")
+		return TRUE
 	if(panel_open && istype(I, /obj/item/reagent_containers))
 		if(!jammed)
 			if(durability < 100)
-				if(I.reagents.has_reagent(/datum/reagent/oil, 1))
+				if(I.reagents.has_reagent(/datum/reagent/oil))
+					// get how much oil we have
+					var/oil_amount = min(I.reagents.get_reagent_amount(/datum/reagent/oil), max_durability/repair_multiplier)
+					var/oil_needed = CLAMP(round((max_durability-durability)/repair_multiplier), 1, oil_amount)
+					oil_amount = min(oil_amount, oil_needed)
 					to_chat(user, "<span class='notice'>You start lubricating the inner workings of [src]...</span>")
-					if(!do_after(user, 1 SECONDS, target=src))
+					busy = TRUE
+					if(!do_after(user, 5 SECONDS, target=src))
+						busy = FALSE
 						return
-					if(!I.reagents.has_reagent(/datum/reagent/oil, 1)) //things can change, check again.
+					if(!I.reagents.has_reagent(/datum/reagent/oil, oil_amount)) //things can change, check again.
 						to_chat(user, "<span class='notice'>You don't have enough oil left to lubricate [src]!</span>")
-						return
+						busy = FALSE
+						return TRUE
 					to_chat(user, "<span class='notice'>You lubricate the inner workings of [src].</span>")
-					durability += 10
-					if(durability > 100) //if we did an oopsie, set it back to 100.
-						durability = 100
-					I.reagents.remove_reagent(/datum/reagent/oil, 1)
+					durability = min(durability + (oil_amount * repair_multiplier), max_durability)
+					I.reagents.remove_reagent(/datum/reagent/oil, oil_amount)
+					busy = FALSE
 					return TRUE
-				else if(I.reagents.has_reagent(/datum/reagent/oil))
-					to_chat(user, "<span class='notice'>You need at least 1 unit of oil to lubricate [src]!</span>")
-					return
 				else
 					to_chat(user, "<span class='notice'>You need oil to lubricate this!</span>")
-					return
+					return TRUE
 			else
 				to_chat(user, "<span class='notice'>[src] doesn't need any oil right now!</span>")
+				return TRUE
 		else
 			to_chat(user, "<span class='notice'>You can't lubricate a jammed machine!</span>")
-	if(jammed && istype(I, /obj/item/crowbar))
+			return TRUE
+	if(jammed && I.tool_behaviour == TOOL_CROWBAR)
 		if(!panel_open)
+			busy = TRUE
 			to_chat(user, "<span class='notice'>You begin clearing the jam...</span>")
 			if(!do_after(user, 10 SECONDS, target=src))
+				busy = FALSE
 				return
 			to_chat(user, "<span class='notice'>You clear the jam with the crowbar.</span>")
 			playsound(src, 'nsv13/sound/effects/ship/mac_load_unjam.ogg', 100, 1)
 			jammed = FALSE
 			durability += rand(0,5) //give the poor fools a few more uses if they're lucky
+			busy = FALSE
 		else
 			to_chat(user, "<span class='notice'>You need to close the panel to get at the jammed machinery.</span>")
 		return TRUE

--- a/nsv13/code/modules/overmap/fighters/_fighters.dm
+++ b/nsv13/code/modules/overmap/fighters/_fighters.dm
@@ -745,6 +745,7 @@ Been a mess since 2018, we'll fix it someday (probably)
 		return TRUE
 	if(busy)
 		to_chat(user, "<span class='warning'>Someone's already repairing [src]!</span>")
+		return TRUE
 	busy = TRUE
 	to_chat(user, "<span class='notice'>You start welding some dents out of [src]'s hull...</span>")
 	if(I.use_tool(src, user, ((max_integrity-obj_integrity) / repair_speed) SECONDS, volume=100))
@@ -970,6 +971,7 @@ due_to_damage: If the removal was caused voluntarily (FALSE), or if it was cause
 		return TRUE
 	if(busy)
 		to_chat(user, "<span class='warning'>Someone's already repairing [src]!</span>")
+		return TRUE
 	busy = TRUE
 	to_chat(user, "<span class='notice'>You start welding some dents out of [src]...</span>")
 	if(I.use_tool(src, user, ((max_integrity-obj_integrity) / repair_speed) SECONDS, volume=100))

--- a/nsv13/code/modules/overmap/fighters/_fighters.dm
+++ b/nsv13/code/modules/overmap/fighters/_fighters.dm
@@ -743,6 +743,8 @@ Been a mess since 2018, we'll fix it someday (probably)
 	if(obj_integrity >= max_integrity)
 		to_chat(user, "<span class='notice'>[src] isn't in need of repairs.</span>")
 		return TRUE
+	if(busy)
+		to_chat(user, "<span class='warning'>Someone's already repairing [src]!</span>")
 	busy = TRUE
 	to_chat(user, "<span class='notice'>You start welding some dents out of [src]'s hull...</span>")
 	if(I.use_tool(src, user, ((max_integrity-obj_integrity) / repair_speed) SECONDS, volume=100))

--- a/nsv13/code/modules/overmap/fighters/_fighters.dm
+++ b/nsv13/code/modules/overmap/fighters/_fighters.dm
@@ -52,7 +52,6 @@ Been a mess since 2018, we'll fix it someday (probably)
 	var/mutable_appearance/canopy
 	var/random_name = TRUE
 	overmap_verbs = list(.verb/toggle_brakes, .verb/toggle_inertia, .verb/toggle_safety, .verb/show_dradis, .verb/cycle_firemode, .verb/show_control_panel, .verb/change_name, .verb/countermeasure)
-	var/repair_speed = 25 // How much integrity you can repair per second
 	var/busy = FALSE
 
 /obj/structure/overmap/small_craft/Destroy()
@@ -748,9 +747,15 @@ Been a mess since 2018, we'll fix it someday (probably)
 		return TRUE
 	busy = TRUE
 	to_chat(user, "<span class='notice'>You start welding some dents out of [src]'s hull...</span>")
-	if(I.use_tool(src, user, ((max_integrity-obj_integrity) / repair_speed) SECONDS, volume=100))
-		to_chat(user, "<span class='notice'>You weld some dents out of [src]'s hull.</span>")
-		obj_integrity = max_integrity
+	while(obj_integrity < max_integrity)
+		if(!I.use_tool(src, user, 1 SECONDS, volume=100))
+			busy = FALSE
+			return TRUE
+		obj_integrity += 25
+		if(obj_integrity >= max_integrity)
+			obj_integrity = max_integrity
+			break
+	to_chat(user, "<span class='notice'>You finish welding[obj_integrity == max_integrity ? "" : " some of"] the dents out of [src]'s hull.</span>")
 	busy = FALSE
 	return TRUE
 
@@ -974,11 +979,15 @@ due_to_damage: If the removal was caused voluntarily (FALSE), or if it was cause
 		return TRUE
 	busy = TRUE
 	to_chat(user, "<span class='notice'>You start welding some dents out of [src]...</span>")
-	if(I.use_tool(src, user, ((max_integrity-obj_integrity) / repair_speed) SECONDS, volume=100))
-		to_chat(user, "<span class='notice'>You repair [src].</span>")
-		obj_integrity = max_integrity
-		busy = FALSE
-		return TRUE
+	while(obj_integrity < max_integrity)
+		if(!I.use_tool(src, user, 1 SECONDS, volume=100))
+			busy = FALSE
+			return TRUE
+		obj_integrity += 25
+		if(obj_integrity >= max_integrity)
+			obj_integrity = max_integrity
+			break
+	to_chat(user, "<span class='notice'>You finish welding[obj_integrity == max_integrity ? "" : " some of"] the dents out of [src].</span>")
 	busy = FALSE
 
 /obj/item/fighter_component/armour_plating/tier2

--- a/nsv13/code/modules/overmap/fighters/_fighters.dm
+++ b/nsv13/code/modules/overmap/fighters/_fighters.dm
@@ -52,6 +52,8 @@ Been a mess since 2018, we'll fix it someday (probably)
 	var/mutable_appearance/canopy
 	var/random_name = TRUE
 	overmap_verbs = list(.verb/toggle_brakes, .verb/toggle_inertia, .verb/toggle_safety, .verb/show_dradis, .verb/cycle_firemode, .verb/show_control_panel, .verb/change_name, .verb/countermeasure)
+	var/repair_speed = 25 // How much integrity you can repair per second
+	var/busy = FALSE
 
 /obj/structure/overmap/small_craft/Destroy()
 	var/mob/last_pilot = pilot // Old pilot gets first shot
@@ -741,11 +743,13 @@ Been a mess since 2018, we'll fix it someday (probably)
 	if(obj_integrity >= max_integrity)
 		to_chat(user, "<span class='notice'>[src] isn't in need of repairs.</span>")
 		return TRUE
+	busy = TRUE
 	to_chat(user, "<span class='notice'>You start welding some dents out of [src]'s hull...</span>")
-	if(I.use_tool(src, user, 4 SECONDS, volume=100))
+	if(I.use_tool(src, user, ((max_integrity-obj_integrity) / repair_speed) SECONDS, volume=100))
 		to_chat(user, "<span class='notice'>You weld some dents out of [src]'s hull.</span>")
-		obj_integrity += min(10, max_integrity-obj_integrity)
-		return TRUE
+		obj_integrity = max_integrity
+	busy = FALSE
+	return TRUE
 
 /obj/structure/overmap/small_craft/InterceptClickOn(mob/user, params, atom/target)
 	if(user.incapacitated() || !isliving(user))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This makes it so that lubricating ammo sorters and repairing fighter armor can be done in one do_after action. The time of the action scales with how much repair is needed on the given object.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
QOL is nice. Having to spam-click something isn't. 

## Changelog
:cl:
tweak: Tweaks repairing ammo sorters.
tweak: Tweaks repairing fighters and fighter armor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
