### PR TITLE
Fixes munitions not having its own manifest department

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -150,8 +150,8 @@
 		"Science" = GLOB.science_positions_hud,
 		"Supply" = GLOB.supply_positions_hud,
 		"Civilian" = GLOB.civilian_positions_hud,
-		"Silicon" = GLOB.nonhuman_positions, // this is something that doesn't work. need to fix.
-		"Munitions" = GLOB.munitions_positions //NSV ADDED DEPARTMENTS
+		"Munitions" = GLOB.munitions_positions_hud, //NSV ADDED DEPARTMENTS
+		"Silicon" = GLOB.nonhuman_positions // this is something that doesn't work. need to fix.
 	)
 	for(var/datum/data/record/t in GLOB.data_core.general)
 		var/name = t.fields["name"]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #2174 

## Why It's Good For The Game
They're a department and should have their own section

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: Fixed munitions positions falling under the "misc" section of the crew manifest
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
