### PR TITLE
Felinid ears buff

### DIFF
--- a/code/modules/surgery/organs/ears.dm
+++ b/code/modules/surgery/organs/ears.dm
@@ -95,7 +95,7 @@
 	name = "cat ears"
 	icon = 'icons/obj/clothing/hats.dmi'
 	icon_state = "kitty"
-	bang_protect = -2
+	bang_protect = -1 // NSV13 - Allows felinids to man munitions without requiring earmuffs and the muni helmet
 
 /obj/item/organ/ears/cat/Insert(mob/living/carbon/human/H, special = 0, drop_if_replaced = TRUE)
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Slightly buffs felinid ears
This makes it so felinids can man gauss while wearing either full munitions gear (helmet and muni headset) or while wearing earmuffs

## Why It's Good For The Game

Currently felinids require the munitions helmet AND earmuffs (Not bowman) which adds up to bang_protect 3, this makes it extremely inconvenient to play munitions or man the gauss as a felinid. As NSV13 is trying to focus on getting the entire crew doing overmap related things, this should be changed to make it easier for felinids to man the only NSV13 exclusive department.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Changelog
:cl:
balance: Makes felinids less vulnerable to ear damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
