### PR TITLE
Tycoon fixes

### DIFF
--- a/_maps/map_files/Tycoon/Tycoon2.dmm
+++ b/_maps/map_files/Tycoon/Tycoon2.dmm
@@ -5760,9 +5760,6 @@
 /turf/open/floor/monotile/light,
 /area/medical/virology)
 "aop" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -19513,6 +19510,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/holopad,
 /turf/open/floor/carpet/red,
 /area/security/warden)
 "aYs" = (
@@ -47173,6 +47171,10 @@
 /obj/item/wrench,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"ncj" = (
+/obj/machinery/holopad,
+/turf/open/floor/monotile/dark,
+/area/security/brig)
 "ncH" = (
 /obj/item/paper{
 	desc = "You can make out a few squiggles that look like a ragnarok class heavy cruiser with an approval seal hastily crayon'd in. The ship looks like a mess.";
@@ -50231,6 +50233,16 @@
 	},
 /turf/open/floor/plasteel/grid/steel,
 /area/engine/engineering/reactor_core)
+"spj" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = -30
+	},
+/turf/open/floor/monotile/steel,
+/area/security/brig)
 "sqw" = (
 /obj/structure/closet/crate{
 	opened = 1
@@ -73018,7 +73030,7 @@ aaV
 aHQ
 aIa
 byP
-aFO
+spj
 bgw
 aFO
 aXC
@@ -73533,7 +73545,7 @@ aHX
 aFP
 byV
 bDa
-aFP
+ncj
 bZm
 aXE
 aXH


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds holopads and pepper spray refillers to the brig and wardens office and removes the fire alarm in the virology pen
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fixes #2058

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>

![tycoonbrig](https://user-images.githubusercontent.com/95106800/199667509-5e51e1bb-4f01-45ed-bc87-db4712f5f847.PNG)

Brig with added holopads and pepper spray refilled

![tycoonvirology](https://user-images.githubusercontent.com/95106800/199667577-93998119-8178-4792-9e53-e9fe2b4f4446.PNG)

Virology fire alarm removed
<summary>Screenshots&Videos</summary>

</details>

## Changelog
:cl:
add: holopads added to Tycoon brig and Wardens office
add: pepper spray refill added to Tycoon brig
del: virology pen fire alarm removed from Tycoon
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
