### PR TITLE
Galactica Reactor Fix

### DIFF
--- a/_maps/map_files/Galactica/Galactica2.dmm
+++ b/_maps/map_files/Galactica/Galactica2.dmm
@@ -143,14 +143,6 @@
 	},
 /turf/closed/wall/steel,
 /area/nsv/briefingroom)
-"adB" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer2,
-/turf/open/floor/plasteel/ridged/steel,
-/area/engine/engineering/reactor_core)
 "adL" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/general/hidden/layer2{
@@ -3465,10 +3457,11 @@
 "bPe" = (
 /obj/machinery/atmospherics/components/binary/pump/layer2{
 	dir = 8;
-	name = "o2 to AGR#2"
+	name = "O2 to Utility Reactor"
 	},
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 8
+	dir = 8;
+	name = "O2 to Defensive Reactor"
 	},
 /obj/machinery/light{
 	dir = 4
@@ -6418,7 +6411,7 @@
 /obj/machinery/atmospherics/components/binary/pump/rbmk_output{
 	dir = 4;
 	id = "rbmk2_output";
-	name = "AGCNR Coolant Outlet"
+	name = "s Outlet"
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible/layer2{
 	dir = 4
@@ -6977,7 +6970,7 @@
 "dOf" = (
 /obj/machinery/atmospherics/components/binary/pump/layer2{
 	dir = 8;
-	name = "AGR #2 Moderator Line"
+	name = "Utility Reactor Moderator Line"
 	},
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
@@ -8324,7 +8317,7 @@
 "eAl" = (
 /obj/effect/turf_decal/ship/techfloor,
 /obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/machinery/atmospherics/pipe/simple/violet/visible/layer4,
+/obj/machinery/atmospherics/pipe/simple/violet/hidden/layer4,
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
 "eAp" = (
@@ -13686,13 +13679,6 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/security/brig)
-"hkd" = (
-/obj/structure/lattice/catwalk/over/ship,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/engine/engineering/reactor_core)
 "hkh" = (
 /obj/machinery/smartfridge/disks,
 /obj/structure/table/wood,
@@ -19923,7 +19909,7 @@
 	dir = 4
 	},
 /obj/structure/cable/cyan,
-/obj/item/inducer/eng,
+/obj/item/inducer,
 /turf/open/floor/carpet/green,
 /area/engine/engineering/reactor_control)
 "kEZ" = (
@@ -20553,11 +20539,11 @@
 /turf/open/floor/monotile/steel,
 /area/science/nsv/astronomy)
 "kXb" = (
-/obj/machinery/modular_computer/console/preset/engineering{
-	dir = 4;
-	name = "Defensive Reactor engineering console"
-	},
 /obj/structure/cable/yellow,
+/obj/machinery/computer/monitor{
+	dir = 4;
+	name = "Defensive Reactor power monitoring console"
+	},
 /turf/open/floor/durasteel/lino,
 /area/engine/engineering/reactor_control)
 "kXY" = (
@@ -20934,7 +20920,8 @@
 	},
 /obj/machinery/atmospherics/components/binary/pump/rbmk_input{
 	dir = 4;
-	id = "rbmk2_input"
+	id = "rbmk2_input";
+	name = "AGCNR Coolant Input"
 	},
 /turf/open/floor/durasteel/techfloor_grid,
 /area/engine/engineering/reactor_core)
@@ -23414,6 +23401,13 @@
 /obj/structure/ladder,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame3/central)
+"mwX" = (
+/obj/structure/lattice/catwalk/over/ship,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/engineering/reactor_core)
 "mxh" = (
 /obj/structure/cable/orange{
 	icon_state = "2-8"
@@ -28246,13 +28240,13 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/modular_computer/console/preset/engineering{
-	dir = 8;
-	name = "Utility Reactor engineering console"
-	},
 /obj/item/radio/intercom/directional/north,
 /obj/structure/cable/cyan{
 	icon_state = "0-8"
+	},
+/obj/machinery/computer/monitor{
+	dir = 8;
+	name = "Utility Reactor power monitoring console"
 	},
 /turf/open/floor/durasteel/lino,
 /area/engine/engineering/reactor_control)
@@ -29141,11 +29135,12 @@
 	})
 "pCi" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 8
+	dir = 8;
+	name = "Custom to Utility Reactor"
 	},
 /obj/machinery/atmospherics/components/binary/pump/layer2{
 	dir = 8;
-	name = "custom to AGR#2"
+	name = "Custom to Defensive Reactor"
 	},
 /turf/open/floor/engine,
 /area/engine/atmos)
@@ -29357,7 +29352,8 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/binary/pump/rbmk_input{
-	dir = 4
+	dir = 4;
+	name = "AGCNR Coolant Input"
 	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
@@ -34630,10 +34626,11 @@
 "sDg" = (
 /obj/machinery/atmospherics/components/binary/pump/layer2{
 	dir = 8;
-	name = "custom to AGR#2"
+	name = "Custom to Defensive Reactor"
 	},
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 8
+	dir = 8;
+	name = "Custom to Utility Reactor"
 	},
 /obj/machinery/light{
 	dir = 4
@@ -34832,7 +34829,7 @@
 "sHj" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
-	name = "AGCNR Moderator Tank"
+	name = "Defensive Reactor Moderator Tank"
 	},
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
@@ -37442,10 +37439,11 @@
 "tZd" = (
 /obj/machinery/atmospherics/components/binary/pump/layer2{
 	dir = 8;
-	name = "CO2 to AGR#2"
+	name = "CO2 to Defensive Reactor"
 	},
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 8
+	dir = 8;
+	name = "CO2 to Utility Reactor"
 	},
 /turf/open/floor/engine,
 /area/engine/atmos)
@@ -40566,10 +40564,11 @@
 "vHu" = (
 /obj/machinery/atmospherics/components/binary/pump/layer2{
 	dir = 8;
-	name = "n2 to AGR#2"
+	name = "N2 to Defensive Reactor"
 	},
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 8
+	dir = 8;
+	name = "N2 to Utility Reactor"
 	},
 /turf/open/floor/engine,
 /area/engine/atmos)
@@ -41106,6 +41105,14 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/bridge/showroom/corporate)
+"vXy" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer2,
+/turf/open/floor/plasteel/ridged/steel,
+/area/engine/engineering/reactor_core)
 "vXL" = (
 /obj/structure/cable/orange{
 	icon_state = "2-8"
@@ -41770,10 +41777,11 @@
 "wtc" = (
 /obj/machinery/atmospherics/components/binary/pump/layer2{
 	dir = 8;
-	name = "plasma to AGR#2"
+	name = "Plasma to Defensive Reactor"
 	},
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 8
+	dir = 8;
+	name = "Plasma to Utility Reactor"
 	},
 /turf/open/floor/engine,
 /area/engine/atmos)
@@ -42344,10 +42352,11 @@
 "wKy" = (
 /obj/machinery/atmospherics/components/binary/pump/layer2{
 	dir = 8;
-	name = "n2o to AGR#2"
+	name = "N2O to Defensive Reactor"
 	},
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 8
+	dir = 8;
+	name = "N2O to Utility Reactor"
 	},
 /obj/machinery/light{
 	dir = 4
@@ -60417,7 +60426,7 @@ srp
 srp
 vrQ
 cpE
-hkd
+mwX
 oEg
 xQO
 rDP
@@ -61449,7 +61458,7 @@ dqO
 tln
 bSC
 igj
-adB
+vXy
 mwQ
 fXE
 bKv

--- a/_maps/map_files/Galactica/Galactica2.dmm
+++ b/_maps/map_files/Galactica/Galactica2.dmm
@@ -143,6 +143,14 @@
 	},
 /turf/closed/wall/steel,
 /area/nsv/briefingroom)
+"adB" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer2,
+/turf/open/floor/plasteel/ridged/steel,
+/area/engine/engineering/reactor_core)
 "adL" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/general/hidden/layer2{
@@ -391,7 +399,7 @@
 	input_tag = "extra_2_input";
 	name = "Custom Tank 2 Control";
 	output_tag = "extra_2_output";
-	sensors = list("extra_2_sensor"="Custom Tank 2")
+	sensors = list("extra_2_sensor"="Custom  Tank  2")
 	},
 /turf/open/floor/engine,
 /area/engine/atmos)
@@ -1417,7 +1425,6 @@
 /obj/effect/turf_decal/ship/techfloor{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/green/visible,
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
 "aNT" = (
@@ -8302,7 +8309,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/computer/reactor/stats{
 	id = "default_reactor_for_lazy_mappers2";
-	name = "Reactor 2 Statistics Console"
+	name = "Utility Reactor Statistics Console"
 	},
 /turf/open/floor/durasteel/lino,
 /area/engine/engineering/reactor_control)
@@ -8317,6 +8324,7 @@
 "eAl" = (
 /obj/effect/turf_decal/ship/techfloor,
 /obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/atmospherics/pipe/simple/violet/visible/layer4,
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
 "eAp" = (
@@ -8958,7 +8966,7 @@
 "eTh" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/reactor/fuel_rods{
-	name = "Reactor 1 Fuel Management Console"
+	name = "Defensive Reactor Fuel Management Console"
 	},
 /obj/machinery/light,
 /obj/structure/extinguisher_cabinet/south,
@@ -10115,9 +10123,6 @@
 /obj/effect/turf_decal/ship/techfloor{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
 "fye" = (
@@ -10969,7 +10974,7 @@
 	input_tag = "extra_5_input";
 	name = "Custom Tank 5 Control";
 	output_tag = "extra_5_output";
-	sensors = list("extra_5_sensor"="Custom Tank 5")
+	sensors = list("extra_5_sensor"="Custom  Tank  5")
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -11056,7 +11061,7 @@
 "fVd" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/reactor/pump/rbmk_moderator{
-	name = "Reactor 1 moderator valve computer"
+	name = "Defensive Reactor moderator valve computer"
 	},
 /turf/open/floor/durasteel/lino,
 /area/engine/engineering/reactor_control)
@@ -11621,7 +11626,7 @@
 	input_tag = "extra_1_input";
 	name = "Custom Tank 1 Control";
 	output_tag = "extra_1_output";
-	sensors = list("extra_1_sensor"="Custom Tank 1")
+	sensors = list("extra_1_sensor"="Custom  Tank  1")
 	},
 /turf/open/floor/engine,
 /area/engine/atmos)
@@ -11701,7 +11706,7 @@
 	input_tag = "FTLinput";
 	name = "Fuel Monitoring";
 	output_tag = "FTLoutput";
-	sensors = list("FTLsensor"="FTL Fuel Tank")
+	sensors = list("FTLsensor"="FTL  Fuel  Tank")
 	},
 /turf/open/floor/engine,
 /area/engine/engineering/ftl_room)
@@ -11914,6 +11919,9 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame5/port)
 "grI" = (
@@ -13678,6 +13686,13 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/security/brig)
+"hkd" = (
+/obj/structure/lattice/catwalk/over/ship,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/engineering/reactor_core)
 "hkh" = (
 /obj/machinery/smartfridge/disks,
 /obj/structure/table/wood,
@@ -14452,7 +14467,7 @@
 	input_tag = "nuclear_mix_in_3";
 	name = "Nuclear Reactor Gas Tank Control";
 	output_tag = "nuclear_min_out_3";
-	sensors = list("nuclear_mix_sensor_3"="Nuclear Reactor Gas Mix Tank 3")
+	sensors = list("nuclear_mix_sensor_3"="Nuclear  Reactor  Gas  Mix  Tank  3")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -19908,6 +19923,7 @@
 	dir = 4
 	},
 /obj/structure/cable/cyan,
+/obj/item/inducer/eng,
 /turf/open/floor/carpet/green,
 /area/engine/engineering/reactor_control)
 "kEZ" = (
@@ -20539,7 +20555,7 @@
 "kXb" = (
 /obj/machinery/modular_computer/console/preset/engineering{
 	dir = 4;
-	name = "reactor #1 engineering console"
+	name = "Defensive Reactor engineering console"
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/durasteel/lino,
@@ -20667,7 +20683,6 @@
 /obj/effect/turf_decal/ship/techfloor{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/green/visible,
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
 "lbY" = (
@@ -21036,7 +21051,7 @@
 "lms" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/reactor/stats{
-	name = "Reactor 1 Statistics Console"
+	name = "Defensive Reactor Statistics Console"
 	},
 /turf/open/floor/durasteel/lino,
 /area/engine/engineering/reactor_control)
@@ -23021,7 +23036,7 @@
 	},
 /obj/machinery/computer/reactor/pump/rbmk_output{
 	id = "rbmk2_output";
-	name = "Reactor 2 output valve computer"
+	name = "Utility Reactor output valve computer"
 	},
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
@@ -23588,7 +23603,7 @@
 "mCa" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/reactor/control_rods{
-	name = "Reactor 1 Control rod management computer"
+	name = "Defensive Reactor Control rod management computer"
 	},
 /turf/open/floor/durasteel/lino,
 /area/engine/engineering/reactor_control)
@@ -23675,7 +23690,7 @@
 	input_tag = "extra_4_input";
 	name = "Custom Tank 4 Control";
 	output_tag = "extra_4_output";
-	sensors = list("extra_4_sensor"="Custom Tank 4")
+	sensors = list("extra_4_sensor"="Custom  Tank  4")
 	},
 /obj/structure/lattice/catwalk/over/ship,
 /turf/open/floor/plating,
@@ -24733,7 +24748,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/computer/reactor/pump/rbmk_input{
 	id = "rbmk2_input";
-	name = "Reactor 2 inlet valve computer"
+	name = "Utility Reactor inlet valve computer"
 	},
 /turf/open/floor/durasteel/lino,
 /area/engine/engineering/reactor_control)
@@ -25404,7 +25419,7 @@
 "nFZ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/reactor/pump/rbmk_input{
-	name = "Reactor 1 inlet valve computer"
+	name = "Defensive Reactor inlet valve computer"
 	},
 /turf/open/floor/durasteel/lino,
 /area/engine/engineering/reactor_control)
