### PR TITLE
[UPSTREAM] Xeno-Artifact Updates

### DIFF
--- a/code/__DEFINES/xenoartifact_materials.dm
+++ b/code/__DEFINES/xenoartifact_materials.dm
@@ -23,19 +23,23 @@
 #define PROCESS_TYPE_TICK "is_tick"
 
 ///Discovery point reward
-#define XENOA_DP 200
+#define XENOA_DP 350
 #define XENOA_SOLD_DP 350
+///Reserach point reward (modifer)
+#define XENOA_RP 2.5
 
 ///Max vendors / buyers in each catergory
 #define XENOA_MAX_VENDORS 8
 
 //Specific trait defines
-///Bear limit
+///Bear limit at once
 #define XENOA_MAX_BEARS 3
 ///Max targets on expansive
 #define XENOA_MAX_TARGETS 6
 ///Tick chance to untick
 #define XENOA_TICK_CANCEL_PROB 13
+///Max amount of evil clones at once
+#define XENOA_MAX_CLONES 5
 
 ///Chance to avoid target if wearing bomb suit
 #define XENOA_DEFLECT_CHANCE 45

--- a/code/_globalvars/xenoartifact.dm
+++ b/code/_globalvars/xenoartifact.dm
@@ -1,7 +1,7 @@
 ///Global names for science sellers
-GLOBAL_LIST_INIT(xenoa_seller_names, world.file2list("strings/names/science_seller.txt") + "")
-GLOBAL_LIST_INIT(xenoa_seller_dialogue, world.file2list("strings/science_dialogue.txt") + "")
-GLOBAL_LIST_INIT(xenoa_artifact_names, world.file2list("strings/names/artifact_sentience.txt") + "")
+GLOBAL_LIST_INIT(xenoa_seller_names, world.file2list("strings/names/science_seller.txt"))
+GLOBAL_LIST_INIT(xenoa_seller_dialogue, world.file2list("strings/science_dialogue.txt"))
+GLOBAL_LIST_INIT(xenoa_artifact_names, world.file2list("strings/names/artifact_sentience.txt"))
 
 ///traits types, referenced for generation
 GLOBAL_LIST(xenoa_activators)
@@ -14,6 +14,12 @@ GLOBAL_LIST(xenoa_all_traits)
 GLOBAL_LIST(xenoa_bluespace_blacklist)
 GLOBAL_LIST(xenoa_plasma_blacklist)
 GLOBAL_LIST(xenoa_uranium_blacklist)
+
+///List of emotes for emote-trait
+GLOBAL_LIST_INIT(xenoa_emote, list(/datum/emote/flip, /datum/emote/spin, /datum/emote/living/laugh,
+	/datum/emote/living/scream, /datum/emote/living/tremble, /datum/emote/living/whimper,
+	/datum/emote/living/smile, /datum/emote/living/pout, /datum/emote/living/gag,
+	/datum/emote/living/deathgasp, /datum/emote/living/dance, /datum/emote/living/blush))
 
 ///Fill globals
 /proc/generate_xenoa_statics()

--- a/code/datums/components/anti_artifact.dm
+++ b/code/datums/components/anti_artifact.dm
@@ -11,7 +11,7 @@
 	var/datum/callback/reaction
 	var/datum/callback/expire
 
-/datum/component/anti_artifact/Initialize(datum/callback/_reaction = null, datum/callback/_expire = null, _charges = null, _blocks_self = TRUE, _chance = 100, _allowed_slots)
+/datum/component/anti_artifact/Initialize(_charges = null, _blocks_self = TRUE, _chance = 100, _allowed_slots, datum/callback/_reaction, datum/callback/_expire)
 	if(isitem(parent))
 		RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, .proc/on_equip)
 		RegisterSignal(parent, COMSIG_ITEM_DROPPED, .proc/on_drop)

--- a/code/modules/xenoarchaeology/traits/xenoartifact_activators.dm
+++ b/code/modules/xenoarchaeology/traits/xenoartifact_activators.dm
@@ -36,7 +36,7 @@
 		X.process_type = PROCESS_TYPE_LIT
 		sleep(1.8 SECONDS) //Give them a chance to escape
 		START_PROCESSING(SSobj, X)
-		log_game("[key_name_admin(user)] lit [X] at [world.time] using [thing]. [X] located at [X.x] [X.y] [X.z].")
+		log_game("[key_name_admin(user)] lit [X] at [world.time] using [thing]. [X] located at [AREACOORD(X)].")
 
 ///============
 /// Timed activator, activates on a timer. Timer is turned on when used, has a chance to turn off.
@@ -54,7 +54,7 @@
 	X.max_range += 1
 	X.malfunction_mod = 0.5
 
-/datum/xenoartifact_trait/activator/clock/on_item(obj/item/xenoartifact/X, atom/user, atom/item) 
+/datum/xenoartifact_trait/activator/clock/on_item(obj/item/xenoartifact/X, atom/user, atom/item)
 	if(istype(item, /obj/item/clothing/neck/stethoscope))
 		to_chat(user, "<span class='info'>The [X.name] ticks deep from within.\n</span>")
 		return TRUE
@@ -64,7 +64,7 @@
 	var/obj/item/xenoartifact/X = source
 	X.process_type = PROCESS_TYPE_TICK
 	START_PROCESSING(SSobj, X)
-	log_game("[key_name_admin(user)] set clock on [X] at [world.time] using [thing]. [X] located at [X.x] [X.y] [X.z].")
+	log_game("[key_name_admin(user)] set clock on [X] at [world.time] using [thing]. [X] located at [AREACOORD(X)].")
 
 ///============
 /// Signal activator, responds to respective signals sent through signallers
@@ -92,7 +92,7 @@
 /datum/xenoartifact_trait/activator/signal/pass_input(datum/source, obj/item/thing, mob/user, atom/target, params)
 	var/obj/item/xenoartifact/X = source
 	X.default_activate(charge, user, target)
-	log_game("[key_name_admin(user)] signalled [X] at [world.time]. [X] located at [X.x] [X.y] [X.z].")
+	log_game("[key_name_admin(user)] signalled [X] at [world.time]. [X] located at [AREACOORD(X)].")
 
 ///============
 /// Battery activator, needs a cell to activate
@@ -131,15 +131,12 @@
 /datum/xenoartifact_trait/activator/weighted/pass_input(datum/source, obj/item/thing, mob/living/carbon/user, mob/living/carbon/human/target)
 	var/obj/item/clothing/gloves/artifact_pinchers/P
 	//Grab ref to gloves for check
-	if(istype(target))
-		P = target.get_item_by_slot(ITEM_SLOT_GLOVES)
-	if(istype(user) && !P)
+	if(istype(user))
 		P = user.get_item_by_slot(ITEM_SLOT_GLOVES)
-	
-	if(P?.safety) //This trait is a special tism
-		return
+		if(istype(P) && P?.safety) //This trait is a special tism
+			return
 	var/obj/item/xenoartifact/X = source
-	X.default_activate(charge, user, target)
+	X.default_activate(charge, user, user)
 
 ///============
 /// Pitch activator, artifact activates when thrown. Credit to EvilDragon#4532
@@ -154,4 +151,22 @@
 
 /datum/xenoartifact_trait/activator/pitch/pass_input(datum/source, obj/item/thing, mob/user, atom/target)
 	var/obj/item/xenoartifact/X = source
+	X.default_activate(charge, user, target)
+
+///============
+/// Honk, activated when honked or used by a clown
+///============
+/datum/xenoartifact_trait/activator/honk
+	desc = "Honked"
+	label_desc = "Honked: The material is squishy & humorous. Perhaps the clown would know how to use it?"
+	charge = 25
+	signals = list(COMSIG_PARENT_ATTACKBY, COMSIG_MOVABLE_IMPACT, COMSIG_ITEM_ATTACK_SELF, COMSIG_ITEM_AFTERATTACK)
+	weight = 25
+
+/datum/xenoartifact_trait/activator/honk/pass_input(datum/source, obj/item/thing, mob/user, atom/target)
+	var/obj/item/xenoartifact/X = source
+	//Make sure we're being silly before we activate it - isclown( ) refers to the simplemob
+	if(!(istype(thing, /obj/item/bikehorn) || istype(thing, /obj/item/bikehorn/golden) || isclown(target) || HAS_TRAIT(user, TRAIT_NAIVE) || HAS_TRAIT(target, TRAIT_NAIVE)))
+		return
+	charge = charge*((thing?.force || 10)*0.1)
 	X.default_activate(charge, user, target)

--- a/code/modules/xenoarchaeology/traits/xenoartifact_majors.dm
+++ b/code/modules/xenoarchaeology/traits/xenoartifact_majors.dm
@@ -23,7 +23,7 @@
 		addtimer(CALLBACK(src, .proc/release, X, AM), X.charge*0.5 SECONDS)
 		AM.forceMove(X)
 		X.buckle_mob(AM)
-		if(isliving(target)) //stop awful hobbit-sis from wriggling 
+		if(isliving(target)) //stop awful hobbit-sis from wriggling
 			var/mob/living/victim = target
 			victim.Paralyze(X.charge*0.5 SECONDS, ignore_canstun = TRUE)
 		X.cooldownmod = X.charge*0.6 SECONDS
@@ -36,7 +36,7 @@
 	AM.forceMove(T)
 	if(spawn_russian)
 		new /mob/living/simple_animal/hostile/russian(T)
-		log_game("[X] spawned (/mob/living/simple_animal/hostile/russian) at [world.time]. [X] located at [X.x] [X.y] [X.z]")
+		log_game("[X] spawned (/mob/living/simple_animal/hostile/russian) at [world.time]. [X] located at [AREACOORD(X)]")
 		spawn_russian = FALSE
 
 ///============
@@ -56,7 +56,7 @@
 	if(istype(target, /obj/item/stock_parts/cell))
 		var/obj/item/stock_parts/cell/C = target //Have to type convert to work with other traits
 		C.give((X.charge/100)*C.maxcharge)
-		
+
 	else if(istype(target, /mob/living))
 		var/damage = X.charge*0.25
 		var/mob/living/carbon/victim = target
@@ -91,11 +91,13 @@
 	flags = PLASMA_TRAIT | URANIUM_TRAIT
 
 /datum/xenoartifact_trait/major/laser/activate(obj/item/xenoartifact/X, atom/target, mob/living/user)
+	//light target on fire if we're close
 	if(isliving(target) && get_dist(target, X.loc || user) <= 1)
 		var/mob/living/victim = target
 		victim.adjust_fire_stacks(5*(X.charge/X.charge_req))
 		victim.IgniteMob()
 		return
+	//otherwise shoot laser
 	var/obj/item/projectile/A
 	switch(X.charge)
 		if(0 to 24)
@@ -104,14 +106,18 @@
 			A = new /obj/item/projectile/beam/laser
 		if(80 to 200)
 			A = new /obj/item/projectile/beam/laser/heavylaser
+	//If target is our own turf, aka someone probably threw us, target a random direction to avoid always shooting east
+	if(istype(target, /turf) && X.loc == target)
+		target = get_edge_target_turf(pick(NORTH, EAST, SOUTH, WEST))
+	//FIRE!
 	A.preparePixelProjectile(get_turf(target), X)
 	A.fire()
-	playsound(get_turf(src), 'sound/mecha/mech_shield_deflect.ogg', 50, TRUE) 
+	playsound(get_turf(src), 'sound/mecha/mech_shield_deflect.ogg', 50, TRUE)
 
 ///============
 /// Corginator, turns the target into a corgi for a short time
 ///============
-/datum/xenoartifact_trait/major/corginator ///All of this is stolen from corgium. 
+/datum/xenoartifact_trait/major/corginator ///All of this is stolen from corgium.
 	desc = "Fuzzy" //Weirdchamp
 	label_desc = "Fuzzy: The shape is hard to discern under all the hair sprouting out from the surface. You swear you've heard it bark before."
 	flags = BLUESPACE_TRAIT
@@ -151,7 +157,7 @@
 	//Kill timer
 	deltimer(timer)
 	timer = null
-	
+
 	var/obj/shapeshift_holder/H = locate() in new_corgi
 	if(!H)
 		return
@@ -249,11 +255,11 @@
 	var/light_mod
 
 /datum/xenoartifact_trait/major/lamp/on_init(obj/item/xenoartifact/X)
-	X.light_system = MOVABLE_LIGHT
 	X.light_color = pick(LIGHT_COLOR_FIRE, LIGHT_COLOR_BLUE, LIGHT_COLOR_GREEN, LIGHT_COLOR_RED, LIGHT_COLOR_ORANGE, LIGHT_COLOR_PINK)
 
 /datum/xenoartifact_trait/major/lamp/activate(obj/item/xenoartifact/X, atom/target, atom/user)
-	X.set_light(1.4+(X.charge*0.5), max(X.charge*0.05, 0.1), X.light_color)
+	X.visible_message("<span class='notice'>The [X] lights up!</span>")
+	X.set_light(X.charge*0.08, max(X.charge*0.05, 5), X.light_color)
 	addtimer(CALLBACK(src, .proc/unlight, X), (X.charge*0.6) SECONDS)
 	X.cooldownmod = (X.charge*0.6) SECONDS
 
@@ -276,14 +282,19 @@
 	if(size >= 1)
 		new /obj/effect/forcefield/xenoartifact_type(get_turf(X.loc), (X.charge*0.4) SECONDS)
 	if(size >= 3)
-		new /obj/effect/forcefield/xenoartifact_type(get_step(X, NORTH), (X.charge*0.4) SECONDS)
-		new /obj/effect/forcefield/xenoartifact_type(get_step(X, SOUTH), (X.charge*0.4) SECONDS)
+		var/outcome = pick(0, 1)
+		if(outcome || size >= 5)
+			new /obj/effect/forcefield/xenoartifact_type(get_step(X, NORTH), (X.charge*0.4) SECONDS)
+			new /obj/effect/forcefield/xenoartifact_type(get_step(X, SOUTH), (X.charge*0.4) SECONDS)
+		else
+			new /obj/effect/forcefield/xenoartifact_type(get_step(X, EAST), (X.charge*0.4) SECONDS)
+			new /obj/effect/forcefield/xenoartifact_type(get_step(X, WEST), (X.charge*0.4) SECONDS)
 	if(size >= 5)
 		new /obj/effect/forcefield/xenoartifact_type(get_step(X, WEST), (X.charge*0.4) SECONDS)
 		new /obj/effect/forcefield/xenoartifact_type(get_step(X, EAST), (X.charge*0.4) SECONDS)
 
 	X.cooldownmod = (X.charge*0.4) SECONDS
-	
+
 /obj/effect/forcefield/xenoartifact_type //Special wall type for artifact
 	desc = "An impenetrable artifact wall."
 
@@ -325,19 +336,20 @@
 	desc = "Hypodermic"
 	label_desc = "Hypodermic: The Artifact's shape is comprised of many twisting tubes and vials, it seems a liquid may be inside."
 	flags = BLUESPACE_TRAIT | PLASMA_TRAIT | URANIUM_TRAIT
+	blacklist_traits = list(/datum/xenoartifact_trait/minor/long)
 	var/datum/reagent/formula
 	var/amount
 
 /datum/xenoartifact_trait/major/chem/on_init(obj/item/xenoartifact/X)
-	amount = pick(5, 9, 10, 15)
+	amount = pick(7, 14, 21)
 	formula = get_random_reagent_id(CHEMICAL_RNG_GENERAL)
 
 /datum/xenoartifact_trait/major/chem/activate(obj/item/xenoartifact/X, atom/target)
 	if(target?.reagents)
 		playsound(get_turf(X), pick('sound/items/hypospray.ogg','sound/items/hypospray2.ogg'), 50, TRUE)
 		var/datum/reagents/R = target.reagents
-		R.add_reagent(formula, amount)
-		log_game("[X] injected [key_name_admin(target)] with [amount]u of [formula] at [world.time]. [X] located at [X.x] [X.y] [X.z]")
+		R.add_reagent(formula, amount*(initial(formula.metabolization_rate)))
+		log_game("[X] injected [key_name_admin(target)] with [amount]u of [formula] at [world.time]. [X] located at [AREACOORD(X)]")
 
 ///============
 /// Push, pushes target away from artifact
@@ -387,7 +399,7 @@
 	var/sound
 
 /datum/xenoartifact_trait/major/horn/on_init(obj/item/xenoartifact/X)
