### PR TITLE
[Upstream] Chemistry Quality of Life Stuff

### DIFF
--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -12,6 +12,8 @@
 #define AMOUNT_VISIBLE	(1<<5)	//! For non-transparent containers that still have the general amount of reagents in them visible.
 #define NO_REACT        (1<<6)  //! Applied to a reagent holder, the contents will not react with each other.
 
+#define ABSOLUTELY_GRINDABLE   (1<<7)  //! used in 'All-In-One Grinder' that it can grind anything if it has this bitflag
+
 /// Is an open container for all intents and purposes.
 #define OPENCONTAINER 	(REFILLABLE | DRAINABLE | TRANSPARENT)
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -472,6 +472,10 @@
 /atom/proc/is_drainable()
 	return reagents && (reagents.flags & DRAINABLE)
 
+/// Is this atom grindable to get reagents
+/atom/proc/is_grindable()
+	return reagents && (reagents.flags & ABSOLUTELY_GRINDABLE)
+
 /// Are you allowed to drop this atom
 /atom/proc/AllowDrop()
 	return FALSE

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -12,6 +12,7 @@
 	var/mode = IV_INJECTING
 	var/obj/item/reagent_containers/beaker
 	var/static/list/drip_containers = typecacheof(list(/obj/item/reagent_containers/blood,
+									/obj/item/reagent_containers/chem_bag,
 									/obj/item/reagent_containers/food,
 									/obj/item/reagent_containers/glass))
 	var/can_convert = TRUE // If it can be made into an anesthetic machine or not

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -22,6 +22,13 @@
 	var/useramount = 30 // Last used amount
 	var/list/pillStyles = null
 
+	// Persistent UI states
+	var/saved_name_state = "Auto"
+	var/saved_volume_state = "Auto"
+	/// UNSANITIZED. DO NOT DISPLAY OUTSIDE TGUI WITHOUT HTML_ENCODE AND TRIM.
+	var/saved_name = ""
+	var/saved_volume = 10
+
 /obj/machinery/chem_master/Initialize(mapload)
 	create_reagents(100)
 
@@ -177,6 +184,10 @@
 	data["mode"] = mode
 	data["condi"] = condi
 	data["screen"] = screen
+	data["saved_name"] = saved_name
+	data["saved_volume"] = saved_volume
+	data["saved_name_state"] = saved_name_state
+	data["saved_volume_state"] = saved_volume_state
 	data["analyzeVars"] = analyzeVars
 	data["chosenPillStyle"] = chosenPillStyle
 	data["isPillBottleLoaded"] = bottle ? 1 : 0
@@ -206,6 +217,32 @@
 		return
 
 	switch(action)
+		if("setSavedNameState")
+			var/state = params["name_state"]
+			if(!state || (state != "Auto" && state != "Manual"))
+				return
+			saved_name_state = state
+			. = TRUE
+		if("setSavedName")
+			var/name = trim(params["name"], MAX_NAME_LEN)
+			if(!name)
+				return
+			if(CHAT_FILTER_CHECK(name))
+				to_chat(usr, "<span class='warning'>ERROR: Packaging name contains prohibited word(s).</span>")
+				return
+			saved_name = name
+			. = TRUE
+		if("setSavedVolumeState")
+			if(!params["volume_state"] || (params["volume_state"] != "Auto" && params["volume_state"] != "Exact"))
+				return
+			saved_volume_state = params["volume_state"]
+			. = TRUE
+		if("setSavedVolume")
+			var/vol = text2num(params["volume"])
+			if(!vol || vol < 0.01 || vol > 50)
+				return
+			saved_volume = vol
+			. = TRUE
 		if("eject")
 			replace_beaker(usr)
 			. = TRUE
@@ -268,6 +305,8 @@
 				vol_each_max = min(40, vol_each_max)
 			else if (item_type == "bottle" && !condi)
 				vol_each_max = min(30, vol_each_max)
+			else if (item_type == "bag" && !condi)
+				vol_each_max = min(200, vol_each_max)
 			else if (item_type == "condimentPack" && condi)
 				vol_each_max = min(10, vol_each_max)
 			else if (item_type == "condimentBottle" && condi)
@@ -286,6 +325,14 @@
 				return
 			// Get item name
 			var/name = params["name"]
+			if(CHAT_FILTER_CHECK(name))
+				to_chat(usr, "<span class='warning'>ERROR: Packaging name contains prohibited word(s).</span>")
+				return
+			if(name) // if we were passed a name from UI, html_encode it before adding to the world.
+				name = trim(html_encode(name), MAX_NAME_LEN)
+				if(!name) // our saved name was bad, clear it
+					saved_name = ""
+					return TRUE
 			var/name_has_units = item_type == "pill" || item_type == "patch"
 			if(!name)
 				var/name_default = reagents.get_master_reagent_name()
@@ -316,6 +363,7 @@
 						else
 							P = new/obj/item/reagent_containers/pill(drop_location())
 						P.name = trim("[name] pill")
+						P.label_name = trim(name)
 						if(chosenPillStyle == RANDOM_PILL_STYLE)
 							P.icon_state ="pill[rand(1,21)]"
 						else
@@ -330,6 +378,7 @@
 					for(var/i = 0; i < amount; i++)
 						P = new/obj/item/reagent_containers/pill/patch(drop_location())
 						P.name = trim("[name] patch")
+						P.label_name = trim(name)
 						adjust_item_drop_location(P)
 						reagents.trans_to(P, vol_each, transfered_by = usr)
 					. = TRUE
@@ -338,6 +387,16 @@
 					for(var/i = 0; i < amount; i++)
 						P = new/obj/item/reagent_containers/glass/bottle(drop_location())
 						P.name = trim("[name] bottle")
+						P.label_name = trim(name)
+						adjust_item_drop_location(P)
+						reagents.trans_to(P, vol_each, transfered_by = usr)
+					. = TRUE
+				if("bag")
+					var/obj/item/reagent_containers/chem_bag/P
+					for(var/i = 0; i < amount; i++)
+						P = new/obj/item/reagent_containers/chem_bag(drop_location())
+						P.name = trim("[name] chemical bag")
+						P.label_name = trim(name)
 						adjust_item_drop_location(P)
 						reagents.trans_to(P, vol_each, transfered_by = usr)
 					. = TRUE
@@ -347,6 +406,7 @@
 						P = new/obj/item/reagent_containers/food/condiment/pack(drop_location())
 						P.originalname = name
 						P.name = trim("[name] pack")
+						P.label_name = trim(name)
 						P.desc = "A small condiment pack. The label says it contains [name]."
 						reagents.trans_to(P, vol_each, transfered_by = usr)
 					. = TRUE
@@ -356,6 +416,7 @@
 						P = new/obj/item/reagent_containers/food/condiment(drop_location())
 						P.originalname = name
 						P.name = trim("[name] bottle")
+						P.label_name = trim(name)
 						reagents.trans_to(P, vol_each, transfered_by = usr)
 					. = TRUE
 		if("analyze")

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -158,7 +158,7 @@
 				to_chat(user, "<span class='notice'>You fill [src] to the brim.</span>")
 		return TRUE
 
-	if(!I.grind_results && !I.juice_results)
+	if(!I.grind_results && !I.juice_results && !I.is_grindable())
 		if(user.a_intent == INTENT_HARM)
 			return ..()
 		else
@@ -287,7 +287,7 @@
 			break
 		var/obj/item/I = i
 		check_trash(I)
-		if(I.grind_results)
+		if(I.grind_results || I.is_grindable())
 			if(istype(I, /obj/item/reagent_containers))
 				var/obj/item/reagent_containers/p = I
 				if(!p.prevent_grinding)

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -3,6 +3,8 @@
 	desc = "..."
 	icon = 'icons/obj/chemical.dmi'
 	w_class = WEIGHT_CLASS_TINY
+	/// this is to support when you don't want to display "bottle" part with a custom name. i.e.) "Bica-Kelo mix" rather than "Bica-Kelo mix bottle"
+	var/label_name
 	///How many units are we currently transferring?
 	var/amount_per_transfer_from_this = 5
 	///Possible amounts of units transfered a click
@@ -35,6 +37,8 @@
 		var/datum/disease/F = new spawned_disease()
 		var/list/data = list("viruses"= list(F))
 		reagents.add_reagent(/datum/reagent/blood, disease_amount, data)
+	if(!label_name)
+		label_name = name
 
 	add_initial_reagents()
 

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -7,6 +7,7 @@
 	var/blood_type = null
 	var/unique_blood = null
 	var/labelled = 0
+	reagent_flags = TRANSPARENT | ABSOLUTELY_GRINDABLE
 	fill_icon_thresholds = list(10, 20, 30, 40, 50, 60, 70, 80, 90, 100)
 
 /obj/item/reagent_containers/blood/Initialize(mapload)
@@ -14,6 +15,16 @@
 	if(blood_type != null)
 		reagents.add_reagent(unique_blood ? unique_blood : /datum/reagent/blood, 200, list("viruses"=null,"blood_DNA"=null,"blood_type"=blood_type,"resistances"=null,"trace_chem"=null))
 		update_icon()
+
+/obj/item/reagent_containers/blood/examine(mob/user)
+	. = ..()
+	if(reagents)
+		if(volume == reagents.total_volume)
+			. += "<span class='notice'>It is fully filled.</span>"
+		else if(!reagents.total_volume)
+			. += "<span class='notice'>It's empty.</span>"
+		else
+			. += "<span class='notice'>It seems [round(reagents.total_volume/volume*100)]% filled.</span>"
 
 /obj/item/reagent_containers/blood/on_reagent_change(changetype)
 	if(reagents)

--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -17,108 +17,129 @@
 
 /obj/item/reagent_containers/glass/bottle/epinephrine
 	name = "epinephrine bottle"
+	label_name = "epinephrine"
 	desc = "A small bottle. Contains epinephrine - used to stabilize patients."
 	list_reagents = list(/datum/reagent/medicine/epinephrine = 30)
 
 /obj/item/reagent_containers/glass/bottle/tricordrazine
 	name = "tricordrazine bottle"
+	label_name = "tricordrazine"
 	desc = "A small bottle of tricordrazine. Used to aid in patient recovery."
 	list_reagents = list(/datum/reagent/medicine/tricordrazine = 30)
 
 /obj/item/reagent_containers/glass/bottle/spaceacillin
 	name = "spaceacillin bottle"
+	label_name = "spaceacillin"
 	desc = "A small bottle of spaceacillin. Used to cure some diseases."
 	list_reagents = list(/datum/reagent/medicine/spaceacillin = 30)
 
 /obj/item/reagent_containers/glass/bottle/antitoxin
 	name = "antitoxin bottle"
+	label_name = "antitoxin"
 	desc = "A small bottle of anti-toxin. Used to treat toxin damage."
 	list_reagents = list(/datum/reagent/medicine/antitoxin = 30)
 
 /obj/item/reagent_containers/glass/bottle/toxin/mutagen
 	name = "mutagen toxin bottle"
