### PR TITLE
Made catastrophic loss of life actually call the shuttle

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -154,7 +154,8 @@ SUBSYSTEM_DEF(shuttle)
 		log_game("[msg] Alive: [alive], Roundstart: [total], Threshold: [threshold]")
 		emergencyNoRecall = TRUE
 		priority_announce("Catastrophic casualties detected: crisis shuttle protocols activated - jamming recall signals across all frequencies.", sound = SSstation.announcer.get_rand_alert_sound())
-		if(emergency.timeLeft(1) > emergencyCallTime * 0.4)
+		//NSV13 - made the shuttle get called if it hasn't been called yet
+		if((emergency.timeLeft(1) > emergencyCallTime * 0.4) || !emergency.timer)
 			emergency.request(null, set_coefficient = 0.4)
 
 /datum/controller/subsystem/shuttle/proc/block_recall(lockout_timer)

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -1,5 +1,10 @@
 #define MAX_TRANSIT_REQUEST_RETRIES 10
 
+#define AUTOEVAC_STATUS_NO_EVAC 0
+#define AUTOEVAC_STATUS_TIMER_STARTED 1
+#define AUTOEVAC_STATUS_NEED_EVAC 2
+#define AUTOEVAC_STATUS_EVAC_CALLED 3
+
 SUBSYSTEM_DEF(shuttle)
 	name = "Shuttle"
 	wait = 10
@@ -64,6 +69,8 @@ SUBSYSTEM_DEF(shuttle)
 	var/datum/turf_reservation/preview_reservation
 
 	var/shuttles_loaded = FALSE
+
+	var/autoevac_status = AUTOEVAC_STATUS_NO_EVAC //NSV13 - modified autoevac handling
 
 /datum/controller/subsystem/shuttle/Initialize(timeofday)
 	ordernum = rand(1, 9000)
@@ -130,16 +137,17 @@ SUBSYSTEM_DEF(shuttle)
 			if(MC_TICK_CHECK)
 				break
 
+// NSV13 - rewrote basically this whole proc to add a state machine, fix some math, and add voting
 /datum/controller/subsystem/shuttle/proc/CheckAutoEvac()
-	if(emergencyNoEscape || emergencyNoRecall || !emergency || !SSticker.HasRoundStarted())
+	if(emergencyNoEscape || emergencyNoRecall || !emergency || !SSticker.HasRoundStarted() || autoevac_status == AUTOEVAC_STATUS_EVAC_CALLED)
 		return
 
 	var/threshold = CONFIG_GET(number/emergency_shuttle_autocall_threshold)
 	if(!threshold)
 		return
 
-	// NSV13 - additional checks here
 	if(emergency.timeLeft(1) < emergencyCallTime * 0.5 && emergency.timer)
+		autoevac_status = AUTOEVAC_STATUS_NO_EVAC
 		return
 
 	var/alive = 0
@@ -150,26 +158,41 @@ SUBSYSTEM_DEF(shuttle)
 
 	var/total = GLOB.joined_player_list.len
 	if(total <= 0)
+		autoevac_status = AUTOEVAC_STATUS_NO_EVAC
 		return //no players no autoevac
 
 	if(alive / total <= threshold)
