### PR TITLE
Adds a camera to Eclipse Xenobiology

### DIFF
--- a/_maps/map_files/Eclipse/Eclipse1.dmm
+++ b/_maps/map_files/Eclipse/Eclipse1.dmm
@@ -510,6 +510,11 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible/layer2,
 /turf/open/floor/engine/n2,
 /area/engine/atmos)
+"cw" = (
+/obj/effect/turf_decal/box/white,
+/obj/machinery/camera/autoname,
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "cx" = (
 /obj/effect/turf_decal/ship/outline,
 /obj/structure/closet/crate,
@@ -37693,7 +37698,7 @@ bc
 jp
 wj
 zA
-XV
+cw
 XV
 WP
 XV


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds another camera to the Eclipse Xenobiology cells.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
There are currently a couple of tiles in xenobio cells that aren't covered by a camera (see screenshots). This fixes that. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>
Before

![EclipseXenobio](https://user-images.githubusercontent.com/95106800/210220692-9d091cdd-1397-47e6-a3f8-6f1cbdde30e8.PNG)

![EclipseXenobio2](https://user-images.githubusercontent.com/95106800/210220700-9d662a43-0401-4eb5-a0d2-e0d8db0eedc8.PNG)

After

![NewEclipseXenobio](https://user-images.githubusercontent.com/95106800/210220722-2b5021e1-02d3-4c28-903e-66f864fbd2bd.PNG)

![NewEclipseXenobio2](https://user-images.githubusercontent.com/95106800/210220725-a00eeca0-0993-4a09-8d45-2a78c8025c94.PNG)



</details>

## Changelog
:cl:
add: Camera added to Eclipse Xenobio
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
