### PR TITLE
Adds proper handling to VLS tube exiting

### DIFF
--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/vls.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/vls.dm
@@ -70,6 +70,12 @@
 			playsound(src, load_sound, 100, 1)
 		state = 2
 
+// Handles removal of stuff
+/obj/machinery/ship_weapon/vls/Exited(atom/movable/gone, direction)
+	. = ..()
+	if(ammo?.Find(gone))
+		ammo -= gone
+
 /obj/machinery/ship_weapon/vls/PostInitialize()
 	..()
 	if(maintainable)

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/vls.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/vls.dm
@@ -73,8 +73,11 @@
 // Handles removal of stuff
 /obj/machinery/ship_weapon/vls/Exited(atom/movable/gone, direction)
 	. = ..()
-	if(ammo?.Find(gone))
-		ammo -= gone
+	if(!ammo?.Find(gone)) // Remove our ammo
+		return
+	ammo -= gone
+	if(!length(ammo)) // Set notloaded if applicable
+		state = STATE_NOTLOADED
 
 /obj/machinery/ship_weapon/vls/PostInitialize()
 	..()

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/torpedo_launcher.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/torpedo_launcher.dm
@@ -56,12 +56,6 @@
 			return TRUE
 	return ..()
 
-// Torp removal
-/obj/machinery/ship_weapon/vls/Exited(atom/movable/gone, direction)
-	. = ..()
-	if(ammo?.Find(gone))
-		ammo -= gone
-
 /obj/machinery/ship_weapon/torpedo_launcher/spawn_frame(disassembled)
 	var/obj/structure/ship_weapon/torpedo_launcher_assembly/M = new /obj/structure/ship_weapon/torpedo_launcher_assembly(loc)
 

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/torpedo_launcher.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/torpedo_launcher.dm
@@ -56,6 +56,12 @@
 			return TRUE
 	return ..()
 
+// Torp removal
+/obj/machinery/ship_weapon/vls/Exited(atom/movable/gone, direction)
+	. = ..()
+	if(ammo?.Find(gone))
+		ammo -= gone
+
 /obj/machinery/ship_weapon/torpedo_launcher/spawn_frame(disassembled)
 	var/obj/structure/ship_weapon/torpedo_launcher_assembly/M = new /obj/structure/ship_weapon/torpedo_launcher_assembly(loc)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
I've been trying to fix the conveyor/VLS loading and unloading bug for ages, but I haven't been able to find a way to fix it. So, instead, you get the next best thing.

This gives VLS tubes an Exited() proc, which checks for if ammo is exiting them somehow, and removes the ammo from the tube's ammo list if it is.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
- Fixes #2181 

Nulls in ammo are bad, as is torp duplication.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/9423435/214199895-5738042b-0792-4de2-9416-c375fa331913.png)

Missile got loaded and unloaded from the VLS tube, no phantom nuke.

</details>

## Changelog
:cl:
fix: VLS tubes now properly handle missiles exiting them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
