### PR TITLE
Fixes ammo sorters on Shrike having too little capacity

### DIFF
--- a/_maps/map_files/Shrike/Shrike2.dmm
+++ b/_maps/map_files/Shrike/Shrike2.dmm
@@ -4147,8 +4147,7 @@
 /turf/open/floor/monotile/steel,
 /area/quartermaster/storage)
 "oM" = (
-/obj/machinery/ammo_sorter{
-	max_capacity = 20;
+/obj/machinery/ammo_sorter/upgraded{
 	name = "Railgun Slug Rack I"
 	},
 /obj/item/ship_weapon/ammunition/railgun_ammo,
@@ -5750,8 +5749,7 @@
 /obj/item/ship_weapon/ammunition/railgun_ammo,
 /obj/item/ship_weapon/ammunition/railgun_ammo,
 /obj/item/ship_weapon/ammunition/railgun_ammo,
-/obj/machinery/ammo_sorter{
-	max_capacity = 20;
+/obj/machinery/ammo_sorter/upgraded{
 	name = "Railgun Slug Rack III"
 	},
 /turf/open/floor/plasteel/dark/side{
@@ -12145,8 +12143,7 @@
 /obj/item/ship_weapon/ammunition/railgun_ammo,
 /obj/item/ship_weapon/ammunition/railgun_ammo,
 /obj/item/ship_weapon/ammunition/railgun_ammo,
-/obj/machinery/ammo_sorter{
-	max_capacity = 20;
+/obj/machinery/ammo_sorter/upgraded{
 	name = "Railgun Slug Rack II"
 	},
 /turf/open/floor/plasteel/dark,


### PR DESCRIPTION
## About The Pull Request

Added an upgraded version of the ammo sorter to use on the Shrike.
Also added the option to force loading ammo into sorters (bypasses jamming but not capacity)

## Why It's Good For The Game

Fits the original intent of the map. The added matter bins can't be deconstructed for extra materials so that's not a big concern.
fixes #2122 

## Changelog
:cl:
fix: Fixed railgun ammo racks on Shrike not storing all rounds.
/:cl:
