### PR TITLE
Camera helmet numbers consistency

### DIFF
--- a/nsv13/code/modules/clothing/helmet_camera.dm
+++ b/nsv13/code/modules/clothing/helmet_camera.dm
@@ -38,7 +38,6 @@
 			on_drop(equipper)
 			return
 		if(builtInCamera && H)
-			builtInCamera.c_tag = "Helmet Cam #[rand(0,999)]"
 			builtInCamera.forceMove(equipper) //I hate this. But, it's necessary.
 			RegisterSignal(equipper, COMSIG_MOVABLE_MOVED, PROC_REF(update_camera_location))
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes a line that randomizes the helmet camera numbers every time it is equipped

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Allows players to know which helmet camera is which without having to guess

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
tweak: Helmet camera number tags are more consistent
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
