### PR TITLE
Fixes the Aetherwhisp's torpedo tubes

### DIFF
--- a/nsv13/code/modules/overmap/types/solgov.dm
+++ b/nsv13/code/modules/overmap/types/solgov.dm
@@ -141,7 +141,7 @@
 /obj/structure/overmap/nanotrasen/solgov/apply_weapons()
 	// Solgov do not need Nanotrasen weapons registered on roundstart. This bloats the ship's weapon_types and makes cycling via spacebar take much longer
 	// . = ..()
-	weapon_types[FIRE_MODE_TORPEDO] = new/datum/ship_weapon/torpedo_launcher(src)
+	weapon_types[FIRE_MODE_AMS] = new /datum/ship_weapon/vls(src)
 
 /obj/structure/overmap/nanotrasen/solgov/carrier/ai/apply_weapons() // Kmc why didn't you use /solgov/ai for your ship childtypes
 	apply_medium_ai_weapons()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This fixes the Aetherwhisp's torpedo tubes by replacing the FIRE_MODE_TORPEDO definition in the whisp's munitions setup with FIRE_MODE_VLS and using the VLS weapon type (similar to other ships).

This is needed because torpedo tubes fire based off of FIRE_MODE_VLS (presumably so you don't have to select them differently with spacebar). Since the Whisp tried to load FIRE_MODE_TORPEDO as its torpedo weapon, this meant that it tried to assign the torpedo tubes to a nonexistent VLS weapon, which would result in them not firing.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
This makes the whisp's torps work again, which is probably a good thing.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Loading and firing torps functions properly. 

</details>

## Changelog
:cl:
fix: Fixes the Aetherwhisp's torpedos. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
