### PR TITLE
[READY] Fixes asteroid mining - get_overmap() fix and unit tests

### DIFF
--- a/code/modules/client/loadout/loadout.dm
+++ b/code/modules/client/loadout/loadout.dm
@@ -34,14 +34,13 @@ GLOBAL_LIST_EMPTY(gear_datums)
 		if(!initial(G.unlocktype))
 			WARNING("Loadout - No unlock type defined: [G]")
 			continue
-		if(!initial(G.cost) && initial(G.unlocktype) == GEAR_METACOIN)
+		if(initial(G.unlocktype) == GEAR_METACOIN && !initial(G.cost))
 			WARNING("Loadout - Metacoin item, Missing cost: [G]")
-		// end NSV13
-		else if(!initial(G.cost))
-			WARNING("Loadout - Missing cost: [G]")
 			continue
-		if(!initial(G.ckey) && initial(G.unlocktype) == GEAR_DONATOR)
-			WARNING("Loadout - Donator Item, No assigned control key: [G]")
+		else if(initial(G.unlocktype) == GEAR_DONATOR && !initial(G.cost) && !initial(G.ckey))
+			WARNING("Loadout - Donator item, Missing cost and no assigned ckey: [G]")
+			continue
+		// end NSV13
 		if(!initial(G.path) && use_category != "OOC") //OOC category does not contain actual items
 			WARNING("Loadout - Missing path definition: [G]")
 			continue

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -74,6 +74,7 @@
 #include "unit_test.dm"
 #include "random_ruin_mapsize.dm"
 #include "ftl.dm" // NSV13 FTL unit tests
+#include "get_overmap.dm" // NSV13 get_overmap unit tests
 
 #ifdef REFERENCE_TRACKING_DEBUG //Don't try and parse this file if ref tracking isn't turned on. IE: don't parse ref tracking please mr linter
 #include "find_reference_sanity.dm"

--- a/code/modules/unit_tests/get_overmap.dm
+++ b/code/modules/unit_tests/get_overmap.dm
@@ -12,6 +12,7 @@
 
 /datum/unit_test/basic_mob_overmap/Destroy()
 	QDEL_NULL(dummy)
+	. = ..()
 
 /// A mob inside a basic fighter should have its get_overmap return the fighter
 /datum/unit_test/fighter_pilot_overmap
@@ -19,7 +20,7 @@
 	var/mob/living/carbon/human/dummy
 
 /datum/unit_test/fighter_pilot_overmap/New()
-	for(var/obj/structure/overmap/small_craft/combat/light/OM as() in main.overmaps_in_ship)
+	for(var/obj/structure/overmap/small_craft/combat/light/OM as() in SSstar_system.find_main_overmap().overmaps_in_ship)
 		fighter = OM
 		break
 
@@ -38,3 +39,4 @@
 	fighter.stop_piloting(dummy)
 	QDEL_NULL(dummy)
 	QDEL_NULL(fighter)
+	. = ..()

