### PR TITLE
Improves tug loading/unloading

### DIFF
--- a/nsv13/code/modules/overmap/fighters/tug.dm
+++ b/nsv13/code/modules/overmap/fighters/tug.dm
@@ -121,12 +121,15 @@
 		return ..()
 	if(get_dist(dropping, src) > 3)
 		to_chat(M, "<span class='warning'>[dropping] is too far away!")
+		return
 
 	visible_message("<span class='notice'>[M] starts loading [dropping] onto [src]...</span>")
 	if(!do_after(M, 5 SECONDS, src))
 		return
+
 	if(get_dist(dropping, src) > 3)
 		to_chat(M, "<span class='warning'>[dropping] is too far away!")
+		return
 
 	hitch(dropping)
 

--- a/nsv13/code/modules/overmap/fighters/tug.dm
+++ b/nsv13/code/modules/overmap/fighters/tug.dm
@@ -107,7 +107,7 @@
 	set_light(5)
 
 /obj/vehicle/sealed/car/realistic/fighter_tug/proc/hitch(obj/structure/overmap/small_craft/target)
-	if(!target || LAZYFIND(loaded, target) || target.mag_lock)//No sucking
+	if(!target || !istype(target) || LAZYFIND(loaded, target) || target.mag_lock)//No sucking
 		return FALSE
 	loaded += target
 	STOP_PROCESSING(SSphysics_processing, target)
@@ -129,7 +129,7 @@
 		return
 
 	visible_message("<span class='notice'>[M] starts loading [craft] onto [src]...</span>")
-	if(!do_after(M, 5 SECONDS, src))
+	if(!do_after(M, 5 SECONDS, target = src))
 		return
 
 	if(get_dist(craft, src) > 3)

--- a/nsv13/code/modules/vehicles/_vehicle.dm
+++ b/nsv13/code/modules/vehicles/_vehicle.dm
@@ -40,6 +40,7 @@ MASSIVE THANKS TO MONSTER860 FOR HELP WITH THIS. HE EXPLAINED PHYSICS AND MATH T
 	var/bounce_factor = 0.2 // how much of our velocity to keep on collision
 	var/lateral_bounce_factor = 0.95 // mostly there to slow you down when you drive (pilot?) down a 2x2 corridor
 
+	COOLDOWN_DECLARE(key_cooldown) // Anti-spam for keys
 	var/brakes = FALSE //Helps you stop the tug
 	var/last_slowprocess = 0
 	var/last_squeak = 0
@@ -77,6 +78,7 @@ MASSIVE THANKS TO MONSTER860 FOR HELP WITH THIS. HE EXPLAINED PHYSICS AND MATH T
 
 /obj/vehicle/sealed/car/realistic/proc/toggle_brakes()
 	brakes = !brakes
+	to_chat(usr, "<span class='notice'>You toggle the brakes [brakes ? "on" : "off"].")
 
 /obj/effect/decal/cleanable/tyre_marks
 	name = "Tyre tracks"
@@ -99,8 +101,9 @@ MASSIVE THANKS TO MONSTER860 FOR HELP WITH THIS. HE EXPLAINED PHYSICS AND MATH T
 	return TRUE //Placeholder for everything but fighters. We can later extend this if / when we want to code in ship engines.
 
 /obj/vehicle/sealed/car/realistic/driver_move(mob/user, direction)
-	if(key_type && !is_key(inserted_key))
+	if(key_type && !is_key(inserted_key) && COOLDOWN_FINISHED(src, key_cooldown))
 		to_chat(user, "<span class='warning'>[src] has no key inserted!</span>")
+		COOLDOWN_START(src, key_cooldown, 1 SECONDS)
 		return FALSE
 	if(world.time >= last_enginesound_time + engine_sound_length)
 		last_enginesound_time = world.time

--- a/nsv13/code/modules/vehicles/_vehicle.dm
+++ b/nsv13/code/modules/vehicles/_vehicle.dm
@@ -101,9 +101,10 @@ MASSIVE THANKS TO MONSTER860 FOR HELP WITH THIS. HE EXPLAINED PHYSICS AND MATH T
 	return TRUE //Placeholder for everything but fighters. We can later extend this if / when we want to code in ship engines.
 
 /obj/vehicle/sealed/car/realistic/driver_move(mob/user, direction)
-	if(key_type && !is_key(inserted_key) && COOLDOWN_FINISHED(src, key_cooldown))
-		to_chat(user, "<span class='warning'>[src] has no key inserted!</span>")
-		COOLDOWN_START(src, key_cooldown, 1 SECONDS)
+	if(key_type && !is_key(inserted_key))
+		if(COOLDOWN_FINISHED(src, key_cooldown))
+			to_chat(user, "<span class='warning'>[src] has no key inserted!</span>")
+			COOLDOWN_START(src, key_cooldown, 1 SECONDS)
 		return FALSE
 	if(world.time >= last_enginesound_time + engine_sound_length)
 		last_enginesound_time = world.time


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This PR improves tug fighter handling.
Firstly, it gives the fighter tug a bit more range when loading fighters, which should help with hitbox jank. It also adds a popup that allows you to confirm which fighter you're loading.
Secondly, it adds click-drag loading, which lets people load fighters from outside the tug as long as they're close enough.
I also tweaked the description for the tug and added a few minor notification/warning messages I forgot to add earlier.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
Tugs right now are a massive pain to work with, and this should *hopefully* make them easier to use.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://user-images.githubusercontent.com/9423435/233859106-81fbf760-17af-45b3-81d9-e499cb5016b6.mp4


https://user-images.githubusercontent.com/9423435/233859123-ca662fbc-1e87-4071-a8e3-416a55577194.mp4



</details>

## Changelog
:cl:
add: Tugs can now be loaded by click-dragging fighters onto them.
tweak: Tweaks tug loading/unloading.
fix: Tugs can't stack fighters on magcats anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