+	label_name = "mutagen toxin"
 	desc = "A small bottle of mutagen toxins. Do not drink, Might cause unpredictable mutations."
 	list_reagents = list(/datum/reagent/toxin/mutagen = 30)
 
 /obj/item/reagent_containers/glass/bottle/toxin
 	name = "toxin bottle"
+	label_name = "toxin"
 	desc = "A small bottle of toxins. Do not drink, it is poisonous."
 	list_reagents = list(/datum/reagent/toxin = 30)
 
 /obj/item/reagent_containers/glass/bottle/cyanide
 	name = "cyanide bottle"
+	label_name = "cyanide"
 	desc = "A small bottle of cyanide. Bitter almonds?"
 	list_reagents = list(/datum/reagent/toxin/cyanide = 30)
 
 /obj/item/reagent_containers/glass/bottle/spewium
 	name = "spewium bottle"
+	label_name = "spewium"
 	desc = "A small bottle of spewium."
 	list_reagents = list(/datum/reagent/toxin/spewium = 30)
 
 /obj/item/reagent_containers/glass/bottle/morphine
 	name = "morphine bottle"
+	label_name = "morphine"
 	desc = "A small bottle of morphine."
 	icon = 'icons/obj/chemical.dmi'
 	list_reagents = list(/datum/reagent/medicine/morphine = 30)
 
 /obj/item/reagent_containers/glass/bottle/chloralhydrate
 	name = "chloral hydrate bottle"
+	label_name = "chloral hydrate"
 	desc = "A small bottle of Choral Hydrate. Mickey's Favorite!"
 	icon_state = "bottle20"
 	list_reagents = list(/datum/reagent/toxin/chloralhydrate = 30)
 
 /obj/item/reagent_containers/glass/bottle/mannitol
 	name = "mannitol bottle"
+	label_name = "mannitol"
 	desc = "A small bottle of Mannitol. Useful for healing brain damage."
 	list_reagents = list(/datum/reagent/medicine/mannitol = 30)
 
 /obj/item/reagent_containers/glass/bottle/charcoal
 	name = "charcoal bottle"
+	label_name = "charcoal"
 	desc = "A small bottle of charcoal, which removes toxins and other chemicals from the bloodstream."
 	list_reagents = list(/datum/reagent/medicine/charcoal = 30)
 
 /obj/item/reagent_containers/glass/bottle/mutagen
 	name = "unstable mutagen bottle"
+	label_name = "unstable mutagen"
 	desc = "A small bottle of unstable mutagen. Randomly changes the DNA structure of whoever comes in contact."
 	list_reagents = list(/datum/reagent/toxin/mutagen = 30)
 
 /obj/item/reagent_containers/glass/bottle/plasma
 	name = "liquid plasma bottle"
+	label_name = "liquid plasma"
 	desc = "A small bottle of liquid plasma. Extremely toxic and reacts with micro-organisms inside blood."
 	list_reagents = list(/datum/reagent/toxin/plasma = 30)
 
 /obj/item/reagent_containers/glass/bottle/synaptizine
 	name = "synaptizine bottle"
+	label_name = "synaptizine"
 	desc = "A small bottle of synaptizine."
 	list_reagents = list(/datum/reagent/medicine/synaptizine = 30)
 
 /obj/item/reagent_containers/glass/bottle/formaldehyde
 	name = "formaldehyde bottle"
+	label_name = "formaldehyde"
 	desc = "A small bottle of formaldehyde."
 	list_reagents = list(/datum/reagent/toxin/formaldehyde = 30)
 
 /obj/item/reagent_containers/glass/bottle/cryostylane
 	name = "cryostylane bottle"
+	label_name = "cryostylane"
 	desc = "A small bottle of cryostylane. It feels cold to the touch."
 	list_reagents = list(/datum/reagent/cryostylane = 30)
 
 /obj/item/reagent_containers/glass/bottle/ammonia
 	name = "ammonia bottle"
+	label_name = "ammonia"
 	desc = "A small bottle of ammonia."
 	list_reagents = list(/datum/reagent/ammonia = 30)
 
 /obj/item/reagent_containers/glass/bottle/diethylamine
 	name = "diethylamine bottle"
+	label_name = "diethylamine"
 	desc = "A small bottle of diethylamine."
 	list_reagents = list(/datum/reagent/diethylamine = 30)
 
 /obj/item/reagent_containers/glass/bottle/facid
 	name = "Fluorosulfuric Acid Bottle"
+	label_name = "Fluorosulfuric Acid"
 	desc = "A small bottle. Contains a small amount of fluorosulfuric acid."
 	list_reagents = list(/datum/reagent/toxin/acid/fluacid = 30)
 
 /obj/item/reagent_containers/glass/bottle/adminordrazine
 	name = "Adminordrazine Bottle"
+	label_name = "Adminordrazine"
 	desc = "A small bottle. Contains the liquid essence of the gods."
 	icon = 'icons/obj/drinks.dmi'
 	icon_state = "holyflask"
@@ -126,21 +147,25 @@
 
 /obj/item/reagent_containers/glass/bottle/viralbase
 	name = "Highly potent Viral Base Bottle"
+	label_name = "Highly potent Viral Base"
 	desc = "A small bottle. Contains a trace amount of a substance found by scientists that can be used to create extremely advanced diseases once exposed to uranium."
 	list_reagents = list(/datum/reagent/consumable/virus_food/viralbase = 1)
 
 /obj/item/reagent_containers/glass/bottle/capsaicin
 	name = "Capsaicin Bottle"