--- a/code/modules/unit_tests/get_overmap.dm
+++ b/code/modules/unit_tests/get_overmap.dm
@@ -1,0 +1,40 @@
+/// A mob on the main ship should have its get_overmap return the main ship
+/datum/unit_test/basic_mob_overmap
+	var/mob/living/carbon/human/dummy
+
+/datum/unit_test/basic_mob_overmap/New()
+	var/turf/center = SSmapping.get_station_center()
+	dummy = new(center)
+
+/datum/unit_test/basic_mob_overmap/Run()
+	dummy.update_overmap()
+	TEST_ASSERT_EQUAL(dummy.get_overmap(), SSstar_system.find_main_overmap(), "The mob's overmap was not the main ship")
+
+/datum/unit_test/basic_mob_overmap/Destroy()
+	QDEL_NULL(dummy)
+
+/// A mob inside a basic fighter should have its get_overmap return the fighter
+/datum/unit_test/fighter_pilot_overmap
+	var/obj/structure/overmap/small_craft/combat/light/fighter = null
+	var/mob/living/carbon/human/dummy
+
+/datum/unit_test/fighter_pilot_overmap/New()
+	for(var/obj/structure/overmap/small_craft/combat/light/OM as() in main.overmaps_in_ship)
+		fighter = OM
+		break
+
+	if(!fighter)
+		var/turf/center = SSmapping.get_station_center()
+		fighter = new (center)
+
+	dummy = new()
+	fighter.start_piloting(dummy, OVERMAP_USER_ROLE_PILOT | OVERMAP_USER_ROLE_GUNNER)
+
+/datum/unit_test/fighter_pilot_overmap/Run()
+	dummy.update_overmap()
+	TEST_ASSERT_EQUAL(dummy.get_overmap(), fighter, "The mob's overmap was not the light fighter")
+
+/datum/unit_test/fighter_pilot_overmap/Destroy()
+	fighter.stop_piloting(dummy)
+	QDEL_NULL(dummy)
+	QDEL_NULL(fighter)

--- a/code/modules/unit_tests/get_overmap.dm
+++ b/code/modules/unit_tests/get_overmap.dm
@@ -39,13 +39,14 @@
 	QDEL_NULL(fighter)
 	. = ..()
 
+
+/*
+ * Reactivate when map loading system improves
 /// A mob inside a sabre should have its get_overmap return the sabre
 /datum/unit_test/sabre_occupant_overmap
 	var/obj/structure/overmap/small_craft/transport/sabre/sabre = null
 	var/mob/living/carbon/human/dummy = null
 
-/*
- * Reactivate when map loading system improves
 /datum/unit_test/sabre_occupant_overmap/Run()
 	for(var/obj/structure/overmap/small_craft/transport/sabre/OM as() in SSstar_system.find_main_overmap().overmaps_in_ship)
 		sabre = OM
@@ -116,4 +117,38 @@
 	QDEL_NULL(fighter)
 	. = ..()
 
-/// A sabre that docks with an asteroid should have its get_overmap return the asteroid while inside, and then null after leaving
+/* This doesn't work because the interior doesn't load in a reasonable amount of time
+/// A small craft that docks with an asteroid should have its get_overmap return the asteroid while inside, and then null after leaving
+/datum/unit_test/asteroid_docking
+	var/obj/structure/overmap/small_craft/combat/light/fighter = null
+
+/datum/unit_test/asteroid_docking/Run()
+	var/start = world.time
+	var/time_limit = 1 MINUTES
+	for(var/obj/structure/overmap/small_craft/combat/light/OM as() in SSstar_system.find_main_overmap().overmaps_in_ship)
+		fighter = OM
+		break
+
+	if(!fighter)
+		var/turf/center = SSmapping.get_station_center()
+		ASSERT(center)
+		fighter = new (center)
+
+	fighter.ftl_drive = TRUE //This won't work in real life but it will for the test
+	var/obj/item/fighter_component/docking_computer/DC = fighter.loadout.get_slot(HARDPOINT_SLOT_DOCKING)
+	DC.docking_mode = TRUE
+	fighter.check_overmap_elegibility(ignore_position = TRUE, ignore_cooldown = TRUE)
+	TEST_ASSERT_EQUAL(fighter.get_overmap(), null, "The fighter's overmap was not null after entering the overmap from the ship")
+
+	var/obj/structure/overmap/asteroid/asteroid = new(get_turf(fighter))
+	fighter.docking_act(asteroid)
+	while((world.time - start) < time_limit)
+		sleep(10)
+	TEST_ASSERT_EQUAL(fighter.get_overmap(), asteroid, "The fighter's overmap was not the asteroid after docking")
+	fighter.check_overmap_elegibility(ignore_position = TRUE, ignore_cooldown = TRUE)
+	TEST_ASSERT_EQUAL(fighter.get_overmap(), null, "The fighter's overmap was not null after entering the overmap from the asteroid")
+
+/datum/unit_test/asteroid_docking/Destroy()
+	QDEL_NULL(fighter)
+	. = ..()
+*/

