### PR TITLE
Make turnstiles shock when broken and make them repairable

### DIFF
--- a/nsv13/code/modules/Security/genpop.dm
+++ b/nsv13/code/modules/Security/genpop.dm
@@ -177,14 +177,9 @@
 		return TRUE
 	return FALSE
 
-/obj/machinery/turnstile/proc/has_power()
-	if(machine_stat & NOPOWER)
-		return FALSE
-	return TRUE
-
 ///Shock user if we can
 /obj/machinery/turnstile/proc/try_shock(mob/user)
-	if(!has_power())		// unpowered, no shock
+	if(machine_stat & NOPOWER)		// unpowered, no shock
 		return FALSE
 	if(!COOLDOWN_FINISHED(src, shock_cooldown)) //Don't shock in very short succession to avoid stuff getting out of hand.
 		return FALSE

--- a/nsv13/code/modules/Security/genpop.dm
+++ b/nsv13/code/modules/Security/genpop.dm
@@ -109,9 +109,6 @@
 	. = ..()
 	icon_state = "turnstile"
 
-/obj/machinery/turnstile/CanAtmosPass(turf/T)
-	return TRUE
-
 //Shock mobs attempting to pass through if we're broken
 /obj/machinery/turnstile/Bumped(atom/movable/AM)
 	. = ..()

--- a/nsv13/code/modules/Security/genpop.dm
+++ b/nsv13/code/modules/Security/genpop.dm
@@ -19,7 +19,6 @@
 	//Robust! It'll be tough to break...
 	armor = list("melee" = 50, "bullet" = 20, "laser" = 0, "energy" = 80, "bomb" = 10, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 50, "stamina" = 0)
 	anchored = TRUE
-	use_power = FALSE
 	idle_power_usage = 2
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	layer = OPEN_DOOR_LAYER

--- a/nsv13/code/modules/Security/genpop.dm
+++ b/nsv13/code/modules/Security/genpop.dm
@@ -140,9 +140,9 @@
 	if(item.tool_behaviour == TOOL_WELDER)
 		try_to_repair(item, user)
 		return 1
+	. = ..()
 	if(machine_stat & BROKEN)
 		try_shock(user)
-	. = ..()
 
 ///Handle someone trying to repair us. Produces appropriate chat messages.
 /obj/machinery/turnstile/proc/try_to_repair(obj/item/weldingtool/W, mob/user)

--- a/nsv13/code/modules/Security/genpop.dm
+++ b/nsv13/code/modules/Security/genpop.dm
@@ -15,6 +15,7 @@
 	pass_flags_self = PASSGLASS | LETPASSTHROW | PASSGRILLE | PASSSTRUCTURE
 	obj_integrity = 250
 	max_integrity = 250
+	integrity_failure = 74
 	//Robust! It'll be tough to break...
 	armor = list("melee" = 50, "bullet" = 20, "laser" = 0, "energy" = 80, "bomb" = 10, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 50, "stamina" = 0)
 	anchored = TRUE
@@ -163,12 +164,6 @@
 		update_icon()
 		return
 
-///Mark as broken when below 30% health.
-/obj/machinery/turnstile/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
-	. = ..()
-	var/healthpercent = (obj_integrity/max_integrity) * 100
-	if(healthpercent < 30)
-		machine_stat |= BROKEN
 
 /obj/machinery/turnstile/CanAllowThrough(atom/movable/mover, turf/target)
 	. = ..()

--- a/nsv13/code/modules/Security/genpop.dm
+++ b/nsv13/code/modules/Security/genpop.dm
@@ -141,7 +141,7 @@
 	if(machine_stat & BROKEN)
 		return FALSE
 	var/allowed = allowed(mover)
-	//Sec can drag you out unceremoniously.
+	////Everyone with access (including released prisoners) can drag you out.
 	if(!allowed && mover.pulledby)
 		allowed = allowed(mover.pulledby)
 	if(get_dir(loc, target) == dir || allowed) //Make sure looking at appropriate border

--- a/nsv13/code/modules/Security/genpop.dm
+++ b/nsv13/code/modules/Security/genpop.dm
@@ -136,34 +136,30 @@
 	flick("deny", src)
 	playsound(src,'sound/machines/deniedbeep.ogg',50,0,3)
 
-///Shock attacker if we're broken, get repaired if weldered
+///Shock attacker if we're broken
 /obj/machinery/turnstile/attackby(obj/item/item, mob/user, params)
-	if(item.tool_behaviour == TOOL_WELDER)
-		try_to_repair(item, user)
-		return 1
 	. = ..()
 	if(machine_stat & BROKEN)
 		try_shock(user)
 
-///Handle someone trying to repair us. Produces appropriate chat messages.
-/obj/machinery/turnstile/proc/try_to_repair(obj/item/weldingtool/W, mob/user)
+/obj/machinery/turnstile/welder_act(mob/living/user, obj/item/I)
 	//Shamelessly copied airlock code
+	. = TRUE //Never attack it with a welding tool
+	if(!I.tool_start_check(user, amount=0))
+		return
 	if(obj_integrity >= max_integrity)
 		to_chat(user, "<span class='notice'>The turnstile doesn't need repairing.</span>")
-		return
-	if(!W.tool_start_check(user, amount=0))
 		return
 	user.visible_message("[user] is welding the turnstile.", \
 				"<span class='notice'>You begin repairing the turnstile...</span>", \
 				"<span class='italics'>You hear welding.</span>")
-	if(W.use_tool(src, user, 40, volume=50))
+	if(I.use_tool(src, user, 40, volume=50))
 		obj_integrity = max_integrity
 		set_machine_stat(machine_stat & ~BROKEN)
 		user.visible_message("[user.name] has repaired [src].", \
 							"<span class='notice'>You finish repairing the turnstile.</span>")
 		update_icon()
 		return
-
 
 /obj/machinery/turnstile/CanAllowThrough(atom/movable/mover, turf/target)
 	. = ..()
@@ -198,7 +194,6 @@
 		return TRUE
 	else
 		return FALSE
-
 
 //Officer interface.
 /obj/machinery/genpop_interface


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Turnstiles now shock attackers and mobs that Bump() them when they're broken. They break when below 30% durability. To make that bearable they can now be repaired with welders.

The code was quite heavily refactored in order to stop them from activating when they were clicked on, which runs CanAllowThrough which did the audio and animation for moving through or bumping the turnstile. That was bad because Can AllowThrough is supposed to have no side effects. It now uses a signal which gets attached to the turf with a /datum/element/connect_loc. That datum takes care of unregistering and re registering in case the turnstile would ever get moved.

Another refactor is the removal of the unused atmos proc CanAtmosPass. It isn't necessary because atmos passing through machines is the default.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Turnstiles being breakable with a cultivator put them at odds with perma that is closed using airlocks, which shock the attacker. This PR puts them in line with each other. Also fixes the touching activating the turnstile bug and redoes dodgy code.
Fixes #2061
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://www.youtube.com/watch?v=8gPfCM5iTgc

</details>

## Changelog
:cl:
add: Turnstiles now break when heavily damaged
add: Turnstiles now shock you when broken.
add: Turnstiles can now be repaired with a welder
refactor: Refactored Turnstile code a bit.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