-	sound = pick(list('sound/effects/adminhelp.ogg', 'sound/effects/applause.ogg', 'sound/effects/bubbles.ogg', 
+	sound = pick(list('sound/effects/adminhelp.ogg', 'sound/effects/applause.ogg', 'sound/effects/bubbles.ogg',
 					'sound/effects/empulse.ogg', 'sound/effects/explosion1.ogg', 'sound/effects/explosion_distant.ogg',
 					'sound/effects/laughtrack.ogg', 'sound/effects/magic.ogg', 'sound/effects/meteorimpact.ogg',
 					'sound/effects/phasein.ogg', 'sound/effects/supermatter.ogg', 'sound/weapons/armbomb.ogg',
@@ -449,6 +461,7 @@
 	label_desc = "Destabilizing: The Artifact collapses an improper bluespace matrix on the target, sending them to an unknown location."
 	weight = 25
 	flags = URANIUM_TRAIT
+	blacklist_traits = list(/datum/xenoartifact_trait/minor/aura)
 	var/obj/item/xenoartifact/exit
 
 /datum/xenoartifact_trait/major/distablizer/on_init(obj/item/xenoartifact/X)
@@ -485,3 +498,61 @@
 /datum/xenoartifact_trait/major/distablizer/Destroy()
 	GLOB.destabliization_exits -= exit
 	..()
+
+///============
+/// Dissipating, the artifact creates a could of smoke.
+///============
+/datum/xenoartifact_trait/major/smokey
+	desc = "Dissipating"
+	label_desc = "Dissipating: The Artifact is dissipating as if it was made of smoke."
+	flags = URANIUM_TRAIT | PLASMA_TRAIT | BLUESPACE_TRAIT
+
+/datum/xenoartifact_trait/major/smokey/activate(obj/item/xenoartifact/X, atom/target, atom/user, setup)
+	var/datum/effect_system/smoke_spread/E = new()
+	E.set_up(max(3, X.charge*0.08), get_turf(X))
+	E.start()
+
+///============
+/// Marker, colors target with a random color
+///============
+/datum/xenoartifact_trait/major/marker
+	label_name = "Marker"
+	label_desc = "Marker: The Artifact causes the target to refract a unique color index."
+	flags = PLASMA_TRAIT | BLUESPACE_TRAIT
+	///The color this artifact dispenses
+	var/color
+
+/datum/xenoartifact_trait/major/marker/on_init(obj/item/xenoartifact/X)
+	color = pick(COLOR_RED, COLOR_GREEN, COLOR_BLUE, COLOR_PURPLE, COLOR_ORANGE, COLOR_YELLOW, COLOR_CYAN, COLOR_PINK, "all")
+
+/datum/xenoartifact_trait/major/marker/activate(obj/item/xenoartifact/X, atom/target, atom/user, setup)
+	if(color == "all")
+		target.color = pick(COLOR_RED, COLOR_GREEN, COLOR_BLUE, COLOR_PURPLE, COLOR_ORANGE, COLOR_YELLOW, COLOR_CYAN, COLOR_PINK)
+	else
+		target.color = color
+
+///============
+/// emote, makes user do a random emote
+///============
+/datum/xenoartifact_trait/major/emote
+	label_name = "Emotional"
+	label_desc = "Emotional: The Artifact causes the target to experience, or preform, a random emotion."
+	flags = PLASMA_TRAIT | BLUESPACE_TRAIT | URANIUM_TRAIT
+	///Emote to preform
+	var/datum/emote/emote
+
+/datum/xenoartifact_trait/major/emote/on_init(obj/item/xenoartifact/X)
+	emote = pick(GLOB.xenoa_emote)
+	emote = new emote()
+
+/datum/xenoartifact_trait/major/emote/activate(obj/item/xenoartifact/X, atom/target, atom/user, setup)
+	if(iscarbon(target))
+		emote.run_emote(target)
+	//Not all mobs can preform the given emotes, spin is pretty common though
+	else if(isliving(target))
+		var/datum/emote/spin/E = new()
+		E.run_emote(target)
+
+/datum/xenoartifact_trait/major/emote/Destroy()
+	. = ..()
+	QDEL_NULL(emote)

--- a/code/modules/xenoarchaeology/traits/xenoartifact_malfunctions.dm
+++ b/code/modules/xenoarchaeology/traits/xenoartifact_malfunctions.dm
@@ -173,7 +173,7 @@
 	T.alpha = 255
 	T.pixel_y = initial(T.pixel_y)
 	T.pixel_x = initial(T.pixel_x)
-	T.color = COLOR_BLUE
+	T.color = pick(COLOR_RED, COLOR_GREEN, COLOR_BLUE, COLOR_PURPLE, COLOR_ORANGE, COLOR_YELLOW, COLOR_CYAN, COLOR_PINK) //NSV13 - Yes
 	//Handle limit and hardel
 	clones += T
 	RegisterSignal(T, COMSIG_PARENT_QDELETING, .proc/handle_death)

--- a/code/modules/xenoarchaeology/traits/xenoartifact_malfunctions.dm
+++ b/code/modules/xenoarchaeology/traits/xenoartifact_malfunctions.dm
@@ -3,23 +3,26 @@
 // Bear, produces a bear until it reaches its upper limit
 //============
 /datum/xenoartifact_trait/malfunction/bear
-	label_name = "P.B.R." 
+	label_name = "P.B.R."
 	label_desc = "Parallel Bearspace Retrieval: A strange malfunction causes the Artifact to open a gateway to deep bearspace."
 	weight = 15
-	var/bears //bear per bears
+	flags = URANIUM_TRAIT
+	var/list/bears = list() //bear per bears
 
 /datum/xenoartifact_trait/malfunction/bear/activate(obj/item/xenoartifact/X)
-	if(bears < XENOA_MAX_BEARS)
-		bears++
-		var/mob/living/simple_animal/hostile/bear/new_bear = new(get_turf(X.loc))
-		new_bear.name = pick("Freddy", "Bearington", "Smokey", "Beorn", "Pooh", "Paddington", "Winnie", "Baloo", "Rupert", "Yogi", "Fozzie", "Boo") //Why not?
-		log_game("[X] spawned a (/mob/living/simple_animal/hostile/bear) at [world.time]. [X] located at [X.x] [X.y] [X.z]")
-	else
-		X.visible_message("<span class='danger'>The [X.name] shatters as bearspace collapses! Too many bears!</span>")
-		var/obj/effect/decal/cleanable/ash/A = new(get_turf(X))
-		A.color = X.material
-		qdel(X)
+	if(length(bears) >= XENOA_MAX_BEARS)
+		return
+	var/turf/T = get_turf(X)
+	var/mob/living/simple_animal/hostile/bear/new_bear = new(T)
+	new_bear.name = pick("Freddy", "Bearington", "Smokey", "Beorn", "Pooh", "Winnie", "Baloo", "Rupert", "Yogi", "Fozzie", "Boo") //Why not?
+	bears += new_bear
+	RegisterSignal(new_bear, COMSIG_MOB_DEATH, .proc/handle_death)
+	log_game("[X] spawned a (/mob/living/simple_animal/hostile/bear) at [world.time]. [X] located at [AREACOORD(X)]")
 	X.cooldown += 20 SECONDS
+
+/datum/xenoartifact_trait/malfunction/bear/proc/handle_death(datum/source)
+	bears -= source
+	UnregisterSignal(source, COMSIG_MOB_DEATH)
 
 //============
 // Badtarget, changes target to user
@@ -27,6 +30,7 @@
 /datum/xenoartifact_trait/malfunction/badtarget
 	label_name = "Maltargeting"
 	label_desc = "Maltargeting: A strange malfunction that causes the Artifact to always target the original user."
+	flags = BLUESPACE_TRAIT | URANIUM_TRAIT | PLASMA_TRAIT
 
 /datum/xenoartifact_trait/malfunction/badtarget/activate(obj/item/xenoartifact/X, atom/target, atom/user)
 	var/mob/living/M
@@ -53,8 +57,11 @@
 		//Im okay with this targetting clothing in other non-worn slots
 		for(var/obj/item/clothing/I in victim.contents)
 			clothing_list += I
-		victim.dropItemToGround(pick(clothing_list))
-		X.cooldown += 10 SECONDS
+		//Stops this from stripping funky stuff
+		var/obj/item/clothing/C = pick(clothing_list)
+		if(!HAS_TRAIT_FROM(C, TRAIT_NODROP, GLUED_ITEM_TRAIT))
+			victim.dropItemToGround(C)
+			X.cooldown += 10 SECONDS
 
 //============
 // Trauma, gives target trauma, amazing
@@ -63,6 +70,7 @@
 	label_name = "C.D.E."
 	label_desc = "Cerebral Dysfunction Emergence: A strange malfunction that causes the Artifact to force brain traumas to develop in a given target."
 	weight = 25
+	flags = BLUESPACE_TRAIT | URANIUM_TRAIT
 	var/datum/brain_trauma/trauma
 
 /datum/xenoartifact_trait/malfunction/trauma/on_init(obj/item/xenoartifact/X)
@@ -75,7 +83,7 @@
 /datum/xenoartifact_trait/malfunction/trauma/activate(obj/item/xenoartifact/X, atom/target, atom/user)
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
-		H.Unconscious(5 SECONDS)
+		H.Unconscious(0.3 SECONDS)
 		H.gain_trauma(trauma, TRAUMA_RESILIENCE_BASIC)
 		X.cooldownmod += 10 SECONDS
 
@@ -83,13 +91,14 @@
 // Heated, causes artifact explode in flames
 //============
 /datum/xenoartifact_trait/malfunction/heated
-	label_name = "Combustible" 
+	label_name = "Combustible"
 	label_desc = "Combustible: A strange malfunction that causes the Artifact to violently combust."
 	weight = 15
+	flags = URANIUM_TRAIT
 
 /datum/xenoartifact_trait/malfunction/heated/activate(obj/item/xenoartifact/X, atom/target, atom/user)
 	var/turf/T = get_turf(X)
-	playsound(T, 'sound/effects/bamf.ogg', 50, TRUE) 
+	playsound(T, 'sound/effects/bamf.ogg', 50, TRUE)
 	for(var/turf/open/turf in RANGE_TURFS(max(1, 4*((X.charge*1.5)/100)), T))
 		if(!locate(/obj/effect/safe_fire) in turf)
 			new /obj/effect/safe_fire(turf)
@@ -123,6 +132,7 @@
 /datum/xenoartifact_trait/malfunction/radioactive
 	label_name = "Radioactive"
 	label_desc = "Radioactive: The Artifact Emmits harmful particles when a reaction takes place."
+	flags = BLUESPACE_TRAIT | URANIUM_TRAIT | PLASMA_TRAIT
 
 /datum/xenoartifact_trait/malfunction/radioactive/on_init(obj/item/xenoartifact/X)
 	X.rad_act(25)
@@ -139,3 +149,126 @@
 
 /datum/xenoartifact_trait/malfunction/radioactive/activate(obj/item/xenoartifact/X)
 	X.rad_act(25)
+
+//============
+// twin, makes an evil twin of the target
+//============
+/datum/xenoartifact_trait/malfunction/twin
+	label_name = "Anti-Cloning"
+	label_desc = "Anti-Cloning: The Artifact produces an arguably maleviolent clone of target."
+	flags = BLUESPACE_TRAIT | URANIUM_TRAIT | PLASMA_TRAIT
+	var/list/clones = list()
+
+/datum/xenoartifact_trait/malfunction/twin/activate(obj/item/xenoartifact/X, mob/living/target, atom/user, setup)
+	//Stop artifact making one morbillion clones
+	if(length(clones) >= XENOA_MAX_CLONES)
+		return
+	//Twin setup
+	var/mob/living/simple_animal/hostile/twin/T = new(get_turf(X))
+	//Setup appearence for evil twin
+	T.name = target.name
+	T.appearance = target.appearance
+	if(istype(target) && length(target.vis_contents))
+		T.add_overlay(target.vis_contents)
+	T.alpha = 255
+	T.pixel_y = initial(T.pixel_y)
+	T.pixel_x = initial(T.pixel_x)
+	T.color = COLOR_BLUE
+	//Handle limit and hardel
+	clones += T
+	RegisterSignal(T, COMSIG_PARENT_QDELETING, .proc/handle_death)
+
+/datum/xenoartifact_trait/malfunction/twin/proc/handle_death(datum/source)
+	clones -= source
+	UnregisterSignal(source, COMSIG_PARENT_QDELETING)
+
+/mob/living/simple_animal/hostile/twin
+	name = "evil twin"
+	desc = "It looks just like... someone!"
+	mob_biotypes = list(MOB_ORGANIC, MOB_HUMANOID)
+	speak_chance = 0
+	turns_per_move = 5
+	response_help = "pokes"
+	response_disarm = "shoves"
+	response_harm = "hits"
+	speed = 0
+	maxHealth = 10
+	health = 10
+	melee_damage = 5
+	attacktext = "punches"
+	attack_sound = 'sound/weapons/punch1.ogg'
+	a_intent = INTENT_HARM
+	atmos_requirements = list("min_oxy" = 5, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0)
+	unsuitable_atmos_damage = 15
+	faction = list("evil_clone")
+	status_flags = CANPUSH
+	del_on_death = TRUE
+	do_footstep = TRUE
+	mobchatspan = "syndmob"
+
+//============
+// explode, a very small explosion takes place, destroying the artifact in the process
+//============
+/datum/xenoartifact_trait/malfunction/explode
+	label_name = "Delaminating"
+	label_desc = "Delaminating: The Artifact violently collapses, exploding."
+	flags = URANIUM_TRAIT
+
+/datum/xenoartifact_trait/malfunction/explode/activate(obj/item/xenoartifact/X, atom/target, atom/user, setup)
+	. = ..()
+	X.visible_message("<span class='warning'>The [X] begins to heat up, it's delaminating!</span>")
+	apply_wibbly_filters(X, 3)
+	addtimer(CALLBACK(src, .proc/explode, X), 10 SECONDS)
+
+/datum/xenoartifact_trait/malfunction/explode/proc/explode(obj/item/xenoartifact/X)
+	SSexplosions.explode(X, 0, 1, 2, 1)
+	qdel(X)
+
+//============
+// absorbant, absorbs nearby gasses
+//============
+/datum/xenoartifact_trait/malfunction/absorbant
+	label_name = "Absorbing"
+	label_desc = "Absorbing: The Artifact absorbs large volumes of nearby gasses."
+	flags = BLUESPACE_TRAIT | URANIUM_TRAIT | PLASMA_TRAIT
+	///What gasses we've S U C K E D
+	var/datum/gas_mixture/air_contents
+	///Gasses we can suck. Currently everything but, it's here if we need to blacklist in the future
+	var/list/scrubbing = list(GAS_PLASMA, GAS_CO2, GAS_NITROUS, GAS_BZ, GAS_NITRYL, GAS_TRITIUM, GAS_HYPERNOB, GAS_H2O, GAS_O2, GAS_N2, GAS_STIMULUM, GAS_PLUOXIUM)
+	///Adjust for balance - I'm sure this will have no ramifications
+	var/volume = 1000000
+	var/volume_rate = 200000
+	///Ref to artifact for destruction
+	var/obj/item/xenoartifact/parent
+
+/datum/xenoartifact_trait/malfunction/absorbant/on_init(obj/item/xenoartifact/X)
+	air_contents = new(volume)
+	air_contents.set_temperature(T20C)
+	parent = X
+
+/datum/xenoartifact_trait/malfunction/absorbant/activate(obj/item/xenoartifact/X, atom/target, atom/user, setup)
+	X.visible_message("<space class='warning'>[X] begins to vacuum nearby gasses!</span>")
+	var/turf/T = get_turf(X)
+	var/datum/gas_mixture/mixture = T.return_air()
+	mixture.scrub_into(air_contents, volume_rate / mixture.return_volume(), scrubbing)
+	X.air_update_turf()
+
+//Throw sucked gas into our tile when we die
+/datum/xenoartifact_trait/malfunction/absorbant/Destroy()
+	. = ..()
+	var/turf/T = get_turf(parent)
+	T.assume_air(air_contents)
+	parent.air_update_turf()
+
+//============
+// Hallucination, shows a random hallucination to the target once
+//============
+/datum/xenoartifact_trait/malfunction/hallucination
+	label_name = "Hallucinogenic"
+	label_desc = "Hallucinogenic: The Artifact causes the target to hallucinate."
+	flags = BLUESPACE_TRAIT | URANIUM_TRAIT | PLASMA_TRAIT
+
+/datum/xenoartifact_trait/malfunction/hallucination/activate(obj/item/xenoartifact/X, atom/target, atom/user, setup)
+	if(isliving(target))
+		var/datum/hallucination/H = pick(GLOB.hallucination_list)
+		H = new H(target)

--- a/code/modules/xenoarchaeology/traits/xenoartifact_minors.dm
+++ b/code/modules/xenoarchaeology/traits/xenoartifact_minors.dm
@@ -9,7 +9,7 @@
 
 /datum/xenoartifact_trait/minor/looped/on_item(obj/item/xenoartifact/X, atom/user, atom/item)
 	if(istype(item, /obj/item/multitool))
-		to_chat(user, "<span class='info'>The [item.name] displays a resistance reading of [X.charge_req*0.1].</span>") 
+		to_chat(user, "<span class='info'>The [item.name] displays a resistance reading of [X.charge_req*0.1].</span>")
 		return TRUE
 	return ..()
 
@@ -41,13 +41,13 @@
 		X.cooldown = -1000 SECONDS //This is better than making a unique interaction in xenoartifact.dm
 		return
 	charges = pick(0, 1, 2)
-	playsound(get_turf(X), 'sound/machines/capacitor_charge.ogg', 50, TRUE) 
+	playsound(get_turf(X), 'sound/machines/capacitor_charge.ogg', 50, TRUE)
 	X.cooldown = saved_cooldown
 	saved_cooldown = null
 
 /datum/xenoartifact_trait/minor/capacitive/on_item(obj/item/xenoartifact/X, atom/user, atom/item)
 	if(istype(item, /obj/item/multitool))
-		to_chat(user, "<span class='info'>The [item.name] displays an overcharge reading of [charges/3].</span>") 
+		to_chat(user, "<span class='info'>The [item.name] displays an overcharge reading of [charges/3].</span>")
 		return TRUE
 	return ..()
 
@@ -110,6 +110,8 @@
 /datum/xenoartifact_trait/minor/sentient
 	label_name = "Sentient"
 	label_desc = "Sentient: The Artifact seems to be alive, influencing events around it. The Artifact wants to return to its master..."
+	//Slightly increase weight - muh arpee serber
+	weight = 55
 	///he who lives inside
 	var/mob/living/simple_animal/shade/man
 	///His doorbell
@@ -121,9 +123,15 @@
 
 /datum/xenoartifact_trait/minor/sentient/on_init(obj/item/xenoartifact/X)
 	addtimer(CALLBACK(src, .proc/get_canidate, X), 5 SECONDS)
+	RegisterSignal(X, COMSIG_PARENT_EXAMINE, .proc/handle_ghost, TRUE)
 
-/datum/xenoartifact_trait/minor/sentient/proc/get_canidate(obj/item/xenoartifact/X)
-	var/list/mob/dead/observer/candidates = pollGhostCandidates("Do you want to play as the maleviolent force inside the [X.name]?", ROLE_SENTIENCE, null, FALSE, 5 SECONDS, POLL_IGNORE_SENTIENCE_POTION)
+//Proc used to give access to ghosts when original player leaves
+/datum/xenoartifact_trait/minor/sentient/proc/handle_ghost(datum/source, mob/M, list/examine_text)
+	if(isobserver(M) && man && !man?.key && (alert(M, "Are you sure you want to control of [man]?", "Assume control of [man]", "Yes", "No") == "Yes"))
+		man.key = M.ckey
+
+/datum/xenoartifact_trait/minor/sentient/proc/get_canidate(obj/item/xenoartifact/X, mob/M)
+	var/list/mob/dead/observer/candidates = pollGhostCandidates("Do you want to play as the maleviolent force inside the [X.name]?", ROLE_SENTIENCE, null, FALSE, 8 SECONDS, POLL_IGNORE_SENTIENCE_POTION)
 	if(LAZYLEN(candidates))
 		var/mob/dead/observer/C = pick(candidates)
 		setup_sentience(X, C.ckey)
@@ -133,14 +141,14 @@
 
 /datum/xenoartifact_trait/minor/sentient/proc/setup_sentience(obj/item/xenoartifact/X, ckey)
 	if(!(SSzclear.get_free_z_level()))
-		playsound(get_turf(X), 'sound/machines/buzz-sigh.ogg', 50, TRUE) 
-		return	
+		playsound(get_turf(X), 'sound/machines/buzz-sigh.ogg', 50, TRUE)
+		return
 	man = new(get_turf(X))
 	man.name = pick(GLOB.xenoa_artifact_names)
 	man.real_name = "[man.name] - [X]"
 	man.key = ckey
 	man.status_flags |= GODMODE
-	log_game("[key_name_admin(man)] took control of the sentient [X]. [X] located at [X.x] [X.y] [X.z]")
+	log_game("[key_name_admin(man)] took control of the sentient [X]. [X] located at [AREACOORD(X)]")
 	man.forceMove(X)
 	man.anchored = TRUE
 	var/obj/effect/proc_holder/spell/targeted/xeno_senitent_action/P = new /obj/effect/proc_holder/spell/targeted/xeno_senitent_action(,X)
@@ -168,14 +176,15 @@
 /obj/effect/proc_holder/spell/targeted/xeno_senitent_action/Initialize(mapload, var/obj/item/xenoartifact/Z)
 	. = ..()
 	xeno = Z
-	range = Z.max_range+3
+	range = Z.max_range+1
 
 /obj/effect/proc_holder/spell/targeted/xeno_senitent_action/cast(list/targets, mob/living/simple_animal/revenant/user = usr)
+	if(!xeno)
+		return
 	for(var/atom/M in targets)
-		if(xeno)
-			xeno.true_target = list(M)
-			xeno.default_activate(xeno.charge_req+50)
-			charge_max = xeno.cooldown+xeno.cooldownmod
+		xeno.true_target += xeno.process_target(M)
+		xeno.default_activate(xeno.charge_req+10)
+		charge_max = xeno.cooldown+xeno.cooldownmod
 
 /datum/xenoartifact_trait/minor/sentient/Destroy(force, ...)
 	. = ..()
@@ -216,14 +225,14 @@
 	X.alpha = X.alpha * 0.55
 
 /datum/xenoartifact_trait/minor/delicate/activate(obj/item/xenoartifact/X, atom/user)
-	if(X.obj_integrity)
+	if(X.obj_integrity > 0)
 		X.obj_integrity -= 100
 		X.visible_message("<span class='danger'>The [X.name] cracks!</span>", "<span class='danger'>The [X.name] cracks!</span>")
-	else if(X.obj_integrity <= 0)
+	else
 		X.visible_message("<span class='danger'>The [X.name] shatters!</span>", "<span class='danger'>The [X.name] shatters!</span>")
 		var/obj/effect/decal/cleanable/ash/A = new(get_turf(X))
 		A.color = X.material
-		playsound(get_turf(X), 'sound/effects/glassbr1.ogg', 50, TRUE) 
+		playsound(get_turf(X), 'sound/effects/glassbr1.ogg', 50, TRUE)
 		qdel(X)
 
 //============
@@ -271,7 +280,7 @@
 
 /datum/xenoartifact_trait/minor/wearable/on_init(obj/item/xenoartifact/X)
 	X.slot_flags = ITEM_SLOT_GLOVES
-	
+
 /datum/xenoartifact_trait/minor/wearable/activate(obj/item/xenoartifact/X, atom/user)
 	X.true_target |= list(user)
 
@@ -335,7 +344,7 @@
 /datum/xenoartifact_trait/minor/signalsend/activate(obj/item/xenoartifact/X)
 	var/datum/signal/signal = new(list("code" = X.code))
 	X.send_signal(signal)
-	log_game("[X] sent signal code [X.code] on frequency [X.frequency] at [world.time]. [X] located at [X.x] [X.y] [X.z]")
+	log_game("[X] sent signal code [X.code] on frequency [X.frequency] at [world.time]. [X] located at [AREACOORD(X)]")
 
 //============
 // Anchor, the artifact can be anchored, anchors when activated
@@ -343,7 +352,7 @@
 /datum/xenoartifact_trait/minor/anchor
 	desc = "Anchored"
 	label_desc = "Anchored: The Artifact buckles to the floor with the weight of a sun every time it activates. Heavier than you, somehow."
-	blacklist_traits = list(/datum/xenoartifact_trait/minor/wearable)
+	blacklist_traits = list(/datum/xenoartifact_trait/minor/wearable, /datum/xenoartifact_trait/minor/haunted)
 	flags = BLUESPACE_TRAIT | URANIUM_TRAIT
 
 /datum/xenoartifact_trait/minor/anchor/activate(obj/item/xenoartifact/X, atom/target, atom/user)
@@ -399,7 +408,8 @@
 			 "up" = CALLBACK(src, .proc/haunted_step, X, NORTH),
 			 "down" = CALLBACK(src, .proc/haunted_step, X, SOUTH),
 			 "left" = CALLBACK(src, .proc/haunted_step, X, WEST),
-			 "right" = CALLBACK(src, .proc/haunted_step, X, EAST)), 10 SECONDS))
+			 "right" = CALLBACK(src, .proc/haunted_step, X, EAST),
+			 "activate" = CALLBACK(src, .proc/activate_parent, X)), 10 SECONDS))
 
 /datum/xenoartifact_trait/minor/haunted/proc/haunted_step(obj/item/xenoartifact/ref, dir)
 	if(isliving(ref.loc)) //Make any mobs drop this before it moves
