### PR TITLE
Minor overmap mode updates

### DIFF
--- a/nsv13/code/controllers/subsystem/overmap_mode.dm
+++ b/nsv13/code/controllers/subsystem/overmap_mode.dm
@@ -566,9 +566,10 @@ SUBSYSTEM_DEF(overmap_mode)
 			if(SSovermap_mode.mode_initialised)
 				qdel(SSovermap_mode.mode)
 				SSovermap_mode.mode = new S()
+				message_admins("[key_name_admin(usr)] has changed the overmap gamemode to [SSovermap_mode.mode.name]")
 			else
 				SSovermap_mode.forced_mode = S
-			message_admins("[key_name_admin(usr)] has changed the overmap gamemode to [SSovermap_mode.mode.name]")
+				message_admins("[key_name_admin(usr)] has changed the overmap gamemode to [initial(S.name)]")
 			return
 		if("add_objective")
 			var/list/objectives_pool = subtypesof(/datum/overmap_objective)

--- a/nsv13/code/controllers/subsystem/overmap_mode.dm
+++ b/nsv13/code/controllers/subsystem/overmap_mode.dm
@@ -96,7 +96,7 @@ SUBSYSTEM_DEF(overmap_mode)
 			required_players = min_pop[config_tag]
 		else
 			required_players = initial(GM.required_players)
-		var/max_players = -1
+		var/max_players = 0
 		if(config_tag in max_pop)
 			max_players = max_pop[config_tag]
 		else
@@ -104,9 +104,8 @@ SUBSYSTEM_DEF(overmap_mode)
 
 		if(player_check < required_players)
 			mode_cache -= M
-		else if(max_players > 0)
-			if(player_check > max_players)
-				mode_cache -= M
+		else if((max_players > 0) && (player_check > max_players))
+			mode_cache -= M
 
 	if(length(mode_cache))
 		var/list/mode_select = list()
@@ -483,7 +482,7 @@ SUBSYSTEM_DEF(overmap_mode)
 	var/instanced = FALSE							//Have we yet run the instance proc for this objective?
 	var/objective_number = 0						//The objective's index in the list. Useful for creating arbitrary report titles
 	var/required_players = 0						//Minimum number of players to get this if it's a random/extended objective
-	var/maximum_players = -1								//Maximum number of players to get this if it's a random/extended objective. -1 means no cap.
+	var/maximum_players = 0							//Maximum number of players to get this if it's a random/extended objective. 0 is unlimited.
 
 /datum/overmap_objective/New()
 

--- a/nsv13/code/controllers/subsystem/overmap_mode.dm
+++ b/nsv13/code/controllers/subsystem/overmap_mode.dm
@@ -58,68 +58,77 @@ SUBSYSTEM_DEF(overmap_mode)
 	//Set starting systems for the player ships
 	//Load and set objectives
 
-	mode_cache = typecacheof(/datum/overmap_gamemode, TRUE)
+	mode_cache = subtypesof(/datum/overmap_gamemode)
 
 	var/list/probabilities = config.Get(/datum/config_entry/keyed_list/omode_probability)
 	var/list/min_pop = config.Get(/datum/config_entry/keyed_list/omode_min_pop)
 	var/list/max_pop = config.Get(/datum/config_entry/keyed_list/omode_max_pop)
 
-	for(var/D in subtypesof(/datum/overmap_gamemode))
-		var/datum/overmap_gamemode/N = new D()
-		N.selection_weight = probabilities[N.config_tag]
-		N.required_players = min_pop[N.config_tag]
-		N.max_players = max_pop[N.config_tag]
-		mode_cache[D] = N
+	for(var/M in mode_cache)
+		var/datum/overmap_gamemode/GM = M
+		if(initial(GM.whitelist_only)) //Remove all of our only whitelisted modes
+			mode_cache -= M
 
-	var/list/mode_pool = mode_cache
-
-	for(var/M in mode_pool)
-		var/datum/overmap_gamemode/GM = mode_pool[M]
-		if(GM.whitelist_only) //Remove all of our only whitelisted modes
-			QDEL_NULL(mode_pool[M])
-			mode_pool -= M
-
-	if(SSmapping.config.omode_blacklist.len > 0)
+	if(length(SSmapping.config.omode_blacklist) > 0)
 		if(locate("all") in SSmapping.config.omode_blacklist)
-			mode_pool = list() //Clear the list
+			mode_cache.Cut()
 		else
 			for(var/S in SSmapping.config.omode_blacklist) //Grab the string to be the path - is there a proc for this?
 				var/B = text2path("/datum/overmap_gamemode/[S]")
