### PR TITLE
Showers no longer are useless for contamination above 0 but below 18

### DIFF
--- a/code/game/objects/structures/shower.dm
+++ b/code/game/objects/structures/shower.dm
@@ -241,7 +241,7 @@
 	if(strength <= RAD_BACKGROUND_RADIATION)
 		qdel(healthy_green_glow)
 		return
-	healthy_green_glow.strength -= max(0, (healthy_green_glow.strength - (RAD_BACKGROUND_RADIATION * 2)) * 0.2)
+	healthy_green_glow.strength -= max(0, healthy_green_glow.strength * 0.2)
 
 /obj/machinery/shower/process()
 	if(on)

--- a/code/game/objects/structures/shower.dm
+++ b/code/game/objects/structures/shower.dm
@@ -241,8 +241,7 @@
 	if(strength <= RAD_BACKGROUND_RADIATION)
 		qdel(healthy_green_glow)
 		return
-	healthy_green_glow.strength -= max(0, healthy_green_glow.strength * 0.2)
-
+	healthy_green_glow.strength -= max(0, healthy_green_glow.strength * 0.2) //NSV13 - Now removes rads towards 0, instead of towards (background radiation * 2).
 /obj/machinery/shower/process()
 	if(on)
 		wash_atom(loc)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Basically, for some reason, showers currently are unable to wash off as much contamination as background_radiation * 2, despite one being some background neutrons flying around, and the other being contamination in clothing / *on* things right now. 
This makes removing the last 18 contamination on targets very prolonged, pretty much *requiring* SSU use.
This PR removes that limitation, making showers always remove 20% of current contam per tick.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Green outlines are funny but also kind of dangerous.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
No.

## Changelog
:cl:
balance: Showers can now also affect the last 18 contamination on targets.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
