### PR TITLE
Removes the annoying warning signs that show up in Visual Studio Code

### DIFF
--- a/nsv13/code/modules/vehicles/_vehicle.dm
+++ b/nsv13/code/modules/vehicles/_vehicle.dm
@@ -163,11 +163,8 @@ MASSIVE THANKS TO MONSTER860 FOR HELP WITH THIS. HE EXPLAINED PHYSICS AND MATH T
 		for(var/turf/T in locs)
 			if(isspaceturf(T))
 				continue
-			if(occupants.len)
-				var/mob/M = return_drivers()[1]
-				var/client/C = M.client
-				if(brakes)
-					drag += braking_efficiency
+			if(brakes)
+				drag += braking_efficiency
 			var/datum/gas_mixture/env = T.return_air()
 			var/pressure = env.return_pressure()
 			drag += velocity_mag * pressure * 0.0001 // 1 atmosphere should shave off 1% of velocity per tile


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes the resulting warning signs that show up in visual studio code as a result of this PR:
* https://github.com/BeeStation/NSV13/pull/2315

Also removes a redundant if condition as the tug is now just checking if the breaks is on and not if there's a person inside the vehicle. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Helps keep the notifications in Visual Studio Code to the minimum of 'What You Have Broken While Coding' rather than notifications about variables being defined but not used.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
code: Removed a redundant if condition, tug will probably now keep the breaks on until you turn it off and not just when there's someone inside the thingy, also removed two unused variables.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
