### PR TITLE
Minor Tycoon Fixes

### DIFF
--- a/_maps/map_files/Tycoon/Tycoon2.dmm
+++ b/_maps/map_files/Tycoon/Tycoon2.dmm
@@ -5582,10 +5582,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/monotile/steel,
 /area/engine/engineering)
 "aoa" = (
@@ -8392,7 +8392,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/turf/open/space/basic,
+/turf/open/floor/monotile/steel,
 /area/engine/gravity_generator)
 "ayE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
@@ -48787,7 +48787,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
 "psx" = (
@@ -52026,10 +52025,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/monotile/steel,
 /area/engine/engineering)
 "uti" = (
@@ -52922,7 +52918,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/machinery/door/airlock/ship/engineering,
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "10"
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "wat" = (


### PR DESCRIPTION
## About The Pull Request

Fixes the lack of floortile under grav-gen entrance so it doesn't space engineering when you try to access it, grants the proper perms to the nearby maint door (engi only) and moves the layer adapter near the new jump drive closer to it so it looks a bit more neat.

## Why It's Good For The Game

Fix man good. See above.

## Changelog
:cl:
tweak: Fixed a couple minor mapping errors in Tycoon engineering.
/:cl: