### PR TITLE
Hammer the Hammerhead Hangar

### DIFF
--- a/_maps/map_files/Hammerhead/Hammerhead.dmm
+++ b/_maps/map_files/Hammerhead/Hammerhead.dmm
@@ -268,7 +268,6 @@
 	name = "Launch tubes 1 and 2"
 	})
 "aaY" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2/starboard{
 	name = "Launch tubes 1 and 2"
@@ -287,6 +286,12 @@
 	dir = 4
 	},
 /obj/machinery/light/runway/delay4,
+/obj/machinery/button/door{
+	id = "launchbay_tube2";
+	name = "Tube 2 Interior Doors";
+	pixel_x = 26;
+	req_one_access_txt = "69"
+	},
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2/starboard{
 	name = "Launch tubes 1 and 2"
@@ -322,9 +327,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2/starboard{
 	name = "Launch tubes 1 and 2"
@@ -344,9 +346,6 @@
 "abj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
 	},
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2/starboard{
@@ -394,8 +393,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
-	dir = 4
+/obj/machinery/button/door{
+	id = "launch3";
+	name = "Tube 3 exterior doors";
+	req_one_access_txt = "69";
+	pixel_x = -26
 	},
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2/port{
@@ -540,16 +542,12 @@
 	dir = 8
 	},
 /obj/structure/fighter_launcher,
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2/starboard{
 	name = "Launch tubes 1 and 2"
 	})
 "abT" = (
 /obj/effect/turf_decal/arrows,
-/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2/starboard{
 	name = "Launch tubes 1 and 2"
@@ -629,9 +627,6 @@
 	},
 /obj/machinery/light{
 	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
 	},
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2/starboard{
@@ -722,8 +717,11 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+/obj/machinery/button/door{
+	id = "launch2";
+	name = "Tube 2 exterior doors";
+	req_one_access_txt = "69";
+	pixel_x = -26
 	},
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2/starboard{
@@ -984,17 +982,6 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
-"adm" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12;69"
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "adn" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
@@ -1078,12 +1065,6 @@
 	},
 /turf/open/floor/durasteel/eris_techfloor_alt,
 /area/security/main)
-"adC" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/turf/open/floor/plating,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
 "adD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -1092,6 +1073,12 @@
 	dir = 4
 	},
 /obj/machinery/light/runway/delay4,
+/obj/machinery/button/door{
+	id = "launchbay_tube3";
+	name = "Tube 3 Interior Doors";
+	pixel_x = 26;
+	req_one_access_txt = "69"
+	},
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2/port{
 	name = "Launch tubes 3 and 4"
@@ -1148,17 +1135,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
-"adL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
 "adO" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -1173,9 +1149,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2/port{
 	name = "Launch tubes 3 and 4"
@@ -1185,9 +1158,6 @@
 	dir = 8
 	},
 /obj/structure/fighter_launcher,
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2/port{
 	name = "Launch tubes 3 and 4"
@@ -1198,7 +1168,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "adS" = (
 /obj/effect/turf_decal/arrows,
-/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2/port{
 	name = "Launch tubes 3 and 4"
@@ -1251,9 +1220,6 @@
 	dir = 8
 	},
 /obj/machinery/light/runway,
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2/starboard{
 	name = "Launch tubes 1 and 2"
@@ -1284,9 +1250,6 @@
 	dir = 4
 	},
 /obj/machinery/light/runway,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2/starboard{
 	name = "Launch tubes 1 and 2"
@@ -1317,9 +1280,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2/port{
 	name = "Launch tubes 3 and 4"
@@ -1349,8 +1309,11 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+/obj/machinery/button/door{
+	id = "launch4";
+	name = "Tube 4 exterior doors";
+	req_one_access_txt = "69";
+	pixel_x = -26
 	},
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2/port{
@@ -1652,11 +1615,11 @@
 /turf/open/floor/durasteel/eris_techfloor_alt,
 /area/hallway/primary/fore)
 "afa" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
 	},
 /turf/open/floor/plating,
 /area/nsv/hanger)
@@ -1761,6 +1724,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/nsv/hanger)
 "afu" = (
@@ -1772,11 +1738,18 @@
 /area/nsv/hanger)
 "afv" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 10
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/binary/valve/layer2,
+/obj/machinery/button/door{
+	id = "launch1";
+	name = "Tube 1 exterior doors";
+	req_one_access_txt = "69";
+	pixel_x = -26
+	},
 /turf/open/floor/plating,
-/area/nsv/hanger)
+/area/nsv/hanger/deck2/starboard{
+	name = "Launch tubes 1 and 2"
+	})
 "afw" = (
 /turf/open/floor/durasteel/eris_techfloor_alt,
 /area/nsv/weapons/fore)
@@ -1795,20 +1768,19 @@
 /turf/open/floor/plating,
 /area/nsv/hanger)
 "afz" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/nsv/hanger)
 "afA" = (
 /obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2/starboard{
 	name = "Launch tubes 1 and 2"
@@ -1839,12 +1811,11 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "afF" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/binary/valve/layer4,
 /turf/open/floor/plating,
-/area/nsv/hanger)
+/area/maintenance/department/chapel)
 "afG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 9