+	label_name = "Capsaicin"
 	desc = "A small bottle. Contains hot sauce."
 	list_reagents = list(/datum/reagent/consumable/capsaicin = 30)
 
 /obj/item/reagent_containers/glass/bottle/frostoil
 	name = "Frost Oil Bottle"
+	label_name = "Frost Oil"
 	desc = "A small bottle. Contains cold sauce."
 	list_reagents = list(/datum/reagent/consumable/frostoil = 30)
 
 /obj/item/reagent_containers/glass/bottle/traitor
 	name = "syndicate bottle"
+	label_name = "syndicate"
 	desc = "A small bottle. Contains a random nasty chemical."
 	icon = 'icons/obj/chemical.dmi'
 	var/extra_reagent = null
@@ -152,184 +177,220 @@
 
 /obj/item/reagent_containers/glass/bottle/polonium
 	name = "polonium bottle"
+	label_name = "polonium"
 	desc = "A small bottle. Contains Polonium."
 	list_reagents = list(/datum/reagent/toxin/polonium = 30)
 
 /obj/item/reagent_containers/glass/bottle/magillitis
 	name = "magillitis bottle"
+	label_name = "magillitis"
 	desc = "A small bottle. Contains a serum known only as 'magillitis'."
 	list_reagents = list(/datum/reagent/magillitis = 5)
 
 /obj/item/reagent_containers/glass/bottle/venom
 	name = "venom bottle"
+	label_name = "venom"
 	desc = "A small bottle. Contains Venom."
 	list_reagents = list(/datum/reagent/toxin/venom = 30)
 
 /obj/item/reagent_containers/glass/bottle/fentanyl
 	name = "fentanyl bottle"
+	label_name = "fentanyl"
 	desc = "A small bottle. Contains Fentanyl."
 	list_reagents = list(/datum/reagent/toxin/fentanyl = 30)
 
 /obj/item/reagent_containers/glass/bottle/formaldehyde
 	name = "formaldehyde bottle"
+	label_name = "formaldehyde"
 	desc = "A small bottle. Contains Formaldehyde."
 	list_reagents = list(/datum/reagent/toxin/formaldehyde = 30)
 
 /obj/item/reagent_containers/glass/bottle/initropidril
 	name = "initropidril bottle"
+	label_name = "initropidril"
 	desc = "A small bottle. Contains initropidril."
 	list_reagents = list(/datum/reagent/toxin/initropidril = 30)
 
 /obj/item/reagent_containers/glass/bottle/pancuronium
 	name = "pancuronium bottle"
+	label_name = "pancuronium"
 	desc = "A small bottle. Contains pancuronium."
 	list_reagents = list(/datum/reagent/toxin/pancuronium = 30)
 
 /obj/item/reagent_containers/glass/bottle/sodium_thiopental
 	name = "sodium thiopental bottle"
+	label_name = "sodium thiopental"
 	desc = "A small bottle. Contains sodium thiopental."
 	list_reagents = list(/datum/reagent/toxin/sodium_thiopental = 30)
 
 /obj/item/reagent_containers/glass/bottle/coniine
 	name = "coniine bottle"
+	label_name = "coniine"
 	desc = "A small bottle. Contains coniine."
 	list_reagents = list(/datum/reagent/toxin/coniine = 30)
 
 /obj/item/reagent_containers/glass/bottle/curare
 	name = "curare bottle"
+	label_name = "curare"
 	desc = "A small bottle. Contains curare."
 	list_reagents = list(/datum/reagent/toxin/curare = 30)
 
 /obj/item/reagent_containers/glass/bottle/amanitin
 	name = "amanitin bottle"
+	label_name = "amanitin"
 	desc = "A small bottle. Contains amanitin."
 	list_reagents = list(/datum/reagent/toxin/amanitin = 30)
 
 /obj/item/reagent_containers/glass/bottle/histamine
 	name = "histamine bottle"
+	label_name = "histamine"
 	desc = "A small bottle. Contains Histamine."
 	list_reagents = list(/datum/reagent/toxin/histamine = 30)
 
 /obj/item/reagent_containers/glass/bottle/diphenhydramine
 	name = "antihistamine bottle"
+	label_name = "antihistamine"
 	desc = "A small bottle of diphenhydramine."
 	list_reagents = list(/datum/reagent/medicine/diphenhydramine = 30)
 
 /obj/item/reagent_containers/glass/bottle/potass_iodide
 	name = "anti-radiation bottle"
+	label_name = "anti-radiation"
 	desc = "A small bottle of potassium iodide."
 	list_reagents = list(/datum/reagent/medicine/potass_iodide = 30)
 
 /obj/item/reagent_containers/glass/bottle/salglu_solution
 	name = "saline-glucose bottle"
+	label_name = "saline-glucose"
 	desc = "A small bottle of saline-glucose solution. Useful for patients lacking in blood volume."
 	list_reagents = list(/datum/reagent/medicine/salglu_solution = 30)
 
 /obj/item/reagent_containers/glass/bottle/atropine
 	name = "atropine bottle"
+	label_name = "atropine"
 	desc = "A small bottle of atropine."
 	list_reagents = list(/datum/reagent/medicine/atropine = 30)
 
 /obj/item/reagent_containers/glass/bottle/romerol
 	name = "romerol bottle"
+	label_name = "romerol"
 	desc = "A small bottle of Romerol. The REAL zombie powder."
 	list_reagents = list(/datum/reagent/romerol = 30)
 
 /obj/item/reagent_containers/glass/bottle/random_virus/minor //for mail only...yet
 	name = "Minor experimental disease culture bottle"
