### PR TITLE
Coffee typo fix

### DIFF
--- a/nsv13/code/modules/coffee/items/coffee_pack.dm
+++ b/nsv13/code/modules/coffee/items/coffee_pack.dm
@@ -22,7 +22,7 @@
 	icon = 'nsv13/icons/obj/coffee.dmi'
 	icon_state = "arabica_beans"
 
-/obj/item/storage/box/coffeepack/robusta/PopulateContents()
+/obj/item/storage/box/coffeepack/arabica/PopulateContents()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_items = 5
 	var/static/list/can_hold = typecacheof(list(/obj/item/reagent_containers/food/snacks/grown/coffee))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a small typo when buying the 2k coffee starter pack which included arabica coffee bag which was empty and couldn't hold items due to a small typo from #2119
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
muh arabica was fake
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Changelog
:cl:
fix: fixed a typo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
