### PR TITLE
Stops small craft from leaving bigger ships without a pilot.

### DIFF
--- a/nsv13/code/modules/overmap/fighters/_fighters.dm
+++ b/nsv13/code/modules/overmap/fighters/_fighters.dm
@@ -471,7 +471,6 @@ Been a mess since 2018, we'll fix it someday (probably)
 		dradis.linked = src
 	set_light(4)
 	obj_integrity = max_integrity
-	RegisterSignal(src, COMSIG_MOVABLE_MOVED, .proc/handle_moved) //Used to smoothly transition from ship to overmap
 	var/obj/item/fighter_component/engine/engineGoesLast = null
 	if(build_components.len)
 		for(var/Ctype in build_components)

--- a/nsv13/code/modules/overmap/fighters/fighters_launcher.dm
+++ b/nsv13/code/modules/overmap/fighters/fighters_launcher.dm
@@ -271,7 +271,7 @@
 	check_overmap_elegibility()
 
 /obj/structure/overmap/small_craft/proc/check_overmap_elegibility(ignore_position = FALSE, ignore_cooldown = FALSE) //What we're doing here is checking if the fighter's hitting the bounds of the Zlevel. If they are, we need to transfer them to overmap space.
-	if(!ignore_position && !is_near_boundary())
+	if(!ignore_position && !is_near_boundary() && !pilot)
 		return FALSE
 	if(!ignore_cooldown && is_docking_on_cooldown())
 		return FALSE

--- a/nsv13/code/modules/overmap/fighters/fighters_launcher.dm
+++ b/nsv13/code/modules/overmap/fighters/fighters_launcher.dm
@@ -267,13 +267,12 @@
 	speed_limit = 20 //Let them accelerate to hyperspeed due to the launch, and temporarily break the speed limit.
 	addtimer(VARSET_CALLBACK(src, speed_limit, initial(speed_limit)), 5 SECONDS) //Give them 5 seconds of super speed mode before we take it back from them
 
-/obj/structure/overmap/small_craft/proc/handle_moved()
-	check_overmap_elegibility()
-
 /obj/structure/overmap/small_craft/proc/check_overmap_elegibility(ignore_position = FALSE, ignore_cooldown = FALSE) //What we're doing here is checking if the fighter's hitting the bounds of the Zlevel. If they are, we need to transfer them to overmap space.
-	if(!ignore_position && !is_near_boundary() && !pilot)
+	if(!ignore_position && !is_near_boundary())
 		return FALSE
 	if(!ignore_cooldown && is_docking_on_cooldown())
+		return FALSE
+	if(!pilot)
 		return FALSE
 	var/obj/structure/overmap/OM = null
 	if(last_overmap)


### PR DESCRIPTION
## About The Pull Request

Removes the ability for fighters, transports and mining ships to leave ships (and asteroids) without their pilot.

## Why It's Good For The Game

Stops ships from leaving their pilots behind on asteroids. Also avoids fighter craft from being lost to the void.

## Changelog
:cl:
tweak: Stops small overmap ships from leaving the map on their own.
/:cl:
