### PR TITLE
Targeting Overhaul

### DIFF
--- a/code/__DEFINES/nsv13.dm
+++ b/code/__DEFINES/nsv13.dm
@@ -113,6 +113,7 @@ GLOBAL_DATUM_INIT(conquest_role_handler, /datum/conquest_role_handler, new)
 #define COMSIG_KB_OVERMAP_WEAPON3_DOWN "keybinding_overmap_weapon3_down"
 #define COMSIG_KB_OVERMAP_WEAPON4_DOWN "keybinding_overmap_weapon4_down"
 #define COMSIG_KB_VEHICLE_TOGGLE_BRAKES "keybinding_vehicle_toggle_brakes"
+#define COMSIG_KB_OVERMAP_UNLOCK_DOWN "keybinding_overmap_unlock_down"
 
 #define OVERMAP_USER_ROLE_PILOT (1<<0)
 #define OVERMAP_USER_ROLE_GUNNER (1<<1)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -112,6 +112,7 @@
 
 	//Homing
 	var/homing = FALSE
+	var/can_home = FALSE //NSV13 - Whether a projectile is assigned a homing target after being fired
 	var/atom/homing_target
 	var/homing_turn_speed = 10		//Angle per tick.
 	var/homing_inaccuracy_min = 0		//in pixels for these. offsets are set once when setting target.

--- a/nsv13/code/__DEFINES/components.dm
+++ b/nsv13/code/__DEFINES/components.dm
@@ -2,6 +2,7 @@
 #define COMSIG_FTL_STATE_CHANGE "ftl_state_change"
 #define COMSIG_MOB_ITEM_EQUIPPED "mob_item_equipped" //Used for aiming component, tells you when a mob equips ANY item
 #define COMSIG_MOB_ITEM_DROPPED "mob_item_dropped"
+#define COMSIG_LOCK_LOST "lock_lost" // When we lost lock on a ship
 
 #define COMSIG_SHIP_RELEASE_BOARDING "release_boarding"
 	#define COMSIG_SHIP_BLOCKS_RELEASE_BOARDING 1

--- a/nsv13/code/__DEFINES/overmap.dm
+++ b/nsv13/code/__DEFINES/overmap.dm
@@ -70,6 +70,8 @@
 #define SENSOR_RANGE_DEFAULT 40
 #define SENSOR_RANGE_FIGHTER 30 //Fighters have crappier sensors. Coordinate with the ATC!
 
+#define VISUAL_RANGE_DEFAULT 80 // How far away you can visually acquire a target.
+
 #define CLOAK_TEMPORARY_LOSS 2 //Cloak handling. When you fire a weapon, you temporarily lose your cloak, and AIs can target you.
 
 GLOBAL_LIST_INIT(overmap_objects, list())

--- a/nsv13/code/__DEFINES/overmap.dm
+++ b/nsv13/code/__DEFINES/overmap.dm
@@ -30,10 +30,13 @@
 
 #define MAX_POSSIBLE_FIREMODE 16 //This should relate to the maximum number of weapons a ship can ever have. Keep this up to date please!
 
-
 //Weapon classes for AIs
 #define WEAPON_CLASS_LIGHT 1
 #define WEAPON_CLASS_HEAVY 2
+
+// AMS targeting modes for STS
+#define AMS_LOCKED_TARGETS "Locked Targets"
+#define AMS_PAINTED_TARGETS "Painted Targets"
 
 //Northeast, Northwest, Southeast, Southwest
 #define ARMOUR_FORWARD_PORT "forward_port"

--- a/nsv13/code/__DEFINES/overmap.dm
+++ b/nsv13/code/__DEFINES/overmap.dm
@@ -70,8 +70,6 @@
 #define SENSOR_RANGE_DEFAULT 40
 #define SENSOR_RANGE_FIGHTER 30 //Fighters have crappier sensors. Coordinate with the ATC!
 
-#define VISUAL_RANGE_DEFAULT 80 // How far away you can visually acquire a target.
-
 #define CLOAK_TEMPORARY_LOSS 2 //Cloak handling. When you fire a weapon, you temporarily lose your cloak, and AIs can target you.
 
 GLOBAL_LIST_INIT(overmap_objects, list())

--- a/nsv13/code/datums/keybinding/overmap.dm
+++ b/nsv13/code/datums/keybinding/overmap.dm
@@ -337,3 +337,23 @@
 	if(M != OM.gunner) return
 	OM.select_weapon(4)
 	return TRUE
+
+/datum/keybinding/overmap/unlock
+	key = "6"
+	name = "unlock"
+	full_name = "Unlock All Targets"
+	description = ""
+	keybind_signal = COMSIG_KB_OVERMAP_UNLOCK_DOWN
+
+/datum/keybinding/overmap/unlock/down(client/user)
+	. = ..()
+	if(.)
+		return
+	if(!user.mob) return
+	var/mob/M = user.mob
+	var/obj/structure/overmap/OM = M.overmap_ship
+	if(!OM) return
+
+	if(M != OM.gunner) return
+	OM.dump_locks()
+	return TRUE

--- a/nsv13/code/game/general_quarters/dropship_types.dm
+++ b/nsv13/code/game/general_quarters/dropship_types.dm
@@ -31,6 +31,8 @@ Credit to TGMC for the interior sprites for all these!
 	speed_limit = 4
 	resize_factor = 2
 //	ftl_goal = 45 SECONDS //sabres can, by default, initiate relative FTL jumps to other ships.
+	autotarget = FALSE // Transports have dedicated TAC consoles, so let them handle targeting
+	no_gun_cam = FALSE
 	loadout_type = /datum/component/ship_loadout/utility
 	dradis_type = null //Sabres can send sonar pulses
 	components = list(/obj/item/fighter_component/fuel_tank/tier2,
@@ -183,4 +185,3 @@ Credit to TGMC for the interior sprites for all these!
 /datum/map_template/dropship/sabre/syndicate
     name = "SU-437 Sabre Interior (Syndicate)"
     mappath = "_maps/templates/boarding/sabre_interior_syndicate.dmm"
- 

--- a/nsv13/code/game/machinery/computer/_ship.dm
+++ b/nsv13/code/game/machinery/computer/_ship.dm
@@ -103,6 +103,11 @@ GLOBAL_LIST_INIT(computer_beeps, list('nsv13/sound/effects/computer/beep.ogg','n
 	density = FALSE
 	anchored = TRUE
 	req_access = null
+	var/obj/machinery/computer/ship/dradis/minor/internal_dradis
+
+/obj/machinery/computer/ship/viewscreen/Initialize(mapload)
+	. = ..()
+	internal_dradis = new(src)
 
 /obj/machinery/computer/ship/viewscreen/examine(mob/user)
 	. = ..()
@@ -113,7 +118,8 @@ GLOBAL_LIST_INIT(computer_beeps, list('nsv13/sound/effects/computer/beep.ogg','n
 		O.ManualFollow(linked)
 		return
 	playsound(src, 'nsv13/sound/effects/computer/hum.ogg', 100, 1)
-	linked.start_piloting(user, OVERMAP_USER_ROLE_OBSERVER)
+	linked.observe_ship(user)
+	internal_dradis.attack_hand(user)
 
 /obj/machinery/computer/ship/viewscreen/ui_interact(mob/user)
 	if(!has_overmap())

--- a/nsv13/code/game/machinery/computer/tactical.dm
+++ b/nsv13/code/game/machinery/computer/tactical.dm
@@ -87,19 +87,23 @@
 			ammo += SW.get_ammo()
 		data["weapons"] += list(list("name" = thename, "ammo" = ammo, "maxammo" = max_ammo))
 	data["ships"] = list()
+	data["painted_targets"] = list()
+	data["target_lock"] = linked.target_lock?.name
 	if(!linked?.current_system)
 		return data
+	for(var/obj/structure/overmap/OM in linked.painted_targets)
+		data["painted_targets"] += list(list("name" = OM.name, "integrity" = OM.obj_integrity, "max_integrity" = OM.max_integrity, "faction" = OM.faction, \
+			"quadrant_fs_armour_current" = OM.armour_quadrants["forward_starboard"]["current_armour"], \
+			"quadrant_fs_armour_max" = OM.armour_quadrants["forward_starboard"]["max_armour"], \
+			"quadrant_as_armour_current" = OM.armour_quadrants["aft_starboard"]["current_armour"], \
+			"quadrant_as_armour_max" = OM.armour_quadrants["aft_starboard"]["max_armour"], \
+			"quadrant_ap_armour_current" = OM.armour_quadrants["aft_port"]["current_armour"], \
+			"quadrant_ap_armour_max" = OM.armour_quadrants["aft_port"]["max_armour"], \
+			"quadrant_fp_armour_current" = OM.armour_quadrants["forward_port"]["current_armour"], \
+			"quadrant_fp_armour_max" = OM.armour_quadrants["forward_port"]["max_armour"]))
 	for(var/obj/structure/overmap/OM in linked.current_system.system_contents)
-		if(OM.z == linked.z && OM.faction != linked.faction && get_dist(linked, OM) <= scan_range && OM.is_sensor_visible(linked) >= SENSOR_VISIBILITY_TARGETABLE)
-			data["ships"] += list(list("name" = OM.name, "integrity" = OM.obj_integrity, "max_integrity" = OM.max_integrity, "faction" = OM.faction, \
-				"quadrant_fs_armour_current" = OM.armour_quadrants["forward_starboard"]["current_armour"], \
-				"quadrant_fs_armour_max" = OM.armour_quadrants["forward_starboard"]["max_armour"], \
-				"quadrant_as_armour_current" = OM.armour_quadrants["aft_starboard"]["current_armour"], \
-				"quadrant_as_armour_max" = OM.armour_quadrants["aft_starboard"]["max_armour"], \
-				"quadrant_ap_armour_current" = OM.armour_quadrants["aft_port"]["current_armour"], \
-				"quadrant_ap_armour_max" = OM.armour_quadrants["aft_port"]["max_armour"], \
-				"quadrant_fp_armour_current" = OM.armour_quadrants["forward_port"]["current_armour"], \
-				"quadrant_fp_armour_max" = OM.armour_quadrants["forward_port"]["max_armour"]))
+		if(OM.z == linked.z && !isasteroid(OM) && OM.faction != linked.faction && get_dist(linked, OM) <= scan_range && OM.is_sensor_visible(linked) >= SENSOR_VISIBILITY_TARGETABLE)
+			data["ships"] += list(list("name" = OM.name, "faction" = OM.faction))
 	return data
 
 /obj/machinery/computer/ship/tactical/set_position(obj/structure/overmap/OM)

--- a/nsv13/code/game/machinery/computer/tactical.dm
+++ b/nsv13/code/game/machinery/computer/tactical.dm
@@ -88,6 +88,7 @@
 	data["quadrant_fp_armour_max"] = linked.armour_quadrants["forward_port"]["max_armour"]
 	data["weapons"] = list()
 	data["target_name"] = (linked.target_lock) ? linked.target_lock.name : "none"
+	data["no_gun_cam"] = linked.no_gun_cam
 	for(var/datum/ship_weapon/SW_type in linked.weapon_types)
 		var/ammo = 0
 		var/max_ammo = 0
@@ -189,7 +190,8 @@
 		data["torpedo_ammo_max"] = 1
 
 	data["target_name"] = (linked.target_lock) ? linked.target_lock.name : "none"
-	data["ships"] = list()
+	data["painted_targets"] = list()
+	data["no_gun_cam"] = linked.no_gun_cam
 	if(!linked?.current_system)
 		return data
 	for(var/obj/structure/overmap/OM in linked.target_painted)
@@ -204,5 +206,4 @@
 			"quadrant_ap_armour_max" = OM.armour_quadrants["aft_port"]["max_armour"], \
 			"quadrant_fp_armour_current" = OM.armour_quadrants["forward_port"]["current_armour"], \
 			"quadrant_fp_armour_max" = OM.armour_quadrants["forward_port"]["max_armour"]))
-
 	return data

--- a/nsv13/code/game/machinery/computer/tactical.dm
+++ b/nsv13/code/game/machinery/computer/tactical.dm
@@ -47,6 +47,17 @@
 	if(!linked)
 		return
 	switch(action)
+		if("toggle_gun_camera")
+			if(linked.no_gun_cam)
+				return
+			if(linked.target_lock)
+				var/scan_range = linked.dradis ? linked.dradis.visual_range : SENSOR_RANGE_DEFAULT
+				if(overmap_dist(linked, linked.target_lock) > scan_range)
+					to_chat(linked.gunner, "<span class='warning'>Target out of visual acquisition range.</span>")
+					return
+				linked.update_gunner_cam(linked.target_lock)
+				return
+			linked.update_gunner_cam()
 		if("lock_ship")
 			var/target_name = params["target"]
 			for(var/obj/structure/overmap/OM in linked.target_painted) // Locking

--- a/nsv13/code/game/machinery/lore_terminal.dm
+++ b/nsv13/code/game/machinery/lore_terminal.dm
@@ -269,6 +269,18 @@ SPECIAL KEYS RESPOND AS FOLLOWS:
 	Tyrosene production:`\
 	1 part hydrogen : 1 part carbon to make hydrocarbon heated to 333K. Mix hydrocarbon and welding fuel to produce tyrosene fuel and apply to tyrosene fuel tanks to allow for fighter refuel ops."
 
+/datum/lore_entry/nt/targeting
+	name = "targeting_systems.ntdoc"
+	title = "Guided Weapons Systems Employment"
+	filename = null
+	content = "Targeting enemy craft:`- Set DRADIS array to targeting mode`- Ensure weapons safety interlocks are disabled`- Move DRADIS cursor over hostile target and depress the designation switch to paint your target`Note: Most large ships only support up to 3 active paints at any given time. Most small craft support one paint.```-------------------```After a target has been painted, you may lock the target by using the tactical console and selecting the target you wish to lock.`If available and in range, your gunner camera will be slaved to the targeting radar and provide you with a view of the target.`Small craft (such as the Rapier or Scimitar) will automatically lock onto the first painted target.`If ordnance is employed without a lock, it will guide onto the first painted target.```-------------------```Always ensure proper emissions control procedures are followed when employing radar-guided ordnance.`Semi-active and active missiles and torpedos will give away the position of the launching craft, which may lead to detection and engagement at inopportune times.`Although some weapons (such as the FTL-1301 Magneton shell) may not require active guidance from the launching craft, a lock is still required for an accurate firing solution.```-------------------```"
+
+/datum/lore_entry/nt/datalink
+	name = "datalink.ntdoc"
+	title = "DRADIS Tactical Data Link Employment"
+	filename = null
+	content = "Transmitting targets via Data Link:`- Set DRADIS array to targeting mode`- Paint and lock onto a target`- Move DRADIS cursor over the friendly you wish to transmit the target to and depress the designation switch```-------------------```When a target is transmitted via datalink, it will automatically be considered painted by the receiving craft's targeting computer.`The transmitting craft will then continuously transmit data via DRADIS uplink to the receiving craft.`In order for the transmission to be successful, the transmitting craft must maintain a track on the target, and the receiving craft must be able to support the additional paint.`If datalink track is lost, the receiving craft will attempt to track the target using its own sensors, and dump the target track if that is unsuccessful.```-------------------```Proper employment of datalink systems is important in establishing an effective kill chain between early-warning craft and strike craft.`This allows for long-range or off-axis strikes by small craft, as well as long-range detection and tracking of stealth-capable craft that would otherwise escape a capital ship's notice.`Note that all information received via datalink should be considered C6 operational intelligence. Do not share opcodes with unauthorized personnel.```-------------------```"
+
 /datum/lore_entry/away_example
 	title = "Intercepted log file"
 	access_tag = "awayexample"

--- a/nsv13/code/modules/munitions/ammunition/missiles/missile_construction.dm
+++ b/nsv13/code/modules/munitions/ammunition/missiles/missile_construction.dm
@@ -158,14 +158,16 @@
 			if(tool.use_tool(src, user, 40, volume=100))
 				to_chat(user, "<span class='notice'>You secure [gs.name] to [src]. </span>")
 				state = 4
+				projectile_type = /obj/item/projectile/guided_munition/missile/dud/homing
 				update_icon()
 			return TRUE
 		if(4)
-			to_chat(user, "<span class='notice'>You start unsecuring [gs.name] to [src]...</span>")
+			to_chat(user, "<span class='notice'>You start unsecuring [gs.name]...</span>")
 			if(tool.use_tool(src, user, 40, volume=100))
-				to_chat(user, "<span class='notice'>You unsecure [gs.name] to [src]. </span>")
+				to_chat(user, "<span class='notice'>You unsecure [gs.name]. </span>")
 				state = 3
 				update_icon()
+				projectile_type = /obj/item/projectile/guided_munition/missile/dud
 			return TRUE
 		if(5)
 			to_chat(user, "<span class='notice'>You start securing [iff.name] to [src]...</span>")
@@ -175,9 +177,9 @@
 				update_icon()
 			return TRUE
 		if(6)
-			to_chat(user, "<span class='notice'>You start unsecuring [iff.name] to [src]...</span>")
+			to_chat(user, "<span class='notice'>You start unsecuring [iff.name]...</span>")
 			if(tool.use_tool(src, user, 40, volume=100))
-				to_chat(user, "<span class='notice'>You unsecure [iff.name] to [src]. </span>")
+				to_chat(user, "<span class='notice'>You unsecure [iff.name]. </span>")
 				state = 5
 				update_icon()
 			return TRUE

--- a/nsv13/code/modules/munitions/ammunition/missiles/missile_types.dm
+++ b/nsv13/code/modules/munitions/ammunition/missiles/missile_types.dm
@@ -40,6 +40,7 @@
 /obj/item/projectile/guided_munition/missile/dud
 	icon_state = "torpedo_dud"
 	damage = 0
+	can_home = FALSE
 
 /obj/item/ship_weapon/ammunition/missile/georgio
 	name = "\improper Georgio"

--- a/nsv13/code/modules/munitions/ammunition/missiles/missile_types.dm
+++ b/nsv13/code/modules/munitions/ammunition/missiles/missile_types.dm
@@ -42,6 +42,9 @@
 	damage = 0
 	can_home = FALSE
 
+/obj/item/projectile/guided_munition/missile/dud/homing
+	can_home = TRUE
+
 /obj/item/ship_weapon/ammunition/missile/georgio
 	name = "\improper Georgio"
 

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
@@ -101,7 +101,7 @@
 /obj/machinery/ship_weapon/deck_turret/animate_projectile(atom/target, lateral=TRUE)
 	var/obj/item/ship_weapon/ammunition/naval_artillery/T = chambered
 	if(T)
-		linked.fire_projectile(T.projectile_type, target,speed=T.speed, homing=TRUE, lateral=weapon_type.lateral)
+		linked.fire_projectile(T.projectile_type, target,speed=T.speed, lateral=weapon_type.lateral)
 
 /obj/machinery/ship_weapon/deck_turret/proc/rack_load(atom/movable/A)
 	if(length(ammo) < max_ammo && istype(A, ammo_type))

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/vls.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/vls.dm
@@ -245,7 +245,8 @@
 	. = ..()
 
 /obj/machinery/computer/ams/ui_act(action, params)
-	. = ..()
+	if(..())
+		return
 	if(action == "data_source")
 		var/obj/structure/overmap/linked = get_overmap()
 		if(!linked)

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/vls.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/vls.dm
@@ -334,6 +334,8 @@
 
 // Proc for handling missile intercept with PDC
 /obj/structure/overmap/proc/handle_pdc_intercept()
+	if(disruption)
+		return FALSE
 	if(!weapon_types[FIRE_MODE_PDC])
 		return FALSE
 	if(light_shots_left <= 0) // Reloading

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/vls.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/vls.dm
@@ -88,7 +88,7 @@
 	// We have different sprites and behaviors for each torpedo
 	var/obj/item/ship_weapon/ammunition/torpedo/T = chambered
 	if(T)
-		var/obj/item/projectile/P = linked.fire_projectile(T.projectile_type, target, homing = TRUE, lateral = weapon_type.lateral)
+		var/obj/item/projectile/P = linked.fire_projectile(T.projectile_type, target, lateral = weapon_type.lateral)
 		if(T.contents.len)
 			for(var/atom/movable/AM in T.contents)
 				to_chat(AM, "<span class='warning'>You feel slightly nauseous as you're shot out into space...</span>")

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/vls.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/vls.dm
@@ -321,7 +321,7 @@
 		if ( ship.essential )
 			continue
 		var/target_range = get_dist(ship,src)
-		if(target_range > 30 || target_range <= 0) //Random pulled from the aether
+		if((target_range > 30 || target_range <= 0) && !(ship in enemies)) // Don't cover ships halfway across the map unless they're targeting us
 			continue
 		if(!QDELETED(ship) && isovermap(ship) && ship.is_sensor_visible(src) >= SENSOR_VISIBILITY_TARGETABLE)
 			last_target = ship

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/vls.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/vls.dm
@@ -428,7 +428,7 @@
 		dradis.relay_sound('nsv13/sound/effects/fighters/launchwarning.ogg')
 		if(COOLDOWN_FINISHED(dradis, last_missile_warning))
 			var/incoming_angle = round(overmap_angle(src, proj))
-			dradis.visible_message("<span class='warning'>STS tracking radar detected. Bearing: [incoming_angle].</span>")
+			dradis.visible_message("<span class='warning'>[icon2html(src, viewers(src))] WARNING: STS radar lock detected. Bearing: [incoming_angle].</span>")
 			COOLDOWN_START(dradis, last_missile_warning, 10 SECONDS)
 
 /obj/structure/overmap/proc/remove_torpedo_target(obj/item/projectile/proj)

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/vls.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/vls.dm
@@ -270,7 +270,7 @@
 		ui.set_autoupdate(TRUE) // Ammo updates, loading delay
 
 /datum/ams_mode/countermeasures/acquire_targets(obj/structure/overmap/OM)
-	var/list/targets = OM.torpedoes_to_target.Copy(1, max_targets)
+	var/list/targets = OM.torpedoes_to_target.Copy(1, min(length(OM.torpedoes_to_target), max_targets))
 	for(var/obj/item/projectile/guided_munition/P in SSprojectiles.processing)
 		if(!P || !istype(P))
 			continue

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/torpedo_launcher.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/torpedo_launcher.dm
@@ -77,11 +77,8 @@
 	// We have different sprites and behaviors for each torpedo
 	var/obj/item/ship_weapon/ammunition/torpedo/T = chambered
 	if(T)
-		if(istype(T, /obj/item/projectile/guided_munition/torpedo/dud)) //Some brainlet MAA loaded an incomplete torp
-			linked.fire_projectile(T.projectile_type, target, homing = FALSE, lateral=TRUE)
-		else
-			var/obj/item/projectile/P = linked.fire_projectile(T.projectile_type, target, homing = TRUE, lateral = TRUE)
-			if(T.contents.len)
-				for(var/atom/movable/AM in T.contents)
-					to_chat(AM, "<span class='warning'>You feel slightly nauseous as you're shot out into space...</span>")
-					AM.forceMove(P)
+		var/obj/item/projectile/P = linked.fire_projectile(T.projectile_type, target, lateral = TRUE)
+		if(T.contents.len)
+			for(var/atom/movable/AM in T.contents)
+				to_chat(AM, "<span class='warning'>You feel slightly nauseous as you're shot out into space...</span>")
+				AM.forceMove(P)

--- a/nsv13/code/modules/overmap/aim_helper.dm
+++ b/nsv13/code/modules/overmap/aim_helper.dm
@@ -20,7 +20,9 @@
 	if(user_gun)
 		user_gun?.onMouseDown(object)
 		return TRUE
-	if(fire_mode == FIRE_MODE_MAC || fire_mode == FIRE_MODE_BLUE_LASER || fire_mode == FIRE_MODE_HYBRID_RAIL)
+	if((fire_mode == FIRE_MODE_MAC || fire_mode == FIRE_MODE_BLUE_LASER || fire_mode == FIRE_MODE_HYBRID_RAIL))
+		aiming_target = object
+		aiming_params = params
 		start_aiming(params, M)
 	else
 		autofire_target = object

--- a/nsv13/code/modules/overmap/aim_helper.dm
+++ b/nsv13/code/modules/overmap/aim_helper.dm
@@ -6,7 +6,10 @@
 		user_gun.onMouseDrag(src_object, over_object, src_location, over_location, params, M)
 		return TRUE
 	if(aiming)
-		lastangle = getMouseAngle(params, M)
+		if(target_lock)
+			lastangle = get_angle(src, get_turf(over_object))
+		else
+			lastangle = getMouseAngle(params, M)
 		draw_beam()
 	else
 		autofire_target = over_object
@@ -23,6 +26,10 @@
 	if((fire_mode == FIRE_MODE_MAC || fire_mode == FIRE_MODE_BLUE_LASER || fire_mode == FIRE_MODE_HYBRID_RAIL))
 		aiming_target = object
 		aiming_params = params
+		if(target_lock)
+			lastangle = get_angle(src, get_turf(object))
+		else
+			lastangle = getMouseAngle(params, M)
 		start_aiming(params, M)
 	else
 		autofire_target = object
@@ -35,7 +42,7 @@
 		user_gun?.onMouseUp(object)
 		return TRUE
 	autofire_target = null
-	lastangle = getMouseAngle(params, M)
+	lastangle = get_angle(src, get_turf(object))
 	stop_aiming()
 	if(fire_mode == FIRE_MODE_MAC || fire_mode == FIRE_MODE_BLUE_LASER || fire_mode == FIRE_MODE_HYBRID_RAIL)
 		fire_weapon(object)
@@ -56,10 +63,8 @@
 	P.color = "#99ff99"
 	var/turf/curloc = get_turf(src)
 	var/turf/targloc = get_turf(aiming_target)
-	if(!istype(targloc))
-		if(!istype(curloc))
-			return
-		targloc = get_turf_in_angle(lastangle, curloc, 10)
+	if(!istype(targloc) || !istype(curloc))
+		return
 	P.preparePixelProjectile(targloc, src, aiming_params, 0)
 	P.layer = BULLET_HOLE_LAYER
 	P.fire(lastangle)
@@ -72,7 +77,6 @@
 	return TRUE
 
 /obj/structure/overmap/proc/start_aiming(params, mob/M)
-	lastangle = getMouseAngle(params, M)
 	aiming = TRUE
 	draw_beam(TRUE)
 

--- a/nsv13/code/modules/overmap/camera.dm
+++ b/nsv13/code/modules/overmap/camera.dm
@@ -163,7 +163,7 @@
 	if(!eye_user.client)
 		return
 	var/obj/structure/overmap/ship = origin
-	var/scan_range = (ship.dradis) ? ship.dradis.visual_range : VISUAL_RANGE_DEFAULT
+	var/scan_range = (ship.dradis) ? ship.dradis.visual_range : SENSOR_RANGE_DEFAULT
 	if(eye_user == ship.gunner && !(QDELETED(ship_target) || get_dist(ship, ship_target) > scan_range)) // No target or our target's out of range, go to origin
 		ship = ship_target
 	eye_user.client.pixel_x = ship.pixel_x

--- a/nsv13/code/modules/overmap/camera.dm
+++ b/nsv13/code/modules/overmap/camera.dm
@@ -167,7 +167,7 @@
 		return
 	var/obj/structure/overmap/ship = origin
 	var/scan_range = (ship.dradis) ? ship.dradis.visual_range : SENSOR_RANGE_DEFAULT
-	if(eye_user == ship.gunner && !(QDELETED(ship_target) || get_dist(ship, ship_target) > scan_range)) // No target or our target's out of range, go to origin
+	if(eye_user == ship.gunner && !(!ship_target || get_dist(ship, ship_target) > scan_range)) // No target or our target's out of range, go to origin
 		ship = ship_target
 	eye_user.client.pixel_x = ship.pixel_x
 	eye_user.client.pixel_y = ship.pixel_y
@@ -176,7 +176,8 @@
 
 // Switches the camera to track a specific target. If no target is passed, we track our origin
 /mob/camera/ai_eye/remote/overmap_observer/proc/track_target(obj/structure/overmap/target)
-	UnregisterSignal(ship_target, list(COMSIG_MOVABLE_MOVED, COMSIG_PARENT_QDELETING))
+	if(ship_target)
+		UnregisterSignal(ship_target, list(COMSIG_MOVABLE_MOVED, COMSIG_PARENT_QDELETING))
 	ship_target = target
 	if(ship_target)
 		RegisterSignal(ship_target, COMSIG_MOVABLE_MOVED, .proc/update)

--- a/nsv13/code/modules/overmap/camera.dm
+++ b/nsv13/code/modules/overmap/camera.dm
@@ -175,7 +175,7 @@
 		return TRUE
 	eye_user.client.pixel_x = ship.pixel_x
 	eye_user.client.pixel_y = ship.pixel_y
-	setLoc(ship.get_center()) //This only happens for gunner cams
+	setLoc(ship.get_center())
 	return TRUE
 
 // Switches the camera to track a specific target. If no target is passed, we track our origin
@@ -184,7 +184,7 @@
 	UnregisterSignal(ship_target, COMSIG_PARENT_QDELETING)
 	ship_target = target
 	if(ship_target)
-		RegisterSignal(ship_target, COMSIG_MOVABLE_MOVED, .proc/update, ship_target)
+		RegisterSignal(ship_target, COMSIG_MOVABLE_MOVED, .proc/update)
 		RegisterSignal(ship_target, COMSIG_PARENT_QDELETING, .proc/handle_target_qdel)
 	update()
 	return TRUE

--- a/nsv13/code/modules/overmap/camera.dm
+++ b/nsv13/code/modules/overmap/camera.dm
@@ -110,6 +110,7 @@
 	eyeobj.off_action.ship = src
 	eyeobj.off_action.Grant(user)
 	eyeobj.setLoc(eyeobj.loc)
+	eyeobj.RegisterSignal(src, COMSIG_MOVABLE_MOVED, /mob/camera/ai_eye/remote/overmap_observer.proc/update)
 	user.reset_perspective(eyeobj)
 	user.remote_control = eyeobj
 
@@ -120,10 +121,6 @@
 	animate_movement = 0 //Stops glitching with overmap movement
 	use_static = FALSE
 	var/obj/structure/overmap/ship_target = null //Lets gunners lock on to their targets for accurate shooting.
-
-/mob/camera/ai_eye/remote/overmap_observer/Initialize(mapload)
-	. = ..()
-	RegisterSignal(origin, COMSIG_MOVABLE_MOVED, .proc/update)
 
 /mob/camera/ai_eye/remote/overmap_observer/Destroy()
 	UnregisterSignal(origin, COMSIG_MOVABLE_MOVED)
@@ -166,13 +163,8 @@
 		return
 	var/obj/structure/overmap/ship = origin
 	var/scan_range = (ship.dradis) ? ship.dradis.visual_range : VISUAL_RANGE_DEFAULT
-	if(QDELETED(ship_target) || get_dist(ship, ship_target) > scan_range) // No target or our target's out of range, go to origin
-		ship_target = ship
-	if(eye_user == ship.gunner)
-		eye_user.client.pixel_x = ship_target.pixel_x
-		eye_user.client.pixel_y = ship_target.pixel_y
-		setLoc(ship_target.get_center()) //This only happens for gunner cams
-		return TRUE
+	if(eye_user == ship.gunner && !(QDELETED(ship_target) || get_dist(ship, ship_target) > scan_range)) // No target or our target's out of range, go to origin
+		ship = ship_target
 	eye_user.client.pixel_x = ship.pixel_x
 	eye_user.client.pixel_y = ship.pixel_y
 	setLoc(ship.get_center())

--- a/nsv13/code/modules/overmap/camera.dm
+++ b/nsv13/code/modules/overmap/camera.dm
@@ -167,7 +167,7 @@
 		return
 	var/obj/structure/overmap/ship = origin
 	var/scan_range = (ship.dradis) ? ship.dradis.visual_range : SENSOR_RANGE_DEFAULT
-	if(eye_user == ship.gunner && !(!ship_target || get_dist(ship, ship_target) > scan_range)) // No target or our target's out of range, go to origin
+	if(eye_user == ship.gunner && !(!ship_target || overmap_dist(ship, ship_target) > scan_range)) // No target or our target's out of range, go to origin
 		ship = ship_target
 	eye_user.client.pixel_x = ship.pixel_x
 	eye_user.client.pixel_y = ship.pixel_y

--- a/nsv13/code/modules/overmap/camera.dm
+++ b/nsv13/code/modules/overmap/camera.dm
@@ -114,6 +114,9 @@
 	user.reset_perspective(eyeobj)
 	user.remote_control = eyeobj
 
+/obj/structure/overmap/proc/remove_eye_control()
+	return TRUE
+
 //Now it's time to handle people observing the ship.
 /mob/camera/ai_eye/remote/overmap_observer
 	name = "Inactive Camera Eye"

--- a/nsv13/code/modules/overmap/camera.dm
+++ b/nsv13/code/modules/overmap/camera.dm
@@ -159,6 +159,7 @@
 		QDEL_NULL(src)
 
 /mob/camera/ai_eye/remote/overmap_observer/proc/update()
+	SIGNAL_HANDLER
 	if(!eye_user.client)
 		return
 	var/obj/structure/overmap/ship = origin
@@ -172,8 +173,7 @@
 
 // Switches the camera to track a specific target. If no target is passed, we track our origin
 /mob/camera/ai_eye/remote/overmap_observer/proc/track_target(obj/structure/overmap/target)
-	UnregisterSignal(ship_target, COMSIG_MOVABLE_MOVED)
-	UnregisterSignal(ship_target, COMSIG_PARENT_QDELETING)
+	UnregisterSignal(ship_target, list(COMSIG_MOVABLE_MOVED, COMSIG_PARENT_QDELETING))
 	ship_target = target
 	if(ship_target)
 		RegisterSignal(ship_target, COMSIG_MOVABLE_MOVED, .proc/update)
@@ -182,5 +182,6 @@
 	return TRUE
 
 /mob/camera/ai_eye/remote/overmap_observer/proc/handle_target_qdel()
+	SIGNAL_HANDLER
 	UnregisterSignal(ship_target, list(COMSIG_MOVABLE_MOVED, COMSIG_PARENT_QDELETING))
 	ship_target = null

--- a/nsv13/code/modules/overmap/camera.dm
+++ b/nsv13/code/modules/overmap/camera.dm
@@ -30,12 +30,8 @@
 			to_chat(gunner, "<span class='warning'>[user] has kicked you off the ship controls!</span>")
 			stop_piloting(gunner)
 		gunner = user
-	user.set_focus(src)
-	LAZYADD(operators,user)
-	CreateEye(user) //Your body stays there but your mind stays with me - 6 (Battlestar galactica)
-	user.overmap_ship = src
+	observe_ship(user)
 	dradis?.attack_hand(user)
-	user.click_intercept = src
 	if(position & (OVERMAP_USER_ROLE_PILOT | OVERMAP_USER_ROLE_GUNNER))
 		user.add_verb(overmap_verbs) //Add the ship panel verbs
 	if(mass < MASS_MEDIUM)
@@ -44,6 +40,15 @@
 	user.client.rescale_view(user.client.overmap_zoomout, 0, ((40*2)+1)-15)
 	return TRUE
 
+// Handles actually "observing" the ship.
+/obj/structure/overmap/proc/observe_ship(mob/living/carbon/user)
+	if(user.overmap_ship == src || LAZYFIND(operators, user))
+		return FALSE
+	user.set_focus(src)
+	LAZYADD(operators,user)
+	CreateEye(user)
+	user.overmap_ship = src
+	user.click_intercept = src
 
 /obj/structure/overmap/proc/stop_piloting(mob/living/M)
 	LAZYREMOVE(operators,M)

--- a/nsv13/code/modules/overmap/camera.dm
+++ b/nsv13/code/modules/overmap/camera.dm
@@ -132,6 +132,9 @@
 
 /mob/camera/ai_eye/remote/overmap_observer/Destroy()
 	UnregisterSignal(origin, COMSIG_MOVABLE_MOVED)
+	if(ship_target)
+		UnregisterSignal(ship_target, COMSIG_MOVABLE_MOVED)
+		ship_target = null
 	return ..()
 
 /datum/action/innate/camera_off/overmap

--- a/nsv13/code/modules/overmap/fighters/_fighters.dm
+++ b/nsv13/code/modules/overmap/fighters/_fighters.dm
@@ -36,6 +36,7 @@ Been a mess since 2018, we'll fix it someday (probably)
 	pixel_collision_size_y = 32 //Avoid center tile viewport jank
 	req_one_access = list(ACCESS_COMBAT_PILOT)
 	var/start_emagged = FALSE
+	max_paints = 1 // Only one target per fighter
 	var/max_passengers = 0 //Change this per fighter.
 	//Component to handle the fighter's loadout, weapons, parts, the works.
 	var/loadout_type = LOADOUT_DEFAULT_FIGHTER

--- a/nsv13/code/modules/overmap/fighters/_fighters.dm
+++ b/nsv13/code/modules/overmap/fighters/_fighters.dm
@@ -47,6 +47,7 @@ Been a mess since 2018, we'll fix it someday (probably)
 	var/list/components = list() //What does this fighter start off with? Use this to set what engine tiers and whatever it gets.
 	var/maintenance_mode = FALSE //Munitions level IDs can change this.
 	var/dradis_type =/obj/machinery/computer/ship/dradis/internal
+	autotarget = TRUE
 	var/obj/machinery/computer/ship/navigation/starmap = null
 	var/resize_factor = 1 //How far down should we scale when we fly onto the overmap?
 	var/escape_pod_type = /obj/structure/overmap/small_craft/escapepod
@@ -113,7 +114,7 @@ Been a mess since 2018, we'll fix it someday (probably)
 	data["weapon_safety"] = weapon_safety
 	data["master_caution"] = master_caution
 	data["rwr"] = (enemies.len) ? TRUE : FALSE
-	data["target_lock"] = (target_painted.len) ? TRUE : FALSE
+	data["target_lock"] = (length(target_painted)) ? TRUE : FALSE
 	data["fuel_warning"] = get_fuel() <= get_max_fuel()*0.4
 	data["fuel"] = get_fuel()
 	data["max_fuel"] = get_max_fuel()
@@ -486,7 +487,7 @@ Been a mess since 2018, we'll fix it someday (probably)
 
 /obj/structure/overmap/small_craft/attackby(obj/item/W, mob/user, params)
 	if(operators && LAZYFIND(operators, user))
-		to_chat(user, "<span class='warning'>You can't reach [src]'s exterior from in here..</span>")
+		to_chat(user, "<span class='warning'>You can't reach [src]'s exterior from in here.</span>")
 		return FALSE
 	for(var/slot in loadout.equippable_slots)
 		var/obj/item/fighter_component/FC = loadout.get_slot(slot)
@@ -525,6 +526,12 @@ Been a mess since 2018, we'll fix it someday (probably)
 				enter(user)
 		else
 			to_chat(user, "<span class='warning'>Access denied.</span>")
+
+/obj/structure/overmap/small_craft/finish_lockon(obj/structure/overmap/target, data_link)
+	if(disruption)
+		to_chat(pilot, "<span class='warning'>ERROR: TGP NOT READY.</span>")
+		return FALSE
+	. = ..()
 
 /obj/structure/overmap/small_craft/proc/enter(mob/user)
 	var/obj/structure/overmap/OM = user.get_overmap()

--- a/nsv13/code/modules/overmap/fighters/_fighters.dm
+++ b/nsv13/code/modules/overmap/fighters/_fighters.dm
@@ -48,6 +48,7 @@ Been a mess since 2018, we'll fix it someday (probably)
 	var/maintenance_mode = FALSE //Munitions level IDs can change this.
 	var/dradis_type =/obj/machinery/computer/ship/dradis/internal
 	autotarget = TRUE
+	no_gun_cam = TRUE
 	var/obj/machinery/computer/ship/navigation/starmap = null
 	var/resize_factor = 1 //How far down should we scale when we fly onto the overmap?
 	var/escape_pod_type = /obj/structure/overmap/small_craft/escapepod

--- a/nsv13/code/modules/overmap/fighters/_fighters.dm
+++ b/nsv13/code/modules/overmap/fighters/_fighters.dm
@@ -286,6 +286,7 @@ Been a mess since 2018, we'll fix it someday (probably)
 			return
 		if("target_lock")
 			relay('nsv13/sound/effects/fighters/switch.ogg')
+			dump_locks()
 			return
 		if("mag_release")
 			if(!mag_lock)

--- a/nsv13/code/modules/overmap/fighters/_fighters.dm
+++ b/nsv13/code/modules/overmap/fighters/_fighters.dm
@@ -1689,9 +1689,9 @@ Utility modules can be either one of these types, just ensure you set its slot t
 		var/sound/chosen = pick('nsv13/sound/effects/ship/torpedo.ogg','nsv13/sound/effects/ship/freespace2/m_shrike.wav','nsv13/sound/effects/ship/freespace2/m_stiletto.wav','nsv13/sound/effects/ship/freespace2/m_tsunami.wav','nsv13/sound/effects/ship/freespace2/m_wasp.wav')
 		F.relay_to_nearby(chosen)
 		if(proj_type == /obj/item/projectile/guided_munition/missile/dud) //Refactor this to something less trash sometime I guess
-			F.fire_projectile(proj_type, target, homing = FALSE, speed=proj_speed, lateral = FALSE)
+			F.fire_projectile(proj_type, target, speed=proj_speed, lateral = FALSE)
 		else
-			F.fire_projectile(proj_type, target, homing = TRUE, speed=proj_speed, lateral = FALSE)
+			F.fire_projectile(proj_type, target, speed=proj_speed, lateral = FALSE)
 	return TRUE
 
 //Utility modules.

--- a/nsv13/code/modules/overmap/fighters/_fighters.dm
+++ b/nsv13/code/modules/overmap/fighters/_fighters.dm
@@ -1696,10 +1696,7 @@ Utility modules can be either one of these types, just ensure you set its slot t
 	if(proj_type)
 		var/sound/chosen = pick('nsv13/sound/effects/ship/torpedo.ogg','nsv13/sound/effects/ship/freespace2/m_shrike.wav','nsv13/sound/effects/ship/freespace2/m_stiletto.wav','nsv13/sound/effects/ship/freespace2/m_tsunami.wav','nsv13/sound/effects/ship/freespace2/m_wasp.wav')
 		F.relay_to_nearby(chosen)
-		if(proj_type == /obj/item/projectile/guided_munition/missile/dud) //Refactor this to something less trash sometime I guess
-			F.fire_projectile(proj_type, target, speed=proj_speed, lateral = FALSE)
-		else
-			F.fire_projectile(proj_type, target, speed=proj_speed, lateral = FALSE)
+		F.fire_projectile(proj_type, target, speed=proj_speed, lateral = FALSE)
 	return TRUE
 
 //Utility modules.

--- a/nsv13/code/modules/overmap/fighters/modules/refueling_kit.dm
+++ b/nsv13/code/modules/overmap/fighters/modules/refueling_kit.dm
@@ -56,7 +56,7 @@
 		cancel_action(us)
 		return
 	// The target isn't an overmap somehow, we're targeting ourselves, or they're an enemy
-	var/obj/structure/overmap/small_craft/them = us.target_painted[1]
+	var/obj/structure/overmap/small_craft/them = us.target_lock
 	if(!them || !istype(them) || (them == us) || (them.faction != us.faction))
 		cancel_action(us, them)
 		return

--- a/nsv13/code/modules/overmap/fighters/modules/repair_kit.dm
+++ b/nsv13/code/modules/overmap/fighters/modules/repair_kit.dm
@@ -58,7 +58,7 @@
 		cancel_action(us)
 		return
 	// The target isn't an overmap somehow, we're targeting ourselves, or they're an enemy
-	var/obj/structure/overmap/small_craft/them = us.target_painted[1]
+	var/obj/structure/overmap/small_craft/them = us.target_lock
 	if(!them || !istype(them) || (them == us) || (them.faction != us.faction))
 		cancel_action(us, them)
 		return

--- a/nsv13/code/modules/overmap/overmap.dm
+++ b/nsv13/code/modules/overmap/overmap.dm
@@ -670,10 +670,6 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 		if(overmap_dist(src, target) > max(dradis?.sensor_range * 2, target.sensor_profile))
 			dump_lock(target)
 			return
-		target_painted[target] = FALSE
-	for(var/obj/structure/overmap/OM in target_painted)
-		if(target_painted[target] != FALSE)
-			return
 	UnregisterSignal(data_link_origin, COMSIG_LOCK_LOST)
 
 /obj/structure/overmap/proc/update_gunner_cam(atom/target)

--- a/nsv13/code/modules/overmap/overmap.dm
+++ b/nsv13/code/modules/overmap/overmap.dm
@@ -670,6 +670,8 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 	if(!gunner)
 		return
 	var/mob/camera/ai_eye/remote/overmap_observer/cam = gunner.remote_control
+	if(!cam)
+		return
 	if(target == cam.ship_target) // Allows us to use this as a toggle
 		target = null
 	cam.track_target(target)

--- a/nsv13/code/modules/overmap/overmap.dm
+++ b/nsv13/code/modules/overmap/overmap.dm
@@ -567,14 +567,6 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 		var/datum/ship_weapon/SW = weapon_types[fire_mode]
 		if(!SW || !(SW.allowed_roles & OVERMAP_USER_ROLE_GUNNER))
 			return FALSE
-	if((length(target_painted) > 0) && locate(fire_mode) in list(FIRE_MODE_TORPEDO, FIRE_MODE_MISSILE, FIRE_MODE_AMS))
-		if(!target_lock) // no selected target, fire at the first one in our list
-			fire(target_painted[1])
-		else if(target_painted.Find(target_lock)) // Fire at a manually selected target
-			fire(target_lock)
-		else // something fucked up, dump the lock
-			target_lock = null
-		return TRUE
 	fire(target)
 	return TRUE
 
@@ -615,6 +607,10 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 /obj/structure/overmap/proc/select_target(obj/structure/overmap/target)
 	if(QDELETED(target) || !istype(target) || !locate(target) in target_painted)
 		dump_lock(target)
+		return
+	if(target_lock == target)
+		target_lock = null
+		update_gunner_cam(src)
 		return
 	target_lock = target
 	var/scan_range = (dradis) ? dradis.visual_range : VISUAL_RANGE_DEFAULT

--- a/nsv13/code/modules/overmap/overmap.dm
+++ b/nsv13/code/modules/overmap/overmap.dm
@@ -655,7 +655,7 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 	if(length(target.target_painted) < target.max_paints)
 		target.finish_lockon(target_lock, src)
 		to_chat(target.gunner, "<span class='notice'>Targeting data for [target] recieved from [src] via datalink.</span>")
-		to_chat(pilot, "<span class='notice'>Targeting paramaters relayed.</span>")
+		to_chat(gunner, "<span class='notice'>Targeting paramaters relayed.</span>")
 
 // if we lose our datalink signal, dump the lock
 /obj/structure/overmap/proc/check_datalink(obj/structure/overmap/data_link_origin, obj/structure/overmap/target)

--- a/nsv13/code/modules/overmap/overmap.dm
+++ b/nsv13/code/modules/overmap/overmap.dm
@@ -150,6 +150,7 @@
 	var/autotarget = FALSE // Whether we autolock onto painted targets or not.
 	var/no_gun_cam = FALSE // Var for disabling the gunner's camera
 	var/list/ams_modes = list()
+	var/list/ams_data_source = AMS_LOCKED_TARGETS
 	var/next_ams_shot = 0
 	var/ams_targeting_cooldown = 1.5 SECONDS
 
@@ -616,21 +617,14 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 /obj/structure/overmap/proc/select_target(obj/structure/overmap/target)
 	if(QDELETED(target) || !istype(target) || !locate(target) in target_painted)
 		target_lock = null
-		update_gunner_cam(src)
+		update_gunner_cam()
 		dump_lock(target)
 		return
 	if(target_lock == target)
 		target_lock = null
-		update_gunner_cam(src)
+		update_gunner_cam()
 		return
 	target_lock = target
-	if(no_gun_cam)
-		return
-	var/scan_range = dradis ? dradis.visual_range : SENSOR_RANGE_DEFAULT
-	if(overmap_dist(src, target) > scan_range)
-		to_chat(gunner, "<span class='warning'>Target out of visual acquisition range.</span>")
-		return
-	update_gunner_cam(target)
 
 /obj/structure/overmap/proc/dump_lock(obj/structure/overmap/target) // Our locked target got destroyed/moved, dump the lock
 	SIGNAL_HANDLER
@@ -676,6 +670,8 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 	if(!gunner)
 		return
 	var/mob/camera/ai_eye/remote/overmap_observer/cam = gunner.remote_control
+	if(target == cam.ship_target) // Allows us to use this as a toggle
+		target = null
 	cam.track_target(target)
 
 // This is so ridicously expensive, who made this.

--- a/nsv13/code/modules/overmap/overmap_ghosts.dm
+++ b/nsv13/code/modules/overmap/overmap_ghosts.dm
@@ -54,7 +54,10 @@
 
 	//Insert the extra machines
 	if(!dradis)
-		dradis = new /obj/machinery/computer/ship/dradis/internal(src)
+		if(mass >= MASS_SMALL)
+			dradis = new /obj/machinery/computer/ship/dradis/internal/large_ship(src)
+		else
+			dradis = new /obj/machinery/computer/ship/dradis/internal(src)
 		dradis.linked = src
 
 	if(!tactical)
@@ -78,7 +81,7 @@
 
 	//Make sure the ship doesn't enter countdown
 	overmap_deletion_traits = DAMAGE_ALWAYS_DELETES
-	
+
 	//Add some verbs
 	overmap_verbs = list(.verb/toggle_brakes, .verb/toggle_inertia, .verb/show_dradis, .verb/show_tactical, .verb/toggle_move_mode, .verb/cycle_firemode)
 

--- a/nsv13/code/modules/overmap/physics.dm
+++ b/nsv13/code/modules/overmap/physics.dm
@@ -420,10 +420,12 @@ This proc is to be used when someone gets stuck in an overmap ship, gauss, WHATE
 	for(var/obj/structure/overmap/OM in target_painted)
 		if(target_painted[OM] != FALSE) // Datalink target, something else is handling tracking for us
 			continue
-		if(overmap_dist(src, OM) < max(dradis ? dradis.sensor_range : SENSOR_RANGE_DEFAULT, OM.sensor_profile) && OM.is_sensor_visible(src))
+		if(overmap_dist(src, OM) < max(dradis ? dradis.sensor_range * 2 : SENSOR_RANGE_DEFAULT, OM.sensor_profile) && OM.is_sensor_visible(src))
 			target_last_tracked[OM] = world.time // We can see the target, update tracking time
 			continue
 		if(target_last_tracked[OM] + target_loss_time < world.time)
+			if(gunner)
+				to_chat(gunner, "<span class='warning'>Target [OM] lost.</span>")
 			dump_lock(OM) // We lost the track
 
 /obj/structure/overmap/small_craft/collide(obj/structure/overmap/other, datum/collision_response/c_response, collision_velocity)
@@ -605,15 +607,15 @@ This proc is to be used when someone gets stuck in an overmap ship, gauss, WHATE
 	if(physics2d && physics2d.collider2d)
 		proj.setup_collider()
 	if(proj.can_home)	//Lets not have projectiles home in on some random tile someone clicked on to launch
-		if((length(target_painted) > 0))
+		if(!isturf(target))
+			proj.set_homing_target(target)
+		else if((length(target_painted) > 0))
 			if(!target_lock) // no selected target, fire at the first one in our list
 				proj.set_homing_target(target_painted[1])
 			else if(target_painted.Find(target_lock)) // Fire at a manually selected target
 				proj.set_homing_target(target_lock)
 			else // something fucked up, dump the lock
 				target_lock = null
-		else if(!isturf(target))
-			proj.set_homing_target(target)
 	if(gunner)
 		proj.firer = gunner
 	else

--- a/nsv13/code/modules/overmap/physics.dm
+++ b/nsv13/code/modules/overmap/physics.dm
@@ -418,7 +418,7 @@ This proc is to be used when someone gets stuck in an overmap ship, gauss, WHATE
 
 	// Lock handling
 	for(var/obj/structure/overmap/OM in target_painted)
-		if(target_painted[OM] != FALSE) // Datalink target, something else is handling tracking for us
+		if(target_painted[OM]) // Datalink target, something else is handling tracking for us
 			continue
 		if(overmap_dist(src, OM) < max(dradis ? dradis.sensor_range * 2 : SENSOR_RANGE_DEFAULT, OM.sensor_profile) && OM.is_sensor_visible(src))
 			target_last_tracked[OM] = world.time // We can see the target, update tracking time

--- a/nsv13/code/modules/overmap/physics.dm
+++ b/nsv13/code/modules/overmap/physics.dm
@@ -416,6 +416,16 @@ This proc is to be used when someone gets stuck in an overmap ship, gauss, WHATE
 			return
 		fire(autofire_target)
 
+	// Lock handling
+	for(var/obj/structure/overmap/OM in target_painted)
+		if(target_painted[OM] != FALSE) // Datalink target, something else is handling tracking for us
+			continue
+		if(overmap_dist(src, OM) < max(dradis ? dradis.sensor_range : SENSOR_RANGE_DEFAULT, OM.sensor_profile) || OM.is_sensor_visible(src))
+			target_last_tracked[OM] = world.time // We can see the target, update tracking time
+			continue
+		if(target_last_tracked[OM] + target_loss_time < world.time)
+			dump_lock(OM) // We lost the track
+
 /obj/structure/overmap/small_craft/collide(obj/structure/overmap/other, datum/collision_response/c_response, collision_velocity)
 	addtimer(VARSET_CALLBACK(src, layer, ABOVE_MOB_LAYER), 0.5 SECONDS)
 	layer = LOW_OBJ_LAYER // Stop us from just bumping right into them after we bounce

--- a/nsv13/code/modules/overmap/physics.dm
+++ b/nsv13/code/modules/overmap/physics.dm
@@ -606,7 +606,7 @@ This proc is to be used when someone gets stuck in an overmap ship, gauss, WHATE
 	proj.faction = faction
 	if(physics2d && physics2d.collider2d)
 		proj.setup_collider()
-	if(proj.can_home)	//Lets not have projectiles home in on some random tile someone clicked on to launch
+	if(proj.can_home)	// Handles projectile homing and alerting the target
 		if(!isturf(target))
 			proj.set_homing_target(target)
 		else if((length(target_painted) > 0))
@@ -616,6 +616,9 @@ This proc is to be used when someone gets stuck in an overmap ship, gauss, WHATE
 				proj.set_homing_target(target_lock)
 			else // something fucked up, dump the lock
 				target_lock = null
+		if(isovermap(proj.homing_target))
+			var/obj/structure/overmap/overmap_target = proj.homing_target
+			overmap_target.on_missile_lock(src, proj)
 	if(gunner)
 		proj.firer = gunner
 	else

--- a/nsv13/code/modules/overmap/physics.dm
+++ b/nsv13/code/modules/overmap/physics.dm
@@ -420,7 +420,7 @@ This proc is to be used when someone gets stuck in an overmap ship, gauss, WHATE
 	for(var/obj/structure/overmap/OM in target_painted)
 		if(target_painted[OM] != FALSE) // Datalink target, something else is handling tracking for us
 			continue
-		if(overmap_dist(src, OM) < max(dradis ? dradis.sensor_range : SENSOR_RANGE_DEFAULT, OM.sensor_profile) || OM.is_sensor_visible(src))
+		if(overmap_dist(src, OM) < max(dradis ? dradis.sensor_range : SENSOR_RANGE_DEFAULT, OM.sensor_profile) && OM.is_sensor_visible(src))
 			target_last_tracked[OM] = world.time // We can see the target, update tracking time
 			continue
 		if(target_last_tracked[OM] + target_loss_time < world.time)

--- a/nsv13/code/modules/overmap/radar.dm
+++ b/nsv13/code/modules/overmap/radar.dm
@@ -39,15 +39,16 @@
 	var/radar_delay = MIN_RADAR_DELAY
 	// Whether we use DRADIS-assisted targeting.
 	var/dradis_targeting = FALSE
+	// Whether we can use the radar
+	var/can_use_radar = TRUE
 
 /obj/machinery/computer/ship/dradis/proc/can_radar_pulse()
+	if(!can_use_radar)
+		return FALSE
 	var/obj/structure/overmap/OM = get_overmap()
 	var/next_pulse = OM.last_radar_pulse + radar_delay
 	if(world.time >= next_pulse)
 		return TRUE
-
-/obj/machinery/computer/ship/dradis/internal/can_radar_pulse()
-	return FALSE
 
 /obj/machinery/computer/ship/dradis/internal/awacs/can_radar_pulse()
 	var/obj/structure/overmap/OM = loc
@@ -56,9 +57,6 @@
 	var/next_pulse = OM.last_radar_pulse + radar_delay
 	if(world.time >= next_pulse)
 		return TRUE
-
-/obj/machinery/computer/ship/dradis/minor/can_radar_pulse()
-	return FALSE
 
 
 /*
@@ -127,6 +125,7 @@ Called by add_sensor_profile_penalty if remove_in is used.
 
 /obj/machinery/computer/ship/dradis/minor //Secondary dradis consoles usable by people who arent on the bridge. All secondary dradis consoles should be a subtype of this
 	name = "air traffic control console"
+	can_use_radar = FALSE
 
 /obj/machinery/computer/ship/dradis/minor/cargo //Another dradis like air traffic control, links to cargo torpedo tubes and delivers freight
 	name = "\improper Cargo freight delivery console"
@@ -184,6 +183,7 @@ Called by add_sensor_profile_penalty if remove_in is used.
 	start_with_sound = FALSE
 	base_sensor_range = SENSOR_RANGE_FIGHTER
 	hail_range = 30
+	can_use_radar = FALSE
 
 /obj/machinery/computer/ship/dradis/internal/has_overmap()
 	return linked
@@ -433,6 +433,7 @@ Called by add_sensor_profile_penalty if remove_in is used.
 			send_radar_pulse()
 	else
 		data["can_radar_pulse"] = FALSE
+	data["can_use_radar"] = can_use_radar
 	return data
 
 /datum/asset/simple/overmap_flight

--- a/nsv13/code/modules/overmap/radar.dm
+++ b/nsv13/code/modules/overmap/radar.dm
@@ -18,6 +18,7 @@
 	var/show_asteroids = FALSE //Used so that mining can track what they're supposed to be drilling.
 	var/mining_sensor_tier = 1
 	var/last_ship_count = 0 //Plays a tone when ship count changes
+	var/last_missile_warning = 0 // Anti-spam for missile warning messages
 	//Alpha sliders to let you filter out info you don't want to see.
 	var/showFriendlies = 100
 	var/showEnemies= 100

--- a/nsv13/code/modules/overmap/radar.dm
+++ b/nsv13/code/modules/overmap/radar.dm
@@ -25,6 +25,7 @@
 	var/showAnomalies = 100
 	var/sensor_range = 0 //Automatically set to equal base sensor range on init.
 	var/base_sensor_range = SENSOR_RANGE_DEFAULT //In tiles. How far your sensors can pick up precise info about ships.
+	var/visual_range = VISUAL_RANGE_DEFAULT
 	var/zoom_factor = 0.5 //Lets you zoom in / out on the DRADIS for more precision, or for better info.
 	var/zoom_factor_min = 0.25
 	var/zoom_factor_max = 2
@@ -271,6 +272,7 @@ Called by add_sensor_profile_penalty if remove_in is used.
 				return
 			if(dradis_targeting && (linked.gunner == usr || linked.pilot == usr) && target.faction != linked.faction)
 				linked.start_lockon(target)
+				return
 			if(world.time < next_hail)
 				return
 			if(target == linked)
@@ -294,6 +296,7 @@ Called by add_sensor_profile_penalty if remove_in is used.
 			radar_delay = newDelay
 		if("dradis_targeting")
 			if(!(linked.gunner == usr || linked.pilot == usr))
+				return
 			dradis_targeting = !dradis_targeting
 
 /obj/machinery/computer/ship/dradis/attackby(obj/item/I, mob/user) //Allows you to upgrade dradis consoles to show asteroids, as well as revealing more valuable ones.
@@ -414,6 +417,7 @@ Called by add_sensor_profile_penalty if remove_in is used.
 	data["sensor_mode"] = (sensor_mode == SENSOR_MODE_PASSIVE) ? "Passive Radar" : "Active Radar"
 	data["pulse_delay"] = "[radar_delay / 10]"
 	data["dradis_targeting"] = dradis_targeting
+	data["can_target"] = (linked?.gunner == user || linked?.pilot == user)
 	if(can_radar_pulse())
 		data["can_radar_pulse"] = TRUE
 		if(sensor_mode == SENSOR_MODE_RADAR && !isobserver(user))

--- a/nsv13/code/modules/overmap/radar.dm
+++ b/nsv13/code/modules/overmap/radar.dm
@@ -25,7 +25,7 @@
 	var/showAnomalies = 100
 	var/sensor_range = 0 //Automatically set to equal base sensor range on init.
 	var/base_sensor_range = SENSOR_RANGE_DEFAULT //In tiles. How far your sensors can pick up precise info about ships.
-	var/visual_range = VISUAL_RANGE_DEFAULT
+	var/visual_range = SENSOR_RANGE_DEFAULT // The default range of a ship's guncam
 	var/zoom_factor = 0.5 //Lets you zoom in / out on the DRADIS for more precision, or for better info.
 	var/zoom_factor_min = 0.25
 	var/zoom_factor_max = 2
@@ -326,6 +326,11 @@ Called by add_sensor_profile_penalty if remove_in is used.
 	//If we fired off a radar, we're visible to _every ship_
 	if(last_radar_pulse+RADAR_VISIBILITY_PENALTY > world.time)
 		return SENSOR_VISIBILITY_FULL
+
+	// We're lighting them up with our tracking radar, so they know we're here until we drop the lock
+	if(observer in target_painted)
+		return SENSOR_VISIBILITY_FULL
+
 	//Convert alpha to an opacity reading.
 	switch(alpha)
 		if(0 to 50) //Nigh on invisible. You cannot detect ships that are this cloaked by any means.

--- a/nsv13/code/modules/overmap/radar.dm
+++ b/nsv13/code/modules/overmap/radar.dm
@@ -270,8 +270,11 @@ Called by add_sensor_profile_penalty if remove_in is used.
 			var/obj/structure/overmap/target = locate(params["target"])
 			if(!target) //Anomalies don't count.
 				return
-			if(dradis_targeting && (linked.gunner == usr || linked.pilot == usr) && target.faction != linked.faction)
-				linked.start_lockon(target)
+			if(dradis_targeting && (linked.gunner == usr || linked.pilot == usr))
+				if(target.faction != linked.faction)
+					linked.start_lockon(target)
+					return
+				linked.datalink_transmit(target)
 				return
 			if(world.time < next_hail)
 				return
@@ -359,8 +362,8 @@ Called by add_sensor_profile_penalty if remove_in is used.
 			blips.Add(list(list("x" = OA.x, "y" = OA.y, "colour" = "#eb9534", "name" = "[(OA.scanned) ? OA.name : "anomaly"]", opacity=showAnomalies*0.01, alignment = "uncharted")))
 	for(var/obj/structure/overmap/OM in GLOB.overmap_objects) //Iterate through overmaps in the world! - Needs to go through global overmaps since it may be on a ship's z level or in hyperspace.
 		var/sensor_visible = (OM != linked && OM.faction != linked.faction) ? ((overmap_dist(linked, OM) > max(sensor_range * 2, OM.sensor_profile)) ? 0 : OM.is_sensor_visible(linked)) : SENSOR_VISIBILITY_FULL //You can always see your own ship, or allied, cloaked ships.
-		if(OM.z == linked.z && sensor_visible >= SENSOR_VISIBILITY_FAINT)
-			var/inRange = (overmap_dist(linked, OM) <= max(sensor_range,OM.sensor_profile)) || OM.faction == linked.faction	//Allies broadcast encrypted IFF so we can see them anywhere.
+		if(OM.z == linked.z && (sensor_visible >= SENSOR_VISIBILITY_FAINT || linked.target_painted[OM] != FALSE))
+			var/inRange = (overmap_dist(linked, OM) <= max(sensor_range,OM.sensor_profile)) || OM.faction == linked.faction	//Allies broadcast encrypted IFF so we can see them anywhere, and we can always see enemies recieved over datalink
 			var/thecolour = "#FFFFFF"
 			var/filterType = showEnemies
 			if(istype(OM, /obj/structure/overmap/asteroid))

--- a/nsv13/code/modules/overmap/radar.dm
+++ b/nsv13/code/modules/overmap/radar.dm
@@ -368,7 +368,7 @@ Called by add_sensor_profile_penalty if remove_in is used.
 			blips.Add(list(list("x" = OA.x, "y" = OA.y, "colour" = "#eb9534", "name" = "[(OA.scanned) ? OA.name : "anomaly"]", opacity=showAnomalies*0.01, alignment = "uncharted")))
 	for(var/obj/structure/overmap/OM in GLOB.overmap_objects) //Iterate through overmaps in the world! - Needs to go through global overmaps since it may be on a ship's z level or in hyperspace.
 		var/sensor_visible = (OM != linked && OM.faction != linked.faction) ? ((overmap_dist(linked, OM) > max(sensor_range * 2, OM.sensor_profile)) ? 0 : OM.is_sensor_visible(linked)) : SENSOR_VISIBILITY_FULL //You can always see your own ship, or allied, cloaked ships.
-		if(OM.z == linked.z && (sensor_visible >= SENSOR_VISIBILITY_FAINT || linked.target_painted[OM] != FALSE))
+		if(OM.z == linked.z && (sensor_visible >= SENSOR_VISIBILITY_FAINT || linked.target_painted[OM]))
 			var/inRange = (overmap_dist(linked, OM) <= max(sensor_range,OM.sensor_profile)) || OM.faction == linked.faction	//Allies broadcast encrypted IFF so we can see them anywhere, and we can always see enemies recieved over datalink
 			var/thecolour = "#FFFFFF"
 			var/filterType = showEnemies

--- a/nsv13/code/modules/overmap/radar.dm
+++ b/nsv13/code/modules/overmap/radar.dm
@@ -185,6 +185,10 @@ Called by add_sensor_profile_penalty if remove_in is used.
 	hail_range = 30
 	can_use_radar = FALSE
 
+/obj/machinery/computer/ship/dradis/internal/large_ship
+	base_sensor_range = SENSOR_RANGE_DEFAULT
+	can_use_radar = TRUE
+
 /obj/machinery/computer/ship/dradis/internal/has_overmap()
 	return linked
 

--- a/nsv13/code/modules/overmap/radar.dm
+++ b/nsv13/code/modules/overmap/radar.dm
@@ -373,7 +373,7 @@ Called by add_sensor_profile_penalty if remove_in is used.
 	for(var/obj/structure/overmap/OM in GLOB.overmap_objects) //Iterate through overmaps in the world! - Needs to go through global overmaps since it may be on a ship's z level or in hyperspace.
 		var/sensor_visible = (OM != linked && OM.faction != linked.faction) ? ((overmap_dist(linked, OM) > max(sensor_range * 2, OM.sensor_profile)) ? 0 : OM.is_sensor_visible(linked)) : SENSOR_VISIBILITY_FULL //You can always see your own ship, or allied, cloaked ships.
 		if(OM.z == linked.z && (sensor_visible >= SENSOR_VISIBILITY_FAINT || linked.target_painted[OM]))
-			var/inRange = (overmap_dist(linked, OM) <= max(sensor_range,OM.sensor_profile)) || OM.faction == linked.faction	//Allies broadcast encrypted IFF so we can see them anywhere, and we can always see enemies recieved over datalink
+			var/inRange = (overmap_dist(linked, OM) <= max(sensor_range,OM.sensor_profile)) || OM.faction == linked.faction || linked.target_painted[OM]	//Allies broadcast encrypted IFF so we can see them anywhere, and we can always see enemies recieved over datalink
 			var/thecolour = "#FFFFFF"
 			var/filterType = showEnemies
 			if(istype(OM, /obj/structure/overmap/asteroid))
@@ -404,7 +404,7 @@ Called by add_sensor_profile_penalty if remove_in is used.
 			var/thefaction = ((OM.faction == "nanotrasen" || OM.faction == "syndicate") && inRange) ? OM.faction : "unaligned" //You runnin with the blues or reds? Obfuscate faction too :)
 			thecolour = (inRange) ? thecolour : "#a66300"
 			filterType = (inRange) ? filterType : 100 //Can't hide things that you don't have sensor resolution on, this is to stop you being able to say, turn off enemy vision, see a target outside of scanner range go dark, and then go HMM.
-			if(sensor_visible <= SENSOR_VISIBILITY_FAINT) //For "transparent" / Somewhat hidden ships, show a reduced sensor ping.
+			if(sensor_visible <= SENSOR_VISIBILITY_FAINT && !linked.target_painted[OM]) //For "transparent" / Somewhat hidden ships, show a reduced sensor ping.
 				filterType = sensor_visible //Sensor_visible already returns a CSS compliant opacity figure.
 			else
 				filterType *= 0.01 //Scale the number down to be an opacity figure for CSS

--- a/nsv13/code/modules/overmap/weapons/projectiles_fx.dm
+++ b/nsv13/code/modules/overmap/weapons/projectiles_fx.dm
@@ -36,6 +36,7 @@ Misc projectile types, effects, think of this as the special FX file.
 	//Not easily stopped.
 	obj_integrity = 300
 	max_integrity = 300
+	can_home = TRUE
 	homing_turn_speed = 2.5
 	flag = "overmap_heavy"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/torpedo
@@ -344,6 +345,7 @@ Misc projectile types, effects, think of this as the special FX file.
 	obj_integrity = 50
 	max_integrity = 50
 	density = TRUE
+	can_home = TRUE
 	armor = list("overmap_light" = 10, "overmap_medium" = 0, "overmap_heavy" = 0)
 
 /obj/item/projectile/guided_munition/torpedo
@@ -427,6 +429,7 @@ Misc projectile types, effects, think of this as the special FX file.
 /obj/item/projectile/guided_munition/torpedo/dud
 	icon_state = "torpedo_dud"
 	damage = 0
+	can_home = FALSE
 
 /obj/item/projectile/guided_munition/Initialize(mapload)
 	. = ..()

--- a/nsv13/code/modules/overmap/weapons/weapons.dm
+++ b/nsv13/code/modules/overmap/weapons/weapons.dm
@@ -87,14 +87,11 @@
 	if(ai_controlled || !linked_areas.len && role != MAIN_OVERMAP) //AI ships and fighters don't have interiors
 		if(torpedoes <= 0)
 			return FALSE
-		var/obj/structure/overmap/OM = target
 		if(isovermap(target))
 			ai_aim = FALSE // This is a homing projectile
 		var/launches = min(torpedoes, burst)
 
 		fire_projectile(torpedo_type, target, speed=3, lateral = TRUE, ai_aim = ai_aim)
-		if(isovermap(OM) && OM.dradis)
-			OM.dradis?.relay_sound('nsv13/sound/effects/fighters/launchwarning.ogg')
 		var/datum/ship_weapon/SW = weapon_types[FIRE_MODE_TORPEDO]
 		relay_to_nearby(pick(SW.overmap_firing_sounds))
 
@@ -105,17 +102,13 @@
 
 /obj/structure/overmap/proc/fire_torpedo_burst(atom/target, ai_aim = FALSE, burst = 1)
 	set waitfor = FALSE
-	var/obj/structure/overmap/OM = target
 	for(var/cycle = 1; cycle <= burst; cycle++)
 		sleep(3)
 		if(QDELETED(src))	//We might get shot.
 			return
 		if(QDELETED(target))
-			OM = null
 			target = null
 		fire_projectile(torpedo_type, target, speed=3, lateral = TRUE, ai_aim = ai_aim)
-		if(isovermap(OM) && OM.dradis)
-			OM.dradis?.relay_sound('nsv13/sound/effects/fighters/launchwarning.ogg')
 		var/datum/ship_weapon/SW = weapon_types[FIRE_MODE_TORPEDO]
 		relay_to_nearby(pick(SW.overmap_firing_sounds))
 
@@ -130,8 +123,6 @@
 		if(istype(OM))
 			ai_aim = FALSE // This is a homing projectile
 		fire_projectile(/obj/item/projectile/guided_munition/missile, target, lateral = FALSE, ai_aim = ai_aim)
-		if(istype(OM, /obj/structure/overmap) && OM.dradis)
-			OM.dradis?.relay_sound('nsv13/sound/effects/fighters/launchwarning.ogg')
 		var/datum/ship_weapon/SW = weapon_types[FIRE_MODE_MISSILE]
 		relay_to_nearby(pick(SW.overmap_firing_sounds))
 		return TRUE

--- a/nsv13/code/modules/overmap/weapons/weapons.dm
+++ b/nsv13/code/modules/overmap/weapons/weapons.dm
@@ -92,7 +92,7 @@
 			ai_aim = FALSE // This is a homing projectile
 		var/launches = min(torpedoes, burst)
 
-		fire_projectile(torpedo_type, target, homing = TRUE, speed=3, lateral = TRUE, ai_aim = ai_aim)
+		fire_projectile(torpedo_type, target, speed=3, lateral = TRUE, ai_aim = ai_aim)
 		if(isovermap(OM) && OM.dradis)
 			OM.dradis?.relay_sound('nsv13/sound/effects/fighters/launchwarning.ogg')
 		var/datum/ship_weapon/SW = weapon_types[FIRE_MODE_TORPEDO]
@@ -113,7 +113,7 @@
 		if(QDELETED(target))
 			OM = null
 			target = null
-		fire_projectile(torpedo_type, target, homing = TRUE, speed=3, lateral = TRUE, ai_aim = ai_aim)
+		fire_projectile(torpedo_type, target, speed=3, lateral = TRUE, ai_aim = ai_aim)
 		if(isovermap(OM) && OM.dradis)
 			OM.dradis?.relay_sound('nsv13/sound/effects/fighters/launchwarning.ogg')
 		var/datum/ship_weapon/SW = weapon_types[FIRE_MODE_TORPEDO]
@@ -129,7 +129,7 @@
 		var/obj/structure/overmap/OM = target
 		if(istype(OM))
 			ai_aim = FALSE // This is a homing projectile
-		fire_projectile(/obj/item/projectile/guided_munition/missile, target, homing = TRUE, lateral = FALSE, ai_aim = ai_aim)
+		fire_projectile(/obj/item/projectile/guided_munition/missile, target, lateral = FALSE, ai_aim = ai_aim)
 		if(istype(OM, /obj/structure/overmap) && OM.dradis)
 			OM.dradis?.relay_sound('nsv13/sound/effects/fighters/launchwarning.ogg')
 		var/datum/ship_weapon/SW = weapon_types[FIRE_MODE_MISSILE]

--- a/tgui/packages/tgui/interfaces/AMS.js
+++ b/tgui/packages/tgui/interfaces/AMS.js
@@ -14,6 +14,12 @@ export const AMS = (props, context) => {
       width={500}
       height={500}>
       <Window.Content scrollable>
+        <Section title="Target Source:">
+          <Button
+            content={data.data_source}
+            icon="bullseye"
+            onClick={() => act('data_source')} />
+        </Section>
         <Section title="AMS Modes:">
           {Object.keys(data.categories).map(key => {
             let value = data.categories[key];

--- a/tgui/packages/tgui/interfaces/Dradis.js
+++ b/tgui/packages/tgui/interfaces/Dradis.js
@@ -91,12 +91,14 @@ export const DradisContent = (props, context) => {
             content="Re-focus"
             icon="camera"
             onClick={() => location.reload()} />
-          <Button
-            content={(data.dradis_targeting) ? "Targeting" : "Hailing"}
-            icon={data.dradis_targeting ? "bullseye" : "square-o"}
-            disabled={!data.can_target}
-            color={(data.dradis_targeting && data.can_radar_pulse) ? "bad" : "good"}
-            onClick={() => act('dradis_targeting')} />
+          {!!data.can_target && (
+            <Button
+              content={(dradis_targeting) ? "Targeting" : "Hailing"}
+              icon={dradis_targeting ? "bullseye" : "square-o"}
+              disabled={!data.can_target}
+              color={(data.dradis_targeting && data.can_radar_pulse) ? "bad" : "good"}
+              onClick={() => act('dradis_targeting')} />
+          )}
         </>
       )}>
       Allies:

--- a/tgui/packages/tgui/interfaces/Dradis.js
+++ b/tgui/packages/tgui/interfaces/Dradis.js
@@ -61,6 +61,7 @@ export const DradisContent = (props, context) => {
   let zoom_factor_max = data.zoom_factor_max;
   let scale_factor = zoom_factor*5;
   let dradis_targeting = data.dradis_targeting;
+  let can_use_radar = data.can_use_radar;
   let dradis = DradisMap(data.ships, zoom_factor, data.width_mod, focus_x, focus_y);
 
   return (
@@ -74,19 +75,23 @@ export const DradisContent = (props, context) => {
           <Button
             icon="search-minus"
             onClick={() => act('zoomout')} />
-          <Button
-            content="Radar Pulse"
-            icon="bullseye"
-            disabled={!data.can_radar_pulse}
-            onClick={() => act('radar_pulse')} />
-          <Button
-            content={data.sensor_mode}
-            icon="project-diagram"
-            onClick={() => act('sensor_mode')} />
-          <Button
-            content={data.pulse_delay}
-            icon="stopwatch"
-            onClick={() => act('radar_delay')} />
+          {!!data.can_use_radar && (
+            <>
+              <Button
+                content="Radar Pulse"
+                icon="bullseye"
+                disabled={!data.can_radar_pulse}
+                onClick={() => act('radar_pulse')} />
+              <Button
+                content={data.sensor_mode}
+                icon="project-diagram"
+                onClick={() => act('sensor_mode')} />
+              <Button
+                content={data.pulse_delay}
+                icon="stopwatch"
+                onClick={() => act('radar_delay')} />
+            </>
+          )}
           <Button
             content="Re-focus"
             icon="camera"
@@ -96,7 +101,7 @@ export const DradisContent = (props, context) => {
               content={(dradis_targeting) ? "Targeting" : "Hailing"}
               icon={dradis_targeting ? "bullseye" : "square-o"}
               disabled={!data.can_target}
-              color={(data.dradis_targeting && data.can_radar_pulse) ? "bad" : "good"}
+              color={(data.dradis_targeting) ? "bad" : "good"}
               onClick={() => act('dradis_targeting')} />
           )}
         </>

--- a/tgui/packages/tgui/interfaces/Dradis.js
+++ b/tgui/packages/tgui/interfaces/Dradis.js
@@ -92,9 +92,10 @@ export const DradisContent = (props, context) => {
             icon="camera"
             onClick={() => location.reload()} />
           <Button
-            content="DRADIS targeting"
-            icon={data.dradis_targeting ? "power-off" : "square-o"}
-            color={data.dradis_targeting ? "good" : "bad"}
+            content={(data.dradis_targeting) ? "Targeting" : "Hailing"}
+            icon={data.dradis_targeting ? "bullseye" : "square-o"}
+            disabled={!data.can_target}
+            color={(data.dradis_targeting && data.can_radar_pulse) ? "bad" : "good"}
             onClick={() => act('dradis_targeting')} />
         </>
       )}>

--- a/tgui/packages/tgui/interfaces/Dradis.js
+++ b/tgui/packages/tgui/interfaces/Dradis.js
@@ -60,6 +60,7 @@ export const DradisContent = (props, context) => {
   let zoom_factor_min = data.zoom_factor_min;
   let zoom_factor_max = data.zoom_factor_max;
   let scale_factor = zoom_factor*5;
+  let dradis_targeting = data.dradis_targeting;
   let dradis = DradisMap(data.ships, zoom_factor, data.width_mod, focus_x, focus_y);
 
   return (
@@ -90,6 +91,11 @@ export const DradisContent = (props, context) => {
             content="Re-focus"
             icon="camera"
             onClick={() => location.reload()} />
+          <Button
+            content="DRADIS targeting"
+            icon={data.dradis_targeting ? "power-off" : "square-o"}
+            color={data.dradis_targeting ? "good" : "bad"}
+            onClick={() => act('dradis_targeting')} />
         </>
       )}>
       Allies:

--- a/tgui/packages/tgui/interfaces/GhostTacticalConsole.js
+++ b/tgui/packages/tgui/interfaces/GhostTacticalConsole.js
@@ -11,7 +11,7 @@ export const GhostTacticalConsole = (props, context) => {
   return (
     <Window
       resizable
-      theme="nanotrasen"
+      theme="hackerman"
       width={560}
       height={600}>
       <Window.Content scrollable>

--- a/tgui/packages/tgui/interfaces/GhostTacticalConsole.js
+++ b/tgui/packages/tgui/interfaces/GhostTacticalConsole.js
@@ -11,7 +11,7 @@ export const GhostTacticalConsole = (props, context) => {
   return (
     <Window
       resizable
-      theme="retro"
+      theme="nanotrasen"
       width={560}
       height={600}>
       <Window.Content scrollable>
@@ -108,84 +108,68 @@ export const GhostTacticalConsole = (props, context) => {
             </LabeledList>
           </Section>
           <Section title="Tracking:">
+            {!data.no_gun_cam && (
+              <Button
+                width="100%"
+                fluid
+                content={"Toggle Gun Camera"}
+                icon="bullseye"
+                onClick={() => act('toggle_gun_camera')} />)}
             {Object.keys(data.painted_targets).map((key, newCurrent) => {
               let value = data.painted_targets[key];
               const [current, setCurrent] = useLocalState(context, 'fs_current', true);
               const [hidden, setHidden] = useLocalState(context, 'fs_hidden', true);
 
               return (
-                <>
-                  {!data.no_gun_cam && (
-                    <Button
-                      width="100%"
-                      fluid
-                      content={"Toggle Gun Camera"}
-                      icon="bullseye"
-                      onClick={() => act('toggle_gun_camera')} />)}
-                  <Fragment key={key}>
-                    {!!value.name && (
-                      <Section>
-                        <Button
-                          width="100%"
-                          fluid
-                          onClick={() => {
-                            setCurrent(value.name);
-                            setHidden(!hidden);
-                          }}>
-                          {`${value.name}`}
-                        </Button>
-                        {!!(current === value.name) && !hidden && (
-                          <Section title="Armour">
-                            <LabeledList>
-                              <LabeledList.Item label="Forward Starboard">
-                                <ProgressBar
-                                  value={(
-                                    value.quadrant_fp_armour_current/value.quadrant_fp_armour_max * 100)* 0.01}
-                                  ranges={{
-                                    good: [0.95, Infinity],
-                                    average: [0.15, 0.9],
-                                    bad: [-Infinity, 0.15],
-                                  }} />
-                              </LabeledList.Item>
-                              <LabeledList.Item label="Forward Port">
-                                <ProgressBar
-                                  value={(
-                                    value.quadrant_fs_armour_current/value.quadrant_fs_armour_max * 100)* 0.01}
-                                  ranges={{
-                                    good: [0.95, Infinity],
-                                    average: [0.15, 0.9],
-                                    bad: [-Infinity, 0.15],
-                                  }} />
-                              </LabeledList.Item>
-                              <LabeledList.Item label="Aft Starboard">
-                                <ProgressBar
-                                  value={(
-                                    value.quadrant_as_armour_current/value.quadrant_as_armour_max * 100)* 0.01}
-                                  ranges={{
-                                    good: [0.95, Infinity],
-                                    average: [0.15, 0.9],
-                                    bad: [-Infinity, 0.15],
-                                  }} />
-                              </LabeledList.Item>
-                              <LabeledList.Item label="Aft Port">
-                                <ProgressBar
-                                  value={(
-                                    value.quadrant_ap_armour_current/value.quadrant_ap_armour_max * 100)* 0.01}
-                                  ranges={{
-                                    good: [0.95, Infinity],
-                                    average: [0.15, 0.9],
-                                    bad: [-Infinity, 0.15],
-                                  }} />
-                              </LabeledList.Item>
-                            </LabeledList>
-                          </Section>
-                        )}
-                        <Section>
+                <Fragment key={key}>
+                  {!!value.name && (
+                    <Section>
+                      <Button
+                        width="100%"
+                        fluid
+                        onClick={() => {
+                          setCurrent(value.name);
+                          setHidden(!hidden);
+                        }}>
+                        {`${value.name}`}
+                      </Button>
+                      {!!(current === value.name) && !hidden && (
+                        <Section title="Armour">
                           <LabeledList>
-                            <LabeledList.Item label="Integrity">
+                            <LabeledList.Item label="Forward Starboard">
                               <ProgressBar
                                 value={(
-                                  value.integrity/value.max_integrity * 100)* 0.01}
+                                  value.quadrant_fp_armour_current / value.quadrant_fp_armour_max * 100) * 0.01}
+                                ranges={{
+                                  good: [0.95, Infinity],
+                                  average: [0.15, 0.9],
+                                  bad: [-Infinity, 0.15],
+                                }} />
+                            </LabeledList.Item>
+                            <LabeledList.Item label="Forward Port">
+                              <ProgressBar
+                                value={(
+                                  value.quadrant_fs_armour_current / value.quadrant_fs_armour_max * 100) * 0.01}
+                                ranges={{
+                                  good: [0.95, Infinity],
+                                  average: [0.15, 0.9],
+                                  bad: [-Infinity, 0.15],
+                                }} />
+                            </LabeledList.Item>
+                            <LabeledList.Item label="Aft Starboard">
+                              <ProgressBar
+                                value={(
+                                  value.quadrant_as_armour_current / value.quadrant_as_armour_max * 100) * 0.01}
+                                ranges={{
+                                  good: [0.95, Infinity],
+                                  average: [0.15, 0.9],
+                                  bad: [-Infinity, 0.15],
+                                }} />
+                            </LabeledList.Item>
+                            <LabeledList.Item label="Aft Port">
+                              <ProgressBar
+                                value={(
+                                  value.quadrant_ap_armour_current / value.quadrant_ap_armour_max * 100) * 0.01}
                                 ranges={{
                                   good: [0.95, Infinity],
                                   average: [0.15, 0.9],
@@ -194,22 +178,36 @@ export const GhostTacticalConsole = (props, context) => {
                             </LabeledList.Item>
                           </LabeledList>
                         </Section>
-                        <Button
-                          fluid
-                          content={data.target_name === value.name ? `Stop Targeting ${value.name}` : `Target ${value.name}`}
-                          icon="bullseye"
-                          onClick={() =>
-                            act('lock_ship', { target: value.name })} />
-                        <Button
-                          fluid
-                          content={`Stop Tracking ${value.name}`}
-                          icon="bullseye"
-                          onClick={() =>
-                            act('dump_lock', { target: value.name })} />
+                      )}
+                      <Section>
+                        <LabeledList>
+                          <LabeledList.Item label="Integrity">
+                            <ProgressBar
+                              value={(
+                                value.integrity / value.max_integrity * 100) * 0.01}
+                              ranges={{
+                                good: [0.95, Infinity],
+                                average: [0.15, 0.9],
+                                bad: [-Infinity, 0.15],
+                              }} />
+                          </LabeledList.Item>
+                        </LabeledList>
                       </Section>
-                    )}
-                  </Fragment>
-                </>);
+                      <Button
+                        fluid
+                        content={data.target_name === value.name ? `Stop Targeting ${value.name}` : `Target ${value.name}`}
+                        icon="bullseye"
+                        onClick={() =>
+                          act('lock_ship', { target: value.name })} />
+                      <Button
+                        fluid
+                        content={`Stop Tracking ${value.name}`}
+                        icon="bullseye"
+                        onClick={() =>
+                          act('dump_lock', { target: value.name })} />
+                    </Section>
+                  )}
+                </Fragment>);
             })}
           </Section>
         </Section>

--- a/tgui/packages/tgui/interfaces/GhostTacticalConsole.js
+++ b/tgui/packages/tgui/interfaces/GhostTacticalConsole.js
@@ -188,10 +188,16 @@ export const GhostTacticalConsole = (props, context) => {
                       </Section>
                       <Button
                         fluid
-                        content={`Target ${value.name}`}
+                        content={data.target_name === value.name ? `Stop Targeting ${value.name}` : `Target ${value.name}`}
                         icon="bullseye"
                         onClick={() =>
-                          act('target_ship', { target: value.name })} />
+                          act('lock_ship', { target: value.name })} />
+                      <Button
+                        fluid
+                        content={`Stop Tracking ${value.name}`}
+                        icon="bullseye"
+                        onClick={() =>
+                          act('dump_lock', { target: value.name })} />
                     </Section>
                   )}
                 </Fragment>);

--- a/tgui/packages/tgui/interfaces/GhostTacticalConsole.js
+++ b/tgui/packages/tgui/interfaces/GhostTacticalConsole.js
@@ -108,61 +108,84 @@ export const GhostTacticalConsole = (props, context) => {
             </LabeledList>
           </Section>
           <Section title="Tracking:">
-            {Object.keys(data.ships).map((key, newCurrent) => {
-              let value = data.ships[key];
+            {Object.keys(data.painted_targets).map((key, newCurrent) => {
+              let value = data.painted_targets[key];
               const [current, setCurrent] = useLocalState(context, 'fs_current', true);
               const [hidden, setHidden] = useLocalState(context, 'fs_hidden', true);
 
               return (
-                <Fragment key={key}>
-                  {!!value.name && (
-                    <Section>
-                      <Button
-                        width="100%"
-                        fluid
-                        onClick={() => {
-                          setCurrent(value.name);
-                          setHidden(!hidden);
-                        }}>
-                        {`${value.name}`}
-                      </Button>
-                      {!!(current === value.name) && !hidden && (
-                        <Section title="Armour">
+                <>
+                  {!data.no_gun_cam && (
+                    <Button
+                      width="100%"
+                      fluid
+                      content={"Toggle Gun Camera"}
+                      icon="bullseye"
+                      onClick={() => act('toggle_gun_camera')} />)}
+                  <Fragment key={key}>
+                    {!!value.name && (
+                      <Section>
+                        <Button
+                          width="100%"
+                          fluid
+                          onClick={() => {
+                            setCurrent(value.name);
+                            setHidden(!hidden);
+                          }}>
+                          {`${value.name}`}
+                        </Button>
+                        {!!(current === value.name) && !hidden && (
+                          <Section title="Armour">
+                            <LabeledList>
+                              <LabeledList.Item label="Forward Starboard">
+                                <ProgressBar
+                                  value={(
+                                    value.quadrant_fp_armour_current/value.quadrant_fp_armour_max * 100)* 0.01}
+                                  ranges={{
+                                    good: [0.95, Infinity],
+                                    average: [0.15, 0.9],
+                                    bad: [-Infinity, 0.15],
+                                  }} />
+                              </LabeledList.Item>
+                              <LabeledList.Item label="Forward Port">
+                                <ProgressBar
+                                  value={(
+                                    value.quadrant_fs_armour_current/value.quadrant_fs_armour_max * 100)* 0.01}
+                                  ranges={{
+                                    good: [0.95, Infinity],
+                                    average: [0.15, 0.9],
+                                    bad: [-Infinity, 0.15],
+                                  }} />
+                              </LabeledList.Item>
+                              <LabeledList.Item label="Aft Starboard">
+                                <ProgressBar
+                                  value={(
+                                    value.quadrant_as_armour_current/value.quadrant_as_armour_max * 100)* 0.01}
+                                  ranges={{
+                                    good: [0.95, Infinity],
+                                    average: [0.15, 0.9],
+                                    bad: [-Infinity, 0.15],
+                                  }} />
+                              </LabeledList.Item>
+                              <LabeledList.Item label="Aft Port">
+                                <ProgressBar
+                                  value={(
+                                    value.quadrant_ap_armour_current/value.quadrant_ap_armour_max * 100)* 0.01}
+                                  ranges={{
+                                    good: [0.95, Infinity],
+                                    average: [0.15, 0.9],
+                                    bad: [-Infinity, 0.15],
+                                  }} />
+                              </LabeledList.Item>
+                            </LabeledList>
+                          </Section>
+                        )}
+                        <Section>
                           <LabeledList>
-                            <LabeledList.Item label="Forward Starboard">
+                            <LabeledList.Item label="Integrity">
                               <ProgressBar
                                 value={(
-                                  value.quadrant_fp_armour_current / value.quadrant_fp_armour_max * 100) * 0.01}
-                                ranges={{
-                                  good: [0.95, Infinity],
-                                  average: [0.15, 0.9],
-                                  bad: [-Infinity, 0.15],
-                                }} />
-                            </LabeledList.Item>
-                            <LabeledList.Item label="Forward Port">
-                              <ProgressBar
-                                value={(
-                                  value.quadrant_fs_armour_current / value.quadrant_fs_armour_max * 100) * 0.01}
-                                ranges={{
-                                  good: [0.95, Infinity],
-                                  average: [0.15, 0.9],
-                                  bad: [-Infinity, 0.15],
-                                }} />
-                            </LabeledList.Item>
-                            <LabeledList.Item label="Aft Starboard">
-                              <ProgressBar
-                                value={(
-                                  value.quadrant_as_armour_current / value.quadrant_as_armour_max * 100) * 0.01}
-                                ranges={{
-                                  good: [0.95, Infinity],
-                                  average: [0.15, 0.9],
-                                  bad: [-Infinity, 0.15],
-                                }} />
-                            </LabeledList.Item>
-                            <LabeledList.Item label="Aft Port">
-                              <ProgressBar
-                                value={(
-                                  value.quadrant_ap_armour_current / value.quadrant_ap_armour_max * 100) * 0.01}
+                                  value.integrity/value.max_integrity * 100)* 0.01}
                                 ranges={{
                                   good: [0.95, Infinity],
                                   average: [0.15, 0.9],
@@ -171,36 +194,22 @@ export const GhostTacticalConsole = (props, context) => {
                             </LabeledList.Item>
                           </LabeledList>
                         </Section>
-                      )}
-                      <Section>
-                        <LabeledList>
-                          <LabeledList.Item label="Integrity">
-                            <ProgressBar
-                              value={(
-                                value.integrity / value.max_integrity * 100) * 0.01}
-                              ranges={{
-                                good: [0.95, Infinity],
-                                average: [0.15, 0.9],
-                                bad: [-Infinity, 0.15],
-                              }} />
-                          </LabeledList.Item>
-                        </LabeledList>
+                        <Button
+                          fluid
+                          content={data.target_name === value.name ? `Stop Targeting ${value.name}` : `Target ${value.name}`}
+                          icon="bullseye"
+                          onClick={() =>
+                            act('lock_ship', { target: value.name })} />
+                        <Button
+                          fluid
+                          content={`Stop Tracking ${value.name}`}
+                          icon="bullseye"
+                          onClick={() =>
+                            act('dump_lock', { target: value.name })} />
                       </Section>
-                      <Button
-                        fluid
-                        content={data.target_name === value.name ? `Stop Targeting ${value.name}` : `Target ${value.name}`}
-                        icon="bullseye"
-                        onClick={() =>
-                          act('lock_ship', { target: value.name })} />
-                      <Button
-                        fluid
-                        content={`Stop Tracking ${value.name}`}
-                        icon="bullseye"
-                        onClick={() =>
-                          act('dump_lock', { target: value.name })} />
-                    </Section>
-                  )}
-                </Fragment>);
+                    )}
+                  </Fragment>
+                </>);
             })}
           </Section>
         </Section>

--- a/tgui/packages/tgui/interfaces/TacticalConsole.js
+++ b/tgui/packages/tgui/interfaces/TacticalConsole.js
@@ -89,8 +89,8 @@ export const TacticalConsole = (props, context) => {
             </LabeledList>
           </Section>
           <Section title="Tracking:">
-            {Object.keys(data.ships).map((key, newCurrent) => {
-              let value = data.ships[key];
+            {Object.keys(data.painted_targets).map((key, newCurrent) => {
+              let value = data.painted_targets[key];
               const [current, setCurrent] = useLocalState(context, 'fs_current', true);
               const [hidden, setHidden] = useLocalState(context, 'fs_hidden', true);
 
@@ -172,7 +172,13 @@ export const TacticalConsole = (props, context) => {
                         content={`Target ${value.name}`}
                         icon="bullseye"
                         onClick={() =>
-                          act('target_ship', { target: value.name })} />
+                          act('lock_ship', { target: value.name })} />
+                      <Button
+                        fluid
+                        content={`Stop Tracking ${value.name}`}
+                        icon="bullseye"
+                        onClick={() =>
+                          act('dump_lock', { target: value.name })} />
                     </Section>
                   )}
                 </Fragment>);

--- a/tgui/packages/tgui/interfaces/TacticalConsole.js
+++ b/tgui/packages/tgui/interfaces/TacticalConsole.js
@@ -89,6 +89,13 @@ export const TacticalConsole = (props, context) => {
             </LabeledList>
           </Section>
           <Section title="Tracking:">
+            {!data.no_gun_cam && (
+              <Button
+                width="100%"
+                fluid
+                content={"Toggle Gun Camera"}
+                icon="bullseye"
+                onClick={() => act('toggle_gun_camera')} />)}
             {Object.keys(data.painted_targets).map((key, newCurrent) => {
               let value = data.painted_targets[key];
               const [current, setCurrent] = useLocalState(context, 'fs_current', true);

--- a/tgui/packages/tgui/interfaces/TacticalConsole.js
+++ b/tgui/packages/tgui/interfaces/TacticalConsole.js
@@ -169,7 +169,7 @@ export const TacticalConsole = (props, context) => {
                       </Section>
                       <Button
                         fluid
-                        content={`Target ${value.name}`}
+                        content={data.target_name === value.name ? `Stop Targeting ${value.name}` : `Target ${value.name}`}
                         icon="bullseye"
                         onClick={() =>
                           act('lock_ship', { target: value.name })} />


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This PR generally overhauls how guided weapons are handled. I tried to touch as little as possible that wasn't on the base overmap object or projectile object, so hopefully it shouldn't conflict too much.

<details>
<summary>Gameplay Changes</summary>
You can now use DRADIS to lock onto targets. This requires you to press the mode swap button in the top right of the DRADIS panel, which switches from hailing mode to targeting mode and back.
Fired guided projectiles will now always track locked targets, instead of only tracking targets when sprite-clicked. If a locked target isn't selected, they'll track towards the first painted target.
The Tactical console now only displays locked targets, instead of displaying all targets in range. It is also used to select which target is the "locked" target. 
The Datalink is now a bit more in-depth. Clicking on a friendly when in targeting mode in DRADIS allows you to transmit your current locked target to them if they aren't at their max target paints. This allows the mainship to transmit data to fighters, as well as allowing fighters to transmit targeting data to each other.
Fighters also now have a use for the "target lock" button on their control panel. Clicking it will dump all active locks. This can also be done with the unlock hotkey, defaulting to 6.
I also gave ship gunners an optical camera, similar to way back when. This version of the camera is much more limited, only able to view targets out to your base sensor range. However, it also allows you to look across the edges of the overmap Z level, so you can nail that one destroyer that's been constantly corner peeking and glitching out your view. It's still a bit jank where Zs are concerned, but I haven't been able to fix that.
Finally, AI ships will now target incoming missiles with their point defense cannons, and will target ships locking onto them with flak.
</details>

<details>
<summary>Code Changes</summary>
Targets are now handled in two places: target_lock and target_painted. Target_painted is an associative list of the active paints of a ship, listing both the target and the ship that's providing the target with datalink (if applicable).
Torpedoes_to_target is once again used. Torpedoes are added to this list when fired at a ship with homing, and ships will target these when autonomous targeting fires. 
Additionally, most of the handling for homing has been moved off of the fire_projectile proc chain and onto the projectile itself. Projectiles now have a can_home var, which determines whether a gun will try to assign that projectile a homing target. 
The gun camera can be disabled on ships using the no_gun_cam variable, and autotarget functionality can be added to ships by setting autotarget to true. This automatically sets a painted target to be the locked target.
There's also a few new signals and a new proc that gets called when a missile is launched at a ship, which might be useful for other coders.

Most of these changes should be pretty modular, and you can override the targeting procs to add other checks or do specific things.
</details>

Please let me know if there's anything I missed or that I should add.
I was considering adding some functionality to the ATC's console to let them pass datalink targets to fighters, but that'd require mass map changes so I figured I'd hold off on it.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
The targeting changes allow you a lot more freedom when launching missiles. You can now launch them at different angles to try and get around flak clouds or confuse point defenses. You can also actually make use of NAC guidance without having to sprite-click. This also gives some QOL to fighter pilots, since right now they need to spriteclick to lock onto other ships.
The datalink changes should also make the datalink system as a whole clearer, and gives pilots/bridgies more options when using it. 
Adding a targeting camera with limited range gets around some of the more annoying parts of edge combat, allowing you to see ships that are just off screen or on the other side of the z-transition. It should have a shorter range than the AI detection range, which should prevent players from just using it to snipe in a corner.
Giving AI the ability to shoot down missiles more easily also nerfs easy standoff attacks, since before this AI ships would just kind of sit there and take any long-range missiles you launched at them.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
For these videos the gun camera's range was set to infinity so I could see the target. It doesn't have this much range in practice. If anyone ever wants to do the same for testing and/or adminbus shenanigans VV the ship's DRADIS and set visual_range to something really big. 
<details>
<summary>Screenshots&Videos</summary>

AI PDC:


https://user-images.githubusercontent.com/9423435/207431773-7b06d59c-5331-48eb-ae01-216a8dbba22b.mp4

Target locking:

https://user-images.githubusercontent.com/9423435/207432375-3e215127-727c-4d98-bc82-bfe94544aac2.mp4

Fighter locking:

https://user-images.githubusercontent.com/9423435/207432930-a376d367-0e04-4795-9b15-4472dc111663.mp4



</details>

## Changelog
:cl:
refactor: Refactors how targeting is handled
add: DRADIS now has a targeting mode, cycled using the hailing/targeting button. Clicking on enemies in targeting mode will paint them, and clicking on friendlies will pass your current target lock to them via datalink
tweak: Tweaks how datalink functions. It is no longer automatic, and the sending ship must maintain a lock to maintain the datalink transmission. Targets recieved via datalink are also visible on DRADIS now.
tweak: Painted targets will now be lost if radar contact is not maintained.
add: Readds the gunner's optical camera. This works on large ships and some small ships with TAC consoles, and has a range similar to that of the ship's base sensor range.
balance: AI ships will now target incoming ordnance with PDCs, and will target ships locking them with flak.
balance: All overmap ships are now limited to 3 target paints, except for fighters, which are limited to one paint. Fighters will also automatically lock onto the target they paint.
fix: Fixes some null handling issues in target lists.
code: Homing is now based on the projectile being fired instead of the weapon.
tweak: Non-fighter ghost ships now have access to active radar.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
