### PR TITLE
AMS shot counter

### DIFF
--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/vls.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/vls.dm
@@ -202,8 +202,6 @@
 		return FALSE
 	if(QDELETED(target))
 		return FALSE
-	if(OM.ams_shot_limit <= OM.ams_shots_fired)
-		return FALSE
 	// OM.fire_weapon(target, mode=weapon_type, lateral=TRUE)
 	weapon_type.fire( target )
 	OM.ams_shots_fired += 1
@@ -224,6 +222,11 @@
 		return list()
 	. = ..()
 
+/datum/ams_mode/sts/handle_autonomy(obj/structure/overmap/OM, datum/ship_weapon/weapon_type)
+	if(OM.ams_shot_limit <= OM.ams_shots_fired)
+		return FALSE
+	return ..()
+
 /datum/ams_mode/countermeasures
 	name = "Anti-missile countermeasures"
 	desc = "This mode will target oncoming missiles and attempt to counter them with the ship's own missile complement. Recommended for usage exclusively with ECM missiles."
@@ -243,8 +246,8 @@
 /obj/machinery/computer/ams/ui_act(action, params)
 	if(..())
 		return
+	var/obj/structure/overmap/linked = get_overmap()
 	if(action == "data_source")
-		var/obj/structure/overmap/linked = get_overmap()
 		if(!linked)
 			return
 		if(linked.ams_data_source == AMS_LOCKED_TARGETS)
@@ -253,13 +256,13 @@
 		linked.ams_data_source = AMS_LOCKED_TARGETS
 		return
 	if(action == "set_shot_limit")
-		var/obj/structure/overmap/linked = get_overmap()
 		linked.ams_shot_limit = sanitize_integer(params["shot_limit"], 1, 100, 5)
 		return
 	if(action == "select")
 		var/datum/ams_mode/target = locate(params["target"])
 		if(!target)
 			return FALSE
+		linked.ams_shots_fired = 0
 		target.enabled = !target.enabled
 
 /obj/machinery/computer/ams/ui_data(mob/user)

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/vls.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/vls.dm
@@ -202,8 +202,11 @@
 		return FALSE
 	if(QDELETED(target))
 		return FALSE
+	if(OM.ams_shot_limit <= OM.ams_shots_fired)
+		return FALSE
 	// OM.fire_weapon(target, mode=weapon_type, lateral=TRUE)
 	weapon_type.fire( target )
+	OM.ams_shots_fired += 1
 	OM.next_ams_shot = world.time + OM.ams_targeting_cooldown
 
 //Subtypes.
@@ -249,10 +252,15 @@
 			return
 		linked.ams_data_source = AMS_LOCKED_TARGETS
 		return
-	var/datum/ams_mode/target = locate(params["target"])
-	if(!target)
-		return FALSE
-	target.enabled = !target.enabled
+	if(action == "set_shot_limit")
+		var/obj/structure/overmap/linked = get_overmap()
+		linked.ams_shot_limit = sanitize_integer(params["shot_limit"], 1, 100, 5)
+		return
+	if(action == "select")
+		var/datum/ams_mode/target = locate(params["target"])
+		if(!target)
+			return FALSE
+		target.enabled = !target.enabled
 
 /obj/machinery/computer/ams/ui_data(mob/user)
 	..()
@@ -271,6 +279,7 @@
 		categories[++categories.len] = category
 	data["categories"] = categories
 	data["data_source"] = OM.ams_data_source
+	data["shot_limit"] = OM.ams_shot_limit
 	return data
 
 /obj/machinery/computer/ams/ui_interact(mob/user, datum/tgui/ui)

--- a/nsv13/code/modules/overmap/overmap.dm
+++ b/nsv13/code/modules/overmap/overmap.dm
@@ -153,6 +153,8 @@
 	var/list/ams_data_source = AMS_LOCKED_TARGETS
 	var/next_ams_shot = 0
 	var/ams_targeting_cooldown = 1.5 SECONDS
+	var/ams_shot_limit = 5
+	var/ams_shots_fired = 0
 
 	// Railgun aim helper
 	var/last_tracer_process = 0
@@ -577,6 +579,7 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 		playsound(tactical, sound, 100, 1)
 	if(params_list["ctrl"]) //Ctrl click to lock on to people
 		start_lockon(target)
+		ams_shots_fired = 0
 		return TRUE
 	if(user == gunner)
 		var/datum/ship_weapon/SW = weapon_types[fire_mode]

--- a/nsv13/code/modules/overmap/weapons/weapons.dm
+++ b/nsv13/code/modules/overmap/weapons/weapons.dm
@@ -51,6 +51,8 @@
 
 	if(weapon_safety)
 		return FALSE
+	if(mode = FIRE_MODE_AMS)
+		ams_shots_fired = 0
 	if(SW?.fire(target, ai_aim=ai_aim))
 		return TRUE
 	else

--- a/nsv13/code/modules/overmap/weapons/weapons.dm
+++ b/nsv13/code/modules/overmap/weapons/weapons.dm
@@ -51,7 +51,7 @@
 
 	if(weapon_safety)
 		return FALSE
-	if(mode = FIRE_MODE_AMS)
+	if(mode == FIRE_MODE_AMS)
 		ams_shots_fired = 0
 	if(SW?.fire(target, ai_aim=ai_aim))
 		return TRUE

--- a/tgui/packages/tgui/interfaces/AMS.js
+++ b/tgui/packages/tgui/interfaces/AMS.js
@@ -39,7 +39,7 @@ export const AMS = (props, context) => {
         <Section title="Shots to fire:">
           <NumberInput
             animated
-            value={parseInt(data.shot_limit)}
+            value={parseInt(data.shot_limit, 10)}
             unit="shots"
             width="125px"
             minValue={1}

--- a/tgui/packages/tgui/interfaces/AMS.js
+++ b/tgui/packages/tgui/interfaces/AMS.js
@@ -2,7 +2,7 @@
 
 import { Fragment } from 'inferno';
 import { useBackend, useLocalState } from '../backend';
-import { Button, Section } from '../components';
+import { Button, NumberInput, Section } from '../components';
 import { Window } from '../layouts';
 
 export const AMS = (props, context) => {
@@ -35,6 +35,19 @@ export const AMS = (props, context) => {
               </Section>
             );
           })}
+        </Section>
+        <Section title="Shots to fire:">
+          <NumberInput
+            animated
+            value={parseInt(data.shot_limit)}
+            unit="shots"
+            width="125px"
+            minValue={1}
+            maxValue={100}
+            step={1}
+            onChange={(e, value) => act('set_shot_limit', {
+              shot_limit: value,
+            })} />
         </Section>
       </Window.Content>
     </Window>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
It gives the AMS management console an input to set how many shots should fire at a time. The counter will be reset when a new target is painted/locked, when the tactical officer clicks on the overmap with the AMS selected, or when someone toggles modes on the AMS console.

## Why It's Good For The Game
Launching all the missiles is kind of annoying. If you don't want this, it goes up to 100, so just do that.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
Procedure: 
1. Load or lazyload a bunch of VLS tubes
2. Use the AMS console to set the limit
3. Spawn enemy fleet
4. Target them or their missiles
</details>

## Changelog
:cl:
add: Add limit on number of VLS shots fired at once to AMS control console
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