--- a/code/modules/unit_tests/get_overmap.dm
+++ b/code/modules/unit_tests/get_overmap.dm
@@ -94,6 +94,9 @@
 	. = ..()
 
 /// A fighter that leaves and re-enters a larger ship should have its get_overmap return null while in space, and the ship when back on the ship
+/datum/unit_test/fighter_docking
+	var/obj/structure/overmap/small_craft/combat/light/fighter = null
+
 /datum/unit_test/fighter_docking/Run()
 	for(var/obj/structure/overmap/small_craft/combat/light/OM as() in SSstar_system.find_main_overmap().overmaps_in_ship)
 		fighter = OM
@@ -108,5 +111,9 @@
 	TEST_ASSERT_EQUAL(fighter.get_overmap(), null, "The fighter's overmap was not null after entering the overmap")
 	fighter.transfer_from_overmap(SSstar_system.find_main_overmap())
 	TEST_ASSERT_EQUAL(fighter.get_overmap(), SSstar_system.find_main_overmap(), "The fighter's overmap was not the ship after docking")
+
+/datum/unit_test/fighter_docking/Destroy()
+	QDEL_NULL(fighter)
+	. = ..()
 
 /// A sabre that docks with an asteroid should have its get_overmap return the asteroid while inside, and then null after leaving

--- a/code/modules/unit_tests/get_overmap.dm
+++ b/code/modules/unit_tests/get_overmap.dm
@@ -1,6 +1,6 @@
 /// A mob on the main ship should have its get_overmap return the main ship
 /datum/unit_test/basic_mob_overmap
-	var/mob/living/carbon/human/dummy
+	var/mob/living/carbon/human/dummy = null
 
 /datum/unit_test/basic_mob_overmap/Run()
 	var/turf/center = SSmapping.get_station_center()
@@ -16,7 +16,7 @@
 /// A mob inside a basic fighter should have its get_overmap return the fighter
 /datum/unit_test/fighter_pilot_overmap
 	var/obj/structure/overmap/small_craft/combat/light/fighter = null
-	var/mob/living/carbon/human/dummy
+	var/mob/living/carbon/human/dummy = null
 
 /datum/unit_test/fighter_pilot_overmap/Run()
 	for(var/obj/structure/overmap/small_craft/combat/light/OM as() in SSstar_system.find_main_overmap().overmaps_in_ship)
@@ -30,11 +30,30 @@
 
 	dummy = new()
 	fighter.start_piloting(dummy, OVERMAP_USER_ROLE_PILOT | OVERMAP_USER_ROLE_GUNNER)
-	dummy.update_overmap()
 	TEST_ASSERT_EQUAL(dummy.get_overmap(), fighter, "The mob's overmap was not the light fighter")
 	fighter.stop_piloting(dummy)
 
 /datum/unit_test/fighter_pilot_overmap/Destroy()
 	QDEL_NULL(dummy)
 	QDEL_NULL(fighter)
+	. = ..()
+
+/// A mob inside a sabre should have its get_overmap return the sabre
+/datum/unit_test/sabre_occupant_overmap
+	var/obj/structure/overmap/small_craft/transport/sabre/sabre = null
+	var/mob/living/carbon/human/dummy = null
+
+/datum/unit_test/sabre_occupant_overmap/Run()
+	for(var/obj/structure/overmap/small_craft/transport/sabre/OM as() in SSstar_system.find_main_overmap().overmaps_in_ship)
+		sabre = OM
+		break
+
+	ASSERT(sabre) // Can't just make a new one, that doesn't work right
+
+	dummy = new()
+	sabre.enter(dummy)
+	TEST_ASSERT_EQUAL(dummy.get_overmap(), sabre, "The mob's overmap was not the sabre")
+
+/datum/unit_test/fighter_pilot_overmap/Destroy()
+	QDEL_NULL(dummy)
 	. = ..()