@@ -407,6 +417,13 @@
 		M.dropItemToGround(ref)
 	playsound(get_turf(ref), 'sound/effects/magic.ogg', 50, TRUE)
 	step(ref, dir)
+
+///Used for ghost command
+/datum/xenoartifact_trait/minor/haunted/proc/activate_parent(obj/item/xenoartifact/ref)
+	//Get a target to style on
+	ref.true_target = ref.get_target_in_proximity(min(ref.max_range+1, 5))
+	if(ref.true_target.len)
+		ref.check_charge(ref.true_target[1])
 
 /datum/xenoartifact_trait/minor/haunted/on_item(obj/item/xenoartifact/X, atom/user, atom/item)
 	if(istype(item, /obj/item/storage/book/bible))
@@ -432,3 +449,29 @@
 	X.visible_message("<span class='danger'>The [X] halts and begins to hum deeply.", "The [X] halts and begins to hum deeply.</span>")
 	playsound(get_turf(X), 'sound/effects/seedling_chargeup.ogg', 50, TRUE)
 	sleep(3 SECONDS)
+
+//============
+// Blink, the artifact dissapears for a short duration after use
+//============
+/datum/xenoartifact_trait/minor/blink
+	label_name = "Desynced"
+	label_desc = "Desynced: The Artifact falls in & out of existence regularly."
+	flags = BLUESPACE_TRAIT | PLASMA_TRAIT | URANIUM_TRAIT
+	///Where your eyes don't go
+	var/obj/effect/confiscate
+
+/datum/xenoartifact_trait/minor/blink/activate(obj/item/xenoartifact/X, atom/target, atom/user, setup)
+	X.visible_message("<span class='warning'>[X] slips between dimensions!</span>")
+	confiscate = new(get_turf(X))
+	X.forceMove(confiscate)
+	addtimer(CALLBACK(src, .proc/comeback, X), X.charge*0.20 SECONDS)
+
+/datum/xenoartifact_trait/minor/blink/proc/comeback(obj/item/xenoartifact/X)
+	X.visible_message("<span class='warning'>[X] slips between dimensions!</span>")
+	X.forceMove(get_turf(confiscate))
+	QDEL_NULL(confiscate)
+
+/datum/xenoartifact_trait/minor/blink/Destroy(force, ...)
+	. = ..()
+	if(!isnull(confiscate))
+		comeback()

