### PR TITLE
[PORT] Ecto Sniffer yells over Science Comms now

### DIFF
--- a/code/game/machinery/ecto_sniffer.dm
+++ b/code/game/machinery/ecto_sniffer.dm
@@ -13,10 +13,18 @@
 	var/sensor_enabled = TRUE
 	///List of ckeys containing players who have recently activated the device, players on this list are prohibited from activating the device untill their residue decays.
 	var/list/ectoplasmic_residues = list()
+	var/obj/item/radio/radio //NSV13 - Ecto Sniffer Radio Yelling
 
 /obj/machinery/ecto_sniffer/Initialize()
 	. = ..()
 	wires = new/datum/wires/ecto_sniffer(src)
+	//NSV13 - Ecto Sniffer Radio Yelling - Start
+	radio = new(src)
+	radio.keyslot = new /obj/item/encryptionkey/headset_sci
+	radio.subspace_transmission = TRUE
+	radio.canhear_range = 0
+	radio.recalculateChannels()
+	//NSV13 - Ecto Sniffer Radio Yelling - Stop
 
 /obj/machinery/ecto_sniffer/attack_ghost(mob/user)
 	if(!on || !sensor_enabled || !is_operational)
@@ -34,11 +42,15 @@
 /obj/machinery/ecto_sniffer/proc/activate(mob/activator)
 	flick("ecto_sniffer_flick", src)
 	playsound(loc, 'sound/machines/ectoscope_beep.ogg', 25)
-	visible_message("<span class='notice'>[src] beeps, detecting ectoplasm! There may be additional positronic brain matrixes available!</span>")
+	//NSV13 - Ecto Sniffer Radio Yelling - Start
+	var/msg = "[src] beeps, detecting ectoplasm! There may be additional positronic brain matrices available!"
+	radio.talk_into(src, msg, RADIO_CHANNEL_SCIENCE)
+	//NSV13 - Ecto Sniffer Radio Yelling - Stop
+	visible_message("<span class='notice'></span>")
 	use_power(10)
 	if(activator?.ckey)
 		ectoplasmic_residues[activator.ckey] = TRUE
-		addtimer(CALLBACK(src, .proc/clear_residue, activator.ckey), 30 SECONDS)
+		addtimer(CALLBACK(src, .proc/clear_residue, activator.ckey), 60 SECONDS) //NSV13 - Ecto Sniffer Radio Yelling - 30 SECONDS to 60 SECONDS
 
 /obj/machinery/ecto_sniffer/attack_hand(mob/living/user, list/modifiers)
 	. = ..()
@@ -70,6 +82,7 @@
 
 /obj/machinery/ecto_sniffer/Destroy()
 	QDEL_NULL(wires)
+	QDEL_NULL(radio) //NSV13 - Ecto Sniffer Radio Yelling
 	ectoplasmic_residues = null
 	. = ..()
 

--- a/code/game/machinery/ecto_sniffer.dm
+++ b/code/game/machinery/ecto_sniffer.dm
@@ -46,7 +46,6 @@
 	var/msg = "[src] beeps, detecting ectoplasm! There may be additional positronic brain matrices available!"
 	radio.talk_into(src, msg, RADIO_CHANNEL_SCIENCE)
 	//NSV13 - Ecto Sniffer Radio Yelling - Stop
-	visible_message("<span class='notice'></span>")
 	use_power(10)
 	if(activator?.ckey)
 		ectoplasmic_residues[activator.ckey] = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ports the following PR from Upstream: 
* https://github.com/BeeStation/BeeStation-Hornet/pull/8229

That PR changes the Ecto Sniffer, making it able to send a message to science comms about ghosts demanding positronic brains rather than screaming the alert into an empty room with nobody around to hear it. 

The PR also makes it take 60 Seconds between individual activation rather than 30 Seconds.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Lowers the amount of materials wasted creating positronic brains that will just sit around doing nothing for hours, by making the Ecto Sniffer scream over Sci-comms when a ghost is demanding a cyborg body.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://user-images.githubusercontent.com/59128051/227172581-847e5a37-fbfe-4fa5-8ca7-fcf607e6573b.mp4

</details>

## Changelog
:cl:WhereAmO
tweak: Ecto Sniffer now sends a message over Science Comms when a Ghost uses it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
