### PR TITLE
Fixes EWAR consoles making infinite radios

### DIFF
--- a/nsv13/code/game/machinery/computer/salvage.dm
+++ b/nsv13/code/game/machinery/computer/salvage.dm
@@ -33,6 +33,10 @@
 	radio.listening = 0
 	radio.recalculateChannels()
 
+/obj/machinery/computer/ship/salvage/Destroy()
+	QDEL_NULL(radio)
+	. = ..()
+
 /obj/machinery/computer/ship/salvage/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This gives EWAR consoles a destroy() so they can clean up their radio properly. Otherwise, it just gets dropped on the floor.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
- Closes #2316 

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
It doesn't give a radio anymore.


## Changelog
:cl:
fix: EWAR consoles now delete their radios properly  when destroyed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
