### PR TITLE
[Upstream] Interrupting a martial arts granter last second no longer breaks it

### DIFF
--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -59,7 +59,7 @@
 			return
 	if(do_after(user,50, user))
 		on_reading_finished(user)
-		reading = FALSE
+	reading = FALSE
 	return TRUE
 
 ///ACTION BUTTONS///


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR makes it so moving after starting to read a martial arts granter book no longer permanently breaks the book itself. 
Basically it let's you start reading it again after having been moved rather than permanently breaking the book.

## Ports from: Beestation
* https://github.com/BeeStation/BeeStation-Hornet/pull/9047
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Reduces the expenses caused by MPs moving around while reading the book about Knife Culture by teaching them the extremely important and critical knowledge of "A book does not magically have it's contents erased if you forget what page you were on because you got distracted by something"
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/BeeStation/NSV13/assets/59128051/d68f1857-09c5-4bfe-9df8-615cadfd422b

</details>

## Changelog
:cl:itsmeow
fix: Martial arts granting books (karate scroll, CQC manual, Ju Jitsu books, etc) no longer break permanently if you interrupt it last second.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
