### PR TITLE
Adds damage scaling to NAC shells.

### DIFF
--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
@@ -1,3 +1,7 @@
+#define NAC_MIN_POWDER_LOAD 0.5 // Min powder, equivelant to 25%
+#define NAC_NORMAL_POWDER_LOAD 2 // "100%" powder
+#define NAC_MAX_POWDER_LOAD 10 // Max powder, or 500%
+
 /obj/machinery/ship_weapon/deck_turret
 	name = "\improper M4-15 'Hood' deck turret"
 	desc = "A huge naval gun which uses chemical accelerants to propel rounds. Inspired by the classics, this gun packs a major punch and is quite easy to reload. Use a multitool on it to re-register loading aparatus."
@@ -80,7 +84,7 @@
 	. = ..()
 	//Ensure that the lazyloaded shells come pre-packed
 	for(var/obj/item/ship_weapon/ammunition/naval_artillery/shell in ammo)
-		shell.speed = 2
+		shell.speed = NAC_NORMAL_POWDER_LOAD
 
 /obj/machinery/ship_weapon/deck_turret/multitool_act(mob/living/user, obj/item/I)
 	. = ..()
@@ -603,10 +607,7 @@
 // Handles shell powder load damage modifiers
 /obj/item/ship_weapon/ammunition/naval_artillery/proc/handle_shell_modifiers(obj/item/projectile/proj)
 	proj.damage = proj.damage * log(speed * 5) // at 2 speed (or 100% powder load), damage mod is 1, logarithmically scaling up/down based on powder load
-	if(proj.armour_penetration)
-		proj.armour_penetration = proj.damage * sqrt(speed * 0.5) // Same as above, scaling with the square root of speed relative to 2
-	else if(speed > 2)
-		proj.armour_penetration += (speed - 2) * 5 // Gives non-AP shells some punch if you really make them go fast
+	proj.armour_penetration += (speed - NAC_NORMAL_POWDER_LOAD) * 5 // We don't have anything to scale off of, so go linearly by a little bit
 
 /obj/item/ship_weapon/ammunition/naval_artillery/cannonball
 	name = "cannon ball"
@@ -737,7 +738,7 @@
 		return FALSE
 	shell.speed += source.bag.power
 	shell.name = "Packed [initial(shell.name)]"
-	shell.speed = CLAMP(shell.speed, 0, 10)
+	shell.speed = CLAMP(shell.speed, NAC_MIN_POWDER_LOAD, NAC_MAX_POWDER_LOAD)
 	source.pack()
 	return TRUE
 

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
@@ -607,10 +607,7 @@
 // Handles shell powder load damage modifiers
 /obj/item/ship_weapon/ammunition/naval_artillery/proc/handle_shell_modifiers(obj/item/projectile/proj)
 	if(speed > NAC_NORMAL_POWDER_LOAD)
-		proj.damage = proj.damage * CLAMP(log(10, speed * 5), 1, 1.75) // at 2 speed (or 100% powder load), damage mod is 1, logarithmically scaling up/down based on powder load
-	else
-		proj.damage = proj.damage * CLAMP(sqrt(speed), 0.6, 1)
-	proj.armour_penetration += max((speed - NAC_NORMAL_POWDER_LOAD) * 2.5, 0) // We don't have anything to scale off of, so go linearly by a little bit
+		proj.armour_penetration += max((speed - NAC_NORMAL_POWDER_LOAD) * 2.5, 0) // We don't have anything to scale off of, so go linearly by a little bit
 
 /obj/item/ship_weapon/ammunition/naval_artillery/cannonball
 	name = "cannon ball"
@@ -642,6 +639,13 @@
 	desc = "A massive diamond-tipped round which can slice through armour plating with ease to deliver a lethal impact. Best suited for targets with heavy armour such as destroyers and up."
 	icon_state = "torpedo_ap"
 	projectile_type = /obj/item/projectile/bullet/mac_round/ap