@@ -2193,17 +2164,9 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"agy" = (
-/obj/effect/turf_decal/stripes/full,
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 1
-	},
-/turf/open/floor/durasteel/riveted,
-/area/maintenance/starboard/central)
 "agz" = (
 /obj/effect/turf_decal/stripes/full,
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/turf/open/floor/durasteel/riveted,
+/turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "agA" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -2454,9 +2417,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "ahm" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 8
 	},
@@ -2465,6 +2425,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/nsv/hanger)
@@ -2531,9 +2494,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "ahF" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -2543,6 +2503,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/nsv/hanger)
 "ahG" = (
@@ -2550,7 +2516,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/binary/valve/layer2,
 /turf/open/floor/plating,
 /area/nsv/hanger)
 "ahH" = (
@@ -2558,7 +2523,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/valve/layer4,
 /turf/open/floor/plating,
 /area/nsv/hanger)
 "ahJ" = (
@@ -2571,16 +2535,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "ahK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/button/door{
+	id = "launch3";
+	name = "Tube 3 exterior doors";
+	req_one_access_txt = "69"
 	},
-/obj/machinery/light/runway,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
+/turf/closed/wall/r_wall/ship,
+/area/nsv/hanger/deck2/port{
+	name = "Launch tubes 3 and 4"
 	})
 "ahL" = (
 /obj/effect/turf_decal/stripes/line{
@@ -2590,9 +2552,6 @@
 	dir = 4
 	},
 /obj/machinery/light/runway,
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
-	dir = 8
-	},
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2/starboard{
 	name = "Launch tubes 1 and 2"
@@ -2628,9 +2587,6 @@
 	dir = 8
 	},
 /obj/machinery/light/runway,
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2/port{
 	name = "Launch tubes 3 and 4"
@@ -2640,9 +2596,6 @@
 	dir = 4
 	},
 /obj/machinery/light/runway,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2/port{
 	name = "Launch tubes 3 and 4"
@@ -2652,9 +2605,6 @@
 	dir = 8
 	},
 /obj/machinery/light/runway,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2/port{
 	name = "Launch tubes 3 and 4"
@@ -3524,7 +3474,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/binary/valve/layer2,
 /turf/open/floor/plating,
 /area/nsv/hanger)
 "akz" = (
@@ -4203,7 +4152,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/binary/valve/layer4,
 /turf/open/floor/plating,
 /area/nsv/hanger)
 "amQ" = (
@@ -5389,6 +5337,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/durasteel/eris_techfloor_alt,
 /area/nsv/hanger)
 "aqC" = (
@@ -5410,6 +5361,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/durasteel/eris_techfloor_alt,
 /area/nsv/hanger)
@@ -5853,14 +5807,15 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "asd" = (
-/obj/machinery/button/door{
-	id = "launchbay_access";
-	name = "Launch bay doors";
-	pixel_y = -26;
-	req_one_access_txt = "69"
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
+	},
+/obj/machinery/button/door{
+	id = "launchbay_tube1";
+	name = "Tube 1 Interior Doors";
+	pixel_x = 8;
+	req_one_access_txt = "69";
+	pixel_y = -26
 	},
 /turf/open/floor/durasteel/eris_techfloor_alt,
 /area/nsv/hanger)