--- a/code/modules/unit_tests/get_overmap.dm
+++ b/code/modules/unit_tests/get_overmap.dm
@@ -51,7 +51,7 @@
 	if(!sabre)
 		var/turf/center = SSmapping.get_station_center()
 		ASSERT(center)
-		sabre = new /obj/structure/overmap/small_craft/sabre(center)
+		sabre = new /obj/structure/overmap/small_craft/transport/sabre(center)
 
 	ASSERT(sabre)
 

--- a/code/modules/unit_tests/get_overmap.dm
+++ b/code/modules/unit_tests/get_overmap.dm
@@ -3,6 +3,7 @@
 	var/mob/living/carbon/human/dummy
 
 /datum/unit_test/basic_mob_overmap/New()
+	. = ..()
 	var/turf/center = SSmapping.get_station_center()
 	dummy = new(center)
 
@@ -20,6 +21,7 @@
 	var/mob/living/carbon/human/dummy
 
 /datum/unit_test/fighter_pilot_overmap/New()
+	. = ..()
 	for(var/obj/structure/overmap/small_craft/combat/light/OM as() in SSstar_system.find_main_overmap().overmaps_in_ship)
 		fighter = OM
 		break

--- a/code/modules/unit_tests/get_overmap.dm
+++ b/code/modules/unit_tests/get_overmap.dm
@@ -48,7 +48,12 @@
 		sabre = OM
 		break
 
-	ASSERT(sabre) // Can't just make a new one, that doesn't work right
+	if(!sabre)
+		var/turf/center = SSmapping.get_station_center()
+		ASSERT(center)
+		sabre = new /obj/structure/overmap/small_craft/sabre(center)
+
+	ASSERT(sabre)
 
 	dummy = new()
 	sabre.enter(dummy)

--- a/code/modules/unit_tests/get_overmap.dm
+++ b/code/modules/unit_tests/get_overmap.dm
@@ -29,6 +29,7 @@
 		fighter = new (center)
 
 	dummy = new()
+	fighter.enter(dummy)
 	fighter.start_piloting(dummy, OVERMAP_USER_ROLE_PILOT | OVERMAP_USER_ROLE_GUNNER)
 	TEST_ASSERT_EQUAL(dummy.get_overmap(), fighter, "The mob's overmap was not the light fighter")
 	fighter.stop_piloting(dummy)

--- a/code/modules/unit_tests/get_overmap.dm
+++ b/code/modules/unit_tests/get_overmap.dm
@@ -2,12 +2,10 @@
 /datum/unit_test/basic_mob_overmap
 	var/mob/living/carbon/human/dummy
 
-/datum/unit_test/basic_mob_overmap/New()
-	. = ..()
-	var/turf/center = SSmapping.get_station_center()
-	dummy = new(center)
-
 /datum/unit_test/basic_mob_overmap/Run()
+	var/turf/center = SSmapping.get_station_center()
+	ASSERT(center, "SSmapping could not find the center")
+	dummy = new(center)
 	dummy.update_overmap()
 	TEST_ASSERT_EQUAL(dummy.get_overmap(), SSstar_system.find_main_overmap(), "The mob's overmap was not the main ship")
 
@@ -20,20 +18,18 @@
 	var/obj/structure/overmap/small_craft/combat/light/fighter = null
 	var/mob/living/carbon/human/dummy
 
-/datum/unit_test/fighter_pilot_overmap/New()
-	. = ..()
+/datum/unit_test/fighter_pilot_overmap/Run()
 	for(var/obj/structure/overmap/small_craft/combat/light/OM as() in SSstar_system.find_main_overmap().overmaps_in_ship)
 		fighter = OM
 		break
 
 	if(!fighter)
 		var/turf/center = SSmapping.get_station_center()
+		ASSERT(center, "SSmapping could not find the center")
 		fighter = new (center)
 
 	dummy = new()
 	fighter.start_piloting(dummy, OVERMAP_USER_ROLE_PILOT | OVERMAP_USER_ROLE_GUNNER)
