### PR TITLE
Allows a second pilot on Atlas

### DIFF
--- a/_maps/map_files/Atlas/job_changes.dm
+++ b/_maps/map_files/Atlas/job_changes.dm
@@ -50,14 +50,8 @@ MAP_REMOVE_JOB(brig_phys)
 /datum/job/pilot/New()
     ..()
     MAP_JOB_CHECK
-    total_positions = 1
-    spawn_positions = 1
-
-/datum/job/detective/New()
-    ..()
-    MAP_JOB_CHECK
-    total_positions = 1
-    spawn_positions = 1
+    total_positions = 2
+    spawn_positions = 2
 
 /datum/job/bartender/New()
     ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Sets pilot total and spawn positions to 2 on the Atlas job_changes
This also removes a unnecessary detective position change that... didn't really do anything. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The Atlas used to have two pilots, a flight leader and a regular pilot. When flight leaders got removed, the total positions for pilots was not changed leaving only one pilot. This PR fixes that by allowing a second pilot.


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
tweak: Atlas now allows for a second pilot
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