--- a/code/modules/xenoarchaeology/xenoartifact.dm
+++ b/code/modules/xenoarchaeology/xenoartifact.dm
@@ -9,15 +9,15 @@
 
 	///How much input the artifact is getting from activator traits
 	var/charge = 0
-	///This isn't a requirement anymore. This just affects how effective the charge is 
-	var/charge_req 
+	///This isn't a requirement anymore. This just affects how effective the charge is
+	var/charge_req
 	///Processing type, used for tick
 	var/process_type
 	///List of targted entities for traits
-	var/list/true_target = list() 
+	var/list/true_target = list()
 
 	///Associated traits & colour
-	var/material 
+	var/material
 	///activation trait, minor 1, minor 2, minor 3, major, malfunction
 	var/list/traits = list()
 	///Internal list of unallowed traits
@@ -32,7 +32,7 @@
 	var/max_range = 1
 
 	//Used for signaler trait
-	var/code 
+	var/code
 	var/frequency
 	var/datum/radio_frequency/radio_connection
 
@@ -45,7 +45,9 @@
 	///Everytime the artifact is used this increases. When this is successfully proc'd the artifact gains a malfunction and this is lowered.
 	var/malfunction_chance = 0
 	///How much the chance can change in a sinlge itteration
-	var/malfunction_mod = 0.3
+	var/malfunction_mod = 1
+	///Ref to trait list for malfunctions
+	var/list/blacklist_ref
 
 	//snowflake variable for shaped
 	var/transfer_prints = FALSE
@@ -60,6 +62,7 @@
 
 	generate_xenoa_statics() //This wont load if it's already done, aka this wont spam
 
+	blacklist_ref = GLOB.xenoa_bluespace_blacklist
 	material = difficulty //Difficulty is set, in most cases
 	if(!material)
 		material = pickweight(list(XENOA_BLUESPACE = 8, XENOA_PLASMA = 5, XENOA_URANIUM = 3, XENOA_BANANIUM = 1)) //Maint artifacts and similar situations
@@ -76,18 +79,20 @@
 
 		if(XENOA_PLASMA)
 			name = "plasma [name]"
+			blacklist_ref = GLOB.xenoa_plasma_blacklist
 			generate_traits(GLOB.xenoa_plasma_blacklist)
 			if(!price)
 				price = pick(200, 300, 500)
-			malfunction_mod = 0.5
+			malfunction_mod = 3
 			extra_masks = pick(1)
 
 		if(XENOA_URANIUM)
 			name = "uranium [name]"
-			generate_traits(GLOB.xenoa_uranium_blacklist, TRUE) 
+			blacklist_ref = GLOB.xenoa_uranium_blacklist
+			generate_traits(GLOB.xenoa_uranium_blacklist, TRUE)
 			if(!price)
-				price = pick(300, 500, 800) 
-			malfunction_mod = 1
+				price = pick(300, 500, 800)
+			malfunction_mod = 5
 			extra_masks = pick(1)
 
 		if(XENOA_BANANIUM)
@@ -95,7 +100,8 @@
 			generate_traits()
 			if(!price)
 				price = pick(500, 800, 1000)
-			extra_masks = pick(0)
+			malfunction_mod = 5
+			extra_masks = 0
 	SEND_SIGNAL(src, XENOA_CHANGE_PRICE, price) //update price, bacon requested signals
 
 	//Initialize traits that require that.
@@ -157,7 +163,7 @@
 	..()
 
 /obj/item/xenoartifact/examine(mob/living/carbon/user)
-	. = ..()	
+	. = ..()
 	if(user.can_see_reagents()) //Not checking carbon throws a runtime concerning observers
 		. += "<span class='notice'>[special_desc]</span>"
 	if(isobserver(user))
