### PR TITLE
Fixes missing variables in sabre FTL component

### DIFF
--- a/nsv13/code/modules/overmap/FTL/components/drive.dm
+++ b/nsv13/code/modules/overmap/FTL/components/drive.dm
@@ -71,6 +71,9 @@
 	pylons = null
 	return ..()
 
+/obj/machinery/computer/ship/ftl_core/swarmer_act()
+	return FALSE
+
 /// Links with available pylons and returns number of connections
 /obj/machinery/computer/ship/ftl_core/proc/get_pylons()
 	var/obj/structure/overmap/OMcache = get_overmap()

--- a/nsv13/code/modules/overmap/FTL/components/drive.dm
+++ b/nsv13/code/modules/overmap/FTL/components/drive.dm
@@ -72,6 +72,8 @@
 	return ..()
 
 /obj/machinery/computer/ship/ftl_core/swarmer_act()
+	to_chat(S, "<span class='warning'>This equipment should be preserved, it will be a useful resource to our masters in the future. Aborting.</span>")
+	S.LoseTarget()
 	return FALSE
 
 /// Links with available pylons and returns number of connections

--- a/nsv13/code/modules/overmap/FTL/components/drive.dm
+++ b/nsv13/code/modules/overmap/FTL/components/drive.dm
@@ -71,7 +71,7 @@
 	pylons = null
 	return ..()
 
-/obj/machinery/computer/ship/ftl_core/swarmer_act()
+/obj/machinery/computer/ship/ftl_core/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
 	to_chat(S, "<span class='warning'>This equipment should be preserved, it will be a useful resource to our masters in the future. Aborting.</span>")
 	S.LoseTarget()
 	return FALSE

--- a/nsv13/code/modules/overmap/FTL/components/drive_pylon.dm
+++ b/nsv13/code/modules/overmap/FTL/components/drive_pylon.dm
@@ -121,8 +121,6 @@
 				set_state(PYLON_STATE_SHUTDOWN)
 
 /obj/machinery/atmospherics/components/binary/drive_pylon/proc/power_drain()
-	if(power_draw)
-		return TRUE
 	var/turf/T = get_turf(src)
 	if(!cable || cable.loc != loc)
 		cable = T.get_cable_node()

--- a/nsv13/code/modules/overmap/FTL/components/drive_pylon.dm
+++ b/nsv13/code/modules/overmap/FTL/components/drive_pylon.dm
@@ -47,7 +47,7 @@
 	air_contents = new(3000)
 	air_contents.set_temperature(T20C)
 
-/obj/machinery/atmospherics/components/binary/drive_pylon/swarmer_act()
+/obj/machinery/atmospherics/components/binary/drive_pylon/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
 	to_chat(S, "<span class='warning'>This equipment should be preserved, it will be a useful resource to our masters in the future. Aborting.</span>")
 	S.LoseTarget()
 	return FALSE

--- a/nsv13/code/modules/overmap/FTL/components/drive_pylon.dm
+++ b/nsv13/code/modules/overmap/FTL/components/drive_pylon.dm
@@ -22,6 +22,7 @@
 	anchored = TRUE
 	idle_power_usage = 500
 	layer = ABOVE_MOB_LAYER
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
 	var/link_id = "default"
 	var/gyro_speed = 0
 	var/req_gyro_speed = 25
@@ -45,6 +46,9 @@
 	update_visuals(FALSE)
 	air_contents = new(3000)
 	air_contents.set_temperature(T20C)
+
+/obj/machinery/atmospherics/components/binary/drive_pylon/swarmer_act()
+	return FALSE
 
 /obj/machinery/atmospherics/components/binary/drive_pylon/process()
 	if(!on)

--- a/nsv13/code/modules/overmap/FTL/components/drive_pylon.dm
+++ b/nsv13/code/modules/overmap/FTL/components/drive_pylon.dm
@@ -48,6 +48,8 @@
 	air_contents.set_temperature(T20C)
 
 /obj/machinery/atmospherics/components/binary/drive_pylon/swarmer_act()
+	to_chat(S, "<span class='warning'>This equipment should be preserved, it will be a useful resource to our masters in the future. Aborting.</span>")
+	S.LoseTarget()
 	return FALSE
 
 /obj/machinery/atmospherics/components/binary/drive_pylon/process()