+	label_name = "Minor experimental disease culture"
 	desc = "A small bottle. Contains a weak version of an untested viral culture in synthblood medium."
 	spawned_disease = /datum/disease/advance/random/minor
 
 /obj/item/reagent_containers/glass/bottle/random_virus
 	name = "Experimental disease culture bottle"
+	label_name = "Experimental disease culture"
 	desc = "A small bottle. Contains an untested viral culture in synthblood medium."
 	spawned_disease = /datum/disease/advance/random
 
 /obj/item/reagent_containers/glass/bottle/pierrot_throat
 	name = "Pierrot's Throat culture bottle"
+	label_name = "Pierrot's Throat culture"
 	desc = "A small bottle. Contains H0NI<42 virion culture in synthblood medium."
 	spawned_disease = /datum/disease/pierrot_throat
 
 /obj/item/reagent_containers/glass/bottle/cold
 	name = "Rhinovirus culture bottle"
+	label_name = "Rhinovirus culture"
 	desc = "A small bottle. Contains XY-rhinovirus culture in synthblood medium."
 	spawned_disease = /datum/disease/advance/cold
 
 /obj/item/reagent_containers/glass/bottle/flu_virion
 	name = "Flu virion culture bottle"
+	label_name = "Flu virion culture"
 	desc = "A small bottle. Contains H13N1 flu virion culture in synthblood medium."
 	spawned_disease = /datum/disease/advance/flu
 
 /obj/item/reagent_containers/glass/bottle/retrovirus
 	name = "Retrovirus culture bottle"
+	label_name = "Retrovirus culture"
 	desc = "A small bottle. Contains a retrovirus culture in a synthblood medium."
 	spawned_disease = /datum/disease/dna_retrovirus
 
 /obj/item/reagent_containers/glass/bottle/gbs
 	name = "GBS culture bottle"
+	label_name = "GBS culture"
 	desc = "A small bottle. Contains Gravitokinetic Bipotential SADS+ culture in synthblood medium."//Or simply - General BullShit
 	amount_per_transfer_from_this = 5
 	spawned_disease = /datum/disease/gbs
 
 /obj/item/reagent_containers/glass/bottle/fake_gbs
 	name = "GBS culture bottle"
+	label_name = "GBS culture"
 	desc = "A small bottle. Contains Gravitokinetic Bipotential SADS- culture in synthblood medium."//Or simply - General BullShit
 	spawned_disease = /datum/disease/fake_gbs
 
 /obj/item/reagent_containers/glass/bottle/brainrot
 	name = "Brainrot culture bottle"
+	label_name = "Brainrot culture"
 	desc = "A small bottle. Contains Cryptococcus Cosmosis culture in synthblood medium."
 	icon_state = "bottle3"
 	spawned_disease = /datum/disease/brainrot
 
 /obj/item/reagent_containers/glass/bottle/magnitis
 	name = "Magnitis culture bottle"
+	label_name = "Magnitis culture"
 	desc = "A small bottle. Contains a small dosage of Fukkos Miracos."
 	spawned_disease = /datum/disease/magnitis
 
 /obj/item/reagent_containers/glass/bottle/wizarditis
 	name = "Wizarditis culture bottle"
+	label_name = "Wizarditis culture"
 	desc = "A small bottle. Contains a sample of Rincewindus Vulgaris."
 	spawned_disease = /datum/disease/wizarditis
 
 /obj/item/reagent_containers/glass/bottle/anxiety
 	name = "Severe Anxiety culture bottle"
+	label_name = "Severe Anxiety culture"
 	desc = "A small bottle. Contains a sample of Lepidopticides."
 	spawned_disease = /datum/disease/anxiety
 
 /obj/item/reagent_containers/glass/bottle/beesease
 	name = "Beesease culture bottle"
+	label_name = "Beesease culture"
 	desc = "A small bottle. Contains a sample of invasive Apidae."
 	spawned_disease = /datum/disease/beesease
 
 /obj/item/reagent_containers/glass/bottle/fluspanish
 	name = "Spanish flu culture bottle"
+	label_name = "Spanish flu culture"
 	desc = "A small bottle. Contains a sample of Inquisitius."
 	spawned_disease = /datum/disease/fluspanish
 
 /obj/item/reagent_containers/glass/bottle/tuberculosis
 	name = "Fungal Tuberculosis culture bottle"
+	label_name = "Fungal Tuberculosis culture"
 	desc = "A small bottle. Contains a sample of Fungal Tubercle bacillus."
 	spawned_disease = /datum/disease/tuberculosis
 
 /obj/item/reagent_containers/glass/bottle/tuberculosiscure
 	name = "BVAK bottle"
+	label_name = "BVAK"
 	desc = "A small bottle containing Bio Virus Antidote Kit."
 	list_reagents = list(/datum/reagent/medicine/atropine = 5, /datum/reagent/medicine/epinephrine = 5, /datum/reagent/medicine/salbutamol = 10, /datum/reagent/medicine/spaceacillin = 10)
 
 /obj/item/reagent_containers/glass/bottle/necropolis_seed
 	name = "bowl of blood"
+	label_name = "blood"
 	desc = "A clay bowl containing a fledgling Necropolis, preserved in blood. A robust virologist may be able to unlock its full potential..."
 	icon_state = "mortar"
 	spawned_disease = /datum/disease/advance/random/necropolis
 
 /obj/item/reagent_containers/glass/bottle/felinid
 	name = "Nano-Feline Assimilative Toxoplasmosis culture bottle"
