### PR TITLE
only send mail 20% of the time

### DIFF
--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -71,7 +71,8 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 
 /obj/docking_port/mobile/supply/initiate_docking()
 	if(getDockedId() == "supply_away") // Buy when we leave home.
-		create_mail()
+		if(prob(20)) //NSV13 Only send mail 1/5 of the time
+			create_mail()
 		buy()
 	. = ..() // Fly/enter transit.
 	if(. != DOCKING_SUCCESS)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes mail crates have a 20% chance to be on each cargo shuttle instead of always beign there.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Due to a frequent lack of cargo staff and the often quite busy gameplay loop of NSV, mail tends to pile up in cargo. Only sending a mail crate some of the time should reduce that without flat out removing mail, which would be a horrible thing for bluewasabi, who put a bunch of work into making custom mail for NSV.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
Too lazy to do that for a two line change. Real chads test on production anyway.
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
balance: Each cargo shuttle now only has a 20% chance of carrying a mail crate.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
