### PR TITLE
Plasma Canister Fix

### DIFF
--- a/_maps/map_files/Serendipity/job_changes.dm
+++ b/_maps/map_files/Serendipity/job_changes.dm
@@ -29,7 +29,7 @@ MAP_REMOVE_JOB(air_traffic_controller)
     cant_discount = TRUE
     surplus = 0
 
-/datum/supply_pack/engineering/plasma_canister/New() //Plasma gun needs plasma gas
+/datum/supply_pack/materials/plasma_canister/New() //Plasma gun needs plasma gas
 	.=..()
 	if(SSmapping?.config?.map_name != JOB_MODIFICATION_MAP_NAME)
 		return

--- a/nsv13/code/modules/cargo/packs.dm
+++ b/nsv13/code/modules/cargo/packs.dm
@@ -769,8 +769,8 @@
 					/obj/item/reagent_containers/glass/bottle/sacid)
 	crate_name = "Chemical Supply Crate - Chalcogens"
 
-/datum/supply_pack/engineering/plasma_canister //Purely used for the Serendipity's plasma caster
-	name = "Replacement Plasma Canister"
+/datum/supply_pack/materials/plasma_canister //Purely used for the Serendipity's plasma caster
+	name = "Phoron Canister"
 	desc = "A single can of phoron gas, for all your plasma needs!"
 	cost = 2500
 	contains = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Moves the plasma canister on the dipity cargo list from engineering to canisters and materials

## Why It's Good For The Game

Fixes a small mistake from the Serendipity PR

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: Fixed the proper position of the plasma canister in the cargo list
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
