### PR TITLE
Ethereal Lightbulb

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -96,7 +96,7 @@
 		var/healthpercent = max(H.health, 0) / 100
 		if(!emageffect)
 			current_color = rgb(r2 + ((r1-r2)*healthpercent), g2 + ((g1-g2)*healthpercent), b2 + ((b1-b2)*healthpercent))
-		ethereal_light.set_light_range_power_color(2 + (3 * healthpercent), 2 + (2 * healthpercent), current_color) //NSV13- Its not a performance issue here, and we're theoretically balanced for PVE.
+		ethereal_light.set_light_range_power_color(2 + (3 * healthpercent), 2 + (2 * healthpercent), current_color) //NSV13- Makes the base brightness a radius of two, and reduces the rate of brightness decline from damage.
 		ethereal_light.set_light_on(TRUE)
 		fixed_mut_color = copytext_char(current_color, 2)
 	else

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -96,7 +96,7 @@
 		var/healthpercent = max(H.health, 0) / 100
 		if(!emageffect)
 			current_color = rgb(r2 + ((r1-r2)*healthpercent), g2 + ((g1-g2)*healthpercent), b2 + ((b1-b2)*healthpercent))
-		ethereal_light.set_light_range_power_color(2 + (3 * healthpercent), 2 + (2 * healthpercent), current_color)
+		ethereal_light.set_light_range_power_color(2 + (3 * healthpercent), 2 + (2 * healthpercent), current_color) //NSV13- Its not a performance issue here, and we're theoretically balanced for PVE.
 		ethereal_light.set_light_on(TRUE)
 		fixed_mut_color = copytext_char(current_color, 2)
 	else

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -96,7 +96,7 @@
 		var/healthpercent = max(H.health, 0) / 100
 		if(!emageffect)
 			current_color = rgb(r2 + ((r1-r2)*healthpercent), g2 + ((g1-g2)*healthpercent), b2 + ((b1-b2)*healthpercent))
-		ethereal_light.set_light_range_power_color(1 + (2 * healthpercent), 1 + (1 * healthpercent), current_color)
+		ethereal_light.set_light_range_power_color(2 + (3 * healthpercent), 2 + (2 * healthpercent), current_color)
 		ethereal_light.set_light_on(TRUE)
 		fixed_mut_color = copytext_char(current_color, 2)
 	else


### PR DESCRIPTION
## About The Pull Request

This PR doubles ethereal light radius from a radius of 1, to a radius of 2, so instead of it being a highlighter of where the ethereal is, it can actually be used by the ethereal.

## Why It's Good For The Game

Ethereals are lightbulbs, not glowsticks. Provides actually semi-useful light radius from their only unique species trait.

## Changelog
:cl:
tweak: Doubled Ethereal light radius.
/:cl:
