### PR TITLE
Implements KNPC Patrol nodes on the Hammerhead and the Snake, also fixes another issue.

### DIFF
--- a/_maps/map_files/Hammerhead/Hammerhead.dmm
+++ b/_maps/map_files/Hammerhead/Hammerhead.dmm
@@ -466,6 +466,11 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/effect/landmark/patrol_node{
+	next_id = list("science","arrivals","atmos");
+	name = "Engineering patrol node";
+	id = "engineering"
+	},
 /turf/open/floor/durasteel,
 /area/hallway/primary/aft)
 "abz" = (
@@ -3055,6 +3060,11 @@
 	codes_txt = "patrol;next_patrol=Arrivals-B-0";
 	location = "MaintDetour-3"
 	},
+/obj/effect/landmark/patrol_node{
+	next_id = list("dress_room","arrivals","science");
+	name = "Medbay patrol node";
+	id = "medbay"
+	},
 /turf/open/floor/durasteel,
 /area/hallway/primary/central)
 "aji" = (
@@ -3741,6 +3751,11 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 8
 	},
+/obj/effect/landmark/patrol_node{
+	next_id = list("hall_split");
+	name = "Hangar Bay patrol node";
+	id = "hangar_bay"
+	},
 /turf/open/floor/durasteel,
 /area/hallway/primary/fore)
 "alB" = (
@@ -3811,6 +3826,11 @@
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=HOP";
 	location = "Bridge-Ext"
+	},
+/obj/effect/landmark/patrol_node{
+	next_id = list("library_split","security");
+	name = "Bridge patrol node";
+	id = "bridge"
 	},
 /turf/open/floor/durasteel,
 /area/hallway/primary/fore)
@@ -10955,6 +10975,11 @@
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=MaintDetour-2";
 	location = "MaintDetour-1"
+	},
+/obj/effect/landmark/patrol_node{
+	next_id = list("escape","hangar_bay","dress_room");
+	name = "Hallway Split patrol node";
+	id = "hall_split"
 	},
 /turf/open/floor/durasteel,
 /area/hallway/primary/fore)
@@ -24936,6 +24961,14 @@
 /obj/effect/landmark/start/pilot,
 /turf/open/floor/durasteel,
 /area/nsv/hanger)
+"esM" = (
+/obj/effect/landmark/patrol_node{
+	next_id = list("library_split","cargo");
+	name = "Botany Hall patrol node";
+	id = "botany_hall"
+	},
+/turf/open/floor/durasteel,
+/area/hallway/primary/port)
 "etn" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/structure/extinguisher_cabinet/east,
@@ -27715,6 +27748,11 @@
 	codes_txt = "patrol;next_patrol=CentHallCurv-1";
 	location = "CentHallCurv-0.5"
 	},
+/obj/effect/landmark/patrol_node{
+	next_id = list("hall_split","medbay");
+	name = "Dress Room patrol node";
+	id = "dress_room"
+	},
 /turf/open/floor/durasteel,
 /area/hallway/primary/central)
 "glW" = (
@@ -27915,6 +27953,11 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/landmark/patrol_node{
+	next_id = list("arrivals","engineering");
+	name = "Science patrol node";
+	id = "science"
 	},
 /turf/open/floor/durasteel,
 /area/hallway/primary/aft)
@@ -28266,6 +28309,11 @@
 	location = "Brig-0"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/patrol_node{
+	next_id = list("bridge","library_split");
+	name = "List patrol node";
+	id = "security"
+	},
 /turf/open/floor/durasteel,
 /area/hallway/primary/fore)
 "gHQ" = (
@@ -33948,6 +33996,11 @@
 	codes_txt = "patrol;next_patrol=MaintDetour-0.5";
 	location = "MaintDetour-0"
 	},
+/obj/effect/landmark/patrol_node{
+	next_id = list("botany_hall","bridge","hangar");
+	name = "Split Library patrol node";
+	id = "library_split"
+	},
 /turf/open/floor/durasteel,
 /area/hallway/primary/fore)
 "krx" = (
@@ -35196,6 +35249,14 @@
 /obj/machinery/atmospherics/pipe/simple/brown/visible,
 /turf/open/floor/plasteel/techmaint,
 /area/engine/atmos)
+"lgR" = (
+/obj/effect/landmark/patrol_node{
+	next_id = list("botany_hall");
+	name = "Cargo patrol node";
+	id = "cargo"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "lgY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -39703,6 +39764,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
+/obj/effect/landmark/patrol_node{
+	next_id = list("service","hall_split","library_split");
+	name = "Hangar patrol node";
+	id = "hangar"
+	},
 /turf/open/floor/durasteel,
 /area/hallway/primary/fore)
 "nQJ" = (
@@ -42239,6 +42305,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"pyV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/effect/landmark/patrol_node{
+	next_id = list("hangar");
+	name = "Service patrol node";
+	id = "service"
+	},
+/turf/open/floor/durasteel,
+/area/crew_quarters/theatre)
 "pzb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -42547,6 +42629,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