@@ -6935,6 +6890,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/durasteel/eris_techfloor_alt,
 /area/nsv/hanger)
 "avL" = (
@@ -7063,6 +7021,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/durasteel/eris_techfloor_alt,
 /area/nsv/hanger)
@@ -7220,13 +7181,14 @@
 /turf/open/floor/durasteel/eris_techfloor_alt,
 /area/hallway/primary/port)
 "awK" = (
-/obj/machinery/button/door{
-	id = "launchbay_access";
-	name = "Launch bay doors";
-	pixel_y = -26;
-	req_one_access_txt = "69"
-	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/button/door{
+	id = "launchbay_tube2";
+	name = "Tube 2 Interior Doors";
+	pixel_x = 8;
+	req_one_access_txt = "69";
+	pixel_y = -26
+	},
 /turf/open/floor/durasteel/eris_techfloor_alt,
 /area/nsv/hanger)
 "awL" = (
@@ -7287,7 +7249,6 @@
 /area/medical/chemistry)
 "awR" = (
 /obj/effect/turf_decal/arrows/white,
-/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2/starboard{
 	name = "Launch tubes 1 and 2"
@@ -7298,7 +7259,6 @@
 /area/science/robotics/lab)
 "awT" = (
 /obj/effect/turf_decal/arrows/white,
-/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2/port{
 	name = "Launch tubes 3 and 4"
@@ -7453,14 +7413,15 @@
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/security/prison)
 "axu" = (
-/obj/machinery/button/door{
-	id = "launchbay_access";
-	name = "Launch bay doors";
-	pixel_y = -26;
-	req_one_access_txt = "69"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/machinery/button/door{
+	id = "launchbay_tube3";
+	name = "Tube 3 Interior Doors";
+	pixel_x = 8;
+	req_one_access_txt = "69";
+	pixel_y = -26
 	},
 /turf/open/floor/durasteel/eris_techfloor_alt,
 /area/nsv/hanger)
@@ -7676,8 +7637,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
 	},
 /turf/open/floor/plating,
 /area/nsv/hanger)
@@ -7881,10 +7842,23 @@
 /turf/open/floor/carpet/ship,
 /area/bridge/meeting_room)
 "ayw" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/binary/valve/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/light/runway/delay4,
+/obj/machinery/button/door{
+	id = "launchbay_tube1";
+	name = "Tube 1 Interior Doors";
+	pixel_x = 26;
+	req_one_access_txt = "69"
+	},
 /turf/open/floor/plating,
-/area/nsv/hanger)
+/area/nsv/hanger/deck2/starboard{
+	name = "Launch tubes 1 and 2"
+	})
 "ayx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -8044,11 +8018,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
-"ayQ" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/binary/valve/layer2,
-/turf/open/floor/plating,
-/area/nsv/hanger)
 "ayR" = (
 /obj/machinery/camera/autoname,
 /obj/machinery/computer/ship/viewscreen,
@@ -8515,14 +8484,15 @@
 /turf/open/floor/durasteel/eris_techfloor_alt,
 /area/nsv/hanger)
 "aAe" = (
-/obj/machinery/button/door{
-	id = "launchbay_access";
-	name = "Launch bay doors";
-	pixel_y = -26;
-	req_one_access_txt = "69"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "launchbay_tube4";
+	name = "Tube 4 Interior Doors";
+	pixel_x = 8;
+	req_one_access_txt = "69";
+	pixel_y = -26
 	},
 /turf/open/floor/durasteel/eris_techfloor_alt,
 /area/nsv/hanger)
