### PR TITLE
Makes freight warheads purchaseable

### DIFF
--- a/nsv13/code/modules/cargo/packs.dm
+++ b/nsv13/code/modules/cargo/packs.dm
@@ -204,6 +204,15 @@
 					/obj/item/ship_weapon/parts/missile/warhead/decoy)
 	crate_name = "Decoy missile warheads"
 
+/datum/supply_pack/munitions/freight_warheads
+	name = "Torpedo warheads (freight)"
+	desc = "A pack of 3 freight torpedo warheads for delivering cargo to trade stations."
+	cost = 350
+	contains = list(/obj/item/ship_weapon/parts/missile/warhead/freight,
+					/obj/item/ship_weapon/parts/missile/warhead/freight,
+					/obj/item/ship_weapon/parts/missile/warhead/freight)
+	crate_type = /obj/structure/closet/crate/wooden
+
 /datum/supply_pack/munitions/pilot_outfitting
 	name = "Pilot Outfitting Crate"
 	desc = "A full set of of gear for a new pilot"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You know, in case they burn up or something.

## Why It's Good For The Game
Other warheads have crates, so why not?

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
add: Freight torp warheads are purchasable with cargo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
