### PR TITLE
Adds teleporter beacons to the Galactica

### DIFF
--- a/_maps/map_files/Galactica/Galactica1.dmm
+++ b/_maps/map_files/Galactica/Galactica1.dmm
@@ -6591,6 +6591,19 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
+"sf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/item/beacon,
+/turf/open/floor/durasteel,
+/area/engine/break_room)
 "sg" = (
 /obj/structure/chair/office/light,
 /obj/effect/landmark/start/virologist,
@@ -13523,6 +13536,7 @@
 /area/storage/tech)
 "KE" = (
 /obj/effect/turf_decal/ship/nt_floor_logo,
+/obj/item/beacon,
 /turf/open/floor/light,
 /area/bridge/cic)
 "KF" = (
@@ -42502,7 +42516,7 @@ Tm
 xQ
 xQ
 xQ
-FW
+sf
 xQ
 xQ
 xQ

--- a/_maps/map_files/Galactica/Galactica2.dmm
+++ b/_maps/map_files/Galactica/Galactica2.dmm
@@ -8475,6 +8475,7 @@
 	location = "deck2Briefing";
 	name = "deck2Briefing"
 	},
+/obj/item/beacon,
 /turf/open/floor/light,
 /area/nsv/briefingroom)
 "eDI" = (
@@ -9575,6 +9576,7 @@
 	id = "janitor";
 	next_id = "trash"
 	},
+/obj/item/beacon,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/bar{
 	name = "Night Club"
@@ -18234,6 +18236,7 @@
 	location = "deck2Science";
 	name = "deck2Science"
 	},
+/obj/item/beacon,
 /turf/open/floor/monotile/steel,
 /area/science/lab)
 "jKf" = (
@@ -21224,6 +21227,7 @@
 	location = "deck2Medical";
 	name = "deck2Medical"
 	},
+/obj/item/beacon,
 /turf/open/floor/monotile/dark,
 /area/medical/medbay/lobby)
 "lpy" = (
@@ -23845,6 +23849,10 @@
 "mGp" = (
 /turf/closed/wall/steel,
 /area/security/brig)
+"mGR" = (
+/obj/item/beacon,
+/turf/open/floor/noslip/dark,
+/area/maintenance/nsv/bunker)
 "mGU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -36400,6 +36408,7 @@
 	location = "deck2Arrivals";
 	name = "deck2Arrivals"
 	},
+/obj/item/beacon,
 /turf/open/floor/monotile/steel,
 /area/hallway/secondary/entry/arrivals)
 "tuC" = (
@@ -37921,6 +37930,11 @@
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/medical/medbay)
+"unv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/beacon,
+/turf/open/floor/plasteel/tech/grid,
+/area/quartermaster/warehouse)
 "unF" = (
 /obj/structure/rack,
 /obj/item/storage/firstaid/ancient,
@@ -79197,7 +79211,7 @@ pHZ
 sxJ
 ruo
 nbc
-iED
+unv
 frE
 ndp
 hxj
@@ -101317,7 +101331,7 @@ viF
 kgH
 dzd
 kgH
-mnA
+mGR
 wyu
 gbZ
 xcc


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Does what the title says! Adds tracking beacons for the teleporter to the following areas: Departures, Briefing Room, CIC, Engineering Lobby, Medical Lobby, Science Lobby, Bar/Messhall, Nuclear Bunker, and Cargo Warehouse
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
We have a teleporter on the Galactica, but currently don't have any beacons to teleport to. What's the point of having a teleporter if you can't teleport?
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![GalacticaBeacons](https://user-images.githubusercontent.com/95106800/216319434-9ef35aa7-706b-48dd-9f5f-2d34bc723552.PNG)



</details>

## Changelog
:cl:
add: Several teleporter beacons added to Galactica
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