+
+
+/obj/item/ship_weapon/ammunition/naval_artillery/ap/handle_shell_modifiers(obj/item/projectile/proj)
+	if(speed >= NAC_NORMAL_POWDER_LOAD)
+		proj.damage = proj.damage * CLAMP(log(10, speed * 5), 1, 2) // at 2 speed (or 100% powder load), damage mod is 1, logarithmically scaling up/down based on powder load
+	else
+		proj.damage = proj.damage * CLAMP(sqrt(speed), 0.6, 1)
 
 /obj/item/ship_weapon/ammunition/naval_artillery/homing
 	name = "FTL-1301 Magneton Naval Artillery Round"

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
@@ -606,8 +606,11 @@
 
 // Handles shell powder load damage modifiers
 /obj/item/ship_weapon/ammunition/naval_artillery/proc/handle_shell_modifiers(obj/item/projectile/proj)
-	proj.damage = proj.damage * CLAMP(log(10, speed * 5), 0.5, 2) // at 2 speed (or 100% powder load), damage mod is 1, logarithmically scaling up/down based on powder load
-	proj.armour_penetration += (speed - NAC_NORMAL_POWDER_LOAD) * 2.5 // We don't have anything to scale off of, so go linearly by a little bit
+	if(speed > NAC_NORMAL_POWDER_LOAD)
+		proj.damage = proj.damage * CLAMP(log(10, speed * 5), 1, 1.75) // at 2 speed (or 100% powder load), damage mod is 1, logarithmically scaling up/down based on powder load
+	else
+		proj.damage = proj.damage * CLAMP(sqrt(speed), 0.6, 1)
+	proj.armour_penetration += max((speed - NAC_NORMAL_POWDER_LOAD) * 2.5, 0) // We don't have anything to scale off of, so go linearly by a little bit
 
 /obj/item/ship_weapon/ammunition/naval_artillery/cannonball
 	name = "cannon ball"

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
@@ -101,7 +101,8 @@
 /obj/machinery/ship_weapon/deck_turret/animate_projectile(atom/target, lateral=TRUE)
 	var/obj/item/ship_weapon/ammunition/naval_artillery/T = chambered
 	if(T)
-		linked.fire_projectile(T.projectile_type, target,speed=T.speed, lateral=weapon_type.lateral)
+		var/obj/item/projectile/proj = linked.fire_projectile(T.projectile_type, target,speed=T.speed, lateral=weapon_type.lateral)
+		T.handle_shell_modifiers(proj)
 
 /obj/machinery/ship_weapon/deck_turret/proc/rack_load(atom/movable/A)
 	if(length(ammo) < max_ammo && istype(A, ammo_type))
@@ -589,6 +590,23 @@
 
 /obj/item/ship_weapon/ammunition/naval_artillery/armed //This is literally just for mail.
 	armed = TRUE
+
+/obj/item/ship_weapon/ammunition/naval_artillery/attack_hand(mob/user)
+	return FALSE
+
+/obj/item/ship_weapon/ammunition/torpedo/attack_hand(mob/user)
+	return FALSE
+
+/obj/item/ship_weapon/ammunition/missile/attack_hand(mob/user)
+	return FALSE
+
+// Handles shell powder load damage modifiers
+/obj/item/ship_weapon/ammunition/naval_artillery/proc/handle_shell_modifiers(obj/item/projectile/proj)
+	proj.damage = proj.damage * log(speed * 5) // at 2 speed (or 100% powder load), damage mod is 1, logarithmically scaling up/down based on powder load
+	if(proj.armour_penetration)
+		proj.armour_penetration = proj.damage * sqrt(speed * 0.5) // Same as above, scaling with the square root of speed relative to 2
+	else if(speed > 2)
+		proj.armour_penetration += (speed - 2) * 5 // Gives non-AP shells some punch if you really make them go fast
 
 /obj/item/ship_weapon/ammunition/naval_artillery/cannonball
 	name = "cannon ball"

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
@@ -606,7 +606,7 @@
 
 // Handles shell powder load damage modifiers
 /obj/item/ship_weapon/ammunition/naval_artillery/proc/handle_shell_modifiers(obj/item/projectile/proj)
-	proj.damage = proj.damage * CLAMP(log(speed * 5), 0.5, 2) // at 2 speed (or 100% powder load), damage mod is 1, logarithmically scaling up/down based on powder load
+	proj.damage = proj.damage * CLAMP(log(10, speed * 5), 0.5, 2) // at 2 speed (or 100% powder load), damage mod is 1, logarithmically scaling up/down based on powder load
 	proj.armour_penetration += (speed - NAC_NORMAL_POWDER_LOAD) * 2.5 // We don't have anything to scale off of, so go linearly by a little bit
 
 /obj/item/ship_weapon/ammunition/naval_artillery/cannonball

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
@@ -606,8 +606,8 @@
 
 // Handles shell powder load damage modifiers
 /obj/item/ship_weapon/ammunition/naval_artillery/proc/handle_shell_modifiers(obj/item/projectile/proj)
