### PR TITLE
Incredibly Lazy Chemical Synthesizer Rework

### DIFF
--- a/code/modules/plumbing/plumbers/synthesizer.dm
+++ b/code/modules/plumbing/plumbers/synthesizer.dm
@@ -71,24 +71,24 @@
 	volume_left = max(volume_left - amount*delta_time*0.5, 0)
 
 /obj/machinery/plumbing/synthesizer/attackby(obj/item/O, mob/user, params)
-	if(!istype(O, /obj/item/rcd_ammo))
+	if(!istype(O, /obj/item/synthesizer_cartridge))
 		return ..()
-	var/obj/item/rcd_ammo/R = O
-	if(!R.ammoamt)
+	var/obj/item/synthesizer_cartridge/R = O
+	if(!R.chems)
 		to_chat(user, "<span class='warning'>The [R.name] doesn't have any reagent left!</span>")
 		return ..()
 	var/added_volume = -volume_left //For the difference calculation
-	volume_left = min(volume_left+R.ammoamt*10, src.max_volume) //400 per cartridge
+	volume_left = min(volume_left+R.chems*10, src.max_volume) //400 per cartridge
 	added_volume = added_volume+volume_left
-	R.ammoamt -= added_volume/10
-	if(R.ammoamt <= 0) //Emptied
+	R.chems -= added_volume/10
+	if(R.chems <= 0) //Emptied
 		to_chat(user, "<span class='notice'>You refill the chemical synthesizer with the [R.name], emptying it completely!</span>")
 		qdel(R)
 		return
 	if(added_volume == 0) //No change
 		to_chat(user, "<span class='notice'>The chemical synthesizer is full!</span>")
 		return
-	to_chat(user, "<span class='notice'>You refill the chemical synthesizer with the [R.name], leaving [R.ammoamt*10] units in it.</span>")
+	to_chat(user, "<span class='notice'>You refill the chemical synthesizer with the [R.name], leaving [R.chems*10] units in it.</span>")
 
 /obj/machinery/plumbing/synthesizer/examine(mob/user)
 	. = ..()

--- a/code/modules/plumbing/plumbers/synthesizer.dm
+++ b/code/modules/plumbing/plumbers/synthesizer.dm
@@ -70,7 +70,7 @@
 	reagents.add_reagent(reagent_id, amount*delta_time*0.5)
 	volume_left = max(volume_left - amount*delta_time*0.5, 0)
 
-/obj/machinery/plumbing/synthesizer/attackby(obj/item/O, mob/user, params)
+/obj/machinery/plumbing/synthesizer/attackby(obj/item/O, mob/user, params) //NSV13 - Changed cartidge object
 	if(!istype(O, /obj/item/synthesizer_cartridge))
 		return ..()
 	var/obj/item/synthesizer_cartridge/R = O

--- a/nsv13/code/game/objects/items/custom_items.dm
+++ b/nsv13/code/game/objects/items/custom_items.dm
@@ -112,3 +112,14 @@
 /obj/item/kirbyplants/random/plush/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/two_handed, require_twohands=TRUE, force_unwielded=0, force_wielded=0, wieldsound='sound/items/bikehorn.ogg')
+
+/obj/item/synthesizer_cartridge
+	name = "chemical component cartridge"
+	desc = "A cartridge for a chemical synthesizer."
+	icon = 'icons/obj/ammo.dmi'
+	icon_state = "rcd"
+	item_state = "rcdammo"
+	w_class = WEIGHT_CLASS_TINY
+	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
+	var/chems = 40

--- a/nsv13/code/modules/cargo/packs.dm
+++ b/nsv13/code/modules/cargo/packs.dm
@@ -692,3 +692,11 @@
 					/obj/item/reagent_containers/glass/bottle/sacid,
 					/obj/item/reagent_containers/glass/bottle/sacid)
 	crate_name = "Chemical Supply Crate - Chalcogens"
+
+/datum/supply_pack/medical/synthesizer_cartridge
+	name = "Chemical Synthesizer Cartridge Supply Crate"
+	desc = "This crate contains cartridges for a chemical synthesizer"
+	cost = 1000
+	contains = list(/obj/item/synthesizer_cartridge,
+					/obj/item/synthesizer_cartridge,
+					/obj/item/synthesizer_cartridge)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR gives the synth a bespoke restocking item that is available from cargo.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Apparently people fight over RCD cartridges.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>

![image](https://user-images.githubusercontent.com/45891563/209586192-cd74b8ce-a434-4ebc-a2ef-83427e4dcae8.png)

<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
add: Added chem synth refill cartridge
balance: Reworked chem synth to use its own bespoke cartridge from cargo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
