### PR TITLE
Fixes crates with missing names

### DIFF
--- a/nsv13/code/modules/cargo/packs.dm
+++ b/nsv13/code/modules/cargo/packs.dm
@@ -212,6 +212,7 @@
 					/obj/item/ship_weapon/parts/missile/warhead/freight,
 					/obj/item/ship_weapon/parts/missile/warhead/freight)
 	crate_type = /obj/structure/closet/crate/wooden
+	crate_name = "Freight torpedo warheads"
 
 /datum/supply_pack/munitions/pilot_outfitting
 	name = "Pilot Outfitting Crate"
@@ -223,6 +224,7 @@
 					/obj/item/clothing/head/beret/ship/pilot,
 					/obj/item/radio/headset/munitions/pilot,
 					/obj/item/clothing/suit/space/hardsuit/pilot)
+	crate_name = "Pilot outfitting crate"
 
 /datum/supply_pack/munitions/missile_warheads
 	name = "Missile Warheads"
@@ -290,6 +292,7 @@
 					/obj/item/fighter_component/docking_computer,
 					/obj/item/fighter_component/battery,
 					/obj/item/fighter_component/primary/cannon)
+	crate_name = "Light fighter starter kit"
 
 /datum/supply_pack/munitions/fighter_construction/heavy
 	name = "Heavy Fighter Starter Kit"
@@ -309,6 +312,7 @@
 					/obj/item/fighter_component/secondary/ordnance_launcher/torpedo,
 					/obj/item/fighter_component/battery,
 					/obj/item/fighter_component/primary/cannon/heavy)
+	crate_name = "Heavy fighter starter kit"
 
 /datum/supply_pack/munitions/fighter_construction/utility
 	name = "Utility Fighter Starter Kit"
@@ -328,6 +332,7 @@
 					/obj/item/fighter_component/secondary/utility/hold,
 					/obj/item/fighter_component/primary/utility/refuel,
 					/obj/item/fighter_component/countermeasure_dispenser)
+	crate_name = "Utility fighter starter kit"
 
 /datum/supply_pack/munitions/light_cannon
 	name = "Light Cannon Ammunition"
@@ -531,6 +536,7 @@
 	desc = "One cryogenic Tyrosene fuel pump, capable of fully refuelling 3 fighters. Handle with care."
 	cost = 1500
 	contains = list(/obj/structure/reagent_dispensers/fueltank/cryogenic_fuel)
+	crate_name = "Fighter fuel crate"
 
 /datum/supply_pack/engineering/control_rods
 	name = "Nanocarbon Reactor Control Rods (x5)"
@@ -604,6 +610,7 @@
 					/obj/item/ammo_box/magazine/smgm9mm,
 					/obj/item/ammo_box/c9mm,
 					/obj/item/ammo_box/c9mm)
+	crate_name = "MP-16A4 ammo crate"
 
 /datum/supply_pack/security/armory/marine_rifle
 	name = "M4A-16A1 Assault Rifle Crate"
@@ -622,6 +629,7 @@
 					/obj/item/ammo_box/magazine/m556,
 					/obj/item/ammo_box/magazine/m556,
 					/obj/item/ammo_box/magazine/m556)
+	crate_name = "M4A-16A1 ammo crate"
 
 /datum/supply_pack/engineering/hulljuice
 	name = "Hulljuice Tank Crate"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Several NSV added crates are now named instead of just being called crate. These are; pilot outfits, freight warheads, fighter starter kits (all of them), fighter fuel, and gun ammo crates.



<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Crates that should have names, but not have names should be named. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: Fixes NSV added crates with missing crate names
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
