### PR TITLE
Turns the expanded lizard hiss regex from #2311 into a character pref

### DIFF
--- a/SQL/beestation_schema.sql
+++ b/SQL/beestation_schema.sql
@@ -117,7 +117,7 @@ CREATE TABLE IF NOT EXISTS `SS13_characters` (
 	`preferred_squad` VARCHAR(32) NOT NULL COLLATE 'utf8mb4_general_ci',
 	`preferred_pilot_role` VARCHAR(32) NOT NULL COLLATE 'utf8mb4_general_ci',
 	`flavor_text` MEDIUMTEXT NOT NULL COLLATE 'utf8mb4_general_ci',
-  `lizard_hiss_style` VARCHAR(32) NOT NULL COLLATE 'utf8mb4_general_ci',
+	`lizard_hiss_style` VARCHAR(32) NOT NULL COLLATE 'utf8mb4_general_ci',
 	PRIMARY KEY (`slot`, `ckey`) USING BTREE
 ) COLLATE='utf8mb4_general_ci' ENGINE=InnoDB;
 

--- a/SQL/beestation_schema.sql
+++ b/SQL/beestation_schema.sql
@@ -117,6 +117,7 @@ CREATE TABLE IF NOT EXISTS `SS13_characters` (
 	`preferred_squad` VARCHAR(32) NOT NULL COLLATE 'utf8mb4_general_ci',
 	`preferred_pilot_role` VARCHAR(32) NOT NULL COLLATE 'utf8mb4_general_ci',
 	`flavor_text` MEDIUMTEXT NOT NULL COLLATE 'utf8mb4_general_ci',
+  `lizard_hiss_style` VARCHAR(32) NOT NULL COLLATE 'utf8mb4_general_ci',
 	PRIMARY KEY (`slot`, `ckey`) USING BTREE
 ) COLLATE='utf8mb4_general_ci' ENGINE=InnoDB;
 
@@ -457,7 +458,7 @@ CREATE TABLE IF NOT EXISTS `SS13_schema_revision` (
   `date` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`major`,`minor`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (6, 1);
+INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (6, 2);
 
 
 

--- a/code/__DEFINES/nsv13.dm
+++ b/code/__DEFINES/nsv13.dm
@@ -31,6 +31,10 @@
 #define CONQUEST_ROLE_LINECOOK "Line Cook"
 #define CONQUEST_ROLE_GRUNT "Autofill"
 
+//Lizard hiss preference options
+#define LIZARD_HISS_LEGACY "Legacy (s only)"
+#define LIZARD_HISS_EXPANDED "Expanded (x and s)"
+
 GLOBAL_DATUM_INIT(conquest_role_handler, /datum/conquest_role_handler, new)
 
 #define COMSIG_ATOM_DAMAGE_ACT "comsig_atom_damage_act" //Used when an atom takes damage.

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -227,7 +227,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			dat += "<b>Socks:</b><BR><a href ='?_src_=prefs;preference=socks;task=input'>[active_character.socks]</a><BR>"
 			dat += "<b>Backpack:</b><BR><a href ='?_src_=prefs;preference=bag;task=input'>[active_character.backbag]</a><BR>"
 			dat += "<b>Jumpsuit:</b><BR><a href ='?_src_=prefs;preference=suit;task=input'>[active_character.jumpsuit_style]</a><BR>"
-			dat += "<b>Uplink Spawn Location:</b><BR><a href ='?_src_=prefs;preference=uplink_loc;task=input'>[active_character.uplink_spawn_loc == UPLINK_IMPLANT ? UPLINK_IMPLANT_WITH_PRICE : active_character.uplink_spawn_loc]</a><BR></td>"
+			dat += "<b>Uplink Spawn Location:</b><BR><a href ='?_src_=prefs;preference=uplink_loc;task=input'>[active_character.uplink_spawn_loc == UPLINK_IMPLANT ? UPLINK_IMPLANT_WITH_PRICE : active_character.uplink_spawn_loc]</a><BR>"
+			dat += "<b>Lizard Hiss:</b><BR><a href ='?_src_=prefs;preference=lizard_hiss_style;task=input'>[active_character.lizard_hiss_style]</a><BR></td>" //NSV13
 
 			var/use_skintones = active_character.pref_species.use_skintones
 			if(use_skintones)
@@ -1804,6 +1805,11 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					var/msg = capped_multiline_input(usr, "Set the flavor text for your 'examine' verb.\nThe rules are the following;\nNo Memes.\nNothing that people can't see at a glance.\nNothing that's Out Of Character.\nNothing that breaks the game.", "Flavor Text", active_character.flavor_text)
 					if(msg)
 						active_character.flavor_text = html_decode(strip_html(msg))
+				if("lizard_hiss_style")
+					if(active_character.lizard_hiss_style == LIZARD_HISS_EXPANDED)
+						active_character.lizard_hiss_style = LIZARD_HISS_LEGACY
+					else
+						active_character.lizard_hiss_style = LIZARD_HISS_EXPANDED
 				//NSV13 end
 				if ("preferred_map")
 					var/maplist = list()

--- a/code/modules/client/preferences2/character_save.dm
+++ b/code/modules/client/preferences2/character_save.dm
@@ -76,6 +76,8 @@
 	var/preferred_pilot_role = PILOT_COMBAT
 	//NSV13 - Added Flavor Text
 	var/flavor_text = ""
+	//Nsv13 - lizard hiss style pref
+	var/lizard_hiss_style = LIZARD_HISS_EXPANDED
 
 
 /datum/character_save/New()
@@ -163,6 +165,9 @@
 
 	//NSV13 flavor text
 	SAFE_READ_QUERY(34, flavor_text)
+
+	//NSV13 lizard hiss style
+	SAFE_READ_QUERY(35, lizard_hiss_style)
 
 	//Sanitize. Please dont put query reads below this point. Please.
 
@@ -353,7 +358,8 @@
 			equipped_gear,
 			preferred_squad,
 			preferred_pilot_role,
-			flavor_text
+			flavor_text,
+			lizard_hiss_style
 		) VALUES (
 			:slot,
 			:ckey,
@@ -389,7 +395,8 @@
 			:equipped_gear,
 			:preferred_squad,
 			:preferred_pilot_role,
-			:flavor_text
+			:flavor_text,
+			:lizard_hiss_style
 		)
 	"}, list(
 		// Now for the above but in a fucking monsterous list
