### PR TITLE
Allows ghosts to double-click into dropship/sabre interiors again

### DIFF
--- a/nsv13/code/modules/overmap/boarding/interiors.dm
+++ b/nsv13/code/modules/overmap/boarding/interiors.dm
@@ -196,8 +196,8 @@ The meat of this file. This will instance the dropship's interior in reserved sp
 		target_area.name = "[src.name] interior #[rand(0,999)]" //Avoid naming conflicts.
 	else if(!(target_area.area_flags & UNIQUE_AREA))
 		target_area.name = src.name
-		linked_areas += target_area
-		target_area.overmap_fallback = src // We might be able to remove this since I learned how room reservations work
+	linked_areas += target_area
+	target_area.overmap_fallback = src // We might be able to remove this since I learned how room reservations work
 	interior_status = INTERIOR_READY
 	return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Does what it says in the title

## Why It's Good For The Game
This is useful when I want to get inside of a ship as a ghost to see stuff

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: Allowed overmap double-click to view interior to work on smaller ships again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
