### PR TITLE
Adds map name to metric tracking

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -116,6 +116,12 @@ SUBSYSTEM_DEF(mapping)
 	initialize_reserved_level(transit.z_value)
 	return ..()
 
+/datum/controller/subsystem/mapping/get_metrics()
+	. = ..()
+	var/list/custom = list()
+	custom["map"] = config.map_name
+	.["custom"] = custom
+
 /datum/controller/subsystem/mapping/proc/wipe_reservations(wipe_safety_delay = 100)
 	if(clearing_reserved_turfs || !initialized)			//in either case this is just not needed.
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
### Ports
- https://github.com/BeeStation/BeeStation-Hornet/pull/8472

## About The Pull Request

This adds the current map as a thing to be tracked in SSmetrics. This allows us to take a look at the impact of the current map on maptick, time dilation and other subsystem costs.
This is allows us to actually verify claims that a particular map is very laggy over long periods of time, meaning that if we need to disable a map for lag reasons we have evidence for it rather than basing it off a gut feeling.

## Why It's Good For The Game

See above.

## Testing Photographs and Procedure

```json
        "mapping": {
            "cost": 0,
            "tick_usage": 0,
            "custom": {
                "map": "Kilo Station"
            }
        },
```

((From Bee, but it's going to be the same here))

## Changelog
:cl:PowerfulBacon
code: Adds current map to metric tracking
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
