### PR TITLE
Makes catwalks behave like floors for mouse-related purposes

### DIFF
--- a/code/controllers/subsystem/minor_mapping.dm
+++ b/code/controllers/subsystem/minor_mapping.dm
@@ -43,6 +43,8 @@ SUBSYSTEM_DEF(minor_mapping)
 	for(var/turf/open/floor/plating/T in all_turfs)
 		if(is_blocked_turf(T))
 			continue
+		if(locate(/obj/structure/lattice/catwalk) in T) // NSV13 - Do not spawn mice on catwalks
+			continue
 		if(locate(/obj/structure/cable) in T)
 			exposed_wires += T
 

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -90,7 +90,7 @@
 /mob/living/simple_animal/mouse/handle_automated_action()
 	if(prob(chew_probability))
 		var/turf/open/floor/F = get_turf(src)
-		if(istype(F) && !F.intact && !(locate(/obj/structure/lattice/catwalk) in T)) // NSV13 - Do not eat wires through catwalks
+		if(istype(F) && !F.intact && !(locate(/obj/structure/lattice/catwalk) in F)) // NSV13 - Do not eat wires through catwalks
 			var/obj/structure/cable/C = locate() in F
 			if(C && prob(15))
 				if(C.avail())

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -90,7 +90,7 @@
 /mob/living/simple_animal/mouse/handle_automated_action()
 	if(prob(chew_probability))
 		var/turf/open/floor/F = get_turf(src)
-		if(istype(F) && !F.intact)
+		if(istype(F) && !F.intact && !(locate(/obj/structure/lattice/catwalk) in T)) // NSV13 - Do not eat wires through catwalks
 			var/obj/structure/cable/C = locate() in F
 			if(C && prob(15))
 				if(C.avail())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Prevents turfs with a wire and a catwalk from being considered for mouse migration. Prevents mice from chewing wires that are covered by catwalks.

## Why It's Good For The Game
These are supposed to be better than exposed wires

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
tweak: Mice will no longer spawn or eat on catwalk wires
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
