### PR TITLE
Fixes ship brakes

### DIFF
--- a/nsv13/code/datums/keybinding/vehicle.dm
+++ b/nsv13/code/datums/keybinding/vehicle.dm
@@ -7,7 +7,7 @@
 // Toggling brakes for tugs/similar vehicles
 /datum/keybinding/vehicle/toggle_brakes
 	key = "Alt"
-	name = "toggle_brakes"
+	name = "toggle_car_brakes"
 	full_name = "Toggle Brakes"
 	description = "Toggle a vehicle's brakes."
 	keybind_signal = COMSIG_KB_VEHICLE_TOGGLE_BRAKES


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Fixes a bug introduced in #2315 that broke ship brake keybinds. It wasn't testmerged so I have to do it in a separate PR.

As it turns out, a change I made to the vehicle toggle_brakes didn't get commited properly, so overmap/toggle_brakes and vehicle/toggle_brakes ended up with the same name keys, and vehicle/toggle_brakes overrode overmap/toggle_brakes.

It has a different key now, so it should work.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
Bugs are bad.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/9423435/221296554-a31bb8cf-8400-4c8a-b192-7393b2363985.png)

![image](https://user-images.githubusercontent.com/9423435/221296814-e3a3aaeb-4211-436a-a406-b061d78408ae.png)

</details>

## Changelog
:cl:
fix: Fixes the overmap brakes hotkey.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
