### PR TITLE
[PORT] Implements a feature that makes the RPED drop the lowest rated parts instead of everything at once

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -275,6 +275,7 @@
 	maxcharge = 10000
 	materials = list(/datum/material/glass=60)
 	chargerate = 1500
+	rating = 1 //NSV13 - RPED QoL
 
 /obj/item/stock_parts/cell/high/plus
 	name = "high-capacity power cell+"
@@ -294,6 +295,7 @@
 	maxcharge = 20000
 	materials = list(/datum/material/glass=300)
 	chargerate = 2000
+	rating = 2 //NSV13 - RPED QoL
 
 /obj/item/stock_parts/cell/super/empty/Initialize(mapload)
 	. = ..()
@@ -306,6 +308,7 @@
 	maxcharge = 30000
 	materials = list(/datum/material/glass=400)
 	chargerate = 3000
+	rating = 3 //NSV13 - RPED QoL
 
 /obj/item/stock_parts/cell/hyper/empty/Initialize(mapload)
 	. = ..()
@@ -319,6 +322,7 @@
 	maxcharge = 40000
 	materials = list(/datum/material/glass=600)
 	chargerate = 4000
+	rating = 4 //NSV13 - RPED QoL
 
 /obj/item/stock_parts/cell/bluespace/empty/Initialize(mapload)
 	. = ..()

--- a/nsv13.dme
+++ b/nsv13.dme
@@ -3670,6 +3670,7 @@
 #include "nsv13\code\datums\achievements\nsv_achievements.dm"
 #include "nsv13\code\datums\ai_laws\laws.dm"
 #include "nsv13\code\datums\components\crafting\recipes.dm"
+#include "nsv13\code\datums\components\storage\concrete\rped.dm"
 #include "nsv13\code\datums\elements\turf_transparency.dm"
 #include "nsv13\code\datums\freight_type\_freight_type.dm"
 #include "nsv13\code\datums\freight_type\group\_group.dm"

--- a/nsv13/code/datums/components/storage/concrete/rped.dm
+++ b/nsv13/code/datums/components/storage/concrete/rped.dm
@@ -1,0 +1,65 @@
+/datum/component/storage/concrete/rped/quick_empty(mob/M)
+	var/atom/A = parent
+	if(!M.canUseStorage() || !A.Adjacent(M) || M.incapacitated())
+		return
+	if(check_locked(null, M, TRUE))
+		return FALSE
+	A.add_fingerprint(M)
+	var/list/things = contents()
+	var/lowest_rating = INFINITY
+	for(var/obj/item/B in things)
+		if(istype(B, /obj/item/stock_parts/cell))
+			var/obj/item/stock_parts/cell/C = B
+			if(C.rating < lowest_rating)
+				lowest_rating = C.rating
+		else if(B.get_part_rating() < lowest_rating)
+			lowest_rating = B.get_part_rating()
+	for(var/obj/item/B in things)
+		if(istype(B, /obj/item/stock_parts/cell))
+			var/obj/item/stock_parts/cell/C = B
+			if(C.rating > lowest_rating)
+				things.Remove(B)
+		else if(B.get_part_rating() > lowest_rating)
+			things.Remove(B)
+	if(lowest_rating == INFINITY)
+		to_chat(M, "<span class='notice'>There's no parts to dump out from [parent].</span>")
+		return
+	to_chat(M, "<span class='notice'>You start dumping out Tier/Cell rating [lowest_rating] parts from [parent].</span>")
+	var/turf/T = get_turf(A)
+	var/datum/progressbar/progress = new(M, length(things), T)
+	while (do_after(M, 10, TRUE, T, FALSE, CALLBACK(src, .proc/mass_remove_from_storage, T, things, progress)))
+		stoplag(1)
+	qdel(progress)
+
+/datum/component/storage/concrete/bluespace/rped/quick_empty(mob/M)
+	var/atom/A = parent
+	if(!M.canUseStorage() || !A.Adjacent(M) || M.incapacitated())
+		return
+	if(check_locked(null, M, TRUE))
+		return FALSE
+	A.add_fingerprint(M)
+	var/list/things = contents()
+	var/lowest_rating = INFINITY
+	for(var/obj/item/B in things)
+		if(istype(B, /obj/item/stock_parts/cell))
+			var/obj/item/stock_parts/cell/C = B
+			if(C.rating < lowest_rating)
+				lowest_rating = C.rating
+		else if(B.get_part_rating() < lowest_rating)
+			lowest_rating = B.get_part_rating()
+	for(var/obj/item/B in things)
+		if(istype(B, /obj/item/stock_parts/cell))
+			var/obj/item/stock_parts/cell/C = B
+			if(C.rating > lowest_rating)
+				things.Remove(B)
+		else if(B.get_part_rating() > lowest_rating)
+			things.Remove(B)
+	if(lowest_rating == INFINITY)
+		to_chat(M, "<span class='notice'>There's no parts to dump out from [parent].</span>")
+		return
+	to_chat(M, "<span class='notice'>You start dumping out Tier/Cell rating [lowest_rating] parts from [parent].</span>")
+	var/turf/T = get_turf(A)
+	var/datum/progressbar/progress = new(M, length(things), T)
+	while (do_after(M, 10, TRUE, T, FALSE, CALLBACK(src, .proc/mass_remove_from_storage, T, things, progress)))
+		stoplag(1)
+	qdel(progress)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ports a modified version of the following PR from Citadel Station 13
[13763](https://github.com/Citadel-Station-13/Citadel-Station-13/pull/13763)

Also makes the power cells, some of them, have a stock part rating, I believe this will not affect anything else beyond the stuff introduced in this PR.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Sort out those annoying low tier parts instead of having to manually go through it all in a big pile to find the highest tier parts.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://user-images.githubusercontent.com/59128051/202993696-673404b2-7472-46b3-b411-a277db6af09d.mp4


</details>

## Changelog
:cl:Hatterhat
tweak: RPEDs now drop their lowest part tier first when quick-emptied (used inhand).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
