### PR TITLE
[PORT] Pixel Shift Out of the Way!

### DIFF
--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -222,11 +222,15 @@
 	///Override for sound_environments. If this is set the user will always hear a specific type of reverb (Instead of the area defined reverb)
 	var/sound_environment_override = SOUND_ENVIRONMENT_NONE
 
+	///Currently possesses a typing indicator icon
+	var/typing_indicator = FALSE
+
+	//NSV13 - CHANGES START HERE
 	///Is the mob pixel shifted?
 	var/is_shifted
 
 	///Is the mob actively shifting?
 	var/shifting
 
-	///Currently possesses a typing indicator icon
-	var/typing_indicator = FALSE
+	///Takes the four cardinal direction defines. Any atoms moving into this atom's tile will be allowed to from the added directions.
+	var/passthroughable = NONE

--- a/nsv13/code/modules/pixelshifting/pixelshifting.dm
+++ b/nsv13/code/modules/pixelshifting/pixelshifting.dm
@@ -1,3 +1,6 @@
+#define MAXIMUM_PIXEL_SHIFT 16
+#define PASSABLE_SHIFT_THRESHOLD 8
+
 /mob/proc/unpixel_shift()
 	return
 
@@ -5,34 +8,66 @@
 	return
 
 /mob/living/unpixel_shift()
+	. = ..()
+	passthroughable = NONE
 	if(is_shifted)
 		is_shifted = FALSE
 		pixel_x = body_pixel_x_offset + base_pixel_x
 		pixel_y = body_pixel_y_offset + base_pixel_y
 
+/mob/living/set_pull_offsets(mob/living/pull_target, grab_state)
+	pull_target.unpixel_shift()
+	return ..()
+
+/mob/living/reset_pull_offsets(mob/living/pull_target, override)
+	pull_target.unpixel_shift()
+	return ..()
+
 /mob/living/pixel_shift(direction)
+	passthroughable = NONE
 	switch(direction)
 		if(NORTH)
 			if(!canface())
 				return FALSE
-			if(pixel_y <= 16 + base_pixel_y)
+			if(pixel_y <= MAXIMUM_PIXEL_SHIFT + base_pixel_y)
 				pixel_y++
 				is_shifted = TRUE
 		if(EAST)
 			if(!canface())
 				return FALSE
-			if(pixel_x <= 16 + base_pixel_x)
+			if(pixel_x <= MAXIMUM_PIXEL_SHIFT + base_pixel_x)
 				pixel_x++
 				is_shifted = TRUE
 		if(SOUTH)
 			if(!canface())
 				return FALSE
-			if(pixel_y >= -16 + base_pixel_y)
+			if(pixel_y >= -MAXIMUM_PIXEL_SHIFT + base_pixel_y)
 				pixel_y--
 				is_shifted = TRUE
 		if(WEST)
 			if(!canface())
 				return FALSE
-			if(pixel_x >= -16 + base_pixel_x)
+			if(pixel_x >= -MAXIMUM_PIXEL_SHIFT + base_pixel_x)
 				pixel_x--
 				is_shifted = TRUE
+
+
+	// Yes, I know this sets it to true for everything if more than one is matched.
+	// Movement doesn't check diagonals, and instead just checks EAST or WEST, depending on where you are for those.
+	if(pixel_y > PASSABLE_SHIFT_THRESHOLD)
+		passthroughable |= EAST | SOUTH | WEST
+	if(pixel_x > PASSABLE_SHIFT_THRESHOLD)
+		passthroughable |= NORTH | SOUTH | WEST
+	if(pixel_y < -PASSABLE_SHIFT_THRESHOLD)
+		passthroughable |= NORTH | EAST | WEST
+	if(pixel_x < -PASSABLE_SHIFT_THRESHOLD)
+		passthroughable |= NORTH | EAST | SOUTH
+
+/mob/living/CanAllowThrough(atom/movable/mover, turf/target)
+	// Make sure to not allow projectiles of any kind past where they normally wouldn't.
+	if(!istype(mover, /obj/item/projectile) && !mover.throwing && passthroughable & get_dir(loc, target))
+		return TRUE
+	return ..()
+
+#undef MAXIMUM_PIXEL_SHIFT
+#undef PASSABLE_SHIFT_THRESHOLD


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Out of the way son, **_DOOR STUCK_**
Expands upon what @BetaCentari ported in this PR:
* https://github.com/BeeStation/NSV13/pull/2133

By porting yet another PR related to Pixel shifting from Skyrat!
* https://github.com/Skyrat-SS13/Skyrat-tg/pull/15175

What this PR specifically does is introduce the ability to have people move through the tile you are standing on if you have pixel shifted 8 pixels away, however someone shooting at you will still hit you and someone throwing a glass of alcohol will still also drench your face.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Clown Car Compacted Shuttle. 
One tile, **20 players**
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://user-images.githubusercontent.com/59128051/211640852-0adaf1ec-2c5b-446e-8f61-f67043980f11.mp4


</details>

## Changelog
:cl:RimiNosha
qol: You can now use pixel shift to loiter in your favorite hallways without being pushed around. Bullets and thrown items will still hit you.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
