### PR TITLE
Fixes midshipman department assignments

### DIFF
--- a/nsv13/code/modules/jobs/job_types/marine/midshipman.dm
+++ b/nsv13/code/modules/jobs/job_types/marine/midshipman.dm
@@ -68,3 +68,55 @@ Marine & all their unique stuff!
 	name = "squad medic uniform"
 	desc = "A cheaply made and uncomfortable uniform worn by squad medics. It has a conspicuous blue cross on the back. Shooting its bearer may constitute a war crime."
 	icon_state = "marine_medic"
+
+/datum/job/assistant/after_spawn(mob/living/carbon/human/H, mob/M)
+	. = ..()
+	// Assign department
+	var/department
+	if(M && M.client && M.client.prefs && M.client.prefs.active_character)
+		department = M.client.prefs.active_character.preferred_security_department
+		if(department == "None")
+			return
+		else if(!(department in GLOB.available_depts))
+			department = pick(GLOB.available_depts)
+
+	var/ears = null
+	var/accessory = null
+	var/list/dep_access = null
+	switch(department)
+		if(SEC_DEPT_SUPPLY)
+			ears = /obj/item/radio/headset/headset_cargo
+			dep_access = list(ACCESS_MAILSORTING, ACCESS_CARGO)
+			accessory = /obj/item/clothing/accessory/armband/cargo
+		if(SEC_DEPT_ENGINEERING)
+			ears = /obj/item/radio/headset/headset_eng
+			dep_access = list(ACCESS_CONSTRUCTION, ACCESS_ENGINE, ACCESS_AUX_BASE)
+			accessory = /obj/item/clothing/accessory/armband/engine
+		if(SEC_DEPT_MEDICAL)
+			ears = /obj/item/radio/headset/headset_med
+			dep_access = list(ACCESS_MEDICAL, ACCESS_MORGUE, ACCESS_CLONING)
+			accessory =  /obj/item/clothing/accessory/armband/medblue
+		if(SEC_DEPT_SCIENCE)
+			ears = /obj/item/radio/headset/headset_sci
+			dep_access = list(ACCESS_RESEARCH)
+			accessory = /obj/item/clothing/accessory/armband/science
+		if(SEC_DEPT_MUNITIONS)
+			ears = /obj/item/radio/headset/munitions/munitions_tech
+			dep_access = list(ACCESS_MUNITIONS, ACCESS_MUNITIONS_STORAGE)
+			accessory = /obj/item/clothing/accessory/armband/munitions
+
+	if(accessory)
+		var/obj/item/clothing/under/U = H.w_uniform
+		U.attach_accessory(new accessory)
+	if(ears)
+		if(H.ears)
+			qdel(H.ears)
+		H.equip_to_slot_or_del(new ears(H), ITEM_SLOT_EARS)
+
+	var/obj/item/card/id/W = H.wear_id
+	W.access |= dep_access
+
+	if(department)
+		to_chat(M, "<b>You have been assigned to [department]!</b>")
+	else
+		to_chat(M, "<b>You have not been assigned to any department. Help in any way you can!</b>")

--- a/nsv13/code/modules/jobs/job_types/marine/midshipman.dm
+++ b/nsv13/code/modules/jobs/job_types/marine/midshipman.dm
@@ -72,13 +72,12 @@ Marine & all their unique stuff!
 /datum/job/assistant/after_spawn(mob/living/carbon/human/H, mob/M)
 	. = ..()
 	// Assign department
-	var/department
-	if(M && M.client && M.client.prefs && M.client.prefs.active_character)
-		department = M.client.prefs.active_character.preferred_security_department
-		if(department == "None")
-			return
-		else if(!(department in GLOB.available_depts))
-			department = pick(GLOB.available_depts)
+	var/department = M?.client?.prefs?.active_character?.preferred_security_department
+	if(department == "None")
+		to_chat(M, "<b>You have not been assigned to any department. Help in any way you can!</b>")
+		return
+	else if(!(department in GLOB.available_depts))
+		department = pick(GLOB.available_depts)
 
 	var/ears = null
 	var/accessory = null
@@ -116,7 +115,4 @@ Marine & all their unique stuff!
 	var/obj/item/card/id/W = H.wear_id
 	W.access |= dep_access
 
-	if(department)
-		to_chat(M, "<b>You have been assigned to [department]!</b>")
-	else
-		to_chat(M, "<b>You have not been assigned to any department. Help in any way you can!</b>")
+	to_chat(M, "<b>You have been assigned to [department]!</b>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
There were a couple of things that were wrong, the first being that this just wasn't happening at all because the assistant.dm file is unticked, and because it was unticked it also got overwritten. It also only assigned up to (number of departments) midshipmen to their departments, and you couldn't get a security officer and a middie assigned to the same department.

## Why It's Good For The Game
Makes a mechanic we thought was supposed to be there actually there. Removes conflicts between security officer and midshipman list use.

## Changelog
:cl: [SharkeeByond](https://github.com/SharkeeByond)
fix: Made midshipmen actually get assigned to departments
fix: Made more than one midshipman be able to be assigned to a given department
fix: Made departments able to have both security officers and midshipmen assigned to them at the same time
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
