### PR TITLE
Allows cyborgs to pilot transport small craft

### DIFF
--- a/nsv13/code/game/general_quarters/dropship.dm
+++ b/nsv13/code/game/general_quarters/dropship.dm
@@ -165,6 +165,10 @@
 	name = "circuit board (dropship helm computer)"
 	build_path = /obj/machinery/computer/ship/helm/console/dropship
 
+/obj/machinery/computer/ship/helm/console/dropship/attack_robot(mob/user)
+	. = ..()
+	return attack_hand(user)
+	
 /obj/machinery/computer/ship/helm/console/dropship/attack_hand(mob/living/user)
 	. = ..()
 	var/obj/structure/overmap/OM = has_overmap()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Allows cyborgs to use the flight console on transport small craft such as Sabres and the dropship. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Cyborgs could already use the helm console on the Rocinante to mine on their own, so they should be able to use Sabres on their own as well. 


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

TBA

</details>

## Changelog
:cl:
tweak: Cyborgs can now fly transport small craft
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