-		var/msg
-		// NSV13 - If the dead can't vote, just call the shuttle. Don't jam recalls.
-		// If they can, make sure the security level will get the shuttle here quickly and do a transfer vote.
-		if(CONFIG_GET(flag/no_dead_vote))
-			emergency.request(null, set_coefficient = 0.5)
-			msg = "Automatically dispatching emergency shuttle due to crew death."
-			priority_announce("Catastrophic casualties detected: crisis shuttle protocols activated.", sound = SSstation.announcer.get_rand_alert_sound())
-		else
-			if(GLOB.security_level < SEC_LEVEL_RED)
-				set_security_level(SEC_LEVEL_RED)
-			if(SSvote.mode != "transfer")
-				SSvote.initiate_vote("transfer", "Crisis Protocols", forced=TRUE, popup=FALSE)
-				msg = "Automatically initiating transfer vote due to crew death."
-				priority_announce("Catastrophic casualties detected: crisis shuttle protocols activated.", sound = SSstation.announcer.get_rand_alert_sound())
-		if(msg)
-			message_admins(msg)
-			log_game("[msg] Alive: [alive], Roundstart: [total], Threshold: [threshold]")
+		switch(autoevac_status)
+			if(AUTOEVAC_STATUS_NO_EVAC)
+				addtimer(VARSET_CALLBACK(src, autoevac_status, AUTOEVAC_STATUS_NEED_EVAC), 2 MINUTES)
+				autoevac_status = AUTOEVAC_STATUS_TIMER_STARTED
+				return
+			if(AUTOEVAC_STATUS_TIMER_STARTED)
+				// Still waiting to see if they come back
+				return
+			if(AUTOEVAC_STATUS_NEED_EVAC)
+				var/msg
+				// If the dead can't vote, just call the shuttle. Don't jam recalls.
+				// If they can, make sure the security level will get the shuttle here quickly and do a transfer vote.
+				if(CONFIG_GET(flag/no_dead_vote))
+					emergency.request(null, set_coefficient = 0.5)
+					msg = "Automatically dispatching emergency shuttle due to crew death."
+					priority_announce("Catastrophic casualties detected: crisis shuttle protocols activated.", sound = SSstation.announcer.get_rand_alert_sound())
+					autoevac_status = AUTOEVAC_STATUS_EVAC_CALLED
+				else
+					if(GLOB.security_level < SEC_LEVEL_RED)
+						set_security_level(SEC_LEVEL_RED)
+					if(!SSvote.mode)
+						SSvote.initiate_vote("transfer", "Crisis Protocols", forced=TRUE, popup=FALSE)
+						msg = "Automatically initiating transfer vote due to crew death."
+						priority_announce("Catastrophic casualties detected: crisis shuttle protocols activated.", sound = SSstation.announcer.get_rand_alert_sound())
+						autoevac_status = AUTOEVAC_STATUS_EVAC_CALLED
+				if(msg)
+					message_admins(msg)
+					log_game("[msg] Alive: [alive], Roundstart: [total], Threshold: [threshold]")
+	else
+		autoevac_status = AUTOEVAC_STATUS_NO_EVAC
+
 
 /datum/controller/subsystem/shuttle/proc/block_recall(lockout_timer)
 	emergencyNoRecall = TRUE
@@ -915,3 +938,8 @@ SUBSYSTEM_DEF(shuttle)
 					message_admins("[key_name_admin(usr)] loaded [mdp] with the shuttle manipulator.")
 					log_admin("[key_name(usr)] loaded [mdp] with the shuttle manipulator.</span>")
 					SSblackbox.record_feedback("text", "shuttle_manipulator", 1, "[mdp.name]")
+
+#undef AUTOEVAC_STATUS_NO_EVAC
+#undef AUTOEVAC_STATUS_TIMER_STARTED
+#undef AUTOEVAC_STATUS_NEED_EVAC
+#undef AUTOEVAC_STATUS_EVAC_CALLED

--- a/config/config.txt
+++ b/config/config.txt
@@ -204,7 +204,7 @@ VOTE_DELAY 6000
 VOTE_PERIOD 600
 
 ## prevents dead players from voting or starting votes
-NO_DEAD_VOTE
+#NO_DEAD_VOTE
 
 ## players' votes default to "No vote" (otherwise,  default to "No change")
 DEFAULT_NO_VOTE

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -615,7 +615,7 @@ ARRIVALS_SHUTTLE_DOCK_WINDOW 55
 MICE_ROUNDSTART 10
 
 ## If the percentage of players alive (doesn't count conversions) drops below this threshold the emergency shuttle will be forcefully called (provided it can be)
-EMERGENCY_SHUTTLE_AUTOCALL_THRESHOLD 0.2
+EMERGENCY_SHUTTLE_AUTOCALL_THRESHOLD 0
 
 ## Determines if players are allowed to print integrated circuits, uncomment to allow.
 #IC_PRINTING #ZHIS DOES NOTHING


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Before this would only call the shuttle if the shuttle was already in transit with a large amount of remaining time, because the default callTime is not very long.
Now the shuttle will actually get called if the crew is very dead.

Also removed it from default repo options so that testers aren't interrupted when aghosting

## Why It's Good For The Game
If everyone is dead we should start over

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: Made the "catastrophic casualties" check actually call the emergency shuttle
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
