### PR TITLE
Makes latejoins wake up from cryostasis instead of arriving on a shuttle

### DIFF
--- a/_maps/atlas.json
+++ b/_maps/atlas.json
@@ -21,7 +21,6 @@
     "shuttles": {
         "cargo": "cargo_atlas",
         "ferry": "ferry_fancy",
-        "arrival": "arrival_atlas",
         "emergency": "emergency_atlas"
     },
     "mine_disable": 1,

--- a/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
@@ -1627,18 +1627,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
-"aTc" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 3;
-	height = 15;
-	id = "arrivals_stationary";
-	name = "Deck 2 Arrivals Port";
-	roundstart_template = /datum/map_template/shuttle/arrival/aetherwhisp;
-	width = 7
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "aTh" = (
 /obj/machinery/status_display/evac,
 /turf/closed/wall/ship,
@@ -10809,6 +10797,7 @@
 /turf/open/floor/carpet/blue,
 /area/medical/medbay/lobby)
 "hba" = (
+/obj/effect/landmark/latejoin,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/cryopods)
 "hbl" = (
@@ -18579,6 +18568,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/cryopods)
 "mnZ" = (
@@ -21706,6 +21696,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/cryopods)
 "ond" = (
@@ -29975,6 +29966,7 @@
 /area/medical/medbay/lobby)
 "tDB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/landmark/latejoin,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/cryopods)
 "tEQ" = (
@@ -32593,6 +32585,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/cryopods)
 "vzU" = (
@@ -34347,6 +34340,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/cryopods)
 "wQb" = (
@@ -34725,6 +34719,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/landmark/latejoin,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/cryopods)
 "xeT" = (
@@ -36001,6 +35996,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/cryopods)
 "xWT" = (
@@ -69472,7 +69468,7 @@ baX
 baX
 baX
 baX
-aTc
+baX
 baX
 baX
 baX

--- a/_maps/map_files/Atlas/atlas2.dmm
+++ b/_maps/map_files/Atlas/atlas2.dmm
@@ -2225,6 +2225,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/bridge/cic)
+"kc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/landmark/latejoin,
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck1/hallway)
 "ke" = (
 /obj/effect/turf_decal/tile/ship/brown{
 	dir = 1
@@ -3413,18 +3423,6 @@
 "pT" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
-"pU" = (
-/obj/docking_port/stationary{
-	dir = 4;
-	dwidth = 3;
-	height = 15;
-	id = "arrivals_stationary";
-	name = "Atlas Arrivals";
-	roundstart_template = /datum/map_template/shuttle/arrival/atlas;
-	width = 7
-	},
-/turf/open/floor/engine/airless,
-/area/space/nearstation)
 "pW" = (
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -3847,6 +3845,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/ship/green,
+/obj/effect/landmark/latejoin,
 /turf/open/floor/durasteel/alt,
 /area/hallway/nsv/deck1/hallway)
 "sd" = (
@@ -5208,6 +5207,7 @@
 	pixel_y = 26
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/effect/landmark/latejoin,
 /turf/open/floor/carpet/green,
 /area/hallway/nsv/deck1/hallway)
 "ys" = (
@@ -5731,6 +5731,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/ship/green,
+/obj/effect/landmark/latejoin,
 /turf/open/floor/durasteel/alt,
 /area/hallway/nsv/deck1/hallway)
 "Bl" = (
@@ -6968,6 +6969,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "Hh" = (
@@ -9325,6 +9327,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "RC" = (
@@ -48105,7 +48108,7 @@ mK
 lx
 Am
 PT
-ST
+kc
 sc
 cH
 xT
@@ -50165,7 +50168,7 @@ KN
 cx
 cx
 cx
-pU
+cx
 cx
 cx
 cx

--- a/_maps/map_files/Eclipse/Eclipse1.dmm
+++ b/_maps/map_files/Eclipse/Eclipse1.dmm
@@ -153,6 +153,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/plasteel/dark/side{
 	dir = 4
 	},
@@ -1366,6 +1367,7 @@
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/plasteel/dark/side{
 	dir = 8
 	},
@@ -2166,6 +2168,7 @@
 /area/maintenance/aft)
 "jh" = (
 /obj/machinery/firealarm/directional/west,
+/obj/effect/landmark/latejoin,
 /turf/open/floor/plasteel/dark/side{
 	dir = 8
 	},
@@ -3498,6 +3501,7 @@
 /turf/open/floor/monotile/dark,
 /area/hallway/primary/fore)
 "of" = (
+/obj/effect/landmark/latejoin,
 /turf/open/floor/plasteel/dark/side{
 	dir = 8
 	},
@@ -3857,18 +3861,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/primary/fore)
-"pB" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 3;
-	height = 15;
-	id = "arrivals_stationary";
-	name = "arrivals";
-	roundstart_template = /datum/map_template/shuttle/arrival/box;
-	width = 7
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "pC" = (
 /obj/machinery/door/airlock/ship/hatch,
 /obj/machinery/door/firedoor/border_only/directional/south,
@@ -3965,6 +3957,7 @@
 	pixel_y = -22;
 	req_one_access = null
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/cryopods)
 "qa" = (
@@ -4469,12 +4462,6 @@
 "sx" = (
 /turf/open/floor/plasteel/dark/side,
 /area/construction)
-"sy" = (
-/obj/effect/turf_decal/stripes/full,
-/obj/structure/window/spawner,
-/obj/structure/window/spawner/north,
-/turf/open/floor/plating,
-/area/space/nearstation)
 "sz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
@@ -5663,6 +5650,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/plasteel/dark/side{
 	dir = 4
 	},
@@ -6389,6 +6377,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/plasteel/dark/side{
 	dir = 8
 	},
@@ -7439,6 +7428,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/cryopods)
 "EY" = (
@@ -9046,6 +9036,7 @@
 /turf/open/floor/monotile/steel,
 /area/engine/gravity_generator)
 "LK" = (
+/obj/effect/landmark/latejoin,
 /turf/open/floor/plasteel/dark/side{
 	dir = 4
 	},
@@ -10105,6 +10096,7 @@
 	},
 /area/hallway/primary/fore)
 "PK" = (
+/obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/cryopods)
 "PN" = (
@@ -11097,6 +11089,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/cryopods)
 "TI" = (
@@ -36399,16 +36392,16 @@ gX
 gX
 gX
 gX
-le
-Ti
-Ti
-Ti
-Ti
-Ti
-Ti
-Ti
-Ti
-Ti
+gX
+gX
+gX
+gX
+gX
+gX
+gX
+gX
+gX
+gX
 rK
 kU
 Ea
@@ -36656,16 +36649,16 @@ gX
 gX
 gX
 gX
-kw
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
+gX
+gX
+gX
+gX
+gX
+gX
+gX
+gX
+gX
+gX
 VY
 VY
 KA
@@ -36913,16 +36906,16 @@ gX
 gX
 gX
 gX
-le
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
+gX
+gX
+gX
+gX
+gX
+gX
+gX
+gX
+gX
+gX
 VY
 Pi
 jp
@@ -37170,16 +37163,16 @@ gX
 gX
 gX
 gX
-le
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
+gX
+gX
+gX
+gX
+mj
+gX
+gX
+gX
+gX
+gX
 VY
 mL
 jp
@@ -37427,16 +37420,16 @@ gX
 gX
 gX
 gX
-kw
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
+gX
+gX
+gX
+gX
+zZ
+gX
+gX
+gX
+gX
+gX
 VY
 Pi
 jp
@@ -37684,14 +37677,14 @@ gX
 gX
 gX
 gX
-sy
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
+gX
+gX
+gX
+gX
+zZ
+gX
+gX
+gX
 VY
 VY
 VY
@@ -37941,14 +37934,14 @@ gX
 gX
 gX
 gX
-sy
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
+gX
+gX
+gX
+gX
+zZ
+gX
+gX
+gX
 Ug
 vr
 bC
@@ -38198,14 +38191,14 @@ gX
 gX
 gX
 gX
-sy
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
+gX
+gX
+gX
+gX
+zZ
+Gs
+Gs
+Gs
 VY
 VY
 VY
@@ -38455,16 +38448,16 @@ gX
 gX
 gX
 gX
-kw
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
+gX
+gX
+gX
+gX
+zZ
+gX
+gX
+gX
+gX
+gX
 jr
 VB
 ob
@@ -38712,16 +38705,16 @@ gX
 gX
 gX
 gX
-le
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
+gX
+gX
+gX
+gX
+zZ
+gX
+gX
+gX
+gX
+gX
 jr
 Pi
 jp
@@ -38969,16 +38962,16 @@ gX
 gX
 gX
 gX
-le
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
+gX
+gX
+gX
+gX
+mj
+gX
+gX
+gX
+gX
+gX
 jr
 Pi
 Qr
@@ -39226,16 +39219,16 @@ gX
 gX
 gX
 gX
-kw
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
+gX
+gX
+gX
+gX
+zZ
+gX
+gX
+gX
+gX
+gX
 jr
 Pi
 jp
@@ -39483,14 +39476,14 @@ gX
 gX
 gX
 gX
-sy
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
+gX
+gX
+gX
+gX
+zZ
+gX
+gX
+gX
 VY
 VY
 VY
@@ -39740,14 +39733,14 @@ gX
 gX
 gX
 gX
-sy
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
+gX
+gX
+gX
+gX
+zZ
+Gs
+Gs
+Gs
 Ug
 vr
 bC
@@ -39997,14 +39990,14 @@ gX
 gX
 gX
 gX
-sy
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
-Lm
+gX
+gX
+gX
+gX
+zZ
+gX
+gX
+gX
 VY
 VY
 VY
@@ -40254,16 +40247,16 @@ gX
 gX
 gX
 gX
-kw
-Lm
-Lm
-Lm
-pB
-Lm
-Lm
-Lm
-Lm
-Lm
+gX
+gX
+gX
+gX
+zZ
+gX
+gX
+gX
+gX
+gX
 VY
 Pi
 jp
@@ -40511,16 +40504,16 @@ gX
 gX
 gX
 gX
-le
-Ti
-Ti
-Ti
-Ti
-Ti
-Ti
-Ti
-Ti
-Ti
+gX
+gX
+gX
+gX
+mj
+gX
+gX
+gX
+gX
+gX
 VY
 wN
 jp

--- a/_maps/map_files/Galactica/Galactica1.dmm
+++ b/_maps/map_files/Galactica/Galactica1.dmm
@@ -2406,6 +2406,7 @@
 /obj/effect/turf_decal/tile/ship/half/green{
 	dir = 1
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "gv" = (
@@ -4227,6 +4228,7 @@
 /obj/effect/turf_decal/tile/ship/green{
 	dir = 8
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "kZ" = (
@@ -7484,6 +7486,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/ship/half/green,
+/obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "tk" = (
@@ -11976,6 +11979,13 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
+"Fd" = (
+/obj/effect/turf_decal/tile/ship/half/neutral{
+	dir = 4
+	},
+/obj/effect/landmark/latejoin,
+/turf/open/floor/monotile/steel,
+/area/crew_quarters/dorms)
 "Fe" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	req_access_txt = "12"
@@ -13928,6 +13938,7 @@
 /obj/effect/turf_decal/tile/ship/green{
 	dir = 1
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "JP" = (
@@ -14915,6 +14926,10 @@
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/durasteel,
 /area/storage/tech)
+"Mi" = (
+/obj/effect/landmark/latejoin,
+/turf/open/floor/monotile/steel,
+/area/crew_quarters/dorms)
 "Mj" = (
 /obj/effect/turf_decal/tile/ship/yellow{
 	dir = 4
@@ -16285,6 +16300,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "PM" = (
@@ -50231,8 +50247,8 @@ Uu
 QS
 dx
 YI
-Tu
-Tu
+Mi
+Mi
 IW
 dx
 Mu
@@ -50488,8 +50504,8 @@ Tu
 tV
 dx
 gu
-Tu
-Tu
+Mi
+Mi
 tj
 dx
 MD
@@ -50745,8 +50761,8 @@ Tu
 BC
 dx
 xB
-Tu
-Tu
+Mi
+Mi
 zP
 kc
 MD
@@ -51003,7 +51019,7 @@ Tf
 dx
 JO
 PK
-aZ
+Fd
 kY
 jp
 MD

--- a/_maps/map_files/Galactica/Galactica2.dmm
+++ b/_maps/map_files/Galactica/Galactica2.dmm
@@ -12176,14 +12176,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/medical/chemistry)
-"gyh" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/turf/open/floor/monotile/dark/airless,
-/area/space/nearstation)
 "gyr" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -12729,15 +12721,6 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/shuttle/turbolift/secondary)
-"gHI" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "gHN" = (
 /obj/effect/turf_decal/tile/ship/half/purple{
 	dir = 8
@@ -18606,18 +18589,6 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons/gauss/battery)
-"jSQ" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 3;
-	height = 15;
-	id = "arrivals_stationary";
-	name = "arrivals";
-	roundstart_template = /datum/map_template/shuttle/arrival/box;
-	width = 7
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "jTc" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -28191,15 +28162,6 @@
 /obj/machinery/atmospherics/miner/oxygen,
 /turf/open/floor/engine/o2,
 /area/engine/atmos)
-"pay" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/space/basic,
-/area/space/nearstation)
 "paE" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/effect/turf_decal/tile/yellow{
@@ -33674,14 +33636,6 @@
 	},
 /turf/open/floor/eighties,
 /area/crew_quarters/theatre)
-"sfd" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "sfq" = (
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
@@ -41449,18 +41403,6 @@
 /obj/machinery/lazylift_button,
 /turf/closed/wall/r_wall,
 /area/shuttle/turbolift/secondary)
-"wjt" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "wjA" = (
 /turf/closed/wall/steel,
 /area/hallway/nsv/deck2/primary)
@@ -94357,9 +94299,9 @@ huS
 kCL
 kCL
 kCL
-kCL
-kCL
-qYd
+krf
+tuN
+usq
 kCL
 kCL
 kCL
@@ -94614,16 +94556,16 @@ huS
 kCL
 kCL
 kCL
+udK
 kCL
-kCL
-qYd
+jKD
 kCL
 kCL
 kCL
 dyN
-krf
-tuN
-usq
+dyN
+dyN
+dyN
 dyN
 dyN
 dyN
@@ -94871,16 +94813,16 @@ qif
 kCL
 kCL
 kCL
+pmN
+kCL
+riV
 kCL
 kCL
-qYd
 kCL
-kCL
-kCL
-gyh
-udK
-kCL
-jKD
+dyN
+dyN
+dyN
+dyN
 dyN
 dyN
 dyN
@@ -95128,16 +95070,16 @@ qif
 kCL
 kCL
 kCL
-kCL
-kCL
-qYd
-kCL
-kCL
-kCL
-gyh
 pmN
 kCL
-riV
+jKD
+kCL
+kCL
+kCL
+dyN
+dyN
+dyN
+dyN
 dyN
 dyN
 dyN
@@ -95385,16 +95327,16 @@ lju
 kCL
 kCL
 kCL
+udK
+kCL
+bPu
 kCL
 kCL
-qYd
 kCL
-kCL
-kCL
-gHI
-pmN
-kCL
-jKD
+dyN
+dyN
+dyN
+dyN
 dyN
 dyN
 dyN
@@ -95642,16 +95584,16 @@ lju
 kCL
 kCL
 kCL
+pmN
+kCL
+jKD
 kCL
 kCL
-qYd
 kCL
-kCL
-kCL
-gHI
-udK
-kCL
-bPu
+dyN
+dyN
+dyN
+dyN
 dyN
 dyN
 dyN
@@ -95899,16 +95841,16 @@ lju
 lju
 lju
 kCL
-kCL
-kCL
-qYd
-kCL
-kCL
-kCL
-gHI
 pmN
 kCL
-jKD
+riV
+kCL
+kCL
+kCL
+dyN
+dyN
+dyN
+dyN
 dyN
 dyN
 dyN
@@ -96156,16 +96098,16 @@ aCk
 fsv
 iZn
 qYd
-qYd
-qYd
-qYd
-qYd
-qYd
-qYd
-gHI
-pmN
+udK
 kCL
-riV
+jKD
+qYd
+qYd
+qYd
+dyN
+dyN
+dyN
+dyN
 dyN
 dyN
 dyN
@@ -96413,16 +96355,16 @@ lju
 qif
 lju
 kCL
+pmN
+kCL
+qFr
 kCL
 kCL
-qYd
 kCL
-kCL
-kCL
-gHI
-udK
-kCL
-jKD
+dyN
+dyN
+dyN
+dyN
 dyN
 dyN
 dyN
@@ -96670,16 +96612,16 @@ bYC
 bOQ
 qif
 kCL
-kCL
-kCL
-qYd
-kCL
-kCL
-kCL
-gHI
 pmN
 kCL
-qFr
+jKD
+kCL
+kCL
+kCL
+dyN
+dyN
+dyN
+dyN
 dyN
 dyN
 dyN
@@ -96927,16 +96869,16 @@ lfn
 lfn
 qif
 kCL
+udK
+kCL
+qZh
 kCL
 kCL
-qYd
 kCL
-kCL
-kCL
-gHI
-pmN
-kCL
-jKD
+dyN
+dyN
+dyN
+dyN
 dyN
 dyN
 dyN
@@ -97184,16 +97126,16 @@ lfn
 lfn
 qif
 kCL
+pmN
+kCL
+jKD
 kCL
 kCL
-qYd
 kCL
-kCL
-kCL
-gHI
-udK
-kCL
-qZh
+dyN
+dyN
+dyN
+dyN
 dyN
 dyN
 dyN
@@ -97441,16 +97383,16 @@ rvV
 rvV
 qif
 kCL
-kCL
-kCL
-qYd
-kCL
-kCL
-kCL
-gHI
 pmN
 kCL
-jKD
+oxp
+kCL
+kCL
+kCL
+dyN
+dyN
+dyN
+dyN
 dyN
 dyN
 dyN
@@ -97698,16 +97640,16 @@ lju
 qif
 lju
 kCL
+udK
+kCL
+jKD
 kCL
 kCL
-qYd
 kCL
-kCL
-kCL
-gHI
-pmN
-kCL
-oxp
+dyN
+dyN
+dyN
+dyN
 dyN
 dyN
 dyN
@@ -97955,16 +97897,16 @@ aCk
 hZb
 iZn
 qYd
-qYd
-qYd
-qYd
-qYd
-qYd
-qYd
-gHI
-udK
+pmN
 kCL
-jKD
+xGc
+qYd
+qYd
+qYd
+dyN
+dyN
+dyN
+dyN
 dyN
 dyN
 dyN
@@ -98212,16 +98154,16 @@ lju
 lju
 lju
 kCL
+pmN
 kCL
-kCL
-qYd
+jKD
 kCL
 kCL
 kCL
 dyN
-pmN
-kCL
-xGc
+dyN
+dyN
+dyN
 dyN
 dyN
 dyN
@@ -98469,16 +98411,16 @@ lju
 kCL
 kCL
 kCL
+udK
 kCL
-kCL
-jSQ
+riV
 kCL
 kCL
 kCL
 dyN
-pmN
-kCL
-jKD
+dyN
+dyN
+dyN
 dyN
 dyN
 dyN
@@ -98724,18 +98666,18 @@ fxX
 rDk
 lju
 dyN
-pay
 dyN
 dyN
-sfd
-sfd
-sfd
-dyN
-dyN
-wjt
-udK
+pmN
 kCL
-riV
+jKD
+dyN
+dyN
+dyN
+dyN
+dyN
+dyN
+dyN
 dyN
 dyN
 dyN
@@ -98983,6 +98925,9 @@ lju
 dyN
 dyN
 dyN
+qiV
+uWX
+bZt
 dyN
 dyN
 dyN
@@ -98990,9 +98935,6 @@ dyN
 dyN
 dyN
 dyN
-pmN
-kCL
-jKD
 dyN
 dyN
 dyN
@@ -99247,9 +99189,9 @@ dyN
 dyN
 dyN
 dyN
-qiV
-uWX
-bZt
+dyN
+dyN
+dyN
 dyN
 dyN
 dyN

--- a/_maps/map_files/Gladius/Gladius2.dmm
+++ b/_maps/map_files/Gladius/Gladius2.dmm
@@ -784,6 +784,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/cryopods)
 "aBd" = (
@@ -3633,6 +3634,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/cryopods)
 "ctg" = (
@@ -4267,6 +4269,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/cryopods)
 "cKf" = (
@@ -9513,6 +9516,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/cryopods)
 "fJl" = (
@@ -10135,6 +10139,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/cryopods)
 "gam" = (
@@ -10244,6 +10249,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/cryopods)
 "gcr" = (
@@ -12458,6 +12464,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/cryopods)
 "hpA" = (
@@ -13034,6 +13041,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/cryopods)
 "hGN" = (
@@ -15645,6 +15653,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/cryopods)
 "jcf" = (
@@ -16294,6 +16303,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/cryopods)
 "jwZ" = (
@@ -21379,6 +21389,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/cryopods)
 "msH" = (
@@ -24521,6 +24532,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/cryopods)
 "oeL" = (
@@ -28963,6 +28975,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/cryopods)
 "qDC" = (
@@ -30699,6 +30712,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/cryopods)
 "rxc" = (
@@ -36362,6 +36376,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/cryopods)
 "uJJ" = (
@@ -36493,6 +36508,7 @@
 /obj/machinery/computer/lore_terminal{
 	pixel_x = 6
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/cryopods)
 "uOv" = (
@@ -37704,6 +37720,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/cryopods)
 "vCU" = (
@@ -38403,6 +38420,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/cryopods)
 "vXY" = (
@@ -38914,6 +38932,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/cryopods)
 "wnO" = (
@@ -39367,6 +39386,7 @@
 /area/chapel/main)
 "wAC" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/cryopods)
 "wAT" = (
@@ -40509,18 +40529,6 @@
 /obj/machinery/field/generator,
 /turf/open/floor/plating,
 /area/engine/storage)
-"xlz" = (
-/obj/docking_port/stationary{
-	dir = 2;
-	dwidth = 3;
-	height = 14;
-	id = "arrivals_stationary";
-	name = "gladius arrivals";
-	roundstart_template = /datum/map_template/shuttle/arrival/gladius;
-	width = 7
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "xlA" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "engcell";
@@ -40911,6 +40919,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/cryopods)
 "xwF" = (
@@ -42037,6 +42046,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/cryopods)
 "yfJ" = (
@@ -75777,7 +75787,7 @@ oYR
 gJw
 iCo
 qQs
-xlz
+fiL
 fiL
 fiL
 fiL

--- a/_maps/map_files/Hammerhead/Hammerhead.dmm
+++ b/_maps/map_files/Hammerhead/Hammerhead.dmm
@@ -18044,17 +18044,9 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "bfN" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 3;
-	height = 15;
-	id = "arrivals_stationary";
-	name = "arrivals";
-	roundstart_template = /datum/map_template/shuttle/arrival/box;
-	width = 7
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/landmark/latejoin,
+/turf/open/floor/durasteel/eris_techfloor_alt,
+/area/hallway/primary/central)
 "bfO" = (
 /obj/structure/hull_plate,
 /obj/effect/turf_decal/stripes/line{
@@ -50954,6 +50946,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "uOc" = (
+/obj/effect/landmark/latejoin,
 /turf/open/floor/durasteel/eris_techfloor_alt,
 /area/maintenance/department/crew_quarters/dorms)
 "uOp" = (
@@ -81005,7 +80998,7 @@ aaa
 aaa
 aaa
 aaa
-bfN
+fkN
 aaa
 aaa
 aaa
@@ -89476,7 +89469,7 @@ aLW
 dQn
 aVo
 sbf
-abO
+bfN
 abP
 aXP
 ayy
@@ -89733,7 +89726,7 @@ aLW
 aiM
 aLW
 oeJ
-abO
+bfN
 aBN
 auq
 ayy
@@ -89990,7 +89983,7 @@ aLW
 aiM
 aLW
 wGc
-abO
+bfN
 abP
 hZb
 aws
@@ -90247,7 +90240,7 @@ aLW
 aiM
 aLW
 uOc
-abO
+bfN
 abP
 aMP
 anS
@@ -90504,7 +90497,7 @@ wHc
 aiM
 aLW
 oeJ
-abO
+bfN
 gln
 aXK
 ayy
@@ -90761,7 +90754,7 @@ wHc
 aiM
 aLW
 wGc
-abO
+bfN
 abP
 eAd
 ayy
@@ -91018,7 +91011,7 @@ pRc
 aiM
 aVo
 jfD
-abO
+bfN
 abP
 eAd
 ayy

--- a/_maps/map_files/Serendipity/Serendipity1.dmm
+++ b/_maps/map_files/Serendipity/Serendipity1.dmm
@@ -3769,6 +3769,10 @@
 	},
 /turf/closed/wall/ship,
 /area/maintenance/department/medical)
+"mk" = (
+/obj/effect/landmark/latejoin,
+/turf/open/floor/wood,
+/area/crew_quarters/cryopods)
 "mm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -7355,6 +7359,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/wood,
 /area/crew_quarters/cryopods)
 "yp" = (
@@ -7395,6 +7400,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/wood,
 /area/crew_quarters/cryopods)
 "yx" = (
@@ -10483,17 +10489,11 @@
 /turf/open/floor/plasteel/tiled/light,
 /area/bridge/cic)
 "IQ" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 7;
-	height = 8;
-	id = "arrivals_stationary";
-	name = "Serendipity Arrivals";
-	roundstart_template = /datum/map_template/shuttle/arrival/serendipity;
-	width = 15
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/recharge_station,
+/obj/effect/landmark/start/cyborg,
+/obj/effect/landmark/latejoin,
+/turf/open/floor/wood,
+/area/crew_quarters/cryopods)
 "IT" = (
 /obj/structure/table/glass/plasma,
 /obj/item/paper_bin,
@@ -11641,6 +11641,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/xo)
+"Mh" = (
+/obj/structure/bed,
+/obj/item/bedsheet/random,
+/obj/effect/landmark/start/assistant,
+/obj/effect/landmark/latejoin,
+/turf/open/floor/wood,
+/area/crew_quarters/cryopods)
 "Mi" = (
 /obj/machinery/stasis,
 /obj/effect/turf_decal/tile/ship/blue{
@@ -14615,6 +14622,7 @@
 	pixel_y = -30
 	},
 /obj/effect/landmark/start/assistant,
+/obj/effect/landmark/latejoin,
 /turf/open/floor/wood,
 /area/crew_quarters/cryopods)
 "Wk" = (
@@ -36964,7 +36972,7 @@ zP
 zP
 zP
 zP
-IQ
+zP
 zP
 zP
 zP
@@ -44680,8 +44688,8 @@ Gu
 Tc
 yw
 yo
-Kf
-Kf
+mk
+mk
 wF
 Vp
 Lr
@@ -44935,9 +44943,9 @@ kG
 SB
 Fe
 mm
-zw
-Kf
-zA
+IQ
+mk
+Mh
 Wj
 vP
 Sf

--- a/_maps/map_files/Shrike/Shrike2.dmm
+++ b/_maps/map_files/Shrike/Shrike2.dmm
@@ -894,6 +894,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
+"cP" = (
+/obj/effect/turf_decal/guideline/guideline_out/blue{
+	dir = 6
+	},
+/obj/effect/turf_decal/guideline/guideline_in/red{
+	dir = 6
+	},
+/obj/effect/landmark/latejoin,
+/turf/open/floor/monofloor/corner{
+	dir = 1
+	},
+/area/hallway/nsv/deck2/frame1/starboard{
+	lighting_colour_bulb = "#c1e1ff";
+	lighting_colour_night = "#c1e1ff";
+	lighting_colour_tube = "#c1e1ff"
+	})
 "cQ" = (
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/vending/cola/random,
@@ -1366,6 +1382,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/plating/rusty_techgrid,
 /area/hallway/nsv/deck2/frame1/starboard{
 	lighting_colour_bulb = "#c1e1ff";
@@ -2097,6 +2114,22 @@
 	},
 /turf/open/floor/plating/rusty_techgrid,
 /area/crew_quarters/bar/mess_hall)
+"gB" = (
+/obj/effect/turf_decal/guideline/guideline_out/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/guideline/guideline_in/red{
+	dir = 8
+	},
+/obj/effect/landmark/latejoin,
+/turf/open/floor/monofloor{
+	dir = 4
+	},
+/area/hallway/nsv/deck2/frame1/starboard{
+	lighting_colour_bulb = "#c1e1ff";
+	lighting_colour_night = "#c1e1ff";
+	lighting_colour_tube = "#c1e1ff"
+	})
 "gC" = (
 /turf/open/floor/plating,
 /area/nsv/weapons/gauss/battery/deck2/port{
@@ -4628,17 +4661,26 @@
 /turf/open/floor/plating/rusty_techgrid,
 /area/quartermaster/storage)
 "pX" = (
-/obj/docking_port/stationary{
-	dir = 4;
-	dwidth = 3;
-	height = 12;
-	id = "arrivals_stationary";
-	name = "Deck 2 Arrivals Port";
-	roundstart_template = /datum/map_template/shuttle/arrival/shrike;
-	width = 7
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
-/turf/open/space/basic,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/over/ship,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/landmark/latejoin,
+/turf/open/floor/plating/rusty_techgrid,
+/area/hallway/nsv/deck2/frame1/starboard{
+	lighting_colour_bulb = "#c1e1ff";
+	lighting_colour_night = "#c1e1ff";
+	lighting_colour_tube = "#c1e1ff"
+	})
 "pY" = (
 /obj/structure/fluff/support_beam,
 /turf/open/floor/plating,
@@ -6196,6 +6238,7 @@
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/plating/rusty_techgrid,
 /area/crew_quarters/cryopods)
 "uS" = (
@@ -9289,6 +9332,7 @@
 /obj/machinery/camera/autoname,
 /obj/effect/turf_decal/guideline/guideline_out/blue,
 /obj/effect/turf_decal/guideline/guideline_in/red,
+/obj/effect/landmark/latejoin,
 /turf/open/floor/monofloor{
 	dir = 1
 	},
@@ -9432,6 +9476,7 @@
 /obj/effect/turf_decal/guideline/guideline_in_arrow_con_alt/red{
 	dir = 5
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/monofloor{
 	dir = 1
 	},
@@ -16313,6 +16358,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/lattice/catwalk/over/ship,
+/obj/effect/landmark/latejoin,
 /turf/open/floor/plating/rusty_techgrid,
 /area/hallway/nsv/deck2/frame1/starboard{
 	lighting_colour_bulb = "#c1e1ff";
@@ -52105,7 +52151,7 @@ KI
 KI
 KI
 gi
-pX
+gi
 gi
 gi
 gi
@@ -52857,7 +52903,7 @@ qo
 qo
 qo
 Eh
-YT
+pX
 HE
 eP
 eP
@@ -53114,7 +53160,7 @@ qo
 RD
 IG
 Ey
-YT
+pX
 bs
 LA
 Vt
@@ -53627,8 +53673,8 @@ KI
 qo
 Bo
 IG
-yY
-rk
+cP
+gB
 rk
 cY
 yI

--- a/_maps/map_files/Snake/snake_lower.dmm
+++ b/_maps/map_files/Snake/snake_lower.dmm
@@ -2146,6 +2146,7 @@
 /area/lawoffice)
 "hM" = (
 /obj/machinery/airalarm/directional/south,
+/obj/effect/landmark/latejoin,
 /turf/open/floor/plasteel,
 /area/crew_quarters/cryopods)
 "hO" = (
@@ -8265,17 +8266,12 @@
 /turf/open/floor/plasteel/chapel,
 /area/chapel/main)
 "Dn" = (
-/obj/docking_port/stationary{
-	dir = 4;
-	dwidth = 3;
-	height = 15;
-	id = "arrivals_stationary";
-	name = "arrivals";
-	roundstart_template = /datum/map_template/shuttle/arrival/box;
-	width = 7
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/landmark/latejoin,
+/turf/open/floor/plasteel,
+/area/crew_quarters/cryopods)
 "Dp" = (
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
@@ -8839,6 +8835,7 @@
 /obj/machinery/computer/cryopod{
 	pixel_y = 32
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/plasteel,
 /area/crew_quarters/cryopods)
 "Fz" = (
@@ -10910,6 +10907,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/plasteel,
 /area/crew_quarters/cryopods)
 "Mu" = (
@@ -14194,6 +14192,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/plasteel,
 /area/crew_quarters/cryopods)
 "Xj" = (
@@ -41280,7 +41279,7 @@ ge
 aJ
 aJ
 aJ
-Dn
+aJ
 aJ
 aJ
 aJ
@@ -43590,7 +43589,7 @@ xW
 Ur
 jy
 kJ
-gb
+aJ
 aJ
 aJ
 aJ
@@ -62335,7 +62334,7 @@ ee
 vc
 PH
 Fv
-ww
+Dn
 hM
 ih
 eE

--- a/_maps/map_files/Tycoon/Tycoon2.dmm
+++ b/_maps/map_files/Tycoon/Tycoon2.dmm
@@ -671,17 +671,10 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
 "abW" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 3;
-	height = 15;
-	id = "arrivals_stationary";
-	name = "arrivals";
-	roundstart_template = /datum/map_template/shuttle/arrival/box;
-	width = 7
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/latejoin,
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "abX" = (
 /obj/structure/rack,
 /obj/item/storage/box/teargas,
@@ -3472,6 +3465,7 @@
 "aiJ" = (
 /obj/machinery/camera/autoname,
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/latejoin,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms)
 "aiK" = (
@@ -14213,6 +14207,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/latejoin,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms)
 "aMC" = (
@@ -45176,6 +45171,16 @@
 /area/maintenance/starboard/secondary{
 	name = "Munitions Projects"
 	})
+"keK" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/latejoin,
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "keO" = (
 /turf/open/floor/plating,
 /area/maintenance/nsv/hangar)
@@ -87063,7 +87068,7 @@ aaa
 aaa
 aaa
 aaa
-abW
+aaa
 aaa
 aaa
 aaa
@@ -95238,9 +95243,9 @@ mXe
 ahe
 eot
 aiJ
-aln
-aln
-aln
+abW
+abW
+abW
 eot
 ayG
 azW
@@ -95494,10 +95499,10 @@ auR
 bAN
 aLZ
 jZR
-afT
-afT
+keK
+keK
 aMB
-afT
+keK
 fTr
 aZo
 aZw

--- a/_maps/map_files/Vago/vagodeck1.dmm
+++ b/_maps/map_files/Vago/vagodeck1.dmm
@@ -10236,18 +10236,6 @@
 	},
 /turf/closed/wall/steel,
 /area/maintenance/department/cargo)
-"yk" = (
-/obj/docking_port/stationary{
-	dir = 4;
-	dwidth = 3;
-	height = 15;
-	id = "arrivals_stationary";
-	name = "arrivals";
-	roundstart_template = /datum/map_template/shuttle/arrival/box;
-	width = 7
-	},
-/turf/open/space/basic,
-/area/space)
 "ym" = (
 /obj/structure/ladder,
 /obj/item/radio/intercom{
@@ -35170,7 +35158,7 @@ aa
 aa
 aa
 aa
-yk
+aa
 aa
 aa
 aa

--- a/_maps/map_files/Vago/vagodeck2.dmm
+++ b/_maps/map_files/Vago/vagodeck2.dmm
@@ -146,6 +146,12 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/airlock/forward/port)
+"aV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/landmark/latejoin,
+/turf/open/floor/plating/foam,
+/area/hallway/nsv/deck2/frame2/port)
 "aX" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -2095,6 +2101,7 @@
 "gT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/landmark/latejoin,
 /turf/open/floor/plating/foam,
 /area/crew_quarters/dorms)
 "gU" = (
@@ -8542,6 +8549,7 @@
 	dir = 1;
 	pixel_y = -22
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/plating/foam,
 /area/crew_quarters/dorms)
 "xM" = (
@@ -8983,6 +8991,7 @@
 /obj/machinery/light/small/broken{
 	dir = 8
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/plating/foam,
 /area/crew_quarters/dorms)
 "zL" = (
@@ -13736,6 +13745,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/plating/foam,
 /area/crew_quarters/dorms)
 "WV" = (
@@ -42582,7 +42592,7 @@ aa
 My
 XW
 Ql
-QD
+aV
 gT
 WS
 zK

--- a/_maps/serendipity.json
+++ b/_maps/serendipity.json
@@ -7,7 +7,6 @@
     "space_ruin_levels": -1,
     "space_empty_levels": 0,
     "shuttles": {
-		"arrival": "arrival_serendipity",
         "cargo": "cargo_serendipity",
         "ferry": "ferry_fancy",
         "emergency": "emergency_celerity"

--- a/nsv13/code/datums/shuttles.dm
+++ b/nsv13/code/datums/shuttles.dm
@@ -34,10 +34,6 @@
 	suffix = "aetherwhisp"
 	name = "arrival shuttle (Aetherwhisp)"
 
-/datum/map_template/shuttle/arrival/atlas
-	suffix = "atlas"
-	name = "arrival shuttle (Atlas)"
-
 /datum/map_template/shuttle/arrival/gladius
 	suffix = "gladius"
 	name = "arrival shuttle (Gladius)"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
It makes latejoins wake up from cryostasis instead of arriving on a shuttle

## Why It's Good For The Game
Thematic

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![cryo](https://github.com/BeeStation/NSV13/assets/17987483/0606fdef-0f32-46c0-8ede-da698f468b77)

</details>

## Changelog
:cl:
del: Removed arrivals shuttles
tweak: Late joiners will now spawn near the cryostasis pods
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
