### PR TITLE
Gunpowder bags can be loaded to trolleys by hand

### DIFF
--- a/nsv13/code/modules/munitions/munitions_trolley.dm
+++ b/nsv13/code/modules/munitions/munitions_trolley.dm
@@ -56,6 +56,27 @@
 	loading = FALSE
 	return TRUE
 
+/obj/structure/munitions_trolley/attackby(obj/item/A, mob/living/user, params)
+	. = ..()
+	if(get_dist(A, src) > 1)
+		return FALSE
+	if(istype(A, /obj/item/ship_weapon/ammunition))
+		var/obj/item/ship_weapon/ammunition/M = A
+		if(M.no_trolley)
+			return FALSE
+	if(!allowed[A.type])
+		return FALSE
+	if(loading)
+		to_chat(user, "<span class='notice'>Someone is already loading something onto [src]!</span>")
+		return FALSE
+	to_chat(user, "<span class='notice'>You start to load [A] onto [src]...</span>")
+	loading = TRUE
+	if(do_after(user,20, target = src))
+		load_trolley(A, user)
+		to_chat(user, "<span class='notice'>You load [A] onto [src].</span>")
+	loading = FALSE
+	return
+
 /obj/structure/munitions_trolley/proc/load_trolley(atom/movable/A, mob/user)
 	if(istype(A, /obj/item/ship_weapon/ammunition))
 		var/obj/item/ship_weapon/ammunition/M = A


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Hitting a munition trolley with ammunition in hand (so pretty much just powder bags) will load the trolley.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
QOL
If we can click drag ammo in trolleys, we should be able to load the ammo in our hands as well
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://user-images.githubusercontent.com/95106800/229278730-a2ec9c5e-c390-44b3-9dc3-15e6a975851e.mp4


</details>

## Changelog
:cl:
add: Gunpowder can now be loaded to trolleys by hand
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
