### PR TITLE
[UPSTREAM] All species can now wag their tails if they get one.

### DIFF
--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -96,9 +96,11 @@
 	var/mob/living/T = L.parent
 	if(ishuman(T))
 		var/mob/living/carbon/human/H = T
-		if(iscatperson(H))
-			H.dna.species.start_wagging_tail(H)
-			addtimer(CALLBACK(H.dna.species, TYPE_PROC_REF(/datum/species, stop_wagging_tail), H), 30)
+		if(iscatperson(H) || (istype(H.getorganslot(ORGAN_SLOT_EARS), /obj/item/organ/ears/cat) && istype(H.getorganslot(ORGAN_SLOT_TAIL), /obj/item/organ/tail/cat)))
+			var/obj/item/organ/tail/tail = H.getorganslot(ORGAN_SLOT_TAIL)
+			if(tail)
+				tail.set_wagging(H, TRUE)
+				addtimer(CALLBACK(tail, TYPE_PROC_REF(/obj/item/organ/tail, set_wagging), H, FALSE), 3 SECONDS)
 			description =  "<span class='nicegreen'>They want to play on the table!</span>\n"
 			mood_change = 2
 

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -101,25 +101,22 @@
 	if(!.)
 		return
 	var/mob/living/carbon/human/H = user
-	if(!istype(H) || !H.dna || !H.dna.species || !H.dna.species.can_wag_tail(H))
+	var/obj/item/organ/tail/tail = H?.getorganslot(ORGAN_SLOT_TAIL)
+	if(!tail)
 		return
-	if(!H.dna.species.is_wagging_tail())
-		H.dna.species.start_wagging_tail(H)
-	else
-		H.dna.species.stop_wagging_tail(H)
+	tail.toggle_wag(H)
 
 /datum/emote/living/carbon/human/wag/can_run_emote(mob/user, status_check = TRUE , intentional)
 	if(!..())
 		return FALSE
 	var/mob/living/carbon/human/H = user
-	return H.dna && H.dna.species && H.dna.species.can_wag_tail(user)
+	return istype(H?.getorganslot(ORGAN_SLOT_TAIL), /obj/item/organ/tail)
 
 /datum/emote/living/carbon/human/wag/select_message_type(mob/user, intentional)
 	. = ..()
 	var/mob/living/carbon/human/H = user
-	if(!H.dna || !H.dna.species)
-		return
-	if(H.dna.species.is_wagging_tail())
+	var/obj/item/organ/tail/tail = H.getorganslot(ORGAN_SLOT_TAIL)
+	if(tail?.is_wagging(H))
 		. = null
 
 /datum/emote/living/carbon/human/wing

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -2086,15 +2086,9 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 //Tail Wagging//
 ////////////////
 
-/datum/species/proc/can_wag_tail(mob/living/carbon/human/H)
-	return FALSE
-
-/datum/species/proc/is_wagging_tail(mob/living/carbon/human/H)
-	return FALSE
-
-/datum/species/proc/start_wagging_tail(mob/living/carbon/human/H)
-
 /datum/species/proc/stop_wagging_tail(mob/living/carbon/human/H)
+	var/obj/item/organ/tail/tail = H?.getorganslot(ORGAN_SLOT_TAIL)
+	tail?.set_wagging(H, FALSE)
 
 ///////////////
 //FLIGHT SHIT//

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -31,24 +31,6 @@
 		stop_wagging_tail(H)
 	. = ..()
 
-/datum/species/human/felinid/can_wag_tail(mob/living/carbon/human/H)
-	return ("tail_human" in mutant_bodyparts) || ("waggingtail_human" in mutant_bodyparts)
-
-/datum/species/human/felinid/is_wagging_tail(mob/living/carbon/human/H)
-	return ("waggingtail_human" in mutant_bodyparts)
-
-/datum/species/human/felinid/start_wagging_tail(mob/living/carbon/human/H)
-	if("tail_human" in mutant_bodyparts)
-		mutant_bodyparts -= "tail_human"
-		mutant_bodyparts |= "waggingtail_human"
-	H.update_body()
-
-/datum/species/human/felinid/stop_wagging_tail(mob/living/carbon/human/H)
-	if("waggingtail_human" in mutant_bodyparts)
-		mutant_bodyparts -= "waggingtail_human"
-		mutant_bodyparts |= "tail_human"
-	H.update_body()
-
 /datum/species/human/felinid/on_species_gain(mob/living/carbon/C, datum/species/old_species, pref_load)
 	if(ishuman(C))
 		var/mob/living/carbon/human/H = C

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -53,28 +53,6 @@
 		stop_wagging_tail(H)
 	. = ..()
 
-/datum/species/lizard/can_wag_tail(mob/living/carbon/human/H)
-	return ("tail_lizard" in mutant_bodyparts) || ("waggingtail_lizard" in mutant_bodyparts)
-
-/datum/species/lizard/is_wagging_tail(mob/living/carbon/human/H)
-	return ("waggingtail_lizard" in mutant_bodyparts)
-
-/datum/species/lizard/start_wagging_tail(mob/living/carbon/human/H)
-	if("tail_lizard" in mutant_bodyparts)
-		mutant_bodyparts -= "tail_lizard"
-		mutant_bodyparts -= "spines"
-		mutant_bodyparts |= "waggingtail_lizard"
-		mutant_bodyparts |= "waggingspines"
-	H.update_body()
-
-/datum/species/lizard/stop_wagging_tail(mob/living/carbon/human/H)
-	if("waggingtail_lizard" in mutant_bodyparts)
-		mutant_bodyparts -= "waggingtail_lizard"
-		mutant_bodyparts -= "waggingspines"
-		mutant_bodyparts |= "tail_lizard"
-		mutant_bodyparts |= "spines"
-	H.update_body()
-
 /*
  Lizard subspecies: ASHWALKERS
 */