-
-/datum/unit_test/fighter_pilot_overmap/Run()
 	dummy.update_overmap()
 	TEST_ASSERT_EQUAL(dummy.get_overmap(), fighter, "The mob's overmap was not the light fighter")
 

--- a/code/modules/unit_tests/get_overmap.dm
+++ b/code/modules/unit_tests/get_overmap.dm
@@ -4,7 +4,7 @@
 
 /datum/unit_test/basic_mob_overmap/Run()
 	var/turf/center = SSmapping.get_station_center()
-	ASSERT(center, "SSmapping could not find the center")
+	ASSERT(center)
 	dummy = new(center)
 	dummy.update_overmap()
 	TEST_ASSERT_EQUAL(dummy.get_overmap(), SSstar_system.find_main_overmap(), "The mob's overmap was not the main ship")
@@ -25,16 +25,16 @@
 
 	if(!fighter)
 		var/turf/center = SSmapping.get_station_center()
-		ASSERT(center, "SSmapping could not find the center")
+		ASSERT(center)
 		fighter = new (center)
 
 	dummy = new()
 	fighter.start_piloting(dummy, OVERMAP_USER_ROLE_PILOT | OVERMAP_USER_ROLE_GUNNER)
 	dummy.update_overmap()
 	TEST_ASSERT_EQUAL(dummy.get_overmap(), fighter, "The mob's overmap was not the light fighter")
+	fighter.stop_piloting(dummy)
 
 /datum/unit_test/fighter_pilot_overmap/Destroy()
-	fighter.stop_piloting(dummy)
 	QDEL_NULL(dummy)
 	QDEL_NULL(fighter)
 	. = ..()

--- a/nsv13/code/__HELPERS/overmap.dm
+++ b/nsv13/code/__HELPERS/overmap.dm
@@ -17,9 +17,6 @@
 		var/datum/turf_reservation/reserved = SSmapping.used_turfs[get_turf(src)]
 		if(reserved && reserved.overmap_fallback)
 			return reserved.overmap_fallback
-	// We might be able to remove this last bit
-	var/area/AR = get_area(src)
-	return AR.overmap_fallback
 
 /**
 Helper method to get what ship an observer belongs to for stuff like parallax.

--- a/nsv13/code/game/area/areas.dm
+++ b/nsv13/code/game/area/areas.dm
@@ -1,9 +1,6 @@
 /client/var/last_ambience = null
 
 /area
-	var/obj/structure/overmap/overmap_fallback = null //Used for dropships. Allows you to define an overmap to "fallback" to if get_overmap() fails to find a space level with a linked overmap.
-
-/area
 	ambient_buzz = 'nsv13/sound/ambience/shipambience.ogg' //If you want an ambient sound to play on loop while theyre in a specific area, set this. Defaults to the classic "engine rumble"
 
 /area/space

--- a/nsv13/code/modules/overmap/boarding/interiors.dm
+++ b/nsv13/code/modules/overmap/boarding/interiors.dm
@@ -197,7 +197,6 @@ The meat of this file. This will instance the dropship's interior in reserved sp
 	else if(!(target_area.area_flags & UNIQUE_AREA))
 		target_area.name = src.name
 	linked_areas += target_area
-	target_area.overmap_fallback = src // We might be able to remove this since I learned how room reservations work
 	interior_status = INTERIOR_READY
 	return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This adds a couple unit tests about the get_overmap() method because it keeps breaking. I couldn't get the sabre-related unit tests to work because the maps weren't loading fast enough but oh well.

## Why It's Good For The Game
It fixes asteroid mining, and maybe we'll be able to tell when this breaks more quickly in the future.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: Fixed an issue where the entire area of space thought it was part of an asteroid overmap, preventing sabres from FTL jumping
fix: Fixed a startup check about donator items
code: Added unit tests for get_overmap
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