@@ -176,7 +182,7 @@
 
 	if(isliving(loc) && touch_desc?.on_touch(src, user) && user.can_see_reagents())
 		balloon_alert(user, (initial(touch_desc.desc) ? initial(touch_desc.desc) : initial(touch_desc.label_name)), material)
-		
+
 	var/obj/item/clothing/gloves/artifact_pinchers/P = locate(/obj/item/clothing/gloves/artifact_pinchers) in user.contents
 	if(P?.safety && isliving(loc))
 		return
@@ -217,13 +223,13 @@
 
 ///Run traits. Used to activate all minor, major, and malfunctioning traits in the artifact's trait list. Sets cooldown when properly finished.
 /obj/item/xenoartifact/proc/check_charge(mob/user, charge_mod)
-	log_game("[user] attempted to activate [src] at [world.time]. Located at [x] [y] [z].")
+	log_game("[user] attempted to activate [src] at [world.time]. Located at [AREACOORD(src)].")
 
 	if(COOLDOWN_FINISHED(src, xenoa_cooldown) && !istype(loc, /obj/item/storage))
 		COOLDOWN_START(src, xenoa_cooldown, cooldown+cooldownmod)
-		if(prob(malfunction_chance) && traits.len < 6 + (material == XENOA_URANIUM ? 1 : 0)) //See if we pick up an malfunction
-			generate_trait_unique(GLOB.xenoa_malfs)
-			malfunction_chance = 0 //Lower chance after contracting 
+		if(prob(malfunction_chance) && traits.len < 7 + (material == XENOA_URANIUM ? 1 : 0)) //See if we pick up an malfunction
+			generate_malfunction_unique()
+			malfunction_chance = 0 //Lower chance after contracting
 		else //otherwise increase chance.
 			malfunction_chance = min(malfunction_chance + malfunction_mod, 100)
 
@@ -232,17 +238,26 @@
 
 		for(var/datum/xenoartifact_trait/minor/t in traits)//Minor traits aren't apart of the target loop, specifically becuase they pass data into it.
 			t.activate(src, user, user)
-			log_game("[src] activated minor trait [t] at [world.time]. Located at [x] [y] [z]")
+			log_game("[src] activated minor trait [t] at [world.time]. Located at [AREACOORD(src)]")
 
 		//Clamp charge to avoid fucky wucky
 		charge = max(10, charge)
-   
+
+		//Add holder for muh balance
+		/*
+		Uncomment this if artifact abuse becomes a huge issue
+		if(isliving(loc) || isliving(pulledby))
+			var/mob/living/M = isliving(loc) ? loc : pulledby
+			if(!istype(M.get_item_by_slot(ITEM_SLOT_GLOVES), /obj/item/clothing/gloves/artifact_pinchers) && !istype(get_area(M), /area/science))
+				true_target |= list(M)
+		*/
+
 		for(var/atom/M in true_target) //target loop, majors & malfunctions
-			if(get_dist(get_turf(src), get_turf(M)) <= max_range) 
+			if(get_dist(get_turf(src), get_turf(M)) <= max_range)
 				create_beam(M) //Indicator beam, points to target, M
 				for(var/datum/xenoartifact_trait/t as() in traits) //Major traits
 					if(!istype(t, /datum/xenoartifact_trait/minor))
-						log_game("[src] activated trait [t] at [world.time]. Located at [x] [y] [z]")
+						log_game("[src] activated trait [t] at [world.time]. Located at [AREACOORD(src)]")
 						t.activate(src, M, user)
 		if(!get_trait(/datum/xenoartifact_trait/major/horn))
 			playsound(get_turf(src), 'sound/magic/blink.ogg', 25, TRUE)
@@ -293,14 +308,27 @@
 	new_trait = new new_trait //type converting doesn't work too well here but this should be fine.
 	blacklist += new_trait.blacklist_traits //Cant use initial() to access lists without bork'ing it
 	return new_trait
-	
+
+///generates a malfunction respective to the artifact's type - don't use anywhere but for check_charge malfunctions
+/obj/item/xenoartifact/proc/generate_malfunction_unique(list/blacklist)
+	var/list/malfunctions = GLOB.xenoa_malfs.Copy()
+	malfunctions -= blacklist
+	malfunctions -= traits
+	if(!malfunctions.len)
+		return
+	//Pick one to use
+	var/datum/xenoartifact_trait/T = pick(malfunctions)
+	T = new T
+	traits += T
+
 ///Gets a singular entity, there's a specific traits that handles multiple.
 /obj/item/xenoartifact/proc/get_target_in_proximity(range)
 	for(var/mob/living/M in oview(range, get_turf(src)))
 		. = process_target(M)
 	if(isliving(loc) && !.)
 		. = process_target(loc)
-	return
+	//Return a list becuase byond is fucky and WILL overwrite the typing
+	return list(.)
 
 ///Returns the desired trait and it's values if it's in the artifact's list
 /obj/item/xenoartifact/proc/get_trait(typepath)
@@ -313,7 +341,7 @@
 		if(H.wear_suit && H.head && isclothing(H.wear_suit) && isclothing(H.head))
 			if(H.anti_artifact_check())
 				to_chat(target, "<span class='warning'>The [name] was unable to target you!</span>")
-				playsound(get_turf(target), 'sound/weapons/deflect.ogg', 25, TRUE) 
+				playsound(get_turf(target), 'sound/weapons/deflect.ogg', 25, TRUE)
 				return
 
 	if(isliving(target)) //handle pulling
@@ -321,13 +349,13 @@
 		. = M?.pulling ? M.pulling : M
 	else
 		. = target
-	RegisterSignal(., COMSIG_PARENT_QDELETING, .proc/on_target_del)
+	RegisterSignal(., COMSIG_PARENT_QDELETING, .proc/on_target_del, TRUE)
 	return
 
 ///Hard del handle
 /obj/item/xenoartifact/proc/on_target_del(atom/target)
 	UnregisterSignal(target, COMSIG_PARENT_QDELETING)
-	true_target -= target
+	true_target -= list(target)
 
 ///Helps show how the artifact is working. Hint stuff. Draws a beam between artifact and target
 /obj/item/xenoartifact/proc/create_beam(atom/target)
@@ -372,16 +400,16 @@
 /obj/item/xenoartifact/process(delta_time)
 	switch(process_type)
 		if(PROCESS_TYPE_LIT) //Burning
-			true_target = list(get_target_in_proximity(min(max_range, 5)))
-			if(isliving(true_target[1]))
+			true_target = get_target_in_proximity(min(max_range, 5))
+			if(true_target[1])
 				visible_message("<span class='danger' size='4'>The [name] flicks out.</span>")
 				default_activate(25, null, null)
 				process_type = null
 				return PROCESS_KILL
 		if(PROCESS_TYPE_TICK) //Clock-ing
-			playsound(get_turf(src), 'sound/effects/clock_tick.ogg', 50, TRUE) 
+			playsound(get_turf(src), 'sound/effects/clock_tick.ogg', 50, TRUE)
 			visible_message("<span class='danger' size='10'>The [name] ticks.</span>")
-			true_target = list(get_target_in_proximity(min(max_range, 5)))
+			true_target = get_target_in_proximity(min(max_range, 5))
 			default_activate(25, null, null)
 			if(DT_PROB(XENOA_TICK_CANCEL_PROB, delta_time) && COOLDOWN_FINISHED(src, xenoa_cooldown))
 				process_type = null

--- a/code/modules/xenoarchaeology/xenoartifact_console.dm
+++ b/code/modules/xenoarchaeology/xenoartifact_console.dm
@@ -14,13 +14,18 @@
 		/obj/item/stack/cable_coil = 1)
 	def_components = list(/obj/item/stack/ore/bluespace_crystal = /obj/item/stack/ore/bluespace_crystal/artificial)
 
+///Stability lost on purchase
+#define STABILITY_COST 30
+///Stability gained on-tick
+#define STABILITY_GAIN 5
+
 /obj/machinery/computer/xenoartifact_console
 	name = "research and development listing console"
 	desc = "A science console used to source sellers, and buyers, for various blacklisted research objects."
 	icon_screen = "xenoartifact_console"
 	icon_keyboard = "rd_key"
 	circuit = /obj/item/circuitboard/computer/xenoartifact_console
-	
+
 	///Sellers give artifacts
 	var/list/sellers = list()
 	///Buyers take artifacts
@@ -39,6 +44,8 @@
 	var/list/sold_artifacts = list()
 	///Which department's budget recieves profit
 	var/datum/bank_account/budget
+	///Stability - lowers as people buy artifacts, stops spam buying
+	var/stability = 100
 
 /obj/machinery/computer/xenoartifact_console/Initialize()
 	. = ..()
@@ -53,6 +60,22 @@
 		var/datum/xenoartifact_seller/buyer/B = new
 		buyers += B
 		B.generate()
+	//Start processing to gain stability
+	START_PROCESSING(SSobj, src)
+
+/obj/machinery/computer/xenoartifact_console/Destroy()
+	. = ..()
+	on_inbox_del()
+	qdel(sellers)
+	qdel(buyers)
+	qdel(sold_artifacts)
+	STOP_PROCESSING(SSobj, src)
+
+/obj/machinery/computer/xenoartifact_console/process()
+	stability = min(100, stability + STABILITY_GAIN)
+	//Update UI every 3 seconds, may be delayed
+	if(world.time % 3 == 0)
+		ui_update()
 
 /obj/machinery/computer/xenoartifact_console/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
@@ -85,11 +108,12 @@
 			"main" = E.main, //Sold time
 			"gain" = E.gain, //Profits
 			"traits" = E.traits //traits
