### PR TITLE
Tweaks time requirements for important NSV jobs

### DIFF
--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -11,7 +11,7 @@
 	selection_color = "#ccccff"
 	req_admin_notify = 1
 	minimal_player_age = 14
-	exp_requirements = 1200
+	exp_requirements = 2400 //NSV13 changed to 40h
 	exp_type = EXP_TYPE_COMMAND
 	exp_type_department = EXP_TYPE_COMMAND
 

--- a/code/modules/jobs/job_types/head_of_personnel.dm
+++ b/code/modules/jobs/job_types/head_of_personnel.dm
@@ -12,9 +12,9 @@
 	selection_color = "#ddddff"
 	req_admin_notify = 1
 	minimal_player_age = 10
-	exp_requirements = 1200 //NSV START - Due to how critical this job is on NSV, this is an unfortunate but necessary change.
-	exp_type = EXP_TYPE_CREW
-	exp_type_department = EXP_TYPE_CREW //NSV END
+	exp_requirements = 1200 //NSV START -- Locked behind command
+	exp_type = EXP_TYPE_COMMAND
+	exp_type_department = EXP_TYPE_COMMAND //NSV END
 
 	outfit = /datum/outfit/job/head_of_personnel
 

--- a/code/modules/jobs/job_types/head_of_security.dm
+++ b/code/modules/jobs/job_types/head_of_security.dm
@@ -12,7 +12,7 @@
 	selection_color = "#ffdddd"
 	req_admin_notify = 1
 	minimal_player_age = 14
-	exp_requirements = 1200
+	exp_requirements = 1800 //NSV13 changed to 30 hours
 	exp_type = EXP_TYPE_SECURITY
 	exp_type_department = EXP_TYPE_SECURITY
 

--- a/code/modules/jobs/job_types/warden.dm
+++ b/code/modules/jobs/job_types/warden.dm
@@ -10,7 +10,7 @@
 	supervisors = "the head of security"
 	selection_color = "#ffeeee"
 	minimal_player_age = 7
-	exp_requirements = 600
+	exp_requirements = 900 //NSV13 changed to 15h
 	exp_type = EXP_TYPE_SECURITY
 	exp_type_department = EXP_TYPE_SECURITY
 

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -76,12 +76,14 @@ GLOBAL_LIST_INIT(munitions_positions, list(
 
 // they are for hud_icon-based crew manifest
 // we don't use 'gimmick' here. use common sense here.
+// NSV13 added Master at Arms
 GLOBAL_LIST_INIT(command_positions_hud, list(
 	JOB_HUD_CAPTAIN,
 	JOB_HUD_ACTINGCAPTAIN ,
 	JOB_HUD_HEADOFPERSONNEL,
 	JOB_HUD_HEADOFSECURITY,
 	JOB_HUD_CHIEFENGINEER,
+	JOB_HUD_MASTERATARMS,
 	JOB_HUD_RESEARCHDIRECTOR,
 	JOB_HUD_CHEIFMEDICALOFFICIER,
 	JOB_HUD_RAWCOMMAND))

--- a/nsv13/code/modules/jobs/job_types/air_traffic_controller.dm
+++ b/nsv13/code/modules/jobs/job_types/air_traffic_controller.dm
@@ -9,8 +9,8 @@
 	supervisors = "the Master At Arms"
 	selection_color = "#ffd1a2"
 	chat_color = "#2681a5"
-	exp_requirements = 30
-	exp_type = EXP_TYPE_CREW
+	exp_requirements = 600
+	exp_type = EXP_TYPE_MUNITIONS
 	exp_type_department = EXP_TYPE_MUNITIONS
 
 	outfit = /datum/outfit/job/air_traffic_controller

--- a/nsv13/code/modules/jobs/job_types/bridge.dm
+++ b/nsv13/code/modules/jobs/job_types/bridge.dm
@@ -3,7 +3,7 @@
 	flag = BRIDGE_OFFICER
 	auto_deadmin_role_flags = DEADMIN_POSITION_SECURITY
 	department_head = list(JOB_NAME_HEADOFPERSONNEL)
-	department_flag = ENGSEC 
+	department_flag = ENGSEC
 	faction = "Station"
 	total_positions = 2
 	spawn_positions = 2
@@ -11,7 +11,7 @@
 	selection_color = "#ddddff"
 	req_admin_notify = 1
 	minimal_player_age = 2
-	exp_requirements = 60
+	exp_requirements = 900
 	exp_type = EXP_TYPE_CREW
 
 	outfit = /datum/outfit/job/bridge

--- a/nsv13/code/modules/jobs/job_types/master_at_arms.dm
+++ b/nsv13/code/modules/jobs/job_types/master_at_arms.dm
@@ -12,8 +12,8 @@
 	selection_color = "#ffbc79"
 	chat_color = "#ff7f00"
 	minimal_player_age = 7
-	exp_requirements = 180
-	exp_type = EXP_TYPE_CREW
+	exp_requirements = 1200
+	exp_type = EXP_TYPE_MUNITIONS
 	exp_type_department = EXP_TYPE_MUNITIONS
 
 	outfit = /datum/outfit/job/master_at_arms


### PR DESCRIPTION
## About The Pull Request

Changes the following time requirements, currently still subject to change:
Captain 20 >> 40 hours of command
XO 10 hours of crew >> 20 hours of command
MaA 3 >> 20 hours of munitions
ATC 0.5 >> 10 hours of munitions
HoS 20 >> 30 hours of security
Warden 10 >> 15 hours of security
Bridge staff 1 >> 15 hours of crew

Also fixes the master at arms not showing up as a head of staff on HUDs

## Why It's Good For The Game

Increases the time locks for important positions to avoid inexperienced players picking those roles.

## Testing Photographs and Procedure
Time isn't real you can't take a picture of it.

## Changelog
:cl:
tweak: Tweaked various command, security, and munitions playtime requirements
/:cl: