### PR TITLE
fixes extra charslot in metacoin thingie

### DIFF
--- a/code/modules/client/loadout/loadout_ooc.dm
+++ b/code/modules/client/loadout/loadout_ooc.dm
@@ -9,7 +9,7 @@
 	cost = 10000
 
 /datum/gear/ooc/char_slot/purchase(var/client/C)
-	C?.prefs?.set_max_character_slots(C.prefs.max_usable_slots = 1)
+	C?.prefs?.set_max_character_slots(C?.prefs?.max_usable_slots + 1)
 
 /datum/gear/ooc/real_antagtoken
 	display_name = "antag token"


### PR DESCRIPTION
![image](https://github.com/BeeStation/NSV13/assets/56449763/9394a8b6-9eec-4906-9862-8d157c138148)
(but c'mon, it would be much funnier if it went to 1 instead)

:cl:
fix: buying an extra charslot for torps now unlocks it immediately
/:cl:

i also noticed that apparently nothing checks if something is bought already so s1 may possibly href exploit up to 9 slots (for current game), provided they have enough torps (or any other gear for that matter but i don't see a reason why)