-		))	
+		))
 	data["tab_index"] = tab_index
 	data["current_tab"] = current_tab
 	data["tab_info"] = current_tab_info
 	data["linked_machines"] = linked_machines
+	data["stability"] = stability
 
 	return data
 
@@ -115,27 +139,31 @@
 					current_tab_info = "Sell any export your department produces through open bluespace strings. Anonymously trade and sell ancient alien bombs, explosive slime cores, or just regular bombs."
 				if("Linking")
 					current_tab_info = "Link machines to the Listing Console."
-		else if(current_tab == t)
-			current_tab = ""
-			current_tab_info = ""
 		return
 	else //Buy xenoartifact
 		var/datum/xenoartifact_seller/S = locate(action)
+
+		if(stability < STABILITY_COST)
+			say("Error. Insufficient thread stability.")
+			return
 		if(!linked_inbox)
 			say("Error. No linked hardware.")
+			return
 		else if(budget.account_balance-S.price < 0)
 			say("Error. Insufficient funds.")
-		else if(linked_inbox && budget.account_balance-S.price >= 0)
+			return
+
+		if(linked_inbox && budget.account_balance-S.price >= 0)
 			var/obj/item/xenoartifact/A = new (get_turf(linked_inbox.loc), S.difficulty)
 			var/datum/component/xenoartifact_pricing/X = A.GetComponent(/datum/component/xenoartifact_pricing)
 			if(X)
 				X.price = S.price //dont bother trying to use internal singals for this
 				sellers -= S
+				stability = max(0, stability - STABILITY_COST)
 				budget.adjust_money(-1*S.price)
 				say("Purchase complete. [budget.account_balance] credits remaining in Research Budget")
 				addtimer(CALLBACK(src, .proc/generate_new_seller), (rand(1,3)*60) SECONDS)
 				A = null
-
 	update_icon()
 
 //Auto sells item on pad, finds seller for you
@@ -165,8 +193,8 @@
 				//Give rewards
 				final_price = max(X.modifier*X.price, 1)
 				budget.adjust_money(final_price)
-				linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, (final_price*2.3) * (final_price >= X.price))
-				linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DISCOVERY, (XENOA_SOLD_DP*(final_price/X.price)) * (final_price >= X.price))
+				linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, (final_price*XENOA_RP) * (final_price >= X.price))
+				linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DISCOVERY, ((XENOA_SOLD_DP*(final_price/X.price)) * max(1, final_price/1000)) * (final_price >= X.price))
 
 				//Handle player info
 				entry.main = "[selling_item.name] sold at [station_time_timestamp()] for [final_price] credits, bought for [X.price]."
@@ -192,7 +220,7 @@
 			budget.adjust_money(final_price)
 			sold_artifacts += info
 			qdel(selling_item)
-	if(info)	
+	if(info)
 		say(info)
 
 
@@ -227,12 +255,8 @@
 	UnregisterSignal(linked_inbox, COMSIG_PARENT_QDELETING)
 	linked_inbox = null
 
-/obj/machinery/computer/xenoartifact_console/Destroy()
-	. = ..()
-	on_inbox_del()
-	qdel(sellers)
-	qdel(buyers)
-	qdel(sold_artifacts)
+#undef STABILITY_COST
+#undef STABILITY_GAIN
 
 /obj/machinery/xenoartifact_inbox
 	name = "bluespace straythread pad" //Science words
@@ -276,16 +300,16 @@
 /datum/xenoartifact_seller/proc/change_item()
 	generate()
 
-/datum/xenoartifact_seller/buyer //Buyer off shoot, for player-selling 
+/datum/xenoartifact_seller/buyer //Buyer off shoot, for player-selling
 	var/obj/buying
 
 /datum/xenoartifact_seller/buyer/generate()
 	name = pick(GLOB.xenoa_seller_names)
 	buying = pick(/obj/item/xenoartifact)
 	if(buying == /obj/item/xenoartifact) //Don't bother trying to use istype here
-		dialogue = "[name] is requesting: Anomoly : Class : Artifact"
+		dialogue = "[name] is requesting: Anomaly : Class : Artifact"
 	addtimer(CALLBACK(src, .proc/change_item), (rand(1,3)*60) SECONDS)
-	
+
 //Used to hold information about artifact transactions. Might get standrardized sooner or later.
 /datum/xenoartifact_info_entry
 	var/main =""

--- a/code/modules/xenoarchaeology/xenoartifact_labeler.dm
+++ b/code/modules/xenoarchaeology/xenoartifact_labeler.dm
@@ -19,7 +19,7 @@
 	var/list/major_traits = list()
 
 	var/list/selected_malfunction_traits = list()
-	var/list/malfunction_list = list()  
+	var/list/malfunction_list = list()
 
 	///trait dialogue essentially
 	var/list/info_list = list()
@@ -35,9 +35,13 @@
 /obj/item/xenoartifact_labeler/Initialize(mapload)
 	. = ..()
 	generate_xenoa_statics()
+	//Append activators
 	activator_traits = get_trait_list_desc(activator_traits, GLOB.xenoa_activators)
+	//Minors
 	minor_traits = get_trait_list_desc(minor_traits, GLOB.xenoa_minors)
+	//Majors
 	major_traits = get_trait_list_desc(major_traits, GLOB.xenoa_majors)
+	//Malfs
 	malfunction_list = get_trait_list_desc(malfunction_list, GLOB.xenoa_malfs)
 
 /obj/item/xenoartifact_labeler/ui_interact(mob/user, datum/tgui/ui)
@@ -111,7 +115,7 @@
 	else if(!COOLDOWN_FINISHED(src, sticker_cooldown))
 		to_chat(user, "<span class='warning'>The labeler is still printing.</span>")
 
-///reset all the options	
+///reset all the options
 /obj/item/xenoartifact_labeler/proc/clear_selection()
 	sticker_name = null
 	info_list = list()
@@ -161,7 +165,7 @@
 	icon_state = "sticker_star"
 	name = "artifact label"
 	desc = "An adhesive label describing the characteristics of a Xenoartifact."
-	var/info = "" 
+	var/info = ""
 	var/set_name = FALSE
 	var/mutable_appearance/sticker_overlay
 	var/list/trait_list = list() //List of traits used to compare and generate modifier.
@@ -173,7 +177,7 @@
 	sticker_overlay = mutable_appearance(icon, sticker_state)
 	sticker_overlay.layer = FLOAT_LAYER
 	sticker_overlay.appearance_flags = RESET_COLOR
-	
+
 /obj/item/xenoartifact_label/proc/attempt_attach(atom/target, mob/user, instant = FALSE)
 	if(istype(target, /mob/living))
 		to_chat(target, "<span class='warning'>[user] attempts to stick a [src] to you!</span>")
@@ -206,7 +210,7 @@
 	. = ..()
 	if(proximity_flag)
 		attempt_attach(target, user, FALSE)
-	
+
 /obj/item/xenoartifact_label/proc/add_sticker(mob/target)
 	if(locate(/obj/item/xenoartifact_label) in target) //Remove old stickers
 		qdel(locate(/obj/item/xenoartifact_label) in target)
@@ -226,7 +230,7 @@
 	for(var/t in trait_list)
 		trait = new t
 		if(X.get_trait(trait))
-			xenop.modifier += 0.15 
+			xenop.modifier += 0.15
 		else
 			xenop.modifier -= 0.35
 
@@ -237,8 +241,8 @@
 	return text
 
 /obj/item/xenoartifact_labeler/debug
-	name = "xenoartifact debug labeler"      
-	desc = "Use to create specific Xenoartifacts" 
+	name = "xenoartifact debug labeler"
+	desc = "Use to create specific Xenoartifacts"
 
 /obj/item/xenoartifact_labeler/debug/afterattack(atom/target, mob/user)
 	return

--- a/strings/science_dialogue.txt
+++ b/strings/science_dialogue.txt
@@ -1,8 +1,8 @@
-Hello, Commrade. I think I have something that might interest you.
+Hello, Comrade. I think I have something that might interest you.
 Hello, Friend. I think I have something you might be interested in.
-Commrade, I can offer you only this.
+Comrade, I can offer you only this.
 For you, my Friend, I offer this.
-Commrade, this thing killed my Babushka, take it.
+Comrade, this thing killed my Babushka, take it.
 Friend, you want?
 My buddy thinks I could sell this.
 I'm pretty sure this took several years off my life, take it.

--- a/tgui/packages/tgui/interfaces/XenoartifactConsole.js
+++ b/tgui/packages/tgui/interfaces/XenoartifactConsole.js
@@ -1,6 +1,6 @@
 import { map, toArray } from 'common/collections';
 import { useBackend } from '../backend';
-import { Box, Tabs, Section, Button, BlockQuote, Icon, Collapsible, AnimatedNumber } from '../components';
+import { Box, Tabs, Section, Button, BlockQuote, Icon, Collapsible, AnimatedNumber, ProgressBar } from '../components';
 import { formatMoney } from '../format';
 import { Window } from '../layouts';
 import { sanitizeText } from "../sanitize";
