### PR TITLE
Fixes the problem where engineering areas weren't protected from the Grid Check Event

### DIFF
--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -1,9 +1,12 @@
 #define BP_MAX_ROOM_SIZE 300
 
-GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(/area/engine/engineering, \
-															    /area/engine/supermatter, \
-															    /area/engine/atmospherics_engine, \
-															    /area/ai_monitored/turret_protected/ai))
+GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(list(
+																/area/engine/engineering,
+															    /area/engine/supermatter,
+															    /area/engine/stormdrive,
+															    /area/engine/atmospherics_engine,
+															    /area/ai_monitored/turret_protected/ai,
+															    /area/nsv/engine/engine_room/core))) //NSV13 - Fixes this thing so now engine rooms are safe from power failures
 
 // Gets an atmos isolated contained space
 // Returns an associative list of turf|dirs pairs

--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -6,7 +6,7 @@ GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(list(
 															    /area/engine/stormdrive,
 															    /area/engine/atmospherics_engine,
 															    /area/ai_monitored/turret_protected/ai,
-															    /area/nsv/engine/engine_room/core))) //NSV13 - Fixes this thing so now engine rooms are safe from power failures
+															    /area/nsv/engine/engine_room/core))) //NSV13 - Fixes this thing so now engine rooms are safe from power failures, also added /area/engine/stormdrive and /area/nsv/engine/engine_room/core to the list
 
 // Gets an atmos isolated contained space
 // Returns an associative list of turf|dirs pairs

--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -1,12 +1,9 @@
 #define BP_MAX_ROOM_SIZE 300
 
-GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(list(
-																/area/engine/engineering,
-															    /area/engine/supermatter,
-															    /area/engine/stormdrive,
-															    /area/engine/atmospherics_engine,
-															    /area/ai_monitored/turret_protected/ai,
-															    /area/nsv/engine/engine_room/core))) //NSV13 - Fixes this thing so now engine rooms are safe from power failures
+GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(/area/engine/engineering, \
+															    /area/engine/supermatter, \
+															    /area/engine/atmospherics_engine, \
+															    /area/ai_monitored/turret_protected/ai))
 
 // Gets an atmos isolated contained space
 // Returns an associative list of turf|dirs pairs


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fixes #2106

Also makes it so that protected areas are actually protected from the grid check failure.

Don't know if Atmospherics is supposed to be protected or not so I'm just leaving it out of the list currently until someone tells me otherwise.

Ignore the confusing commits logs, I stupidly uploaded the changes to my master branch before making this branch of the master branch.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
~~Always use protection when dealing with Grid Checks~~
Protected areas are very good!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://user-images.githubusercontent.com/59128051/223128780-81ddb957-3735-450e-b4e5-f4eb0e7a6ef2.mp4

</details>

## Changelog
:cl:
fix: Engine room areas are now protected against power grid checks, don't know about atmos though! :)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
