### PR TITLE
[Modular] Coffee Addictions

### DIFF
--- a/nsv13/code/datums/traits/negative.dm
+++ b/nsv13/code/datums/traits/negative.dm
@@ -6,3 +6,25 @@
 	gain_text = "<span class='notice'>The thought of FTL travel makes you uneasy</span>"
 	lose_text = "<span class='notice'>The thought of FTL travel doesn't seem so bad anymore.</span>"
 	medical_record_text = "Patient is vulnerable to bluespace currents and often gets sick during FTL travel."
+
+/datum/quirk/junkie/coffee_addict
+	name = "Coffee Addict"
+	desc = "You have a strong addiction to caffeine. Probably not great in the long term."
+	value = -1
+	gain_text = "<span class='danger'>You feel like you could use a cup of coffee.</span>"
+	lose_text = "<span class='notice'>You feel like you don't need that much caffeine anymore.</span>"
+	medical_record_text = "Patient is addicted to caffeine."
+	reagent_type = /datum/reagent/consumable/coffee
+	drug_container_type = /obj/item/reagent_containers/food/drinks/coffee
+	process = TRUE
+
+/datum/quirk/junkie/naval_coffee_Addict
+	name = "Naval Coffee Addict"
+	desc = "You have a strong addiction to the paint stripper liquid that the Navy calls coffee. Probably not great in the long term for your liver, or heart."
+	value = -1
+	gain_text = "<span class='danger'>You feel your eyelids growing heavier, you really need a cup of navy coffee to get through this patrol.</span>"
+	lose_text = "<span class='notice'>The stress of the patrol has lessened, you don't feel like you need that much caffeine anymore.</span>"
+	medical_record_text = "Patient is heavily addicted to the dangerous liquid the navy calls coffee."
+	reagent_type = /datum/reagent/consumable/navy_coffee
+	drug_container_type = /obj/item/reagent_containers/food/drinks/coffee/navy_coffee
+	process = TRUE

--- a/nsv13/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/nsv13/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -30,3 +30,7 @@
 	SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "navy_coffee", /datum/mood_event/drink_navy_coffee)
 	..()
 	. = 1
+
+/obj/item/reagent_containers/food/drinks/coffee/navy_coffee
+	name = "naval coffee"
+	list_reagents = list(/datum/reagent/consumable/navy_coffee = 30)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Takes the next step in the form of Coffee Roleplaying by introducing two quirks to choose from
Coffee Addict: Makes them addicted to Coffee and spawn with a coffee cup at the start of the shift.
Naval Coffee Addict: Makes them addicted to Naval Coffee, only acquired through a coffee maker and makes them spawn with one cup of naval coffee at the start of the shift.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Advanced ~~Coffee~~ Naval Roleplaying
Some people say their characters are addicted to coffee, time to make it a reality!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/NSV13/assets/59128051/cd9d705c-45f5-4da6-8f01-be6521a83630

</details>

## Changelog
:cl:
add: Added the Coffee Addict quirk, it works similar to the smoker quirk but makes you addicted to coffee instead!
add: Added the Naval Coffee Addict quirk, it works similar to the smoker quirk but makes you addicted to naval coffee instead, better stock up on coffee cartridges!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
