### PR TITLE
Helmet cams for sec

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -171,13 +171,17 @@
 			return
 	return ..()
 
-/obj/item/clothing/head/helmet/alt
+/obj/item/clothing/head/helmet/alt // NSV modified - headcams
 	name = "bulletproof helmet"
 	desc = "A bulletproof combat helmet that excels in protecting the wearer against traditional projectile weaponry and explosives to a minor extent."
 	icon_state = "helmetalt"
 	item_state = "helmetalt"
 	armor = list("melee" = 15, "bullet" = 60, "laser" = 10, "energy" = 15, "bomb" = 40, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50, "stamina" = 30)
+	flags_inv = HIDEEARS|HIDEFACE
+	flags_cover = HEADCOVERSEYES
+	visor_flags_cover = HEADCOVERSEYES // logical covering due to texture
 	can_flashlight = TRUE
+	var/has_headcam = TRUE
 
 /obj/item/clothing/head/helmet/old
 	name = "degrading helmet"
@@ -191,7 +195,7 @@
 	item_state = "blueshift"
 	custom_premium_price = 450
 
-/obj/item/clothing/head/helmet/riot
+/obj/item/clothing/head/helmet/riot // NSV modified - headcams
 	name = "riot helmet"
 	desc = "It's a helmet specifically designed to protect against close range attacks."
 	icon_state = "riot"
@@ -206,6 +210,7 @@
 	visor_flags_inv = HIDEFACE|HIDESNOUT
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
+	var/has_headcam = TRUE
 
 /obj/item/clothing/head/helmet/riot/update_icon()
 	icon_state = "[initial(icon_state)][up ? "up" : ""]"
@@ -277,7 +282,7 @@
 	toggle_message = "You turn off the light on"
 	alt_toggle_message = "You turn on the light on"
 
-/obj/item/clothing/head/helmet/swat
+/obj/item/clothing/head/helmet/swat // NSV modified - headcams
 	name = "\improper SWAT helmet"
 	desc = "An extremely robust, space-worthy helmet in a nefarious red and black stripe pattern."
 	icon_state = "swatsyndie"
@@ -289,6 +294,7 @@
 	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
 	clothing_flags = STOPSPRESSUREDAMAGE | SNUG_FIT
 	strip_delay = 80
+	var/has_headcam = TRUE
 
 /obj/item/clothing/head/helmet/police
 	name = "police officer's hat"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -151,7 +151,7 @@
 	armor = list("melee" = 35, "bullet" = 25, "laser" = 25, "energy" = 30, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50, "stamina" = 20)
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
 
-/obj/item/clothing/suit/armor/bulletproof // NSV modified - cover arms
+/obj/item/clothing/suit/armor/bulletproof
 	name = "bulletproof armor"
 	desc = "A Type III heavy bulletproof vest that excels in protecting the wearer against traditional projectile weaponry and explosives to a minor extent."
 	icon_state = "bulletproof"
@@ -160,7 +160,6 @@
 	armor = list("melee" = 15, "bullet" = 60, "laser" = 10, "energy" = 10, "bomb" = 40, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50, "stamina" = 40)
 	strip_delay = 70
 	equip_delay_other = 50
-	body_parts_covered = CHEST|GROIN|ARMS // less boarder one shots, but you can still get crippled
 
 /obj/item/clothing/suit/armor/laserproof
 	name = "reflector vest"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -151,7 +151,7 @@
 	armor = list("melee" = 35, "bullet" = 25, "laser" = 25, "energy" = 30, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50, "stamina" = 20)
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
 
-/obj/item/clothing/suit/armor/bulletproof
+/obj/item/clothing/suit/armor/bulletproof // NSV modified - cover arms
 	name = "bulletproof armor"
 	desc = "A Type III heavy bulletproof vest that excels in protecting the wearer against traditional projectile weaponry and explosives to a minor extent."
 	icon_state = "bulletproof"
@@ -160,6 +160,7 @@
 	armor = list("melee" = 15, "bullet" = 60, "laser" = 10, "energy" = 10, "bomb" = 40, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50, "stamina" = 40)
 	strip_delay = 70
 	equip_delay_other = 50
+	body_parts_covered = CHEST|GROIN|ARMS // less boarder one shots, but you can still get crippled
 
 /obj/item/clothing/suit/armor/laserproof
 	name = "reflector vest"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds helmet cameras to many of the security helmets so AI won't complain and will let security wear more than a singular helmet. (also minor logical obscuring to bulletproof helmet due to it's visor)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Helmet cams are good for AI. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

</details>

## Changelog
:cl:
add: Added helmet cam to Bulletproof, Riot and SWAT helmets
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