--- a/nsv13/code/modules/overmap/FTL/ftl_jump.dm
+++ b/nsv13/code/modules/overmap/FTL/ftl_jump.dm
@@ -209,7 +209,7 @@
 			log_runtime("DEBUG: jump_start: aborted jump to [target_system], drive state = [ftl_drive?.ftl_state]")
 			return
 	if((SEND_GLOBAL_SIGNAL(COMSIG_GLOB_CHECK_INTERDICT, src) & BEING_INTERDICTED) && !force) // Override interdiction if the game is over
-		ftl_drive?.radio.talk_into(ftl_drive, "Warning. Local energy anomaly detected - calculated jump parameters invalid. Performing emergency reboot.", ftl_drive.radio_channel)
+		ftl_drive?.radio?.talk_into(ftl_drive, "Warning. Local energy anomaly detected - calculated jump parameters invalid. Performing emergency reboot.", ftl_drive.radio_channel)
 		relay('sound/magic/lightning_chargeup.ogg', channel=CHANNEL_IMPORTANT_SHIP_ALERT)
 		ftl_drive?.depower()
 		log_runtime("DEBUG: jump_start: aborted jump to [target_system] due to interdiction")

--- a/nsv13/code/modules/overmap/FTL/ftl_legacy.dm
+++ b/nsv13/code/modules/overmap/FTL/ftl_legacy.dm
@@ -49,6 +49,8 @@
 			to_chat(user, "<span class='notice'>[src] has already been upgraded to a higher tier than [FI] can offer.</span>")
 
 /obj/machinery/computer/ship/ftl_computer/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
+	to_chat(S, "<span class='warning'>This equipment should be preserved, it will be a useful resource to our masters in the future. Aborting.</span>")
+	S.LoseTarget()
 	return FALSE
 
 /obj/machinery/computer/ship/ftl_computer/vv_edit_var(var_name, var_value)

--- a/nsv13/code/modules/overmap/FTL/ftl_legacy.dm
+++ b/nsv13/code/modules/overmap/FTL/ftl_legacy.dm
@@ -48,6 +48,9 @@
 		else
 			to_chat(user, "<span class='notice'>[src] has already been upgraded to a higher tier than [FI] can offer.</span>")
 
+/obj/machinery/computer/ship/ftl_computer/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
+	return FALSE
+
 /obj/machinery/computer/ship/ftl_computer/vv_edit_var(var_name, var_value)
 	. = ..()
 	if(var_name == "tier")

--- a/nsv13/code/modules/overmap/fighters/modules/ftl_drive.dm
+++ b/nsv13/code/modules/overmap/fighters/modules/ftl_drive.dm
@@ -12,6 +12,8 @@
 	var/ftl_loop = 'nsv13/sound/effects/ship/FTL_loop.ogg'
 	var/ftl_start = 'nsv13/sound/effects/ship/FTL_torchdrive.ogg'
 	var/ftl_exit = 'nsv13/sound/effects/ship/freespace2/warp_close.wav'
+	var/auto_spool_enabled = TRUE
+	var/req_charge = 120
 
 	var/jump_speed_factor = 5.5 //How quickly do we jump? Larger is faster.
 	var/ftl_state = FTL_STATE_IDLE //Mr Gaeta, spool up the FTLs.
@@ -41,6 +43,9 @@
 	. = ..()
 	if(. && istype(OM) && OM.ftl_drive == src)
 		OM.ftl_drive = null
+
+/obj/item/fighter_component/ftl/proc/force_jump(datum/star_system/target_system)
+	jump(target_system, force=TRUE)
 
 /obj/item/fighter_component/ftl/proc/jump(datum/star_system/target_system, force=FALSE)
 	var/obj/structure/overmap/linked = loc


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a reported issue with sabre FTL, pylons not actually drawing power, and swarmer-proofs some stuff

## Why It's Good For The Game
Missing variables make things not work.
Things that use power as a mechanic should use power.
Irreplaceable equipment shouldn't get eaten by swarmers. 

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: Fixed sabre FTL missing a variable
fix: FTL pylons will now add load to the power grid
balance: FTL machines can no longer be eaten by swarmers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