-	proj.damage = proj.damage * log(speed * 5) // at 2 speed (or 100% powder load), damage mod is 1, logarithmically scaling up/down based on powder load
-	proj.armour_penetration += (speed - NAC_NORMAL_POWDER_LOAD) * 5 // We don't have anything to scale off of, so go linearly by a little bit
+	proj.damage = proj.damage * CLAMP(log(speed * 5), 0.5, 2) // at 2 speed (or 100% powder load), damage mod is 1, logarithmically scaling up/down based on powder load
+	proj.armour_penetration += (speed - NAC_NORMAL_POWDER_LOAD) * 2.5 // We don't have anything to scale off of, so go linearly by a little bit
 
 /obj/item/ship_weapon/ammunition/naval_artillery/cannonball
 	name = "cannon ball"

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
@@ -595,15 +595,6 @@
 /obj/item/ship_weapon/ammunition/naval_artillery/armed //This is literally just for mail.
 	armed = TRUE
 
-/obj/item/ship_weapon/ammunition/naval_artillery/attack_hand(mob/user)
-	return FALSE
-
-/obj/item/ship_weapon/ammunition/torpedo/attack_hand(mob/user)
-	return FALSE
-
-/obj/item/ship_weapon/ammunition/missile/attack_hand(mob/user)
-	return FALSE
-
 // Handles shell powder load damage modifiers
 /obj/item/ship_weapon/ammunition/naval_artillery/proc/handle_shell_modifiers(obj/item/projectile/proj)
 	return

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
@@ -606,8 +606,7 @@
 
 // Handles shell powder load damage modifiers
 /obj/item/ship_weapon/ammunition/naval_artillery/proc/handle_shell_modifiers(obj/item/projectile/proj)
-	if(speed > NAC_NORMAL_POWDER_LOAD)
-		proj.armour_penetration += max((speed - NAC_NORMAL_POWDER_LOAD) * 2.5, 0) // We don't have anything to scale off of, so go linearly by a little bit
+	return
 
 /obj/item/ship_weapon/ammunition/naval_artillery/cannonball
 	name = "cannon ball"
@@ -644,8 +643,7 @@
 /obj/item/ship_weapon/ammunition/naval_artillery/ap/handle_shell_modifiers(obj/item/projectile/proj)
 	if(speed >= NAC_NORMAL_POWDER_LOAD)
 		proj.damage = proj.damage * CLAMP(log(10, speed * 5), 1, 2) // at 2 speed (or 100% powder load), damage mod is 1, logarithmically scaling up/down based on powder load
-	else
-		proj.damage = proj.damage * CLAMP(sqrt(speed), 0.6, 1)
+	proj.armour_penetration = proj.armour_penetration * CLAMP(sqrt(speed * 0.5), 0.5, 3)
 
 /obj/item/ship_weapon/ammunition/naval_artillery/homing
 	name = "FTL-1301 Magneton Naval Artillery Round"

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
@@ -730,7 +730,7 @@
 	playsound(src.loc, 'nsv13/sound/effects/ship/freespace2/m_load.wav', 100, 1)
 
 /obj/machinery/deck_turret/payload_gate/proc/chamber(obj/machinery/deck_turret/powder_gate/source)
-	if(!shell)
+	if(!shell || !source?.bag)
 		return FALSE
 	shell.speed += source.bag.power
 	shell.name = "Packed [initial(shell.name)]"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This adds damage and AP scaling to NAC shells based on the powder load at the time of firing.
Damage scales logarithmically on AP shells, and AP scales linearly on base NAC shells.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
Shells at 500% powder load and shells at 50% powder load do the same damage and can punch through the same amount of armor, despite their speed differences with shells of the same mass. That doesn't really make sense.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
Compiles properly, damage/AP scaling is applied properly.

## Changelog
:cl:
balance: TX-101 shell damage & penetration ability now scales with powder load
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