+	label_name = "Nano-Feline Assimilative Toxoplasmosis culture"
 	desc = "A small bottle. Contains a sample of nano-feline toxoplasma in synthblood medium."
 	spawned_disease = /datum/disease/transformation/felinid/contagious
 
 /obj/item/reagent_containers/glass/bottle/advanced_felinid
 	name = "Feline Hysteria culture bottle"
+	label_name = "Feline Hysteria culture"
 	desc = "A small bottle. Contains a sample of a dangerous A.R.C. experimental disease"
 	spawned_disease = /datum/disease/advance/feline_hysteria
 
@@ -337,127 +398,157 @@
 
 /obj/item/reagent_containers/glass/bottle/hydrogen
 	name = "hydrogen bottle"
+	label_name = "hydrogen"
 	list_reagents = list(/datum/reagent/hydrogen = 30)
 
 /obj/item/reagent_containers/glass/bottle/lithium
 	name = "lithium bottle"
+	label_name = "lithium"
 	list_reagents = list(/datum/reagent/lithium = 30)
 
 /obj/item/reagent_containers/glass/bottle/carbon
 	name = "carbon bottle"
+	label_name = "carbon"
 	list_reagents = list(/datum/reagent/carbon = 30)
 
 /obj/item/reagent_containers/glass/bottle/nitrogen
 	name = "nitrogen bottle"
+	label_name = "nitrogen"
 	list_reagents = list(/datum/reagent/nitrogen = 30)
 
 /obj/item/reagent_containers/glass/bottle/oxygen
 	name = "oxygen bottle"
+	label_name = "oxygen"
 	list_reagents = list(/datum/reagent/oxygen = 30)
 
 /obj/item/reagent_containers/glass/bottle/fluorine
 	name = "fluorine bottle"
+	label_name = "fluorine"
 	list_reagents = list(/datum/reagent/fluorine = 30)
 
 /obj/item/reagent_containers/glass/bottle/sodium
 	name = "sodium bottle"
+	label_name = "sodium"
 	list_reagents = list(/datum/reagent/sodium = 30)
 
 /obj/item/reagent_containers/glass/bottle/aluminium
 	name = "aluminium bottle"
+	label_name = "aluminium"
 	list_reagents = list(/datum/reagent/aluminium = 30)
 
 /obj/item/reagent_containers/glass/bottle/silicon
 	name = "silicon bottle"
+	label_name = "silicon"
 	list_reagents = list(/datum/reagent/silicon = 30)
 
 /obj/item/reagent_containers/glass/bottle/phosphorus
 	name = "phosphorus bottle"
+	label_name = "phosphorus"
 	list_reagents = list(/datum/reagent/phosphorus = 30)
 
 /obj/item/reagent_containers/glass/bottle/sulfur
 	name = "sulfur bottle"
+	label_name = "sulfur"
 	list_reagents = list(/datum/reagent/sulfur = 30)
 
 /obj/item/reagent_containers/glass/bottle/chlorine
 	name = "chlorine bottle"
+	label_name = "chlorine"
 	list_reagents = list(/datum/reagent/chlorine = 30)
 
 /obj/item/reagent_containers/glass/bottle/potassium
 	name = "potassium bottle"
+	label_name = "potassium"
 	list_reagents = list(/datum/reagent/potassium = 30)
 
 /obj/item/reagent_containers/glass/bottle/iron
 	name = "iron bottle"
+	label_name = "iron"
 	list_reagents = list(/datum/reagent/iron = 30)
 
 /obj/item/reagent_containers/glass/bottle/copper
 	name = "copper bottle"
+	label_name = "copper"
 	list_reagents = list(/datum/reagent/copper = 30)
 
 /obj/item/reagent_containers/glass/bottle/mercury
 	name = "mercury bottle"
+	label_name = "mercury"
 	list_reagents = list(/datum/reagent/mercury = 30)
 
 /obj/item/reagent_containers/glass/bottle/radium
 	name = "radium bottle"
+	label_name = "radium"
 	list_reagents = list(/datum/reagent/uranium/radium = 30)
 
 /obj/item/reagent_containers/glass/bottle/water
 	name = "water bottle"
+	label_name = "water"
 	list_reagents = list(/datum/reagent/water = 30)
 
 /obj/item/reagent_containers/glass/bottle/ethanol
 	name = "ethanol bottle"
+	label_name = "ethanol"
 	list_reagents = list(/datum/reagent/consumable/ethanol = 30)
 
 /obj/item/reagent_containers/glass/bottle/sugar
 	name = "sugar bottle"
+	label_name = "sugar"
 	list_reagents = list(/datum/reagent/consumable/sugar = 30)
 
 /obj/item/reagent_containers/glass/bottle/sacid
 	name = "sulphuric acid bottle"
+	label_name = "sulphuric acid"
 	list_reagents = list(/datum/reagent/toxin/acid = 30)
 
 /obj/item/reagent_containers/glass/bottle/welding_fuel
 	name = "welding fuel bottle"
+	label_name = "welding fuel"
 	list_reagents = list(/datum/reagent/fuel = 30)
 
 /obj/item/reagent_containers/glass/bottle/silver
 	name = "silver bottle"
+	label_name = "silver"
 	list_reagents = list(/datum/reagent/silver = 30)
 
 /obj/item/reagent_containers/glass/bottle/iodine
 	name = "iodine bottle"
+	label_name = "iodine"
 	list_reagents = list(/datum/reagent/iodine = 30)
 
 /obj/item/reagent_containers/glass/bottle/bromine
 	name = "bromine bottle"
