### PR TITLE
Tweaks astrometrics scans

### DIFF
--- a/nsv13/code/modules/research/astrometrics.dm
+++ b/nsv13/code/modules/research/astrometrics.dm
@@ -15,7 +15,9 @@ you build.
 	circuit = /obj/item/circuitboard/computer/astrometrics
 	var/max_range = 40 //In light years, the range at which we can scan systems for data. This is quite short.
 	var/scan_progress = 0
-	var/scan_goal = 2 MINUTES
+	var/scan_goal
+	var/scan_goal_system = 15 SECONDS
+	var/scan_goal_anomaly = 1 MINUTES
 	var/datum/star_system/scan_target = null
 	var/list/scanned = list()
 	var/datum/techweb/linked_techweb = null
@@ -94,7 +96,7 @@ Clean override of the navigation computer to provide scan functionality.
 			if(!is_in_range(current_system, selected_system))
 				return
 			scan_progress = 0 //Jus' in case.
-			scan_goal = initial(scan_goal)
+			scan_goal = scan_goal_system
 			scan_target = selected_system
 			say("Initiating scan of: [scan_target]")
 			playsound(src, 'nsv13/sound/voice/scan_start.wav', 100, FALSE)
@@ -104,7 +106,7 @@ Clean override of the navigation computer to provide scan functionality.
 			if(!istype(target))
 				return
 			scan_progress = 0 //Jus' in case.
-			scan_goal = initial(scan_goal) / 2
+			scan_goal = scan_goal_anomaly
 			scan_target = target
 			say("Initiating scan of: [scan_target]")
 			radio.talk_into(src, "Initiating scan of: [scan_target]", channel)
@@ -122,9 +124,9 @@ Clean override of the navigation computer to provide scan functionality.
 				return
 			to_chat(usr, "<span class='notice'>[icon2html(target)]: [target.desc]</span>")
 
-/obj/machinery/computer/ship/navigation/astrometrics/process()
+/obj/machinery/computer/ship/navigation/astrometrics/process(delta_time)
 	if(scan_target)
-		scan_progress += 1 SECONDS
+		scan_progress += delta_time SECONDS
 		if(scan_progress >= scan_goal)
 			say("Scan of [scan_target] complete!")
 			playsound(src, 'nsv13/sound/voice/scanning_complete.wav', 100, FALSE)
@@ -133,7 +135,7 @@ Clean override of the navigation computer to provide scan functionality.
 			if(istype(scan_target, /obj/effect/overmap_anomaly))
 				var/obj/effect/overmap_anomaly/OA = scan_target
 				if(OA.research_points > 0 && !OA.scanned) //In case someone else did a scan on it already.
-					var/reward = OA.research_points/2
+					var/reward = OA.research_points * 0.5
 					OA.research_points -= reward
 					linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DISCOVERY, reward)
 				OA.scanned = TRUE

--- a/nsv13/code/modules/research/astrometrics.dm
+++ b/nsv13/code/modules/research/astrometrics.dm
@@ -17,7 +17,7 @@ you build.
 	var/scan_progress = 0
 	var/scan_goal
 	var/scan_goal_system = 15 SECONDS
-	var/scan_goal_anomaly = 1 MINUTES
+	var/scan_goal_anomaly = 2 MINUTES
 	var/datum/star_system/scan_target = null
 	var/list/scanned = list()
 	var/datum/techweb/linked_techweb = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This PR makes system scanning using the astrometrics scanner take 15 seconds, and makes anomaly scanning take 1 minute.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
At present astrometrics scanning is both the only way to find hazardous systems and the only way to get reasonable amounts of discovery research. Shortening system scan time allows the scanning computer to be used for locating hazardous systems in a timely fashion, and shortening the anomaly scan time somewhat makes it a bit less tedious to scan them.
This also makes the code for this a bit clearer.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
Scanning functions properly.

## Changelog
:cl:
balance: Scanning systems using the astrometrics computer now takes 15 seconds, and scanning anomalies takes 1 minute.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