+"pGF" = (
+/obj/effect/landmark/patrol_node{
+	next_id = list("medbay","science");
+	name = "Arrivals patrol node";
+	id = "arrivals"
+	},
+/turf/open/floor/durasteel/eris_techfloor_alt,
+/area/hallway/secondary/entry)
 "pHJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -46922,6 +47012,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"svO" = (
+/obj/effect/landmark/patrol_node{
+	next_id = list("hall_split");
+	name = "Escape patrol node";
+	id = "escape"
+	},
+/turf/open/floor/durasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "svR" = (
 /obj/machinery/door/airlock/highsecurity/ship{
 	name = "Secure Tech Storage";
@@ -51632,6 +51730,20 @@
 	},
 /turf/open/floor/durasteel/eris_techfloor_alt,
 /area/hallway/primary/fore)
+"voQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/landmark/patrol_node{
+	next_id = list("engineering","science","arrivals");
+	name = "Atmos patrol node";
+	id = "atmos"
+	},
+/turf/open/floor/durasteel,
+/area/hallway/primary/aft)
 "vpi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -66461,7 +66573,7 @@ mkc
 pqS
 aYp
 aYp
-aYp
+voQ
 aYp
 aYp
 aYp
@@ -79329,7 +79441,7 @@ sWG
 uyM
 biN
 duW
-aaj
+pGF
 biC
 aHQ
 aaf
@@ -97021,7 +97133,7 @@ bGE
 mJn
 bGE
 tsA
-xnI
+svO
 ary
 aGW
 vRm
@@ -100127,7 +100239,7 @@ uTA
 tgx
 cyK
 xSA
-oaQ
+pyV
 kVF
 cwP
 xSA
@@ -109376,7 +109488,7 @@ afl
 afl
 afl
 afl
-afl
+esM
 dUp
 aUp
 afl
@@ -115273,7 +115385,7 @@ aAJ
 ljz
 ahn
 aaI
-ahn
+lgR
 eXL
 apa
 jzA

--- a/_maps/map_files/Snake/snake_lower.dmm
+++ b/_maps/map_files/Snake/snake_lower.dmm
@@ -2434,6 +2434,10 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/engine,
 /area/nsv/weapons/fore)
+"iJ" = (
+/obj/effect/landmark/carpspawn,
+/turf/open/space/basic,
+/area/space)
 "iK" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -4465,6 +4469,11 @@
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/junction{
 	dir = 8
+	},
+/obj/effect/landmark/patrol_node{
+	next_id = list("bar","chapel","bridge");
+	name = "Munitions patrol node";
+	id = "munitions"
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
@@ -7531,6 +7540,11 @@
 	dir = 4
 	},
 /obj/machinery/light_switch/north,
+/obj/effect/landmark/patrol_node{
+	next_id = "cargo";
+	name = "Bridge patrol node";
+	id = "bridge"
+	},
 /turf/open/floor/plasteel/dark/side,
 /area/hallway/primary/fore)
 "Bq" = (
@@ -13673,6 +13687,26 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/engine,
 /area/nsv/weapons/fore)
+"VC" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/landmark/patrol_node{
+	next_id = list("chapel","bridge","munitions");
+	id = "bar";
+	name = "Bar patrol node"
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/central)
 "VD" = (
 /obj/machinery/telecomms/server/presets/service,
 /turf/open/floor/circuit/green,
@@ -14025,6 +14059,11 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 4
+	},
+/obj/effect/landmark/patrol_node{
+	next_id = list("bar","bridge","munitions");
+	id = "chapel";
+	name = "Chapel patrol node"
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
@@ -28636,7 +28675,7 @@ aJ
 aJ
 aJ
 aJ
-aJ
+iJ
 aJ
 aJ
 aJ
@@ -29900,7 +29939,7 @@ aJ
 aJ
 aJ
 aJ
-aJ
+iJ
 aJ
 aJ
 aJ
@@ -36834,7 +36873,7 @@ aJ
 aJ
 aJ
 aJ
-aJ
+iJ
 aJ
 aJ
 aJ
@@ -36879,7 +36918,7 @@ aJ
 aJ
 aJ
 aJ
-aJ
+iJ
 aJ
 aJ
 aJ
@@ -46598,7 +46637,7 @@ aJ
 aJ
 aJ
 aJ
-aJ
+iJ
 aJ
 aJ
 aJ
@@ -47672,7 +47711,7 @@ aJ
 aJ
 aJ
 aJ
-aJ
+iJ
 aJ
 aJ
 aJ
@@ -50472,7 +50511,7 @@ qn
 XS
 tP
 OY
-RB
+VC
 yk
 fG
 fG
@@ -52253,7 +52292,7 @@ aJ
 aJ
 aJ
 aJ
-aJ
+iJ
 aJ
 aJ
 aJ
@@ -59191,7 +59230,7 @@ aJ
 aJ
 aJ
 aJ
-aJ
+iJ
 aJ
 aJ
 aJ
@@ -60264,7 +60303,7 @@ aJ
 aJ
 aJ
 aJ
-aJ
+iJ
 aJ
 aJ
 aJ
@@ -64847,7 +64886,7 @@ aJ
 aJ
 aJ
 aJ
-aJ
+iJ
 aJ
 aJ
 aJ
@@ -66681,7 +66720,7 @@ aJ
 aJ
 aJ
 aJ
-aJ
+iJ
 aJ
 aJ
 aJ
@@ -70005,7 +70044,7 @@ aJ
 aJ
 aJ
 aJ
-aJ
+iJ
 aJ
 aJ
 aJ

--- a/_maps/map_files/Snake/snake_lower.dmm
+++ b/_maps/map_files/Snake/snake_lower.dmm
@@ -7541,7 +7541,7 @@
 	},
 /obj/machinery/light_switch/north,
 /obj/effect/landmark/patrol_node{
-	next_id = "cargo";
+	next_id = list("cargo","bar","munitions","chapel");
 	name = "Bridge patrol node";
 	id = "bridge"
 	},

