### PR TITLE
Prevents other fleets from shooting boarding objective targets

### DIFF
--- a/nsv13/code/game/gamemodes/overmap/objectives/board_ship.dm
+++ b/nsv13/code/game/gamemodes/overmap/objectives/board_ship.dm
@@ -11,6 +11,7 @@
 	var/ship_type = pick(GLOB.boardable_ship_types)
 	target_ship = instance_overmap(ship_type)
 	target_ship.block_deletion = TRUE
+	target_ship.essential = TRUE
 	RegisterSignal(target_ship, COMSIG_SHIP_BOARDED, PROC_REF(check_completion), target_ship)
 	RegisterSignal(target_ship, COMSIG_SHIP_RELEASE_BOARDING, PROC_REF(release_boarding), target_ship)
 	target_ship.ai_load_interior(SSstar_system.find_main_overmap())
@@ -60,6 +61,7 @@
 	if (target_ship.faction == SSovermap_mode.mode.starting_faction)
 		status = 1
 		target_ship.block_deletion = FALSE
+		target_ship.essential = FALSE
 		UnregisterSignal(target_ship, COMSIG_SHIP_BOARDED)
 		UnregisterSignal(target_ship, COMSIG_SHIP_RELEASE_BOARDING)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Gives the target ship from the boarding game mode essential, which should prevent allied fleets from targeting and shooting the target while the main ship is still in another system
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #1962 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

TBA

</details>

## Changelog
:cl:
fix: Target ships from the boarding gamemode will no longer be targeted by AI fleets
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
