### PR TITLE
Fixes unlinked ammo sorters on Hammerhead

### DIFF
--- a/_maps/map_files/Hammerhead/Hammerhead.dmm
+++ b/_maps/map_files/Hammerhead/Hammerhead.dmm
@@ -22949,7 +22949,8 @@
 /area/hallway/primary/central)
 "dfg" = (
 /obj/machinery/computer/ammo_sorter{
-	dir = 8
+	dir = 8;
+	id = "Hammerheadammo"
 	},
 /turf/open/floor/durasteel/padded,
 /area/nsv/weapons/fore)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Allows ammo sorters on the Hammerhead to link up with the console.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Ammo sorters should be linked to a console.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


![HammerheadAmmosorters](https://user-images.githubusercontent.com/95106800/213342979-58bda3e9-2829-4d73-aa01-0070b8482114.PNG)

</details>

## Changelog
:cl:
fix: Ammo sorters on the Hammerhead now properly link up
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