--- a/code/modules/surgery/organs/tails.dm
+++ b/code/modules/surgery/organs/tails.dm
@@ -8,10 +8,14 @@
 	slot = ORGAN_SLOT_TAIL
 	var/tail_type = "None"
 
-/obj/item/organ/tail/Remove(mob/living/carbon/human/H,  special = 0)
-	..()
-	if(H?.dna?.species)
-		H.dna.species.stop_wagging_tail(H)
+/obj/item/organ/tail/proc/is_wagging(mob/living/carbon/human/H)
+	return FALSE
+
+/obj/item/organ/tail/proc/set_wagging(mob/living/carbon/human/H, wagging = FALSE)
+	return FALSE
+
+/obj/item/organ/tail/proc/toggle_wag(mob/living/carbon/human/H)
+	return set_wagging(H, !is_wagging(H))
 
 /obj/item/organ/tail/cat
 	name = "cat tail"
@@ -33,6 +37,25 @@
 		H.dna.species.mutant_bodyparts -= "tail_human"
 		color = H.hair_color
 		H.update_body()
+
+/obj/item/organ/tail/cat/is_wagging(mob/living/carbon/human/H)
+	if(!H?.dna?.species)
+		return FALSE
+	return ("waggingtail_human" in H.dna.species.mutant_bodyparts)
+
+/obj/item/organ/tail/cat/set_wagging(mob/living/carbon/human/H, wagging = FALSE)
+	. = FALSE
+	if(!H?.dna?.species)
+		return FALSE
+	var/datum/species/species = H.dna.species
+	if(wagging)
+		species.mutant_bodyparts -= "tail_human"
+		species.mutant_bodyparts |= "waggingtail_human"
+		. = TRUE
+	else
+		species.mutant_bodyparts -= "waggingtail_human"
+		species.mutant_bodyparts |= "tail_human"
+	H.update_body()
 
 /obj/item/organ/tail/lizard
 	name = "lizard tail"
@@ -63,3 +86,22 @@
 		tail_type = H.dna.features["tail_lizard"]
 		spines = H.dna.features["spines"]
 		H.update_body()
+
+/obj/item/organ/tail/lizard/is_wagging(mob/living/carbon/human/H)
+	if(!H?.dna?.species)
+		return FALSE
+	return ("waggingtail_lizard" in H.dna.species.mutant_bodyparts)
+
+/obj/item/organ/tail/lizard/set_wagging(mob/living/carbon/human/H, wagging = FALSE)
+	. = FALSE
+	if(!H?.dna?.species)
+		return
+	var/datum/species/species = H.dna.species
+	if(wagging)
+		species.mutant_bodyparts -= list("tail_lizard", "spines")
+		species.mutant_bodyparts |= list("waggingtail_lizard", "waggingspines")
+		. = TRUE
+	else
+		species.mutant_bodyparts -= list("waggingtail_lizard", "waggingspines")
+		species.mutant_bodyparts |= list("tail_lizard", "spines")
+	H.update_body()

--- a/nsv13/code/modules/mob/living/simple_animal/bot/hugbot.dm
+++ b/nsv13/code/modules/mob/living/simple_animal/bot/hugbot.dm
@@ -363,21 +363,14 @@
 		playsound(H, 'sound/weapons/tap.ogg', 50, 0)
 		SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "headpat", /datum/mood_event/headpat)
 	else if(check_zone(zone_selected) == BODY_ZONE_HEAD)
-		var/datum/species/S
 		if(ishuman(H))
-			S = H.dna.species
-
 			visible_message("<span class='notice'>[src] gives [H] a pat on the head to make [H.p_them()] feel better!</span>", \
 						"<span class='notice'>You give [src] a pat on the head to make [H.p_them()] feel better!</span>")
 			SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "headpat", /datum/mood_event/headpat)
-			if(S?.can_wag_tail(src) && !(S?.is_wagging_tail()))
-				var/static/list/many_tails
-				if(!many_tails)
-					many_tails = list("tail_human", "tail_lizard", "mam_tail")
-				for(var/T in many_tails)
-					if(S.mutant_bodyparts[T] && H.dna.features[T] != "None")
-						H.emote("wag")
-						break
+			var/obj/item/organ/tail/tail = H.get_bodypart(ORGAN_SLOT_TAIL)
+			if(!tail)
+				return
+			tail.toggle_wag(H)
 	else
 		visible_message("<span class='notice'>[src] hugs [H] to make [H.p_them()] feel better!</span>", \
 					"<span class='notice'>You hug [H] to make [H.p_them()] feel better!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
## Original PR
* https://github.com/BeeStation/BeeStation-Hornet/pull/9028

## About The Pull Request
This refactors tail wagging, so it's based on the tail organ rather than specific species. Mostly.

The result is that now _all_ species can *wag, if they have a tail.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Give the person a tail and let them wag it all day long no matter the species!
~~**MOFF TAIL WAGGING!!**~~
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/BeeStation/NSV13/assets/59128051/e6873696-81a6-47cf-819d-773b0ccd514d


</details>

## Changelog
:cl:Absolucy
refactor: Refactored tail wagging code a bit.
tweak: All species can now *wag their tail if they have one.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