@@ -9662,7 +9632,6 @@
 /area/chapel/office)
 "aDX" = (
 /obj/effect/turf_decal/delivery/white,
-/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2/port{
 	name = "Launch tubes 3 and 4"
@@ -9891,7 +9860,6 @@
 /area/chapel/office)
 "aEK" = (
 /obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2/port{
 	name = "Launch tubes 3 and 4"
@@ -18619,20 +18587,27 @@
 /area/space/nearstation)
 "bgs" = (
 /obj/effect/turf_decal/delivery/white,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/reagent_dispensers/foamtank,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
 	},
 /turf/open/floor/durasteel,
 /area/nsv/hanger)
 "bgt" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/durasteel/eris_techfloor_alt,
 /area/nsv/hanger)
 "bgv" = (
@@ -18645,74 +18620,39 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/durasteel/riveted,
-/area/maintenance/starboard/central)
-"bgw" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
+	dir = 10
 	},
 /turf/open/floor/durasteel/riveted,
 /area/maintenance/starboard/central)
 "bgy" = (
 /obj/effect/turf_decal/stripes/full,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/durasteel/riveted,
 /area/maintenance/starboard/central)
 "bgz" = (
-/obj/effect/turf_decal/stripes/full,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 1
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/light/runway/delay4,
+/obj/machinery/button/door{
+	id = "launchbay_tube4";
+	name = "Tube 4 Interior Doors";
+	pixel_x = 26;
+	req_one_access_txt = "69"
 	},
-/turf/open/floor/durasteel/riveted,
-/area/maintenance/starboard/central)
-"bgA" = (
-/obj/effect/turf_decal/stripes/full,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/durasteel/riveted,
-/area/maintenance/starboard/central)
+/turf/open/floor/plating,
+/area/nsv/hanger/deck2/port{
+	name = "Launch tubes 3 and 4"
+	})
 "bgC" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "bgD" = (
@@ -21596,20 +21536,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
-"ckt" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12;69"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "ckw" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 4
@@ -21644,23 +21570,14 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar/atrium)
 "clE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/item/radio/intercom{
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/turf/open/floor/durasteel/riveted,
-/area/maintenance/starboard/central)
+/turf/open/floor/durasteel/eris_techfloor_alt,
+/area/hallway/primary/fore)
 "clF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable{
@@ -21724,11 +21641,15 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/service)
 "cpb" = (
-/obj/machinery/atmospherics/components/unary/tank{
-	dir = 1
+/obj/machinery/button/door{
+	id = "launch1";
+	name = "Tube 1 exterior doors";
+	req_one_access_txt = "69"
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/chapel)
+/turf/closed/wall/r_wall/ship,
+/area/nsv/hanger/deck2/starboard{
+	name = "Launch tubes 1 and 2"
+	})
 "cpf" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -22366,12 +22287,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"cIF" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 8
-	},
-/turf/open/floor/durasteel/riveted,
-/area/maintenance/starboard/central)
 "cIN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -22908,9 +22823,6 @@
 	dir = 8
 	},
 /obj/structure/fighter_launcher,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
@@ -23747,9 +23659,6 @@
 	dir = 8
 	},
 /obj/structure/fighter_launcher,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
@@ -24430,12 +24339,15 @@
 /turf/open/floor/plasteel,
 /area/construction)
 "ebZ" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 1
+/obj/machinery/button/door{
+	id = "launch4";
+	name = "Tube 4 exterior doors";
+	req_one_access_txt = "69"
 	},
-/turf/open/floor/durasteel/riveted,
-/area/maintenance/starboard/central)
+/turf/closed/wall/r_wall/ship,
+/area/nsv/hanger/deck2/port{
+	name = "Launch tubes 3 and 4"
+	})
 "eci" = (
 /obj/effect/turf_decal/tile/orange{
 	dir = 4
@@ -24968,9 +24880,6 @@
 /turf/open/floor/durasteel/eris_techfloor_alt,
 /area/security/main)
 "euv" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -24982,6 +24891,12 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/nsv/hanger)
@@ -25017,6 +24932,9 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/nsv/hanger)
 "ewW" = (
@@ -25334,9 +25252,6 @@
 "eIP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
-	dir = 8
 	},
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2/port{
@@ -26316,8 +26231,8 @@
 /area/tcommsat/computer)
 "fpq" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/turf/open/floor/durasteel/riveted,
+/obj/effect/turf_decal/stripes/full,
+/turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "fpD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -26360,18 +26275,6 @@
 	},
 /turf/open/floor/durasteel,
 /area/security/main)
-"fqG" = (
-/obj/machinery/door/poddoor/ship{
-	id = "launchbay_tube2";
-	name = "Launch tube 2 access"
-	},
-/obj/effect/turf_decal/stripes/full,
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plating,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
 "fqL" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -26946,16 +26849,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/toilet/restrooms)
