### PR TITLE
Fixes some logout runtimes

### DIFF
--- a/code/datums/elements/weather_listener.dm
+++ b/code/datums/elements/weather_listener.dm
@@ -25,7 +25,7 @@
 		playlist = weather_playlist
 
 	RegisterSignal(target, COMSIG_MOVABLE_Z_CHANGED, .proc/handle_z_level_change)
-	RegisterSignal(target, COMSIG_MOB_LOGOUT, .proc/handle_logout)
+	RegisterSignal(target, COMSIG_MOB_LOGOUT, .proc/handle_logout, override = TRUE) //NSV13 - the runtime log said to put override = TRUE so I did
 
 /datum/element/weather_listener/Detach(datum/source)
 	. = ..()

--- a/code/datums/hud.dm
+++ b/code/datums/hud.dm
@@ -95,7 +95,7 @@ GLOBAL_LIST_INIT(huds, list(
 	return TRUE
 
 /datum/atom_hud/proc/remove_from_single_hud(mob/M, atom/A) //unsafe, no sanity apart from client
-	if(!M || !M.client || !A || !length(A.hud_list)) //NSV13 - added a little safety
+	if(!M || !M.client || !length(A?.hud_list)) //NSV13 - added a little safety
 		return
 	for(var/i in hud_icons)
 		M.client.images -= A.hud_list[i]

--- a/code/datums/hud.dm
+++ b/code/datums/hud.dm
@@ -95,7 +95,7 @@ GLOBAL_LIST_INIT(huds, list(
 	return TRUE
 
 /datum/atom_hud/proc/remove_from_single_hud(mob/M, atom/A) //unsafe, no sanity apart from client
-	if(!M || !M.client || !A?.hud_list.len)
+	if(!M || !M.client || !A || !length(A.hud_list)) //NSV13 - added a little safety
 		return
 	for(var/i in hud_icons)
 		M.client.images -= A.hud_list[i]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
These keep runtiming when people log out

## Why It's Good For The Game
Fewer runtimes are good

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
code: Added safety to hud removal
code: Suppressed warnings about weather listeners on logout
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