@@ -25964,7 +25979,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/computer/reactor/control_rods{
 	id = "default_reactor_for_lazy_mappers2";
-	name = "Reactor 2 Control rod management computer"
+	name = "Utility Reactor Control rod management computer"
 	},
 /turf/open/floor/durasteel/lino,
 /area/engine/engineering/reactor_control)
@@ -28233,7 +28248,7 @@
 	},
 /obj/machinery/modular_computer/console/preset/engineering{
 	dir = 8;
-	name = "reactor #2 engineering console"
+	name = "Utility Reactor engineering console"
 	},
 /obj/item/radio/intercom/directional/north,
 /obj/structure/cable/cyan{
@@ -32140,7 +32155,7 @@
 "rnr" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/reactor/pump/rbmk_output{
-	name = "Reactor 1 output valve computer"
+	name = "Defensive Reactor output valve computer"
 	},
 /turf/open/floor/durasteel/lino,
 /area/engine/engineering/reactor_control)
@@ -34352,7 +34367,7 @@
 	input_tag = "extra_3_input";
 	name = "Custom Tank 3 Control";
 	output_tag = "extra_3_output";
-	sensors = list("extra_3_sensor"="Custom Tank 3")
+	sensors = list("extra_3_sensor"="Custom  Tank  3")
 	},
 /obj/structure/lattice/catwalk/over/ship,
 /obj/machinery/light{
@@ -35653,7 +35668,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/computer/reactor/pump/rbmk_moderator{
 	id = "rbmk2_moderator";
-	name = "Reactor 2 moderator valve computer"
+	name = "Utility Reactor moderator valve computer"
 	},
 /turf/open/floor/durasteel/lino,
 /area/engine/engineering/reactor_control)
@@ -40787,7 +40802,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/computer/reactor/fuel_rods{
 	id = "default_reactor_for_lazy_mappers2";
-	name = "Reactor 2 Fuel Management Console"
+	name = "Utility Reactor Fuel Management Console"
 	},
 /turf/open/floor/durasteel/lino,
 /area/engine/engineering/reactor_control)
@@ -40858,9 +40873,9 @@
 /obj/machinery/computer/atmos_control/tank/toxin_tank{
 	dir = 4;
 	input_tag = "stormdrive_mix_in";
-	name = "Secondary reactor Gas Tank Control";
+	name = "Defense Reactor Gas Tank Control";
 	output_tag = "stormdrive_mix_out";
-	sensors = list("stormdrive_mix_sensor"="Stormdrive Gas Mix Tank")
+	sensors = list("stormdrive_mix_sensor"="Stormdrive  Gas  Mix  Tank")
 	},
 /obj/structure/lattice/catwalk/over/ship,
 /turf/open/floor/plating,
@@ -44037,7 +44052,9 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 8
+	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
 "xGU" = (
@@ -44709,9 +44726,6 @@
 /obj/effect/turf_decal/ship/techfloor{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 5
-	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
 "yca" = (
@@ -44949,9 +44963,9 @@
 /obj/machinery/computer/atmos_control/tank/toxin_tank{
 	dir = 4;
 	input_tag = "nuclear_mix_in_1";
-	name = "Primary reactor Gas Tank Control";
+	name = "Utility Reactor Gas Tank Control";
 	output_tag = "nuclear_min_out_1";
-	sensors = list("nuclear_mix_sensor_1"="Nuclear Reactor Gas Mix Tank 1")
+	sensors = list("nuclear_mix_sensor_1"="Nuclear  Reactor  Gas  Mix  Tank  1")
 	},
 /obj/structure/lattice/catwalk/over/ship,
 /obj/machinery/atmospherics/pipe/simple/violet/visible/layer4,
@@ -60403,7 +60417,7 @@ srp
 srp
 vrQ
 cpE
-xQO
+hkd
 oEg
 xQO
 rDP
@@ -61435,7 +61449,7 @@ dqO
 tln
 bSC
 igj
-nQh
+adB
 mwQ
 fXE
 bKv


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This correctly rotates a pipe located under the Defensive reactor coolant pipe (see details). It also renames an unholy number of pumps and computers to clarify which reactor is controlled by what, and adds an inducer for those aspiring engineers if they somehow run out of time starting them.

## Why It's Good For The Game

Fix man good. Reactor boom is funny, but bad. Clarification good.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<summary>

![Rotated Pipe](https://github.com/BeeStation/NSV13/assets/75588150/774ff8c0-dcf7-4dd3-8f2a-9dc8d0e60d49)
![Inducer](https://github.com/BeeStation/NSV13/assets/75588150/5d436efa-4bb2-4bab-906f-28760d84dd0c)

</summary>

## Changelog
:cl:
add: Inducer to Galactica Reactor Control room.
fix: Correctly rotated Defensive reactor coolant output pipe on the Galactica
tweak: Renamed reactor pumps and computers for clarification on the Galactica
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->