### PR TITLE
Adds brakes to tugs

### DIFF
--- a/code/__DEFINES/nsv13.dm
+++ b/code/__DEFINES/nsv13.dm
@@ -112,6 +112,7 @@ GLOBAL_DATUM_INIT(conquest_role_handler, /datum/conquest_role_handler, new)
 #define COMSIG_KB_OVERMAP_WEAPON2_DOWN "keybinding_overmap_weapon2_down"
 #define COMSIG_KB_OVERMAP_WEAPON3_DOWN "keybinding_overmap_weapon3_down"
 #define COMSIG_KB_OVERMAP_WEAPON4_DOWN "keybinding_overmap_weapon4_down"
+#define COMSIG_KB_VEHICLE_TOGGLE_BRAKES "keybinding_vehicle_toggle_brakes"
 
 #define OVERMAP_USER_ROLE_PILOT (1<<0)
 #define OVERMAP_USER_ROLE_GUNNER (1<<1)

--- a/code/datums/keybinding/_defines.dm
+++ b/code/datums/keybinding/_defines.dm
@@ -5,12 +5,14 @@
 #define CATEGORY_MISC "MISC"
 #define CATEGORY_ROBOT "ROBOT"
 #define CATEGORY_OVERMAP "OVERMAP" //NSV13 - overmap controls
+#define CATEGORY_VEHICLE "VEHICLE" //NSV13 - realistic vehicles
 
 #define WEIGHT_HIGHEST 0
 #define WEIGHT_CLIENT 10
 #define WEIGHT_ADMIN 20
-#define WEIGHT_OVERMAP 35 //NSV13 - overmap controls override some of the other controls, don't ask me why highest and lowest are named like this
 #define WEIGHT_MOB 30
+#define WEIGHT_VEHICLE 31 // NSV13 - Vehicle keybinds, overrides mob and overmap binds
+#define WEIGHT_OVERMAP 35 //NSV13 - overmap controls override some of the other controls, don't ask me why highest and lowest are named like this
 #define WEIGHT_LIVING 40
 #define WEIGHT_DEAD 50
 #define WEIGHT_ROBOT 60

--- a/nsv13.dme
+++ b/nsv13.dme
@@ -3684,6 +3684,7 @@
 #include "nsv13\code\datums\freight_type\single\reagent\drinking_glass.dm"
 #include "nsv13\code\datums\freight_type\single\reagent\pill_patch.dm"
 #include "nsv13\code\datums\keybinding\overmap.dm"
+#include "nsv13\code\datums\keybinding\vehicle.dm"
 #include "nsv13\code\datums\looping_sounds\_looping_sound.dm"
 #include "nsv13\code\datums\mood_events\nsv_events.dm"
 #include "nsv13\code\datums\traits\negative.dm"

--- a/nsv13/code/datums/keybinding/vehicle.dm
+++ b/nsv13/code/datums/keybinding/vehicle.dm
@@ -1,0 +1,26 @@
+// Keybinds for NSV vehicles
+/datum/keybinding/vehicle
+		category = CATEGORY_VEHICLE
+		weight = WEIGHT_VEHICLE
+
+
+// Toggling brakes for tugs/similar vehicles
+/datum/keybinding/vehicle/toggle_brakes
+	key = "Alt"
+	name = "toggle_brakes"
+	full_name = "Toggle Brakes"
+	description = "Toggle a vehicle's brakes."
+	keybind_signal = COMSIG_KB_VEHICLE_TOGGLE_BRAKES
+
+/datum/keybinding/vehicle/toggle_brakes/down(client/user)
+	. = ..()
+	if(.) return
+	if(!user.mob) return
+
+	var/mob/M = user.mob
+	var/obj/vehicle/sealed/car/realistic/vehicle = M.focus
+	if(!istype(vehicle)) return
+	if(!vehicle.is_driver(M)) return
+
+	vehicle.toggle_brakes()
+	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Tugs can use brakes now. This is done by pressing the tug brake hotkey, which is set to ALT by default.

Tugs also respect delta_time when processing, and they don't call process(null) on every driver_move() anymore. 
To whoever wrote that: Why?

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
Because having the tug drift off into space for the 15 millionth time is slightly infuriating. 

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://user-images.githubusercontent.com/9423435/218234494-346ae3d5-1d2a-44ed-b0f0-38645433c5b5.mp4



</details>

## Changelog
:cl:
add: Tugs have brakes now.
code: Tug code has been very slightly improved.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