@@ -427,7 +434,8 @@
 		"equipped_gear" = json_encode(equipped_gear),
 		"preferred_squad" = preferred_squad,
 		"preferred_pilot_role" = preferred_pilot_role,
-		"flavor_text" = flavor_text
+		"flavor_text" = flavor_text,
+		"lizard_hiss_style" = lizard_hiss_style
 	))
 
 	if(!insert_query.warn_execute())

--- a/code/modules/client/preferences2/preferences2.dm
+++ b/code/modules/client/preferences2/preferences2.dm
@@ -215,7 +215,8 @@
 			equipped_gear,
 			preferred_squad,
 			preferred_pilot_role,
-			flavor_text
+			flavor_text,
+			lizard_hiss_style
 		FROM [format_table_name("characters")] WHERE
 			ckey=:ckey
 	"}, list("ckey" = parent.ckey))

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -77,10 +77,11 @@
 	if(message[1] != "*")
 		message = lizard_hiss.Replace(message, "sss")
 		message = lizard_hiSS.Replace(message, "SSS")
-		message = lizard_kss.Replace(message, "$1kss")
-		message = lizard_kSS.Replace(message, "$1KSS")
-		message = lizard_ecks.Replace(message, "ecks$1")
-		message = lizard_eckS.Replace(message, "ECKS$1")
+		if(owner?.client?.prefs.active_character?.lizard_hiss_style != LIZARD_HISS_LEGACY)
+			message = lizard_kss.Replace(message, "$1kss")
+			message = lizard_kSS.Replace(message, "$1KSS")
+			message = lizard_ecks.Replace(message, "ecks$1")
+			message = lizard_eckS.Replace(message, "ECKS$1")
 	speech_args[SPEECH_MESSAGE] = message
 
 /obj/item/organ/tongue/fly

--- a/tools/savefileimporter/code/character_parser.dm
+++ b/tools/savefileimporter/code/character_parser.dm
@@ -20,9 +20,10 @@ var/global/list/custom_name_types = list(
 	if(!equipped_gear)
 		equipped_gear = list()
 
-	// NSV13 - squad and pilot role
+	// NSV13 - squad, pilot role and lizard hiss style
 	READ_FILE(S["preferred_squad"], preferred_squad, "Able") //Change this line to '	var/preferred_squad = "Able" ' in case of errors when converting files
 	READ_FILE(S["preferred_pilot_role"], preferred_pilot_role, "Combat")
+	READ_FILE(S["lizard_hiss_style"], lizard_hiss_style, LIZARD_HISS_EXPANDED)
 
 	for(var/character_dir in cdirs)
 		S.cd = "/[character_dir]"
@@ -97,7 +98,7 @@ var/global/list/custom_name_types = list(
 		var/list/slot_list = splittext(character_dir, "character")
 		var/slot_number = text2num(slot_list[2])
 
-		// NSV13 - added preferred squad and preferred pilot role
+		// NSV13 - added preferred squad, preferred pilot role and lizard hiss style
 		var/querytext = {"
 		INSERT INTO SS13_characters (
 			slot,
@@ -133,7 +134,8 @@ var/global/list/custom_name_types = list(
 			all_quirks,
 			equipped_gear,
 			preferred_squad,
-			preferred_pilot_role
+			preferred_pilot_role,
+			lizard_hiss_style
 		) VALUES (
 			:slotnum,
 			:ckey,
@@ -168,7 +170,8 @@ var/global/list/custom_name_types = list(
 			:allquirks,
 			:gear,
 			:preferredsquad,
-			:preferredpilotrole
+			:preferredpilotrole,
+			:lizardhissstyle
 		)
 		"}
 
@@ -206,7 +209,8 @@ var/global/list/custom_name_types = list(
 			"allquirks" = json_encode(all_quirks),
 			"gear" = json_encode(equipped_gear),
 			"preferredsquad" = preferred_squad,
-			"preferredpilotrole" = preferred_pilot_role
+			"preferredpilotrole" = preferred_pilot_role,
+			"lizardhissstyle" = lizard_hiss_style
 		)
 
 		var/datum/DBQuery/query = NewDBQuery(querytext, qargs)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. Now you have a character-pref level option to toggle between s-only hissing (Legacy) and x- and s hissing (Expanded)
Defaults to the expanded version.
This also applies retroactively if you happen to turn into a lizard during a round for whatever reason.

Guh, DB prefs are scary, I sure hope this works and doesn't break anything!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Options good, especially when people tend to have different ideas of how their lizard's speech may show itself.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
No.

## Changelog
:cl:
add: Lizard hiss is now handled by a character preference, permitting choice between and new- and old styles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