-"fJM" = (
-/obj/machinery/door/poddoor/ship{
-	id = "launchbay_tube4";
-	name = "Launch tube 4 access"
-	},
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plating,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
 "fKx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 8
@@ -30388,13 +30281,6 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "hYn" = (
-/obj/machinery/button/door{
-	dir = 8;
-	id = "launchbay_access2";
-	name = "Launch bay doors";
-	pixel_x = 22;
-	req_one_access_txt = "69"
-	},
 /obj/structure/table/reinforced,
 /obj/item/clothing/ears/earmuffs,
 /obj/machinery/light{
@@ -30439,15 +30325,6 @@
 	},
 /turf/open/floor/durasteel/eris_techfloor_alt,
 /area/hallway/primary/central)
-"hZk" = (
-/obj/machinery/door/poddoor/ship{
-	id = "launchbay_access";
-	name = "Launch tube access"
-	},
-/obj/effect/turf_decal/stripes/full,
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/durasteel/eris_techfloor_alt,
-/area/nsv/hanger)
 "hZw" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -31545,14 +31422,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "iKg" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10
-	},
+/obj/effect/turf_decal/delivery/white,
 /turf/open/floor/plating,
-/area/maintenance/department/chapel)
+/area/nsv/hanger/deck2/starboard{
+	name = "Launch tubes 1 and 2"
+	})
 "iKp" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/layer_manifold/visible{
@@ -31601,6 +31475,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/firedoor/border_only/directional/north,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "iMz" = (
@@ -31616,7 +31495,6 @@
 	name = "Launch tube 1 access"
 	},
 /obj/effect/turf_decal/stripes/full,
-/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2/starboard{
 	name = "Launch tubes 1 and 2"
@@ -32500,13 +32378,23 @@
 /turf/open/floor/durasteel,
 /area/security/prison)
 "jsv" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12;69"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/central)
+/area/nsv/hanger)
 "jsQ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -32985,12 +32873,22 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "jIZ" = (
-/obj/machinery/door/poddoor/ship{
-	id = "launchbay_access";
-	name = "Launch tube access"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
 	},
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/durasteel/eris_techfloor_alt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/nsv/hanger)
 "jJO" = (
 /obj/machinery/computer/teleporter,
@@ -33153,9 +33051,6 @@
 "jNg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
 	},
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -33336,14 +33231,6 @@
 	},
 /turf/open/floor/durasteel/eris_techfloor_alt,
 /area/hallway/primary/central)
-"jTY" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/turf/open/floor/durasteel/riveted,
-/area/maintenance/starboard/central)
 "jUf" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -33400,25 +33287,6 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/plasteel,
 /area/storage/eva)
-"jVf" = (
-/obj/machinery/door/poddoor/ship{
-	id = "launchbay_access";
-	name = "Launch tube access"
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/durasteel/eris_techfloor_alt,
-/area/nsv/hanger)
-"jVG" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 1
-	},
-/turf/open/floor/durasteel/riveted,
-/area/maintenance/starboard/central)
 "jWq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 8
@@ -34194,11 +34062,21 @@
 /turf/open/floor/plasteel/techmaint,
 /area/engine/atmos)
 "kxL" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery/white,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/central)
+/area/nsv/hanger)
 "kxN" = (
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/tile/green{
@@ -34285,13 +34163,7 @@
 /turf/open/floor/durasteel,
 /area/quartermaster/storage)
 "kzC" = (
-/obj/machinery/door/poddoor/ship{
-	id = "launchbay_access";
-	name = "Launch tube access"
-	},
 /obj/effect/turf_decal/stripes/full,
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/durasteel/eris_techfloor_alt,
 /area/nsv/hanger)
 "kzU" = (
@@ -34588,11 +34460,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/durasteel/eris_techfloor_alt,
 /area/security/prison)
-"kJP" = (
-/obj/effect/spawner/lootdrop/grille_or_trash,
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/turf/open/floor/plating,
-/area/maintenance/department/chapel)
 "kJU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -35983,7 +35850,6 @@
 /turf/open/floor/durasteel/eris_techfloor_alt,
 /area/hallway/primary/aft)
 "lCT" = (
-/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2/port{
 	name = "Launch tubes 3 and 4"
@@ -36402,9 +36268,6 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 8
-	},
 /turf/open/floor/durasteel/riveted,
 /area/maintenance/starboard/central)
 "lSH" = (
@@ -36818,6 +36681,9 @@
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Library";
 	location = "Bar-1"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/durasteel,
 /area/hallway/primary/fore)