+	label_name = "bromine"
 	list_reagents = list(/datum/reagent/bromine = 30)
 
 // Bottles for mail goodies.
 
 /obj/item/reagent_containers/glass/bottle/clownstears
 	name = "bottle of distilled clown misery"
+	label_name = "distilled clown misery"
 	desc = "A small bottle. Contains a mythical liquid used by sublime bartenders; made from the unhappiness of clowns."
 	list_reagents = list(/datum/reagent/consumable/clownstears = 30)
 
 /obj/item/reagent_containers/glass/bottle/saltpetre
 	name = "saltpetre bottle"
+	label_name = "saltpetre"
 	desc = "A small bottle. Contains saltpetre."
 	list_reagents = list(/datum/reagent/saltpetre = 30)
 
 /obj/item/reagent_containers/glass/bottle/flash_powder
 	name = "flash powder bottle"
+	label_name = "flash powder"
 	desc = "A small bottle. Contains flash powder."
 	list_reagents = list(/datum/reagent/flash_powder = 30)
 
 /obj/item/reagent_containers/glass/bottle/caramel
 	name = "bottle of caramel"
+	label_name = "caramel"
 	desc = "A bottle containing caramalized sugar, also known as caramel. Do not lick."
 	list_reagents = list(/datum/reagent/consumable/caramel = 30)
 
 /obj/item/reagent_containers/glass/bottle/ketamine
 	name = "ketamine bottle"
+	label_name = "ketamine"
 	desc = "A small bottle. Contains ketamine, why?"
 	list_reagents = list(/datum/reagent/drug/ketamine = 30)

--- a/code/modules/reagents/reagent_containers/chem_bag.dm
+++ b/code/modules/reagents/reagent_containers/chem_bag.dm
@@ -1,0 +1,29 @@
+/obj/item/reagent_containers/chem_bag
+	name = "chemical bag"
+	desc = "Contains chemicals used for transfusion. Must be attached to an IV drip."
+	icon = 'icons/obj/bloodpack.dmi'
+	icon_state = "bloodpack"
+	volume = 200
+	fill_icon_thresholds = list(10, 20, 30, 40, 50, 60, 70, 80, 90, 100)
+	reagent_flags = TRANSPARENT | ABSOLUTELY_GRINDABLE
+
+/obj/item/reagent_containers/chem_bag/Initialize(mapload)
+	. = ..()
+	if(!icon_state)
+		icon_state = "bloodpack"
+		update_icon()
+
+/obj/item/reagent_containers/chem_bag/examine(mob/user)
+	. = ..()
+	if(reagents)
+		if(volume == reagents.total_volume)
+			. += "<span class='notice'>It is fully filled.</span>"
+		else if(!reagents.total_volume)
+			. += "<span class='notice'>It's empty.</span>"
+		else
+			. += "<span class='notice'>It seems [round(reagents.total_volume/volume*100)]% filled.</span>"
+
+/obj/item/reagent_containers/chem_bag/epinephrine
+	name = "epinephrine chemical bag"
+	label_name = "epinephrine"
+	list_reagents = list(/datum/reagent/medicine/epinephrine = 200)

--- a/nsv13.dme
+++ b/nsv13.dme
@@ -3130,6 +3130,7 @@
 #include "code\modules\reagents\reagent_containers\blood_pack.dm"
 #include "code\modules\reagents\reagent_containers\borghydro.dm"
 #include "code\modules\reagents\reagent_containers\bottle.dm"
+#include "code\modules\reagents\reagent_containers\chem_bag.dm"
 #include "code\modules\reagents\reagent_containers\chem_heirloom.dm"
 #include "code\modules\reagents\reagent_containers\dropper.dm"
 #include "code\modules\reagents\reagent_containers\glass.dm"

--- a/tgui/packages/tgui/interfaces/ChemMaster.js
+++ b/tgui/packages/tgui/interfaces/ChemMaster.js
@@ -1,5 +1,5 @@
 import { useBackend, useSharedState } from '../backend';
