### PR TITLE
Makes munitions control computers buildable

### DIFF
--- a/nsv13/code/game/objects/items/nsv_circuitboards.dm
+++ b/nsv13/code/game/objects/items/nsv_circuitboards.dm
@@ -52,12 +52,6 @@
 /obj/item/circuitboard/computer/ship/munitions_computer
 	name = "circuit board (munitions control computer)"
 	build_path = /obj/machinery/computer/ship/munitions_computer
-	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
-
-/obj/item/circuitboard/computer/ship/munitions_computer/Destroy(force=FALSE)
-	if(!force)
-		return QDEL_HINT_LETMELIVE
-	return ..()
 
 /obj/item/circuitboard/computer/ship/ordnance_computer
 	name = "circuit board (ordnance computer)"

--- a/nsv13/code/modules/research/techweb/all_nsv_nodes.dm
+++ b/nsv13/code/modules/research/techweb/all_nsv_nodes.dm
@@ -23,7 +23,7 @@
 	display_name = "Munitions computer circuitry"
 	description = "Allows you to rebuild Munitions computers after they suffer from gunpowder overdose."
 	prereq_ids = list("comptech")
-	design_ids = list("fighter_computer_circuit", "ordnance_comp_circuit", "fighter_launcher_circuit", "ammo_sorter_computer", "ammo_sorter")
+	design_ids = list("fighter_computer_circuit", "ordnance_comp_circuit", "fighter_launcher_circuit", "ammo_sorter_computer", "ammo_sorter", "munitions_computer_circuit")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)
 	export_price = 1000
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This makes munitions control computers buildable. It also removes the indestructability from them since you can replace them now.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
There's at least a few instances of weapons you can't use on ships because you can't build new control computers, and these aren't weapons themselves so giving them to the crew to build should be fine.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
Compiled properly with no errors, just a line change.

## Changelog
:cl:
add: Munitions control computers can now be built after munitions computer tech is researched.
tweak: Munitions control computer circuits are no longer immortal.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