@@ -37319,7 +37185,6 @@
 	},
 /obj/effect/turf_decal/stripes/full,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2/starboard{
 	name = "Launch tubes 1 and 2"
@@ -37673,12 +37538,6 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/durasteel,
 /area/crew_quarters/dorms)
-"mCt" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/turf/open/floor/plating,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
 "mCG" = (
 /obj/structure/table/glass,
 /obj/item/storage/firstaid/fire,
@@ -38904,6 +38763,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/durasteel,
 /area/nsv/hanger)
 "nrm" = (
@@ -39124,12 +38986,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 8
 	},
 /turf/open/floor/durasteel/riveted,
 /area/maintenance/starboard/central)
@@ -41963,8 +41819,6 @@
 	id = "launchbay_tube4";
 	name = "Launch tube 4 access"
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2/port{
 	name = "Launch tubes 3 and 4"
@@ -42526,9 +42380,6 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 8
-	},
 /turf/open/floor/durasteel/riveted,
 /area/maintenance/starboard/central)
 "pFO" = (
@@ -42547,20 +42398,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
-"pHJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
 "pHX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -42672,12 +42509,6 @@
 	},
 /turf/open/floor/durasteel/eris_techfloor_alt,
 /area/nsv/hanger)
-"pKD" = (
-/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
-/turf/open/floor/plating,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
 "pKI" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -43018,7 +42849,6 @@
 	name = "Launch tube 2 access"
 	},
 /obj/effect/turf_decal/stripes/full,
-/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2/starboard{
 	name = "Launch tubes 1 and 2"
@@ -43196,8 +43026,6 @@
 	id = "launchbay_tube3";
 	name = "Launch tube 3 access"
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2/port{
 	name = "Launch tubes 3 and 4"
@@ -44478,13 +44306,6 @@
 /obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"qVv" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
-/turf/open/floor/durasteel/riveted,
-/area/maintenance/starboard/central)
 "qVT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -44536,20 +44357,6 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/durasteel/eris_techfloor_alt,
 /area/security/main)
-"qYe" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	req_one_access_txt = "12;69"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "qYK" = (
 /obj/structure/girder/displaced,
 /turf/open/floor/plating,
@@ -45187,7 +44994,7 @@
 /area/maintenance/department/crew_quarters/dorms)
 "roi" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
@@ -46936,13 +46743,6 @@
 /turf/open/floor/durasteel/eris_techfloor_alt,
 /area/hallway/primary/central)
 "svV" = (
-/obj/machinery/button/door{
-	dir = 8;
-	id = "launchbay_access";
-	name = "Launch bay doors";
-	pixel_x = 22;
-	req_one_access_txt = "69"
-	},
 /obj/structure/table/reinforced,
 /obj/item/clothing/ears/earmuffs,
 /obj/machinery/light{
@@ -47655,20 +47455,11 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/durasteel,
 /area/nsv/hanger)
-"sSY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/durasteel/eris_techfloor_alt,
-/area/hallway/primary/fore)
 "sTo" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -48026,9 +47817,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
 /obj/machinery/camera/autoname{
 	dir = 8
 	},
@@ -48060,17 +47848,6 @@
 	},
 /turf/open/floor/durasteel,
 /area/ai_monitored/turret_protected/ai)
