### PR TITLE
NAC Loot addition

### DIFF
--- a/_maps/templates/boarding/syndicate/carrier.dmm
+++ b/_maps/templates/boarding/syndicate/carrier.dmm
@@ -2268,6 +2268,10 @@
 	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/ruin/powered/nsv13/boarding_interior)
+"IV" = (
+/obj/effect/spawner/lootdrop/nac_supplies,
+/turf/open/floor/plating,
+/area/ruin/powered/nsv13/boarding_interior)
 "IZ" = (
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
@@ -47816,7 +47820,7 @@ XX
 yv
 Pq
 AB
-xx
+IV
 AB
 AB
 Cu

--- a/_maps/templates/boarding/syndicate/destroyer.dmm
+++ b/_maps/templates/boarding/syndicate/destroyer.dmm
@@ -1478,6 +1478,10 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/ruin/unpowered/boarding_interior)
+"GI" = (
+/obj/effect/spawner/lootdrop/nac_supplies,
+/turf/open/floor/plating,
+/area/ruin/unpowered/boarding_interior)
 "GQ" = (
 /obj/structure/closet/secure_closet/freezer/money,
 /obj/item/coin/gold,
@@ -36006,7 +36010,7 @@ Mk
 vM
 ba
 Hk
-Pf
+GI
 an
 Hk
 kc

--- a/_maps/templates/boarding/syndicate/mako.dmm
+++ b/_maps/templates/boarding/syndicate/mako.dmm
@@ -295,6 +295,10 @@
 "oT" = (
 /turf/open/floor/engine/airless/light,
 /area/ruin/powered/nsv13/boarding_interior)
+"oW" = (
+/obj/effect/spawner/lootdrop/nac_supplies,
+/turf/open/floor/plating,
+/area/ruin/powered/nsv13/boarding_interior)
 "oZ" = (
 /obj/structure/hull_plate,
 /turf/open/floor/engine,
@@ -30012,7 +30016,7 @@ Ca
 Ca
 Ca
 Ca
-Ca
+oW
 MZ
 Cb
 JE

--- a/_maps/templates/boarding/syndicate/mako_carrier.dmm
+++ b/_maps/templates/boarding/syndicate/mako_carrier.dmm
@@ -837,6 +837,10 @@
 /obj/structure/reagent_dispensers/fueltank/cryogenic_fuel,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/nsv13/boarding_interior)
+"SG" = (
+/obj/effect/spawner/lootdrop/nac_supplies,
+/turf/open/floor/plating,
+/area/ruin/powered/nsv13/boarding_interior)
 "SH" = (
 /obj/structure/table/reinforced,
 /obj/item/multitool,
@@ -30042,7 +30046,7 @@ Ca
 Ca
 Ca
 Ca
-Ca
+SG
 xv
 Cb
 OX

--- a/_maps/templates/boarding/syndicate/marine_frigate.dmm
+++ b/_maps/templates/boarding/syndicate/marine_frigate.dmm
@@ -1501,7 +1501,6 @@
 /mob/living/simple_animal/hostile/syndicate/mecha_pilot{
 	access_card = 150;
 	name = "Syndicate Mecha Pilot (929)";
-	spacewalk = TRUE
 	},
 /turf/open/floor/mineral/plastitanium/airless,
 /area/ruin/powered/nsv13/boarding_interior)

--- a/_maps/templates/boarding/syndicate/marine_frigate.dmm
+++ b/_maps/templates/boarding/syndicate/marine_frigate.dmm
@@ -470,6 +470,10 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/nsv13/boarding_interior)
+"kR" = (
+/obj/effect/spawner/lootdrop/nac_supplies,
+/turf/open/floor/plating,
+/area/ruin/powered/nsv13/boarding_interior)
 "kS" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	req_access_txt = "150"
@@ -28720,7 +28724,7 @@ aM
 aM
 aM
 zR
-mr
+kR
 mr
 mr
 zR

--- a/_maps/templates/boarding/syndicate/marine_frigate.dmm
+++ b/_maps/templates/boarding/syndicate/marine_frigate.dmm
@@ -268,8 +268,7 @@
 "hh" = (
 /obj/structure/fluff/empty_cryostasis_sleeper,
 /mob/living/simple_animal/hostile/syndicate/ranged{
-	access_card = 150;
-	wanted_objects = list(obj/item/storage/firstaid)
+	access_card = 150
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/powered/nsv13/boarding_interior)

--- a/_maps/templates/boarding/syndicate/nukefrigate.dmm
+++ b/_maps/templates/boarding/syndicate/nukefrigate.dmm
@@ -1014,6 +1014,10 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/powered/nsv13/boarding_interior)
+"Ke" = (
+/obj/effect/spawner/lootdrop/nac_supplies,
+/turf/open/floor/plating,
+/area/ruin/powered/nsv13/boarding_interior)
 "Kq" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -33690,7 +33694,7 @@ tJ
 cr
 fV
 rw
-Jw
+Ke
 Jw
 Jw
 rw

--- a/nsv13/code/game/objects/effects/spawners/custom_loot_spawners.dm
+++ b/nsv13/code/game/objects/effects/spawners/custom_loot_spawners.dm
@@ -82,6 +82,7 @@
 /obj/effect/spawner/lootdrop/nac_supplies
 	name = "\improper NAC stuff spawner"
 	loot = list(
+		/obj/item/ship_weapon/parts/firing_electronics = 1,
 		/obj/machinery/computer/deckgun = 1,
 		/obj/machinery/deck_turret = 1,
 		/obj/machinery/deck_turret/payload_gate = 1,

--- a/nsv13/code/game/objects/effects/spawners/custom_loot_spawners.dm
+++ b/nsv13/code/game/objects/effects/spawners/custom_loot_spawners.dm
@@ -82,7 +82,6 @@
 /obj/effect/spawner/lootdrop/nac_supplies
 	name = "\improper NAC stuff spawner"
 	loot = list(
-		/obj/item/powder_bag = 10,
 		/obj/machinery/computer/deckgun = 1,
 		/obj/machinery/deck_turret = 1,
 		/obj/machinery/deck_turret/payload_gate = 1,


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
NAC supplies Loot drooper edited to drop ONLY NAC equipment as well as added spawners to all boarding maps for the loot
![](https://cdn.discordapp.com/attachments/935307696381526066/1124795614140575795/image.png)

Reminder to players, nac boards are indestructible, so even if the built component takes a nuke the board will remain... somewhere
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Loot specific to boarding, Allows munit to make a new gun if they collect the gotcha nacs!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>
</details>

## Changelog
:cl:
add: added NAC supply spawner to boarding maps
tweak: tweaked NAC supply spawner
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
