### PR TITLE
Adds virtual Z handling to dropships

### DIFF
--- a/nsv13/code/game/general_quarters/dropship.dm
+++ b/nsv13/code/game/general_quarters/dropship.dm
@@ -59,6 +59,12 @@
 	lighting_colour_bulb = "#e6af68"
 	area_flags = 0 // Not a unique area and spawns are not allowed
 	teleport_restriction = TELEPORT_ALLOW_NONE
+	var/obj/structure/overmap/small_craft/transport/linked_dropship
+
+/area/dropship/get_virtual_z(turf/T)
+	if(linked_dropship)
+		return linked_dropship.get_virtual_z_level()
+	return ..()
 
 //If we ever want to let them build these things..
 /area/dropship/generic

--- a/nsv13/code/game/general_quarters/dropship_types.dm
+++ b/nsv13/code/game/general_quarters/dropship_types.dm
@@ -48,7 +48,7 @@ Credit to TGMC for the interior sprites for all these!
 						/obj/item/fighter_component/countermeasure_dispenser)
 	interior_mode = INTERIOR_DYNAMIC
 	overmap_verbs = list(.verb/toggle_brakes, .verb/toggle_inertia, .verb/toggle_safety, .verb/show_dradis, .verb/cycle_firemode, .verb/show_control_panel, .verb/countermeasure)
-	var/linked_virtual_z // The virtual Z of our transport bird. Same as the area we're in, unless we're in space
+	var/linked_virtual_z // The virtual Z of our transport bird.
 
 /obj/structure/overmap/small_craft/transport/Initialize(mapload, list/build_components)
 	return ..()
@@ -72,17 +72,9 @@ Credit to TGMC for the interior sprites for all these!
 			starmap.use_power = 0
 			starmap.linked = src
 
-// Z override for transports. This returns the Z our aircraft is on, unless it's the overmap, in which case it returns our aircraft's unique Z.
+// Z override for transports. This returns our aircraft's unique Z.
 /obj/structure/overmap/small_craft/transport/get_virtual_z_level()
-	var/turf/T = get_turf(src)
-	if(!T)
-		return 0
-	var/area/A = T.loc
-	if(!A)
-		return 0
-	if(SSmapping.level_trait(A.z, ZTRAIT_OVERMAP))
-		return linked_virtual_z
-	return A.get_virtual_z(T)
+	return linked_virtual_z != null ? linked_virtual_z : 0;
 
 /datum/map_template/dropship
     name = "Marine Dropship"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This gives each dropship their own virtual Z level, instead of having every dropship use the same Z number.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
Having every dropship be on the same Z-level leads to some funky behavior with things such as comms, GPS locators, and SL indicators.

I was also considering making dropships inherit their overmap's Z if they were parked on the overmap (for things such as comms), but this would probably cause issues with a lot of other things that rely on virtual Z levels. I can add it anyways if maints want, but it'll definitely break things.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/9423435/215293748-3709144b-478f-40fc-8b9b-e5cac7592a67.png)

Entering and exiting 2 different dropships, then calling get_virtual_z_level() on the mob.
</details>

## Changelog
:cl:
code: Adds virtual Zs to dropships.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
