### PR TITLE
Fixes VLS tubes voiding torps

### DIFF
--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/vls.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/vls.dm
@@ -48,27 +48,19 @@
 	circuit = /obj/item/circuitboard/machine/vls
 	var/obj/structure/fluff/vls_hatch/hatch = null
 
-/obj/machinery/ship_weapon/vls/proc/on_entered(datum/source, atom/movable/AM, oldloc)
+/obj/machinery/ship_weapon/vls/proc/on_entered(datum/source, atom/movable/torp, oldloc)
 	SIGNAL_HANDLER
 
-	var/can_shoot_this = FALSE
-	for(var/_ammo_type in ammo_type)
-		if(istype(AM, _ammo_type))
-			can_shoot_this = TRUE
-			break
+	if(!is_type_in_list(torp, ammo_type))
+		return FALSE
 
-	if(can_shoot_this)
-		if(ammo?.len >= max_ammo)
-			return FALSE
-		if(loading)
-			return FALSE
-		if(state >= 2)
-			return FALSE
-		ammo += AM
-		AM.forceMove(src)
-		if(load_sound)
-			playsound(src, load_sound, 100, 1)
-		state = 2
+	if(ammo?.len >= max_ammo)
+		return FALSE
+	if(loading)
+		return FALSE
+	if(state >= STATE_LOADED)
+		return FALSE
+	load(torp)
 
 // Handles removal of stuff
 /obj/machinery/ship_weapon/vls/Exited(atom/movable/gone, direction)
@@ -140,12 +132,13 @@
 		return
 	hatch.toggle(HT_CLOSED)
 
-/obj/machinery/ship_weapon/vls/unload_magazine()
+/obj/machinery/ship_weapon/vls/unload()
+	loading = TRUE // This prevents torps from immediately falling back into the VLS tube
 	. = ..()
+	loading = FALSE
 	if(!hatch)
 		return
 	hatch.toggle(HT_CLOSED)
-
 
 /obj/structure/fluff/vls_hatch
 	name = "VLS Launch Hatch"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This fixes VLS tubes voiding torps when being unloaded. This was caused by some jank related to torp autoloading.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
Bugs bad.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://user-images.githubusercontent.com/9423435/230792123-260edcd3-c503-44cd-909c-936687655b02.mp4



</details>

## Changelog
:cl:
fix: Torpedoes no longer fall out of reality when being removed from VLS tubes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
