### PR TITLE
Fixes the manuals to make them send you to the correct page on the Wiki

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -212,7 +212,7 @@
 
 //NSV13 - updated URIs
 /datum/config_entry/string/wikiurl
-	config_entry_value = "https://nsv.beestation13.com/wiki/Main_Page"
+	config_entry_value = "https://nsv.beestation13.com/wiki" //NSV13 - Fixes the damn Wiki books
 
 /datum/config_entry/string/forumurl
 	config_entry_value = "https://forums-nsv.beestation13.com/"

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -212,7 +212,7 @@
 
 //NSV13 - updated URIs
 /datum/config_entry/string/wikiurl
-	config_entry_value = "https://nsv.beestation13.com/wiki" //NSV13 - Fixes the damn Wiki books
+	config_entry_value = "https://nsv.beestation13.com/wiki" //NSV13 - Fixes the damn wiki books
 
 /datum/config_entry/string/forumurl
 	config_entry_value = "https://forums-nsv.beestation13.com/"

--- a/code/game/objects/items/manuals.dm
+++ b/code/game/objects/items/manuals.dm
@@ -329,7 +329,7 @@
 	icon_state = "barbook"
 	author = "Sir John Rose"
 	title = "Barman Recipes: Mixing Drinks and Changing Lives"
-	page_link = "Guide_to_food_and_drinks"
+	page_link = "Guide_to_drinks" //NSV13 - Splitted the Guide to Food and Drinks into Two Seperate Pages
 
 /obj/item/book/manual/wiki/robotics_cyborgs
 	name = "Robotics for Dummies"
@@ -365,7 +365,7 @@
 	icon_state ="cooked_book"
 	author = "the Kanamitan Empire"
 	title = "To Serve Man"
-	page_link = "Guide_to_food_and_drinks"
+	page_link = "Guide_to_food" //NSV13 - Splitted the Guide to Food and Drinks into Two Seperate Pages
 
 /obj/item/book/manual/wiki/tcomms
 	name = "Subspace Telecommunications And You"

--- a/code/game/objects/items/manuals.dm
+++ b/code/game/objects/items/manuals.dm
@@ -329,7 +329,7 @@
 	icon_state = "barbook"
 	author = "Sir John Rose"
 	title = "Barman Recipes: Mixing Drinks and Changing Lives"
-	page_link = "Guide_to_drinks" //NSV13 - Splitted the Guide to Food and Drinks into Two Seperate Pages
+	page_link = "Guide_to_drinks" //NSV13 - Split the Guide to Food and Drinks into two separate pages
 
 /obj/item/book/manual/wiki/robotics_cyborgs
 	name = "Robotics for Dummies"

--- a/code/game/objects/items/manuals.dm
+++ b/code/game/objects/items/manuals.dm
@@ -365,7 +365,7 @@
 	icon_state ="cooked_book"
 	author = "the Kanamitan Empire"
 	title = "To Serve Man"
-	page_link = "Guide_to_food" //NSV13 - Splitted the Guide to Food and Drinks into Two Seperate Pages
+	page_link = "Guide_to_food" //NSV13 - Split the Guide to Food and Drinks into two separate pages
 
 /obj/item/book/manual/wiki/tcomms
 	name = "Subspace Telecommunications And You"

--- a/config/config.txt
+++ b/config/config.txt
@@ -263,7 +263,7 @@ CHECK_RANDOMIZER
 FORUMURL https://forums-nsv.beestation13.com/
 
 ## Wiki address
-WIKIURL https://nsv.beestation13.com/wiki/Main_Page
+WIKIURL https://nsv.beestation13.com/wiki
 
 ## Rules address
 RULESURL https://nsv.beestation13.com/wiki/Rules


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the Manuals that link to the Wiki, now actually send you to the correct Wiki Page rather than some non-existent child of the main page. 

Also makes the Guide to Food and Drinks manuals now point to their correct pages on the Wiki as they have been split into two separate pages to allow an easier time of editing them.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Make Wiki Manuals work is good yes?
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: Manuals now send you to the correct pages on the NSV13 Wiki
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
