### PR TITLE
Fixes holokoi error sprite on Galactica

### DIFF
--- a/_maps/map_files/Galactica/Galactica2.dmm
+++ b/_maps/map_files/Galactica/Galactica2.dmm
@@ -24804,6 +24804,7 @@
 "njV" = (
 /mob/living/simple_animal/hostile/carp/cayenne{
 	desc = "A holographic image of a fish, how tasteful!";
+	random_color = 0;
 	icon_living = "holocarp";
 	icon_state = "holocarp";
 	name = "Space Koi"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Sets the holographic space koi random_color var to false.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #2149 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![holokoifixed](https://user-images.githubusercontent.com/95106800/202620770-f1f592d1-99fa-4119-9b36-fc68c03e93fe.PNG)

Fish fixed 

</details>

## Changelog
:cl:
fix: fixed error holokoi on Galactica
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