--- a/_maps/map_files/Snake/snake_upper.dmm
+++ b/_maps/map_files/Snake/snake_upper.dmm
@@ -972,6 +972,10 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating,
 /area/nsv/crew_quarters/heads/maa)
+"fL" = (
+/obj/effect/landmark/carpspawn,
+/turf/open/space/basic,
+/area/space)
 "fP" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	name = "Mining Airlock";
@@ -6814,6 +6818,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/patrol_node{
+	next_id = "hangar";
+	name = "Cargo patrol node";
+	id = "cargo"
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/fore)
 "NG" = (
@@ -8023,6 +8032,11 @@
 /obj/machinery/camera/autoname,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/landmark/patrol_node{
+	next_id = list("cargo","bar");
+	name = "Hangar patrol node";
+	id = "hangar"
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/central)
@@ -23098,7 +23112,7 @@ zQ
 zQ
 zQ
 zQ
-zQ
+fL
 zQ
 mv
 zQ
@@ -26169,7 +26183,7 @@ zQ
 zQ
 zQ
 zQ
-zQ
+fL
 zQ
 zQ
 zQ
@@ -29282,7 +29296,7 @@ zQ
 zQ
 zQ
 zQ
-zQ
+fL
 zQ
 zQ
 zQ
@@ -30268,7 +30282,7 @@ zQ
 zQ
 zQ
 zQ
-zQ
+fL
 zQ
 zQ
 zQ
@@ -35965,7 +35979,7 @@ zQ
 zQ
 zQ
 zQ
-zQ
+fL
 zQ
 zQ
 zQ
@@ -37720,7 +37734,7 @@ zQ
 zQ
 zQ
 zQ
-zQ
+fL
 zQ
 zQ
 zQ
@@ -42863,7 +42877,7 @@ zQ
 zQ
 zQ
 zQ
-zQ
+fL
 zQ
 zQ
 zQ
@@ -42906,7 +42920,7 @@ zQ
 zQ
 zQ
 zQ
-zQ
+fL
 zQ
 zQ
 zQ
@@ -49841,7 +49855,7 @@ zQ
 zQ
 zQ
 zQ
-zQ
+fL
 zQ
 zQ
 zQ
@@ -52116,7 +52130,7 @@ zQ
 zQ
 zQ
 zQ
-zQ
+fL
 zQ
 zQ
 zQ
@@ -55495,7 +55509,7 @@ zQ
 zQ
 zQ
 zQ
-zQ
+fL
 zQ
 zQ
 zQ
@@ -63175,7 +63189,7 @@ zQ
 zQ
 zQ
 zQ
-zQ
+fL
 zQ
 zQ
 zQ

--- a/_maps/map_files/Snake/snake_upper.dmm
+++ b/_maps/map_files/Snake/snake_upper.dmm
@@ -6819,7 +6819,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/patrol_node{
-	next_id = "hangar";
+	next_id = list("hangar","munitions","bar");
 	name = "Cargo patrol node";
 	id = "cargo"
 	},
@@ -8034,7 +8034,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/patrol_node{
-	next_id = list("cargo","bar");
+	next_id = list("cargo","bar","bridge");
 	name = "Hangar patrol node";
 	id = "hangar"
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fixes #1964
fixes #2207
fixes #2208

This PR adds carpspawn landmarks to the snake, which is apparently the one utilized when spawning lone ops, so you might get a Nukie running for the disk or a gigantic swarm of carps. 

This PR also implements a patrol network for the KNPCs on both the Snake and the Hammerhead
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Functioning KNPCs are Fun, so is having Lone Ops.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: KNPCs have now taken a class in navigating old spaceships and can now patrol the Hammerhead
fix: KNPCs have overcome their fear of tight spaces, so now they can navigate the Snake
fix: The Syndicate Daredevil Lone Troopers have overcome their fear regarding the possibility that the Snake contains a bunch of snakes, and now they can come along to have some fun as well~
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
