### PR TITLE
Replaces wardens energy gun

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -199,6 +199,7 @@
 	new /obj/item/clothing/gloves/krav_maga(src)
 	new /obj/item/door_remote/head_of_security(src)
 	new /obj/item/gun/ballistic/shotgun/automatic/combat/compact(src)
+	new /obj/item/shield/riot/flash //NSV13 - strobe shield instead of energy weaponry
 	new /obj/item/ammo_box/c9mm/rubber(src) //NSV13 - rubber bullets
 	new /obj/item/storage/box/deputy(src)
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -199,7 +199,7 @@
 	new /obj/item/clothing/gloves/krav_maga(src)
 	new /obj/item/door_remote/head_of_security(src)
 	new /obj/item/gun/ballistic/shotgun/automatic/combat/compact(src)
-	new /obj/item/shield/riot/flash //NSV13 - strobe shield instead of energy weaponry
+	new /obj/item/shield/riot/flash(src) //NSV13 - strobe shield instead of energy weaponry
 	new /obj/item/ammo_box/c9mm/rubber(src) //NSV13 - rubber bullets
 	new /obj/item/storage/box/deputy(src)
 

--- a/code/modules/jobs/job_types/warden.dm
+++ b/code/modules/jobs/job_types/warden.dm
@@ -50,7 +50,7 @@
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
 	r_pocket = /obj/item/assembly/flash/handheld
 	l_pocket = /obj/item/restraints/handcuffs
-	suit_store = /obj/item/gun/energy/e_gun/advtaser //NSV13 - give the guy in charge of the brig a better nonlethal
+	suit_store = /obj/item/gun/ballistic/automatic/pistol/glock/security //NSV13 - weird energy gun is not good
 	backpack_contents = list(/obj/item/melee/baton/loaded=1,
 							/obj/item/gun/ballistic/tazer, /obj/item/ammo_box/magazine/tazer_cartridge_storage, /obj/item/ammo_box/magazine/glock, /obj/item/squad_pager/all_channels, /obj/item/melee/classic_baton/police=1) //NSV13
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Replaces wardens iffy energy gun with sec glock and strobe shield in his locker.

This was done at the behest of Sweepergiles' idea and I liked it. It is honestly much better to give the warden these two instead of the future tazer which is a bee station leftover.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less energy, more physical
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/NSV13/assets/79374236/9042797a-91e7-4747-aabf-0d89f6721473)


</details>

## Changelog
:cl:
tweak: Tweaked Warden's round start equipment
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