-				QDEL_NULL(mode_pool[B])
-				mode_pool -= B
+				mode_cache -= B
 
-	if(SSmapping.config.omode_whitelist.len > 0)
+	if(length(SSmapping.config.omode_whitelist) > 0)
 		for(var/S in SSmapping.config.omode_whitelist) //Grab the string to be the path - is there a proc for this?
 			var/W = text2path("/datum/overmap_gamemode/[S]")
-			mode_pool[W] = new W()
+			mode_cache += W
 
 	for(var/mob/dead/new_player/P in GLOB.player_list) //Count the number of connected players
 		if(P.client)
 			player_check ++
 
-	for(var/M in mode_pool) //Check and remove any modes that we have insufficient players for the mode
-		var/datum/overmap_gamemode/GM = mode_pool[M]
-		if(player_check < GM.required_players)
-			QDEL_NULL(mode_pool[M])
-			mode_pool -= M
-		else if(GM.max_players > 0)
-			if(player_check > GM.max_players)
-				QDEL_NULL(mode_pool[M])
-				mode_pool -= M
+	for(var/M in mode_cache) //Check and remove any modes that we have insufficient players for the mode
+		var/datum/overmap_gamemode/GM = M
+		var/config_tag = initial(GM.config_tag)
 
-	if(mode_pool.len)
+		var/required_players = 0
+		if(config_tag in min_pop)
+			required_players = min_pop[config_tag]
+		else
+			required_players = initial(GM.required_players)
+		var/max_players = -1
+		if(config_tag in max_pop)
+			max_players = max_pop[config_tag]
+		else
+			max_players = initial(GM.max_players)
+
+		if(player_check < required_players)
+			mode_cache -= M
+		else if(max_players > 0)
+			if(player_check > max_players)
+				mode_cache -= M
+
+	if(length(mode_cache))
 		var/list/mode_select = list()
-		for(var/M in mode_pool)
-			var/datum/overmap_gamemode/GM = mode_pool[M]
-			for(var/I = 0, I < GM.selection_weight, I++) //Populate with weight number of instances
+		for(var/M in mode_cache)
+			var/datum/overmap_gamemode/GM = M
+			var/config_tag = initial(GM.config_tag)
+
+			var/selection_weight = 0
+			if(config_tag in probabilities)
+				selection_weight = probabilities[config_tag]
+			else
+				selection_weight = initial(GM.selection_weight)
+			for(var/I = 0, I < selection_weight, I++) //Populate with weight number of instances
 				mode_select += M
 
-		if(mode_select.len)
+		if(length(mode_select))
 			var/mode_type = pick(mode_select)
-			mode = mode_pool[mode_type]
-			message_admins("[mode.name] has been selected as the overmap gamemode")
-			log_game("[mode.name] has been selected as the overmap gamemode")
-	if(!mode)
+			mode = new mode_type
+
+	if(mode)
+		message_admins("[mode.name] has been selected as the overmap gamemode")
+		log_game("[mode.name] has been selected as the overmap gamemode")
+	else
 		mode = new/datum/overmap_gamemode/patrol() //Holding that as the default for now - REPLACE ME LATER
 		message_admins("Error: mode section pool empty - defaulting to PATROL")
 		log_game("Error: mode section pool empty - defaulting to PATROL")

--- a/nsv13/code/game/gamemodes/overmap/objectives/rubicon.dm
+++ b/nsv13/code/game/gamemodes/overmap/objectives/rubicon.dm
@@ -25,6 +25,8 @@
 /datum/overmap_objective/clear_system/rubicon
 	system_name = "Rubicon"
 	extension_supported = TRUE
+	required_players = 4
 
 /datum/overmap_objective/clear_system/dolos
 	system_name = "Dolos Remnants"
+	required_players = 4


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This does some backend improvements for selection of overmap mode and objectives. It allows admins to select a gamemode before the overmap_mode subsystem is done initializing, and adds min and max pops for objectives. It also sets the Rubicon and Dolos objective minimum pop to 4 alive, non-AFK players.

## Why It's Good For The Game
Admins don't have to let another gamemode get partly set up before picking a new one.
Being forced into deadpop Rubicon is bad.

## Changelog
:cl:
code: Overmap objectives and modes are not initialized until they are selected
code: If pop and weight for an overmap mode are not set in the config, it will use the coded values
feature: Overmap objectives can have population requirements
feature: Admins can change set overmap mode before the system initializes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
