### PR TITLE
Fixes fuel pumps not having a fueling proximity check

### DIFF
--- a/nsv13/code/modules/overmap/fighters/fuel_tank.dm
+++ b/nsv13/code/modules/overmap/fighters/fuel_tank.dm
@@ -18,6 +18,7 @@
 	var/max_range = 2
 	var/datum/beam/current_beam
 	var/allow_refuel = FALSE
+	var/units_per_second = 50
 
 /obj/structure/reagent_dispensers/fueltank/cryogenic_fuel/ui_act(action, params, datum/tgui/ui)
 	if(..())
@@ -153,7 +154,7 @@
 		return FALSE
 	return TRUE
 
-/obj/structure/reagent_dispensers/fueltank/cryogenic_fuel/process()
+/obj/structure/reagent_dispensers/fueltank/cryogenic_fuel/process(delta_time)
 	if(!fuel_target)
 		soundloop?.stop()
 		return PROCESS_KILL
@@ -168,14 +169,14 @@
 		soundloop?.stop()
 		visible_message("<span class='warning'>[icon2html(src)] [fuel_target] does not have a fuel tank installed!</span>")
 		return PROCESS_KILL
-	var/transfer_amount = min(50, fuel_target.get_max_fuel()-fuel_target.get_fuel()) //Transfer as much as we can
-	if(transfer_amount <= 0)
+	var/transfer_amount = min(min(units_per_second * delta_time, reagents.total_volume), fuel_target.get_max_fuel()-fuel_target.get_fuel()) //Transfer as much as we can
+	if(fuel_target.get_max_fuel() <= fuel_target.get_fuel())
 		soundloop?.stop()
 		visible_message("<span class='warning'>[icon2html(src)] refuelling complete.</span>")
 		playsound(src, 'sound/machines/ping.ogg', 100)
 		fuel_target = null
 		return PROCESS_KILL
-	if(reagents.total_volume < transfer_amount)
+	else if (transfer_amount <= 0)
 		soundloop?.stop()
 		visible_message("<span class='warning'>[icon2html(src)] insufficient fuel.</span>")
 		playsound(src, 'sound/machines/buzz-two.ogg', 100)

--- a/nsv13/code/modules/overmap/fighters/fuel_tank.dm
+++ b/nsv13/code/modules/overmap/fighters/fuel_tank.dm
@@ -155,11 +155,17 @@
 
 /obj/structure/reagent_dispensers/fueltank/cryogenic_fuel/process()
 	if(!fuel_target)
-		soundloop.stop()
+		soundloop?.stop()
+		return PROCESS_KILL
+	if(get_dist(nozzle, fuel_target) > max_range) // make sure we're actually next to the target
+		soundloop?.stop()
+		visible_message("<span class='warning'>[icon2html(src)] [fuel_target] is out of range!</span>")
+		playsound(src, 'sound/machines/buzz-two.ogg', 100)
+		fuel_target = null
 		return PROCESS_KILL
 	var/obj/item/fighter_component/fuel_tank/sft = fuel_target.loadout.get_slot(HARDPOINT_SLOT_FUEL)
 	if(!sft)
-		soundloop.stop()
+		soundloop?.stop()
 		visible_message("<span class='warning'>[icon2html(src)] [fuel_target] does not have a fuel tank installed!</span>")
 		return PROCESS_KILL
 	var/transfer_amount = min(50, fuel_target.get_max_fuel()-fuel_target.get_fuel()) //Transfer as much as we can


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This fixes tyrosene fuel pumps being able to pump fuel into fighters despite being on the other side of the ship from said fighter.
It also adds delta_time functionality to the pump's process proc, which should help compensate for lag-based processing slowdowns and make fueling a bit more consistent. 

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
I'm 99.5% sure the infinite range thing is a bug, and having process respect delta_time is good for when SSobj just decides to not.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://user-images.githubusercontent.com/9423435/210025253-e1912d09-5014-4995-8a4a-24002c06291a.mp4



</details>

## Changelog
:cl:
fix: Tyrosene pumps no longer have infinite range.
fix: Tyrosene pumps will now continue pumping until they're completely out of fuel, instead of pumping until they have less than 50 units of fuel.
tweak: Small craft fueling now respects delta_time. As a side effect of this it's now also twice as fast.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
