### PR TITLE
Adds metrics tracking for TiDi and harddels

### DIFF
--- a/code/controllers/subsystem/metrics.dm
+++ b/code/controllers/subsystem/metrics.dm
@@ -39,6 +39,11 @@ SUBSYSTEM_DEF(metrics)
 	out["elapsed_processed"] = world.time
 	out["elapsed_real"] = (REALTIMEOFDAY - world_init_time)
 	out["client_count"] = length(GLOB.clients)
+	out["time_dilation_current"] = SStime_track.time_dilation_current
+	out["time_dilation_1m"] = SStime_track.time_dilation_avg
+	out["time_dilation_5m"] = SStime_track.time_dilation_avg_slow
+	out["time_dilation_15m"] = SStime_track.time_dilation_avg_fast
+	out["harddel_count"] = length(GLOB.world_qdel_log)
 	out["round_id"] = text2num(GLOB.round_id) // This is so we can filter the metrics by a single round ID
 
 	var/server_name = CONFIG_GET(string/serversqlname)


### PR DESCRIPTION
Copy from my upstream PR: https://github.com/BeeStation/BeeStation-Hornet/pull/8007

-----

## About The Pull Request

Adds TiDi stats and a count of harddels to our metrics json blob.

## Why It's Good For The Game

Better data means better decision making

## Testing Photographs and Procedure

Outputted the metrics through the debug proc. 

```json
{
    "@timestamp": "2022-11-01T13:01:24",
    "cpu": 12.8008,
    "maptick": 0.46314,
    "elapsed_processed": 993,
    "elapsed_real": 1615,
    "client_count": 1,
    "time_dilation_current": 0,
    "time_dilation_1m": 1.7238,
    "time_dilation_5m": 0.3927,
    "time_dilation_15m": 2.499,
    "harddel_count": 38,
    "round_id": 47,
[...]
}
```

## Changelog
:cl:
server: Adds time dilation tracking and harddel counts to the elastic metrics blob
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