-import { AnimatedNumber, Box, Button, ColorBox, LabeledList, NumberInput, Section, Table } from '../components';
+import { AnimatedNumber, Box, Button, ColorBox, Input, LabeledList, NumberInput, Section, Table } from '../components';
 import { Window } from '../layouts';
 
 export const ChemMaster = (props, context) => {
@@ -22,6 +22,12 @@ export const ChemMaster = (props, context) => {
 
 const ChemMasterContent = (props, context) => {
   const { act, data } = useBackend(context);
+  const {
+    saved_volume,
+    saved_name,
+    saved_volume_state,
+    saved_name_state,
+  } = data;
   const {
     screen,
     beakerContents = [],
@@ -102,8 +108,51 @@ const ChemMasterContent = (props, context) => {
         </ChemicalBuffer>
       </Section>
       <Section
-        title="Packaging">
-        <PackagingControls />
+        title="Packaging"
+        buttons={(
+          <>
+            <Box inline color="label" mr={1}>
+              Mode:
+            </Box>
+            <Button
+              icon={saved_volume_state === "Exact" ? "eye-dropper" : "flask"}
+              content={`${saved_volume_state}`}
+              tooltip="Volume Distribution"
+              onClick={() => act('setSavedVolumeState', { volume_state: saved_volume_state === "Exact" ? "Auto" : "Exact" })}
+            />
+            {saved_volume_state === "Exact" && (
+              <NumberInput
+                width="84px"
+                unit="units"
+                stepPixelSize={15}
+                value={saved_volume}
+                minValue={0.01}
+                maxValue={50}
+                onChange={(e, value) => act('setSavedVolume', { volume: value })} />
+            )}
+          </>
+        )}>
+        <Box mb={2}>
+          <Box inline color="label" mr={1}>
+            Naming Mode:
+          </Box>
+          <Button
+            icon={saved_name_state === "Manual" ? "pen" : "print"}
+            content={`${saved_name_state}`}
+            onClick={() => act('setSavedNameState', { name_state: saved_name_state === "Manual" ? "Auto" : "Manual" })}
+          />
+          {saved_name_state === "Manual" && (
+            <Input
+              fluid
+              value={saved_name}
+              placeholder="Name"
+              onInput={(e, value) => {
+                act('setSavedName', { name: value });
+              }} />
+          )}
+        </Box>
+        <PackagingControls
+          volume={saved_volume_state === "Exact" ? saved_volume : "auto"} packagingName={saved_name_state === "Manual" ? saved_name : null} />
       </Section>
       {!!isPillBottleLoaded && (
         <Section
@@ -216,7 +265,7 @@ const PackagingControlsItem = props => {
   );
 };
 
-const PackagingControls = (props, context) => {
+const PackagingControls = ({ volume, packagingName }, context) => {
   const { act, data } = useBackend(context);
   const [
     pillAmount,
@@ -230,6 +279,10 @@ const PackagingControls = (props, context) => {
     bottleAmount,
     setBottleAmount,
   ] = useSharedState(context, 'bottleAmount', 1);
+  const [
+    bagAmount,
+    setBagAmount,
+  ] = useSharedState(context, 'bagAmount', 1);
   const [
     packAmount,
     setPackAmount,
@@ -266,7 +319,8 @@ const PackagingControls = (props, context) => {
           onCreate={() => act('create', {
             type: 'pill',
             amount: pillAmount,
-            volume: 'auto',
+            volume: volume,
+            name: packagingName,
           })} />
       )}
       {!condi && (
@@ -279,7 +333,8 @@ const PackagingControls = (props, context) => {
           onCreate={() => act('create', {
             type: 'patch',
             amount: patchAmount,
-            volume: 'auto',
+            volume: volume,
+            name: packagingName,
           })} />
       )}
       {!condi && (
@@ -292,7 +347,22 @@ const PackagingControls = (props, context) => {
           onCreate={() => act('create', {
             type: 'bottle',
             amount: bottleAmount,
-            volume: 'auto',
+            volume: volume,
+            name: packagingName,
+          })} />
+      )}
+      {!condi && (
+        <PackagingControlsItem
+          label="Bags"
+          amount={bagAmount}
+          amountUnit="bags"
+          sideNote="max 200u"
+          onChangeAmount={(e, value) => setBagAmount(value)}
+          onCreate={() => act('create', {
+            type: 'bag',
+            amount: bagAmount,
+            volume: volume, // NSV13
+            name: packagingName, // NSV13
           })} />
       )}
       {!!condi && (
@@ -305,7 +375,8 @@ const PackagingControls = (props, context) => {
           onCreate={() => act('create', {
             type: 'condimentPack',
             amount: packAmount,
-            volume: 'auto',
+            volume: volume,
+            name: packagingName,
           })} />
       )}
       {!!condi && (
@@ -318,7 +389,8 @@ const PackagingControls = (props, context) => {
           onCreate={() => act('create', {
             type: 'condimentBottle',
             amount: bottleAmount,
-            volume: 'auto',
+            volume: volume,
+            name: packagingName,
           })} />
       )}
     </LabeledList>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ports the following PRs from Upstream:
* https://github.com/BeeStation/BeeStation-Hornet/pull/7589
* https://github.com/BeeStation/BeeStation-Hornet/pull/7862
* https://github.com/BeeStation/BeeStation-Hornet/pull/8059

What those PRs introduce is the following:
First PR adds the ability to switch the output mode from Auto to a specific volume amount, which allows you to easily create large quantities of pills, bottles, patches and etc, with the specified amount of chemicals in every single one of them. 

So you can fill the chem master's internal beaker with 100 units of...Meth, set the pill amount created to max and then change the specific volume amount to 5 units and now you'll have 10 pills all containing exactly 5 units of Meth. 

That PR also introduces a persistent and shared naming method so you don't have to copy paste the same name over and over again into an input box in order to name every batch of pills coming out of the ChemMaster the word "Happy Pills"

Second PR introduces a way to create chemical bags containing chemicals you can use for the IV drip, this can be done in the ChemMaster so now you too can make bags containing liquid meth instead of having to use beakers!

Also that PR makes blood bags grindable...for some reason?

Third PR fixes what the second PR broke.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Chemistry/Medical Quality of Life sounds pretty good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://user-images.githubusercontent.com/59128051/216592402-87c653c7-2903-4619-97ca-1a62619e1e2f.mp4

</details>

## Changelog
:cl:itsmeow, EvilDragonfiend
tweak: ChemMasters now have an exact output units mode for pills/patches/bottles.
tweak: ChemMasters can now have a set name input to use for all pills, instead of prompting every time.
admin: ChemMaster packaging names are now subject to the IC filter.
add: a new reagent container type - Chemical bag (max 200u). printable from ChemMaster. Currently, this does not have many usages - not drinkable, and not insertable into ChemMaster back.(but grindable) only usable for IV drip.
tweak: blood packs are grindable
code: adds a bitflag that allows a grinder can grind a reagent container, and related proc 'is_grindable()'
code: new variable label_name that is used to display specific string without suffix like bottle, pill, patch
fix: bottles now show its names in vending machines
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