-"tfa" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
 "tfb" = (
 /obj/machinery/light{
 	dir = 1
@@ -48634,13 +48411,8 @@
 /obj/item/radio/intercom{
 	pixel_y = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 8
-	},
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/turf/open/floor/durasteel/riveted,
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "twi" = (
 /obj/machinery/armour_plating_nanorepair_well{
@@ -49814,16 +49586,6 @@
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"ufV" = (
-/obj/machinery/door/poddoor/ship{
-	id = "launchbay_tube3";
-	name = "Launch tube 3 access"
-	},
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plating,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
 "ugw" = (
 /obj/structure/grille,
 /obj/structure/cable{
@@ -50002,16 +49764,14 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "unu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/machinery/button/door{
+	id = "launch2";
+	name = "Tube 2 exterior doors";
+	req_one_access_txt = "69"
 	},
-/obj/machinery/light/runway,
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
+/turf/closed/wall/r_wall/ship,
+/area/nsv/hanger/deck2/starboard{
+	name = "Launch tubes 1 and 2"
 	})
 "unC" = (
 /obj/structure/table/reinforced,
@@ -50122,12 +49882,6 @@
 	},
 /turf/open/floor/durasteel,
 /area/ai_monitored/turret_protected/aisat/service/support_ship)
-"uqL" = (
-/obj/machinery/atmospherics/components/unary/tank{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "ura" = (
 /obj/structure/sign/poster/random{
 	pixel_y = 32
@@ -51102,6 +50856,9 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
 "uYp" = (
@@ -52156,12 +51913,6 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/carpet/ship,
 /area/chapel/office)
-"vKA" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/turf/open/floor/plating,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
 "vLb" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -53993,8 +53744,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
 	},
 /turf/open/floor/durasteel/eris_techfloor_alt,
 /area/hallway/primary/fore)
@@ -55446,17 +55197,6 @@
 /obj/machinery/microwave,
 /turf/open/floor/wood,
 /area/science/research)
-"xMK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
 "xMQ" = (
 /obj/structure/bodycontainer/morgue,
 /obj/machinery/light/small{
@@ -55820,12 +55560,6 @@
 /turf/open/floor/durasteel/padded,
 /area/crew_quarters/locker)
 "xXH" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 8
-	},
 /turf/open/floor/durasteel/riveted,
 /area/maintenance/starboard/central)
 "xYl" = (
@@ -98611,7 +98345,7 @@ dJO
 kah
 arZ
 arc
-sSY
+xgn
 aeR
 jdH
 iSh
@@ -98871,8 +98605,8 @@ pjX
 eva
 kah
 kah
-kxL
-uqL
+iSh
+iSh
 wnd
 fwh
 fwh
@@ -99128,7 +98862,7 @@ aly
 aqB
 arO
 kah
-adm
+suQ
 aaW
 aaW
 aaW
@@ -99382,7 +99116,7 @@ afs
 afs
 afs
 ahc
-ahm
+jIZ
 aky
 kzC
 agz
@@ -99393,7 +99127,7 @@ abh
 abh
 abh
 abS
-abh
+afv
 abh
 aea
 acL
@@ -99641,18 +99375,18 @@ aeO
 afq
 aft
 amC
-hZk
-agy
+kzC
+agz
 msf
 aaY
 abT
-pKD
+aaY
 afA
 afA
 afA
-pKD
+aaY
 abT
-mCt
+aaY
 acM
 yfL
 yfL
@@ -99901,7 +99635,7 @@ amP
 kzC
 agz
 iMC
-abb
+ayw
 abj
 abj
 abj
@@ -100156,7 +99890,7 @@ apS
 aqD
 asd
 kah
-cIF
+suQ
 aaW
 aaW
 ail
@@ -100167,7 +99901,7 @@ aaW
 aaW
 qNA
 qNA
-aaW
+cpb
 bfL
 bfK
 bfJ
@@ -100927,7 +100661,7 @@ hmw
 nqC
 brd
 cNT
-bgw
+xXH
 aaW
 abg
 abR
@@ -101184,7 +100918,7 @@ aud
 avK
 awK
 kah
-clE
+twc
 aaW
 aaW
 ail
@@ -101195,7 +100929,7 @@ aaW
 aaW
 qNA
 qNA
-aaW
+unu
 bfL
 bfK
 bfJ
@@ -101438,20 +101172,20 @@ aeY
 aeY
 aeY
 aeY
-ahm
+jsv
 ahG
 kzC
 bgy
 pVU
 aaX
-tfa
-tfa
-tfa
-tfa
+abh
+abh
+abh
+abh
 dcS
 acC
-tfa
-ahK
+abh
+abh
 acS
 aaa
 aaa
@@ -101695,20 +101429,20 @@ afb
 afb
 afb
 afb
-afr
+kxL
 afH
-hZk
-bgz
-fqG
+kzC
+bgy
+pVU
 aaY
 awR
-pKD
+aaY
 afD
-afD
-afD
-pKD
+iKg
+iKg
+aaY
 awR
-mCt
+aaY
 acW
 gMU
 gMU
@@ -101955,16 +101689,16 @@ oHC
 euv
 ahH
 kzC
-bgA
+bgy
 pVU
 abb
-xMK
-xMK
-xMK
-xMK
-xMK
-xMK
-xMK
+abj
+abj
+abj
+abj
+abj
+abj
+abj
 ahL
 ada
 aaa
@@ -102212,7 +101946,7 @@ avf
 awb
 avf
 kah
-ckt
+suQ
 aaW
 aaW
 ail
@@ -102726,7 +102460,7 @@ brd
 mLP
 rmD
 kah
-jsv
+suQ
 adq
 adq
 adI
@@ -102981,17 +102715,17 @@ aeY
 aeY
 aeY
 ahm
-afv
-jVf
-qVv
-ufV
+awr
+aih
+fpq
+qdB
 adA
-abp
-abp
-abp
-abp
+adP
+adP
+adP
+adP
 adQ
-abp
+adP
 abp
 ahS
 aes
@@ -103239,10 +102973,10 @@ afb
 afb
 afr
 afH
-jIZ
-ebZ
+aih
+fpq
 qdB
-adC
+lCT
 awT
 lCT
 aDX
@@ -103250,7 +102984,7 @@ aDX
 aDX
 lCT
 awT
-vKA
+lCT
 aet
 gMU
 gMU
@@ -103495,18 +103229,18 @@ mZW
 mZW
 mZW
 afz
-ayw
-jVf
+afH
+aih
 fpq
-ufV
+qdB
 adD
-adL
-adL
-adL
-adL
+eIP
+eIP
+eIP
+eIP
 jNg
 aeh
-adL
+eIP
 ahT
 aew
 aaa
@@ -103765,7 +103499,7 @@ adq
 adq
 kVX
 kVX
-adq
+ahK
 bfL
 bfK
 bfJ
@@ -104782,7 +104516,7 @@ azY
 aAd
 aAe
 kah
-xXH
+suQ
 adq
 adq
 adI
@@ -104793,7 +104527,7 @@ adq
 adq
 kVX
 kVX
-adq
+ebZ
 bfL
 bfK
 bfJ
@@ -105037,10 +104771,10 @@ afn
 afn
 afn
 axV
-ayQ
-jVf
-jTY
-fJM
+afH
+aih
+fpq
+pph
 adA
 adP
 adP
@@ -105295,10 +105029,10 @@ aeO
 aeO
 afy
 afH
-jIZ
-jVG
+aih
+fpq
 pph
-adC
+lCT
 adS
 lCT
 aEK
@@ -105306,7 +105040,7 @@ aEK
 aEK
 lCT
 adS
-vKA
+lCT
 aey
 gMU
 gMU
@@ -105551,19 +105285,19 @@ afu
 afu
 afu
 afa
-afF
-jVf
-jTY
-fJM
-adD
+agp
+aih
+fpq
+pph
+bgz
 eIP
 eIP
 eIP
 eIP
 eIP
-pHJ
+aeh
 eIP
-unu
+ahT
 aeA
 aaa
 aaa
@@ -105810,7 +105544,7 @@ utk
 sQx
 kah
 kah
-qYe
+suQ
 adq
 adq
 adq
@@ -106067,9 +105801,9 @@ kah
 kah
 kah
 gCm
-iKg
-kJP
-cpb
+aad
+dOG
+aad
 kKP
 spY
 fwh
@@ -106304,26 +106038,26 @@ aqf
 aHB
 voL
 mes
-kjB
+clE
 uXJ
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
+afF
+afF
+afF
+afF
+afF
+afF
+afF
+afF
+afF
+afF
+afF
+afF
+afF
+afF
+afF
+afF
+afF
+afF
 roi
 dOG
 dQI


### PR DESCRIPTION
## About The Pull Request

This PR hammers the hammerhead hangar into a functional state that doesn't require the ATC and actually lets pilots get fighters out.

## Why It's Good For The Game

Fighters are the only heavy armament the hammerhead has left, so we probably should make it so that they can take off without disassembling half of the hangar and all of the firelocks.

## Testing Photographs and Procedure

Works on my machine. There is actually a screenshot there, but I forgot to take a before. Its better, I promise.

https://cdn.discordapp.com/attachments/933214711112163380/1083216334504083496/Unfucked_Hammerhead_Hangar.PNG

## Changelog
:cl:
Fix: Hammerhead fighter launch tubes now functional at round-start due to the addition of blast-door buttons and removal of extra blast-doors, heavy firelocks and unused atmospherics piping.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