@@ -12,6 +12,7 @@ export const XenoartifactConsole = (props, context) => {
     current_tab,
     tab_info,
     points,
+    stability,
   } = data;
   const sellers=toArray(data.seller);
   return (
@@ -20,6 +21,15 @@ export const XenoartifactConsole = (props, context) => {
       height={500}>
       <Window.Content scrollable>
         <Box>
+          <ProgressBar
+            ranges={{
+              good: [0.5, Infinity],
+              average: [0.25, 0.5],
+              bad: [-Infinity, 0.25],
+            }}
+            value={stability*0.01}>
+            Thread stability
+          </ProgressBar>
           <Section title={`Research and Development`} fluid
             buttons={(
               <Box fontFamily="verdana" inline bold>
@@ -34,12 +44,12 @@ export const XenoartifactConsole = (props, context) => {
             </BlockQuote>
           </Section>
           <Tabs row>
-            {tab_index.map(tab_name => (<XenoartifactConsoleTabs 
+            {tab_index.map(tab_name => (<XenoartifactConsoleTabs
               tab_name={tab_name} key={tab_name} />))}
           </Tabs>
           {current_tab === "Listings" && (
-            sellers.map(details => (<XenoartifactListingBuy 
-              name={details.name} dialogue={details.dialogue} 
+            sellers.map(details => (<XenoartifactListingBuy
+              name={details.name} dialogue={details.dialogue}
               price={details.price} key={details.name}
               id={details.id} />))
           )}
@@ -66,7 +76,7 @@ const XenoartifactConsoleTabs = (props, context) => {
   } = props;
   return (
     <Box>
-      <Tabs.Tab 
+      <Tabs.Tab
         selected={current_tab === tab_name}
         onClick={() => act(`set_tab_${tab_name}`
         )}>
@@ -91,8 +101,8 @@ export const XenoartifactListingBuy = (props, context) => {
         <BlockQuote>
           {`${dialogue}`}
         </BlockQuote>
-        <Button onClick={() => act(id)}>
-          {`Purchase: ${price} credits.`} <Icon name="shopping-cart" />
+        <Button icon="shopping-cart" onClick={() => act(id)}>
+          {`${price} credits`}
         </Button>
       </Section>
     </Box>
@@ -153,13 +163,13 @@ export const XenoartifactSell = (props, context) => {
               </BlockQuote>
             </Section>))}
         </Collapsible>
-        <Button onClick={() => act(`sell`)} p={.5}>
-          Export pad contents. <Icon name="shopping-cart" />
+        <Button icon="shopping-cart" onClick={() => act(`sell`)} p={.5}>
+          Export pad contents
         </Button>
       </Section>
-      {buyers.map(details => (<XenoartifactListingSell 
+      {buyers.map(details => (<XenoartifactListingSell
         key={details}
-        name={details.name} dialogue={details.dialogue} price={details.price} 
+        name={details.name} dialogue={details.dialogue} price={details.price}
         id={details.id} />))}
     </Box>
   );

--- a/tgui/packages/tgui/interfaces/XenoartifactLabeler.js
+++ b/tgui/packages/tgui/interfaces/XenoartifactLabeler.js
@@ -4,14 +4,14 @@ import { Window } from '../layouts';
 
 export const XenoartifactLabeler = (props, context) => {
   return (
-    <Window        
+    <Window
       width={350}
       height={500}>
       <Window.Content scrollable={0}>
         <XenoartifactLabelerSticker />
         <Flex direction="row">
           <Flex.Item>
-            <XenoartifactLabelerActivators />
+            <XenoartifactLabelerTraits />
           </Flex.Item>
 
           <Flex.Item>
@@ -23,7 +23,7 @@ export const XenoartifactLabeler = (props, context) => {
   );
 };
 
-const XenoartifactLabelerActivators = (props, context) => {
+const XenoartifactLabelerTraits = (props, context) => {
   const { act, data } = useBackend(context);
   const {
     selected_activator_traits,
@@ -36,12 +36,20 @@ const XenoartifactLabelerActivators = (props, context) => {
     selected_malfunction_traits,
     info_list,
   } = data;
+
+  let alphasort = function (a, b) { return a.localeCompare(b, "en"); };
+
+  const sorted_activators = activator_traits.sort(alphasort);
+  const sorted_minors = minor_traits.sort(alphasort);
+  const sorted_majors = major_traits.sort(alphasort);
+  const sorted_malfs = malfunction_list.sort(alphasort);
+
   return (
     <Box px={1} grow={1} overflowY="auto" height="425px" width="150px">
       <Section title="Material">
         <Box>
           {
-            activator_traits.map(trait => (<XenoartifactLabelerGenerateList 
+            sorted_activators.map(trait => (<XenoartifactLabelerGenerateList
               specific_trait={trait} check_against={selected_activator_traits}
               key={trait}
               trait_type="activator" />))
@@ -51,7 +59,7 @@ const XenoartifactLabelerActivators = (props, context) => {
       <Section title="Notes">
         <Box>
           {
-            minor_traits.map(trait => (<XenoartifactLabelerGenerateList 
+            sorted_minors.map(trait => (<XenoartifactLabelerGenerateList
               specific_trait={trait} check_against={selected_minor_traits}
               key={trait}
               trait_type="minor" />))
@@ -61,9 +69,9 @@ const XenoartifactLabelerActivators = (props, context) => {
       <Section title="Shape">
         <Box>
           {
-            major_traits.map(trait => (<XenoartifactLabelerGenerateList
+            sorted_majors.map(trait => (<XenoartifactLabelerGenerateList
               specific_trait={trait} check_against={selected_major_traits}
-              key={trait} 
+              key={trait}
               trait_type="major" />))
           }
         </Box>
@@ -71,9 +79,9 @@ const XenoartifactLabelerActivators = (props, context) => {
       <Section title="Malfunction">
         <Box>
           {
-            malfunction_list.map(trait => (<XenoartifactLabelerGenerateList 
+            sorted_malfs.map(trait => (<XenoartifactLabelerGenerateList
               key={trait}
-              specific_trait={trait} 
+              specific_trait={trait}
               check_against={selected_malfunction_traits}
               trait_type="malfunction" />))
           }
@@ -90,7 +98,7 @@ const XenoartifactLabelerInfo= (props, context) => {
   } = data;
   return (
     <Box px={1} overflowY="auto" height="425px">
-      {info_list.map(info => 
+      {info_list.map(info =>
         <XenoartifactLabelerGenerateInfo info={info} key={info} />)}
     </Box>
   );
@@ -105,7 +113,7 @@ const XenoartifactLabelerGenerateList = (props, context) => {
   } = props;
   return (
     <Box>
-      <Button.Checkbox content={specific_trait} 
+      <Button.Checkbox content={specific_trait}
         checked={check_against.includes(specific_trait)} onClick={() =>
           act(`assign_${trait_type}_${specific_trait}`)} />
     </Box>
@@ -130,9 +138,9 @@ const XenoartifactLabelerGenerateInfo = (props, context) => {
 
 const XenoartifactLabelerSticker = (props, context) => {
   const { act } = useBackend(context);
-  return ( 
+  return (
     <Box>
-      <Input placeholder="Label Name..." onChange={(e, input) => 
+      <Input placeholder="Label Name..." onChange={(e, input) =>
         act('change_print_name', { name: input })} />
       <Button content="Print" onClick={() => act("print_traits")} />
       <Button content="Clear" onClick={() => act("clear_traits")} />


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ports the following PRs from Upstream:
* https://github.com/BeeStation/BeeStation-Hornet/pull/7839
* https://github.com/BeeStation/BeeStation-Hornet/pull/8012
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Keeps the Xeno-artifact folder relatively up to date with the Beestation Version
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:DrDuckedGoose
tweak: Tweaks Hypodermic injections rates from 5, 10, 15 > (7, 14 , 21 * metabolization_rate).
tweak: Changes C.D.E knockout from 5 Seconds > 2 Seconds
tweak: Barreled will no longer always target east when not given a specific direction, instead it will pick a random direction.
tweak: Lamp now has a visible message which aids in identifying it in well-lit rooms
tweak: Changes logging xyz > area
tweak: Change research point reward from 2.3 * final price > 2.5 * final price
tweak: Change discovery point reward from 350*final_price/initial_price > 350*(final price/initial price)) * max(1, final price/1000)
tweak: Aggressively lowers stun times on all related traits
tweak: Artifacts will now target the user too. The only way to avoid this is to be inside science & wearing safety-pinchers.
tweak: Slightly lower sentient buffs to arfiacts
tweak: Blacklist aura from destabilizing.
tweak: Artifacts malfunction more often.
tweak: All artifacts get an extra slot for malfunctions, 1 > 2
tweak: Extend sentient play offer
tweak: Wall trait now points randomly east or north if it is 3x1
tweak: Increase bananium malfunction chance
tweak: Ghosts can take control of player-less artifacts
tweak: Artifact consoles now have a stability meter that stops spam-buying.
tweak: Sentient artifacts are more common, slightly,
tweak: Ghosts can activate haunted artifacts.
tweak: Tweaks labeler UI to show elements in alphabetical order.
tweak: Tweak console UI to have less clutter.
fix: Swaps over to AREACOORD for logging.
fix: Fix cheeky runtime on Weighted. No longer checks all gloves for safety variable.
fix: Fix issue with weighted signal order preventing activation.
fix: Fix lamp trait runtiming
fix: Fix anti_artifact runtiming
fix: Fix fragile artifacts not breaking due to byond being beyond illogical.
fix: Fix strip malfunction from stripping non-removable clothing..
add: Adds anti-clone malfunction. Creates an evil twin of the target.
add: Add better functions for adding malfunctions that support typing
add: Add exploding malfunction delaminating, unique to bananium.
add: Add all artifact smoke screen trait.
add: Add Plasma & Bluespace trait, Marker trait, colors the target
add: Add all artifact malfunction absorbing. Absorbs nearby gasses, suffocating small rooms. Will spit gasses back out when destroyed.
add: Add Honked activator. Only clowns, and clown related items, can activate this artifact.
add: Add Emotional major. Makes target perform a random emote, from a curated list.
add: Add Desynced minor. Makes the artifact disappear for a short period after activating.
add: Add Hallucinogenic malfunction. Makes the target experience a random hallucination.
add: Add bar to UI that shows thread stability.
fix: Fix flammable trait not activating
fix: Fix haunted activation.
fix: Fix blacklisting on explosive malfunction
tweak: Add limit to clone & bear malfunction.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
