### PR TITLE
Galactica Xenobio and Security Fixes

### DIFF
--- a/_maps/map_files/Galactica/Galactica1.dmm
+++ b/_maps/map_files/Galactica/Galactica1.dmm
@@ -6882,7 +6882,7 @@
 "rK" = (
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/monotile/steel,
+/turf/open/openspace,
 /area/science/xenobiology)
 "rL" = (
 /obj/effect/turf_decal/stripes/line,
@@ -17064,11 +17064,6 @@
 "RI" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hos)
-"RJ" = (
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/monotile/dark,
-/area/science/xenobiology)
 "RK" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -62605,7 +62600,7 @@ Oc
 qX
 XU
 RM
-RJ
+rK
 Jz
 GK
 Hp

--- a/_maps/map_files/Galactica/Galactica1.dmm
+++ b/_maps/map_files/Galactica/Galactica1.dmm
@@ -6879,6 +6879,11 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/science/xenobiology)
+"rK" = (
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/steel,
+/area/science/xenobiology)
 "rL" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/rack,
@@ -8911,9 +8916,7 @@
 /turf/open/floor/plasteel/grid/steel,
 /area/ai_monitored/security/armory)
 "xq" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/beakers,
-/obj/item/storage/box/syringes,
+/obj/machinery/smartfridge/extract/preloaded,
 /turf/open/floor/carpet/purple,
 /area/science/xenobiology)
 "xs" = (
@@ -15065,6 +15068,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/item/storage/box/syringes,
+/obj/item/storage/box/beakers,
 /turf/open/floor/carpet/purple,
 /area/science/xenobiology)
 "MD" = (
@@ -17060,8 +17065,9 @@
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hos)
 "RJ" = (
-/obj/machinery/smartfridge/extract/preloaded,
-/turf/closed/wall/r_wall,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/dark,
 /area/science/xenobiology)
 "RK" = (
 /obj/structure/cable{
@@ -61054,7 +61060,7 @@ UB
 Oc
 kt
 Cl
-RJ
+AI
 AI
 AI
 AI
@@ -62342,7 +62348,7 @@ mW
 dJ
 sa
 vQ
-bA
+rK
 AI
 Dz
 Oy
@@ -62599,7 +62605,7 @@ Oc
 qX
 XU
 RM
-RM
+RJ
 Jz
 GK
 Hp

--- a/_maps/map_files/Galactica/Galactica2.dmm
+++ b/_maps/map_files/Galactica/Galactica2.dmm
@@ -8873,6 +8873,14 @@
 /obj/machinery/light,
 /turf/open/floor/monotile/light,
 /area/medical/chemistry)
+"eQV" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/dark,
+/area/science/nsv/astronomy)
 "eQW" = (
 /obj/effect/turf_decal/tile/ship/half/purple,
 /turf/open/floor/monotile/dark,
@@ -14709,6 +14717,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light,
+/obj/structure/tank_dispenser,
 /turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "hOX" = (
@@ -87126,7 +87135,7 @@ deg
 bso
 whw
 tcr
-kmr
+eQV
 kmr
 tFx
 rGb
@@ -87383,7 +87392,7 @@ tcr
 pDl
 eyN
 tcr
-kmr
+eQV
 kmr
 mgq
 eit

--- a/_maps/map_files/Galactica/Galactica2.dmm
+++ b/_maps/map_files/Galactica/Galactica2.dmm
@@ -177,9 +177,6 @@
 /obj/effect/turf_decal/tile/ship/half/orange,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons)
 "afe" = (
@@ -2092,9 +2089,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "bbk" = (
@@ -2260,12 +2254,6 @@
 	},
 /turf/open/floor/durasteel/lino,
 /area/engine/engineering/reactor_control)
-"bfy" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/monotile/dark,
-/area/nsv/weapons)
 "bfE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/door/airlock/highsecurity/ship{
@@ -7819,7 +7807,6 @@
 	pixel_y = -32;
 	req_one_access_txt = "69"
 	},
-/obj/effect/turf_decal/caution,
 /obj/machinery/camera/autoname{
 	dir = 10
 	},
@@ -7992,13 +7979,6 @@
 "emI" = (
 /turf/closed/wall/steel,
 /area/maintenance/nsv/deck2/frame5/starboard)
-"emT" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/hallway/nsv/deck2/primary)
 "emZ" = (
 /obj/effect/turf_decal/tile/ship/green{
 	dir = 4
@@ -8129,11 +8109,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plating,
 /area/nsv/weapons)
 "eqJ" = (
@@ -10340,10 +10316,6 @@
 	},
 /turf/open/floor/plating,
 /area/mine/laborcamp)
-"fzp" = (
-/obj/machinery/recharge_station,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/frame2/port)
 "fzA" = (
 /obj/structure/stairs{
 	dir = 4
@@ -12090,9 +12062,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "gqZ" = (
@@ -13686,18 +13655,14 @@
 /area/maintenance/nsv/deck2/frame2/starboard)
 "hcC" = (
 /obj/structure/window/reinforced,
-/obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 4;
 	layer = 2.9
 	},
-/obj/effect/turf_decal/ship/delivery/yellow,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 31
 	},
+/obj/effect/turf_decal/ship/delivery/yellow,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "hcE" = (
@@ -14302,9 +14267,6 @@
 	dir = 8
 	},
 /obj/structure/plasticflaps,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "hwb" = (
@@ -15991,9 +15953,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
 	},
 /turf/open/floor/carpet,
 /area/nsv/weapons)
@@ -18360,12 +18319,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame3/central)
-"jGd" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/carpet,
-/area/nsv/weapons)
 "jGh" = (
 /obj/structure/table/reinforced,
 /obj/item/t_scanner,
@@ -19185,9 +19138,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
@@ -21114,13 +21064,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/monotile/dark,
 /area/mine/laborcamp)
-"leV" = (
-/obj/effect/turf_decal/tile/ship/full/blue,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck2/primary)
 "lff" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/general/hidden/layer2{
@@ -21270,9 +21213,6 @@
 /obj/machinery/computer/ship/viewscreen,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
 	},
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons)
@@ -22580,9 +22520,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/carpet,
 /area/nsv/weapons)
 "lQb" = (
@@ -23485,9 +23422,6 @@
 	dir = 4;
 	freq = 1400;
 	location = "Munitions"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
@@ -25309,9 +25243,6 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/effect/landmark/zebra_interlock_point,
 /obj/item/radio/intercom/directional/north,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons)
 "npk" = (
@@ -26617,10 +26548,7 @@
 	dir = 2;
 	req_one_access_txt = "69"
 	},
-/obj/effect/turf_decal/ship/delivery/yellow,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
+/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "oeq" = (
@@ -27505,9 +27433,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/ship/neutral,
-/obj/structure/disposaloutlet{
-	dir = 4
-	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
 "ozp" = (
@@ -27920,9 +27845,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons)
 "oIE" = (
@@ -28291,12 +28213,9 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "oUu" = (
-/obj/effect/turf_decal/tile/ship/half/orange,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/monotile/steel,
-/area/nsv/weapons)
+/obj/machinery/recharge_station,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/frame1/starboard)
 "oUy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -32728,9 +32647,6 @@
 "rpc" = (
 /obj/effect/turf_decal/tile/ship/full/blue,
 /obj/effect/landmark/nuclear_waste_spawner,
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "rpj" = (
@@ -36661,12 +36577,9 @@
 /turf/open/floor/monotile/dark,
 /area/security/brig)
 "tnn" = (
-/obj/effect/turf_decal/tile/ship/full/blue,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/monotile/dark,
-/area/hallway/nsv/deck2/primary)
+/obj/machinery/recharge_station,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/frame2/port)
 "tnr" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -37166,9 +37079,6 @@
 /obj/structure/table/wood/fancy,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
 	},
 /turf/open/floor/carpet,
 /area/nsv/weapons)
@@ -40324,9 +40234,6 @@
 /obj/effect/turf_decal/tile/ship/half/orange,
 /obj/effect/turf_decal/tile/ship/orange{
 	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
 	},
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons)
@@ -43599,16 +43506,6 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/chapel/main)
-"xdc" = (
-/obj/effect/turf_decal/tile/ship/half/neutral{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
-	},
-/turf/open/floor/monotile/dark,
-/area/hallway/nsv/deck2/primary)
 "xdf" = (
 /obj/machinery/atmospherics/components/trinary/mixer/flipped{
 	dir = 1;
@@ -44334,16 +44231,6 @@
 "xwg" = (
 /turf/closed/wall/steel,
 /area/maintenance/nsv/deck2/frame3/central)
-"xwu" = (
-/obj/effect/turf_decal/ship/delivery/yellow,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/effect/landmark/zebra_interlock_point,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/monotile/steel,
-/area/nsv/weapons)
 "xwA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -44878,10 +44765,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
-"xLM" = (
-/obj/machinery/recharge_station,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/frame1/starboard)
 "xLX" = (
 /obj/machinery/ship_weapon/vls,
 /obj/effect/turf_decal/ship/delivery/yellow,
@@ -92720,7 +92603,7 @@ pXB
 ewU
 pXB
 xUX
-fzp
+tnn
 dWH
 bcP
 ugd
@@ -96346,7 +96229,7 @@ aAQ
 biY
 xAd
 ntw
-xdc
+xAd
 xAd
 xAd
 sDJ
@@ -96601,12 +96484,12 @@ sYT
 lju
 gqS
 mpy
-tnn
+rkV
 kbY
-leV
-leV
-tnn
-leV
+jaI
+jaI
+rkV
+jaI
 rpc
 uFe
 ipU
@@ -96864,7 +96747,7 @@ hqf
 ppy
 lju
 qif
-emT
+qif
 vjs
 otC
 ipU
@@ -97121,7 +97004,7 @@ vjs
 sqB
 vjs
 fZo
-jGd
+oTH
 oTH
 ipU
 jse
@@ -98920,7 +98803,7 @@ sYT
 sYT
 oNu
 sYT
-xwu
+agZ
 agZ
 agZ
 sYT
@@ -99177,7 +99060,7 @@ urI
 urI
 qfd
 urI
-bfy
+urI
 urI
 aDc
 wVx
@@ -99691,7 +99574,7 @@ gzr
 ivn
 scN
 rMz
-oUu
+qjl
 urI
 cHC
 ioq
@@ -99948,7 +99831,7 @@ nyd
 nyd
 qrP
 rMz
-oUu
+qjl
 mPx
 aDc
 bgg
@@ -100215,7 +100098,7 @@ jhf
 hqk
 qaM
 fgw
-xLM
+oUu
 eDI
 xyC
 xyC
@@ -100462,7 +100345,7 @@ qwy
 urI
 qmV
 rMz
-oUu
+qjl
 jWg
 aDc
 wUD
@@ -100719,7 +100602,7 @@ roE
 roE
 oSq
 rMz
-oUu
+qjl
 jWg
 cHC
 edA
@@ -100976,7 +100859,7 @@ oqG
 oXF
 wwW
 rMz
-oUu
+qjl
 jWg
 cHC
 ioq
@@ -101233,7 +101116,7 @@ qRz
 qRz
 qRz
 tNI
-oUu
+qjl
 jWg
 aDc
 kRL

--- a/_maps/map_files/Galactica/Galactica2.dmm
+++ b/_maps/map_files/Galactica/Galactica2.dmm
@@ -2919,7 +2919,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/mine/laborcamp/security)
+/area/mine/laborcamp)
 "byR" = (
 /obj/effect/turf_decal/tile/ship/half/orange{
 	dir = 1
@@ -6307,7 +6307,7 @@
 	width = 9
 	},
 /turf/open/space/basic,
-/area/mine/laborcamp/security)
+/area/mine/laborcamp)
 "drf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -7762,7 +7762,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/mine/laborcamp/security)
+/area/mine/laborcamp)
 "ehz" = (
 /obj/effect/turf_decal/ship/techfloor{
 	dir = 4
@@ -18742,7 +18742,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/mine/laborcamp/security)
+/area/mine/laborcamp)
 "jQg" = (
 /obj/effect/turf_decal/box,
 /obj/machinery/portable_atmospherics/canister/water_vapor,
@@ -21607,7 +21607,7 @@
 "ltv" = (
 /obj/structure/gulag_beacon,
 /turf/open/floor/plating,
-/area/mine/laborcamp/security)
+/area/mine/laborcamp)
 "ltA" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
@@ -24047,7 +24047,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
-/area/mine/laborcamp/security)
+/area/mine/laborcamp)
 "mEB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -28862,7 +28862,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
-/area/mine/laborcamp/security)
+/area/mine/laborcamp)
 "pkt" = (
 /obj/machinery/air_sensor/atmos{
 	id_tag = "nuclear_mix_sensor_1"
@@ -38154,7 +38154,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/mine/laborcamp/security)
+/area/mine/laborcamp)
 "uhj" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-02"
@@ -45016,7 +45016,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/mine/laborcamp/security)
+/area/mine/laborcamp)
 "xTO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -84561,14 +84561,14 @@ pXB
 pXB
 pXB
 srp
-wlG
-wlG
+dnK
+dnK
 uhc
-wlG
-wlG
-wlG
+dnK
+dnK
+dnK
 uhc
-wlG
+dnK
 wlG
 wlG
 srp
@@ -84818,14 +84818,14 @@ pXB
 pXB
 pXB
 srp
-wlG
-wlG
+dnK
+dnK
 ehl
-wlG
-wlG
-wlG
+dnK
+dnK
+dnK
 mEA
-wlG
+dnK
 wlG
 wlG
 pXB
@@ -85076,13 +85076,13 @@ dnK
 dnK
 dnK
 dnK
-wlG
+dnK
 byw
-wlG
+dnK
 xTE
-wlG
+dnK
 jQb
-wlG
+dnK
 fXq
 wlG
 pXB
@@ -85333,13 +85333,13 @@ rGv
 rGv
 rGv
 rGv
-wlG
+dnK
 pkn
-wlG
+dnK
 ltv
-wlG
+dnK
 pkn
-wlG
+dnK
 fXq
 wlG
 pXB

--- a/_maps/map_files/Galactica/Galactica2.dmm
+++ b/_maps/map_files/Galactica/Galactica2.dmm
@@ -2260,6 +2260,12 @@
 	},
 /turf/open/floor/durasteel/lino,
 /area/engine/engineering/reactor_control)
+"bfy" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/monotile/dark,
+/area/nsv/weapons)
 "bfE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/door/airlock/highsecurity/ship{
@@ -2700,13 +2706,6 @@
 /obj/machinery/deck_turret/powder_gate,
 /turf/open/floor/plating,
 /area/nsv/magazine/starboard)
-"boY" = (
-/obj/effect/turf_decal/tile/ship/full/blue,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck2/primary)
 "bpd" = (
 /obj/effect/landmark/start/bartender,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -7993,6 +7992,13 @@
 "emI" = (
 /turf/closed/wall/steel,
 /area/maintenance/nsv/deck2/frame5/starboard)
+"emT" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/hallway/nsv/deck2/primary)
 "emZ" = (
 /obj/effect/turf_decal/tile/ship/green{
 	dir = 4
@@ -10334,6 +10340,10 @@
 	},
 /turf/open/floor/plating,
 /area/mine/laborcamp)
+"fzp" = (
+/obj/machinery/recharge_station,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/frame2/port)
 "fzA" = (
 /obj/structure/stairs{
 	dir = 4
@@ -17249,16 +17259,6 @@
 /obj/machinery/status_display/supply,
 /turf/closed/wall/steel,
 /area/quartermaster/storage)
-"jfq" = (
-/obj/effect/turf_decal/ship/delivery/yellow,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/effect/landmark/zebra_interlock_point,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/monotile/steel,
-/area/nsv/weapons)
 "jfu" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	req_access_txt = "12"
@@ -18360,6 +18360,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame3/central)
+"jGd" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet,
+/area/nsv/weapons)
 "jGh" = (
 /obj/structure/table/reinforced,
 /obj/item/t_scanner,
@@ -21108,6 +21114,13 @@
 /obj/machinery/light/small,
 /turf/open/floor/monotile/dark,
 /area/mine/laborcamp)
+"leV" = (
+/obj/effect/turf_decal/tile/ship/full/blue,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/primary)
 "lff" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/general/hidden/layer2{
@@ -23792,10 +23805,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/medical/medbay)
-"mxX" = (
-/obj/machinery/recharge_station,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/frame2/port)
 "myd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -24404,12 +24413,6 @@
 "mLj" = (
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/atmos)
-"mLJ" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/carpet,
-/area/nsv/weapons)
 "mMj" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line,
@@ -26886,13 +26889,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/science/robotics/lab)
-"ojM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/hallway/nsv/deck2/primary)
 "oku" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible/layer2,
 /obj/structure/disposalpipe/segment{
@@ -28295,12 +28291,12 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "oUu" = (
-/obj/effect/turf_decal/tile/ship/full/blue,
+/obj/effect/turf_decal/tile/ship/half/orange,
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/turf/open/floor/monotile/dark,
-/area/hallway/nsv/deck2/primary)
+/turf/open/floor/monotile/steel,
+/area/nsv/weapons)
 "oUy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -32355,6 +32351,9 @@
 	name = "PDSR";
 	req_one_access_txt = "56"
 	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible/layer2{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "rbL" = (
@@ -33371,12 +33370,6 @@
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame2/port)
-"rFR" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/monotile/dark,
-/area/nsv/weapons)
 "rGb" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -36668,12 +36661,12 @@
 /turf/open/floor/monotile/dark,
 /area/security/brig)
 "tnn" = (
-/obj/effect/turf_decal/tile/ship/half/orange,
+/obj/effect/turf_decal/tile/ship/full/blue,
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/turf/open/floor/monotile/steel,
-/area/nsv/weapons)
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck2/primary)
 "tnr" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -40671,10 +40664,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/monotile/steel,
 /area/storage/primary)
-"vsR" = (
-/obj/machinery/recharge_station,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/frame1/starboard)
 "vtt" = (
 /obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/chapel{
@@ -43610,6 +43599,16 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/chapel/main)
+"xdc" = (
+/obj/effect/turf_decal/tile/ship/half/neutral{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck2/primary)
 "xdf" = (
 /obj/machinery/atmospherics/components/trinary/mixer/flipped{
 	dir = 1;
@@ -44335,6 +44334,16 @@
 "xwg" = (
 /turf/closed/wall/steel,
 /area/maintenance/nsv/deck2/frame3/central)
+"xwu" = (
+/obj/effect/turf_decal/ship/delivery/yellow,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/monotile/steel,
+/area/nsv/weapons)
 "xwA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -44869,6 +44878,10 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
+"xLM" = (
+/obj/machinery/recharge_station,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/frame1/starboard)
 "xLX" = (
 /obj/machinery/ship_weapon/vls,
 /obj/effect/turf_decal/ship/delivery/yellow,
@@ -45595,16 +45608,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame2/starboard)
-"yfR" = (
-/obj/effect/turf_decal/tile/ship/half/neutral{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
-	},
-/turf/open/floor/monotile/dark,
-/area/hallway/nsv/deck2/primary)
 "yfS" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold/layer2{
 	dir = 4
@@ -92717,7 +92720,7 @@ pXB
 ewU
 pXB
 xUX
-mxX
+fzp
 dWH
 bcP
 ugd
@@ -96343,7 +96346,7 @@ aAQ
 biY
 xAd
 ntw
-yfR
+xdc
 xAd
 xAd
 sDJ
@@ -96598,12 +96601,12 @@ sYT
 lju
 gqS
 mpy
-oUu
+tnn
 kbY
-boY
-boY
-oUu
-boY
+leV
+leV
+tnn
+leV
 rpc
 uFe
 ipU
@@ -96861,7 +96864,7 @@ hqf
 ppy
 lju
 qif
-ojM
+emT
 vjs
 otC
 ipU
@@ -97118,7 +97121,7 @@ vjs
 sqB
 vjs
 fZo
-mLJ
+jGd
 oTH
 ipU
 jse
@@ -98917,7 +98920,7 @@ sYT
 sYT
 oNu
 sYT
-jfq
+xwu
 agZ
 agZ
 sYT
@@ -99174,7 +99177,7 @@ urI
 urI
 qfd
 urI
-rFR
+bfy
 urI
 aDc
 wVx
@@ -99688,7 +99691,7 @@ gzr
 ivn
 scN
 rMz
-tnn
+oUu
 urI
 cHC
 ioq
@@ -99945,7 +99948,7 @@ nyd
 nyd
 qrP
 rMz
-tnn
+oUu
 mPx
 aDc
 bgg
@@ -100212,7 +100215,7 @@ jhf
 hqk
 qaM
 fgw
-vsR
+xLM
 eDI
 xyC
 xyC
@@ -100459,7 +100462,7 @@ qwy
 urI
 qmV
 rMz
-tnn
+oUu
 jWg
 aDc
 wUD
@@ -100716,7 +100719,7 @@ roE
 roE
 oSq
 rMz
-tnn
+oUu
 jWg
 cHC
 edA
@@ -100973,7 +100976,7 @@ oqG
 oXF
 wwW
 rMz
-tnn
+oUu
 jWg
 cHC
 ioq
@@ -101230,7 +101233,7 @@ qRz
 qRz
 qRz
 tNI
-tnn
+oUu
 jWg
 aDc
 kRL

--- a/_maps/map_files/Galactica/Galactica2.dmm
+++ b/_maps/map_files/Galactica/Galactica2.dmm
@@ -28,6 +28,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plating,
 /area/security/detectives_office)
 "aaQ" = (
@@ -91,6 +94,13 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/turf/open/floor/monotile/steel,
+/area/security/prison)
+"abI" = (
+/obj/effect/turf_decal/tile/ship/half/red,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/monotile/steel,
 /area/security/prison)
@@ -534,6 +544,9 @@
 	name = "detective's office shutters"
 	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/open/floor/plating,
 /area/security/detectives_office)
 "apo" = (
@@ -960,6 +973,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/monotile/dark,
 /area/security/brig)
 "aCa" = (
@@ -1341,6 +1357,9 @@
 "aKw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/monotile/dark,
 /area/security/prison)
@@ -1984,6 +2003,9 @@
 	name = "Night Club"
 	})
 "aYZ" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
 "aZf" = (
@@ -2379,6 +2401,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/monotile/dark,
 /area/security/brig)
@@ -2886,13 +2911,13 @@
 	pixel_y = 28;
 	req_access_txt = "2"
 	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/advanced_airlock_controller/directional/south,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/monotile/dark,
 /area/mine/laborcamp/security)
 "byR" = (
@@ -2992,6 +3017,16 @@
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/medical/medbay)
+"bBs" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "briglockdown"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "bBx" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
@@ -3947,13 +3982,20 @@
 	name = "prisoner processing blast door"
 	},
 /obj/machinery/door/airlock/ship/external/glass{
-	name = "Labour Camp Shuttle Dock"
+	name = "Labour Camp Shuttle Dock";
+	req_one_access_txt = "2"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/open/floor/monotile/dark,
 /area/security/processing)
 "ccJ" = (
@@ -4442,6 +4484,13 @@
 	name = "Brig Infirmary";
 	req_one_access_txt = list(2,34)
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/monotile/dark,
 /area/security/prison)
 "crW" = (
@@ -4741,6 +4790,9 @@
 /obj/effect/turf_decal/tile/ship/half/red,
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "cBR" = (
@@ -6200,6 +6252,16 @@
 /obj/structure/closet/secure_closet/transport_pilot,
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/notkmcstupidhanger)
+"doG" = (
+/obj/effect/turf_decal/tile/ship/half/red{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/monotile/steel,
+/area/security/brig)
 "dpD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -6235,6 +6297,17 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"dra" = (
+/obj/docking_port/stationary{
+	dir = 8;
+	dwidth = 2;
+	height = 5;
+	id = "laborcamp_away";
+	name = "labor camp";
+	width = 9
+	},
+/turf/open/space/basic,
+/area/mine/laborcamp/security)
 "drf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -6362,6 +6435,12 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/effect/landmark/zebra_interlock_point,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
 /turf/open/floor/monotile/dark,
 /area/security/brig)
 "dul" = (
@@ -6388,6 +6467,9 @@
 	},
 /obj/machinery/camera/autoname{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/carpet/red,
 /area/security/detectives_office)
@@ -6520,6 +6602,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
+"dxF" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/security/processing)
 "dxH" = (
 /turf/closed/wall/r_wall,
 /area/chapel/office)
@@ -6529,6 +6618,9 @@
 /area/engine/engineering/ftl_room)
 "dyo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile/dark,
 /area/security/brig)
 "dys" = (
@@ -6638,6 +6730,21 @@
 /obj/machinery/atmospherics/pipe/simple/dark/visible,
 /turf/open/floor/plating,
 /area/engine/atmos)
+"dAn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/monotile/dark,
+/area/security/brig)
 "dAr" = (
 /obj/structure/reagent_dispensers/foamtank/hull_repair_juice,
 /turf/open/floor/monotile/dark/airless,
@@ -6679,6 +6786,12 @@
 /area/mine/laborcamp)
 "dBQ" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plating,
 /area/security/processing)
 "dCb" = (
@@ -6832,6 +6945,9 @@
 "dGV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/open/floor/plating,
 /area/security/brig)
 "dHv" = (
@@ -7095,6 +7211,9 @@
 /obj/structure/sign/nanotrasen{
 	pixel_y = 26
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/monotile/steel,
 /area/security/processing)
 "dRU" = (
@@ -7137,6 +7256,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/monotile/dark,
 /area/security/processing)
@@ -7633,13 +7755,10 @@
 /turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "ehl" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
+	dir = 8
 	},
-/obj/machinery/door/airlock/ship/external/glass{
-	name = "Labour Camp Shuttle Dock"
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
@@ -8195,6 +8314,30 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame2/starboard)
+"evE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/turnstile{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/monotile/steel,
+/area/security/prison)
 "evG" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Medical Storage";
@@ -8235,6 +8378,12 @@
 	name = "detective's office shutters"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/security/detectives_office)
 "ewI" = (
@@ -8873,14 +9022,6 @@
 /obj/machinery/light,
 /turf/open/floor/monotile/light,
 /area/medical/chemistry)
-"eQV" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/monotile/dark,
-/area/science/nsv/astronomy)
 "eQW" = (
 /obj/effect/turf_decal/tile/ship/half/purple,
 /turf/open/floor/monotile/dark,
@@ -8904,6 +9045,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/carpet,
 /area/nsv/weapons)
+"eRF" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/closed/wall/r_wall,
+/area/security/prison)
 "eRH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/structure/cable{
@@ -9018,6 +9165,13 @@
 "eUu" = (
 /obj/machinery/gulag_teleporter,
 /turf/open/floor/durasteel/lino,
+/area/security/processing)
+"eUE" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
 /area/security/processing)
 "eUS" = (
 /obj/structure/fans/tiny,
@@ -9251,6 +9405,12 @@
 /obj/machinery/light_switch/south,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/floor/carpet/ship,
 /area/security/detectives_office)
@@ -9562,6 +9722,9 @@
 "fho" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
 "fhs" = (
@@ -10033,6 +10196,9 @@
 	},
 /obj/machinery/camera/autoname{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/monotile/dark,
 /area/security/prison)
@@ -10719,6 +10885,9 @@
 /obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame2/port)
 "fLA" = (
@@ -11664,6 +11833,12 @@
 "glJ" = (
 /turf/closed/mineral/random/labormineral/volcanic,
 /area/mine/laborcamp)
+"gmx" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
 "gmy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -12958,14 +13133,21 @@
 /turf/open/floor/noslip/dark,
 /area/maintenance/nsv/bunker)
 "gOg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/turf/open/floor/monotile/dark,
-/area/security/brig)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/processing)
 "gOp" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
@@ -13663,6 +13845,13 @@
 /obj/structure/plasticflaps/opaque,
 /turf/open/floor/monotile/steel,
 /area/shuttle/turbolift/tertiary)
+"hjG" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "hjN" = (
 /obj/effect/turf_decal/tile/ship/half/red{
 	dir = 1
@@ -13857,6 +14046,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/monotile/dark,
 /area/security/brig)
@@ -14559,6 +14751,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/monotile/dark,
 /area/security/brig)
 "hJZ" = (
@@ -14650,6 +14845,14 @@
 /obj/item/storage/toolbox/electrical,
 /turf/open/floor/durasteel/padded,
 /area/maintenance/nsv/deck2/frame5/starboard)
+"hMF" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "hMS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -16099,6 +16302,12 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/monotile/dark,
 /area/security/brig)
 "iBg" = (
@@ -16856,6 +17065,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/floor/monotile/dark,
 /area/security/brig)
@@ -17791,6 +18003,16 @@
 /obj/machinery/computer/shuttle_flight/labor{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/durasteel/lino,
 /area/security/processing)
 "jyp" = (
@@ -18512,13 +18734,13 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/advanced_airlock_controller/directional/south,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/monotile/dark,
 /area/mine/laborcamp/security)
 "jQg" = (
@@ -18696,6 +18918,13 @@
 /obj/item/stack/rods,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame5/starboard)
+"jWe" = (
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/monotile/dark,
+/area/security/processing)
 "jWg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -18846,6 +19075,9 @@
 	},
 /obj/effect/turf_decal/tile/ship/half/red{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/monotile/steel,
 /area/security/prison)
@@ -19322,6 +19554,16 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
+"knD" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/security/processing)
 "knF" = (
 /obj/effect/spawner/room/fivexfour,
 /turf/template_noop,
@@ -19493,6 +19735,12 @@
 /obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/monotile/dark,
 /area/security/brig)
@@ -19689,6 +19937,12 @@
 	req_one_access_txt = "4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/monotile/dark,
 /area/security/detectives_office)
 "kyv" = (
@@ -19984,8 +20238,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/turnstile{
-	dir = 4
+/obj/machinery/door/airlock/ship/security/glass{
+	req_one_access_txt = "2"
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
 	},
 /turf/open/floor/monotile/steel,
 /area/security/prison)
@@ -20147,6 +20404,9 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet/south,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/ship,
 /area/security/detectives_office)
 "kLL" = (
@@ -20384,6 +20644,16 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/grid/techfloor/grid,
 /area/engine/engineering/ftl_room)
+"kSP" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "briglockdown"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "kSZ" = (
 /obj/structure/sign/ship/nosmoking,
 /turf/closed/wall/r_wall,
@@ -20430,6 +20700,9 @@
 "kVz" = (
 /obj/effect/turf_decal/tile/ship/half/red{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/monotile/dark,
 /area/security/prison)
@@ -20619,6 +20892,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/monotile/steel,
 /area/security/prison)
@@ -20989,6 +21265,9 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/monotile/steel,
 /area/security/brig)
@@ -21526,6 +21805,18 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
+"lyj" = (
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/airlock/ship/security/glass{
+	req_one_access_txt = "2"
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/turf/open/floor/monotile/steel,
+/area/security/prison)
 "lyA" = (
 /obj/effect/turf_decal/ship/techfloor{
 	dir = 1
@@ -22210,6 +22501,13 @@
 /obj/structure/lattice/catwalk/over/ship,
 /turf/open/floor/plating,
 /area/engine/engineering/reactor_core)
+"lPR" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/processing)
 "lPX" = (
 /obj/structure/chair/fancy/sofa/old/left{
 	dir = 8
@@ -22456,9 +22754,13 @@
 /area/nsv/weapons)
 "lWs" = (
 /obj/machinery/door/airlock/ship/external/glass{
-	name = "Labour Camp Shuttle Dock"
+	name = "Labour Camp Shuttle Dock";
+	req_one_access_txt = "2"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/open/floor/monotile/dark,
 /area/security/processing)
 "lWv" = (
@@ -23737,6 +24039,15 @@
 	},
 /turf/open/floor/plating,
 /area/mine/laborcamp)
+"mEA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/mine/laborcamp/security)
 "mEB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -23858,6 +24169,9 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/monotile/dark,
 /area/security/brig)
 "mIh" = (
@@ -24143,6 +24457,9 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom/directional/south,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "mPq" = (
@@ -24600,6 +24917,9 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/security_officer,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "ngz" = (
@@ -26254,6 +26574,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"oeU" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/dark,
+/area/science/nsv/astronomy)
 "oeW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -26462,6 +26790,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/durasteel/lino,
 /area/security/processing)
@@ -26820,6 +27151,13 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/carpet,
 /area/bridge/showroom/corporate)
+"otB" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "otC" = (
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/carpet/ship,
@@ -27026,6 +27364,9 @@
 "oxL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile/dark,
 /area/security/processing)
 "oxS" = (
@@ -27773,6 +28114,9 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/open/floor/monotile/light,
 /area/security/prison)
 "oSQ" = (
@@ -28056,7 +28400,17 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/airlock/ship/security/glass{
 	name = "Brig Infirmary";
-	req_one_access_txt = list(2,34)
+	req_one_access_txt = "1"
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/monotile/dark,
 /area/security/prison)
@@ -28494,7 +28848,8 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/ship/external/glass{
-	name = "Labour Camp Shuttle Dock"
+	name = "Labour Camp Shuttle Dock";
+	req_one_access_txt = "2"
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "labor";
@@ -29155,6 +29510,9 @@
 	},
 /obj/structure/extinguisher_cabinet/north,
 /obj/machinery/vending/wardrobe/sec_wardrobe,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "pDe" = (
@@ -29254,6 +29612,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/monotile/dark,
 /area/security/brig)
@@ -29358,6 +29719,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/monotile/dark,
 /area/security/prison)
 "pHK" = (
@@ -29383,6 +29747,17 @@
 "pHZ" = (
 /turf/closed/wall/steel,
 /area/quartermaster/warehouse)
+"pIc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/monotile/dark,
+/area/security/brig)
 "pIL" = (
 /obj/machinery/computer/med_data{
 	dir = 8
@@ -29392,6 +29767,9 @@
 	bulb_vacuum_brightness = 2;
 	dir = 4;
 	nightshift_brightness = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/carpet/red,
 /area/security/detectives_office)
@@ -29449,6 +29827,13 @@
 /obj/machinery/door/poddoor/shutters/ship/preopen{
 	id = "briglockdown"
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison)
 "pLC" = (
@@ -31404,6 +31789,13 @@
 /obj/structure/sign/ship/deck/two,
 /turf/closed/wall/r_wall,
 /area/maintenance/nsv/deck2/frame2/starboard)
+"qMt" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "qMF" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/effect/landmark/zebra_interlock_point,
@@ -31481,6 +31873,24 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/freezer,
+/area/security/prison)
+"qPg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/monotile/dark,
 /area/security/prison)
 "qPA" = (
 /turf/closed/wall/r_wall,
@@ -31863,6 +32273,14 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/security/armory/lockup)
+"rbU" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "briglockdown"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
 "rbV" = (
 /obj/structure/frame/machine,
 /turf/open/floor/durasteel/padded,
@@ -32090,6 +32508,9 @@
 /area/quartermaster/warehouse)
 "rjY" = (
 /obj/item/kirbyplants/random,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/carpet/ship,
 /area/security/detectives_office)
 "rki" = (
@@ -32098,6 +32519,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame5/port)
+"rks" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "rkV" = (
 /obj/effect/turf_decal/tile/ship/full/blue,
 /turf/open/floor/monotile/dark,
@@ -32185,6 +32613,16 @@
 /area/nsv/weapons/fore{
 	name = "Artillery Bay"
 	})
+"rot" = (
+/obj/effect/turf_decal/ship/delivery/yellow,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/monotile/dark,
+/area/security/prison)
 "roE" = (
 /obj/machinery/conveyor/slow{
 	id = "torp"
@@ -32438,6 +32876,9 @@
 	dir = 8
 	},
 /obj/machinery/vending/wardrobe/law_wardrobe,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "ruL" = (
@@ -32552,6 +32993,16 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/turnstile{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
 /turf/open/floor/monotile/dark,
 /area/security/brig)
@@ -33442,6 +33893,9 @@
 /obj/machinery/door/airlock/ship/security{
 	name = "Detective's Room";
 	req_one_access_txt = "4;2"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
 /turf/open/floor/carpet/ship,
 /area/security/detectives_office)
@@ -34380,6 +34834,9 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/monotile/dark,
 /area/security/brig)
 "svO" = (
@@ -35057,6 +35514,13 @@
 "sMN" = (
 /obj/machinery/computer/security/labor{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8";
+	tag = ""
 	},
 /turf/open/floor/durasteel/lino,
 /area/security/processing)
@@ -35850,6 +36314,9 @@
 /obj/item/seeds/carrot,
 /obj/item/seeds/glowshroom,
 /obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile/steel,
 /area/security/prison)
 "thQ" = (
@@ -36092,6 +36559,12 @@
 /obj/machinery/door/airlock/ship/security/glass{
 	name = "Security Equipment";
 	req_one_access_txt = "63"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/monotile/dark,
 /area/security/brig)
@@ -36608,12 +37081,21 @@
 /obj/machinery/computer/ship/navigation/public,
 /turf/open/floor/monotile/dark,
 /area/maintenance/nsv/bunker)
+"tDP" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/monotile/dark,
+/area/security/prison)
 "tEq" = (
 /obj/effect/turf_decal/tile/ship/half/red{
 	dir = 1
 	},
 /obj/structure/table,
 /obj/machinery/computer/libraryconsole/bookmanagement,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile/steel,
 /area/security/prison)
 "tEH" = (
@@ -37378,6 +37860,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/durasteel/lino,
 /area/security/processing)
 "tYK" = (
@@ -37523,6 +38008,14 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/carpet/ship/beige_carpet,
 /area/medical/medbay)
+"udo" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "udK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -37650,16 +38143,18 @@
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
 "uhc" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 2;
-	height = 5;
-	id = "laborcamp_away";
-	name = "labor camp";
-	width = 9
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/door/airlock/ship/external/glass{
+	name = "Labour Camp Shuttle Dock";
+	req_one_access_txt = "2"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/mine/laborcamp/security)
 "uhj" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-02"
@@ -37766,6 +38261,9 @@
 /obj/machinery/power/apc/auto_name/north,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet/ship,
 /area/security/detectives_office)
@@ -38332,6 +38830,12 @@
 	name = "detective's office shutters"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/security/detectives_office)
 "uyK" = (
@@ -38555,6 +39059,9 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/security_officer,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/durasteel/lino,
 /area/security/processing)
 "uEH" = (
@@ -38733,6 +39240,12 @@
 /obj/structure/cable{
 	icon_state = "5-10"
 	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/monotile/steel,
 /area/security/processing)
 "uJH" = (
@@ -38848,6 +39361,13 @@
 	pixel_x = 14;
 	pixel_y = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8";
+	tag = ""
+	},
 /turf/open/floor/durasteel/lino,
 /area/security/processing)
 "uLW" = (
@@ -38944,6 +39464,9 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /turf/open/floor/monotile/dark,
 /area/security/brig)
@@ -39338,6 +39861,12 @@
 /area/engine/engineering/reactor_core)
 "uZw" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/monotile/dark,
 /area/security/processing)
 "uZM" = (
@@ -39436,6 +39965,10 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8";
+	tag = ""
 	},
 /turf/open/floor/monotile/dark,
 /area/security/brig)
@@ -39633,6 +40166,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
 /turf/open/floor/monotile/dark,
 /area/security/detectives_office)
 "vgl" = (
@@ -39705,6 +40241,9 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/effect/landmark/zebra_interlock_point,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/open/floor/monotile/dark,
 /area/security/processing)
 "viF" = (
@@ -40038,6 +40577,13 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame2/port)
+"vuy" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/processing)
 "vuJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -40587,13 +41133,20 @@
 /area/hydroponics)
 "vIf" = (
 /obj/machinery/door/airlock/ship/external/glass{
-	name = "Labour Camp Shuttle Dock"
+	name = "Labour Camp Shuttle Dock";
+	req_one_access_txt = "2"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/open/floor/monotile/dark,
 /area/security/processing)
 "vIn" = (
@@ -40641,6 +41194,7 @@
 /obj/machinery/turnstile{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/monotile/steel,
 /area/security/prison)
 "vJF" = (
@@ -40705,6 +41259,20 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/engineering/ftl_room)
+"vLq" = (
+/obj/machinery/door/airlock/ship/external/glass{
+	name = "Labour Camp Shuttle Dock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/door/airlock/ship/external/glass{
+	name = "Labour Camp Shuttle Dock";
+	req_one_access_txt = "2"
+	},
+/turf/open/floor/monotile/dark,
+/area/security/processing)
 "vLx" = (
 /obj/effect/turf_decal/tile/ship/half/neutral{
 	dir = 8
@@ -40995,6 +41563,9 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile/dark,
 /area/security/brig)
 "vVn" = (
@@ -41130,6 +41701,15 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/monotile/steel,
 /area/quartermaster/lobby)
+"vZX" = (
+/obj/effect/turf_decal/tile/ship/half/red{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/monotile/steel,
+/area/security/processing)
 "wab" = (
 /obj/machinery/computer/ship/munitions_computer/west{
 	dir = 4
@@ -43850,6 +44430,12 @@
 	id = "detective_shutters";
 	name = "detective's office shutters"
 	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plating,
 /area/security/detectives_office)
 "xBE" = (
@@ -44220,6 +44806,19 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/quartermaster/lobby)
+"xNH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/monotile/dark,
+/area/security/processing)
 "xNI" = (
 /turf/open/floor/durasteel,
 /area/maintenance/nsv/deck2/frame4/starboard)
@@ -44253,6 +44852,10 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/effect/landmark/zebra_interlock_point,
+/obj/structure/cable{
+	icon_state = "2-8";
+	tag = ""
+	},
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "xPC" = (
@@ -80684,16 +81287,16 @@ dqT
 aCa
 krP
 mPo
-xyp
+eRF
 euA
 oTp
 gFd
 xyp
 lGu
 aYZ
-aYZ
+gmx
 fho
-pLv
+rbU
 lGt
 abe
 ebc
@@ -80947,7 +81550,7 @@ xyp
 xyp
 xyp
 xyp
-gMx
+rot
 gMx
 xyp
 xyp
@@ -81207,7 +81810,7 @@ kBk
 lax
 vUy
 sYG
-pLv
+kSP
 lGt
 omP
 aJw
@@ -81453,7 +82056,7 @@ eZu
 bdA
 pwI
 dfu
-gOg
+mDU
 bHi
 xyp
 sbe
@@ -81462,7 +82065,7 @@ xsa
 aEU
 uFG
 aKw
-uFG
+tDP
 tEq
 pLv
 lGt
@@ -81721,7 +82324,7 @@ uFG
 gBE
 uFG
 aDT
-pLv
+bBs
 hnA
 mkb
 wCS
@@ -82235,7 +82838,7 @@ uFG
 ahv
 uFG
 jqs
-pLv
+kSP
 lGt
 oVI
 aJw
@@ -82490,7 +83093,7 @@ oZW
 xpW
 uFG
 pHy
-uFG
+tDP
 kax
 pLv
 lGt
@@ -82749,7 +83352,7 @@ uFG
 gTX
 uFG
 fQp
-pLv
+bBs
 lGt
 gSy
 mOE
@@ -83263,7 +83866,7 @@ oDU
 ejV
 uFG
 wVG
-pLv
+kSP
 lGt
 xTO
 sQB
@@ -83515,10 +84118,10 @@ crU
 kVz
 fwg
 oXO
-iSy
-uFG
-gTX
-uFG
+abI
+tDP
+qPg
+tDP
 thi
 pLv
 lGt
@@ -83707,7 +84310,7 @@ srp
 srp
 srp
 srp
-srp
+dra
 srp
 srp
 srp
@@ -83768,7 +84371,7 @@ gxD
 xPk
 eKh
 cZj
-xsa
+hjG
 kmi
 aRn
 oSN
@@ -83777,7 +84380,7 @@ lCs
 lOg
 eqJ
 uTA
-pLv
+bBs
 lGt
 xTO
 ebc
@@ -83958,16 +84561,16 @@ pXB
 pXB
 pXB
 srp
-srp
-srp
-srp
-srp
-srp
-srp
+wlG
+wlG
 uhc
-srp
-srp
-srp
+wlG
+wlG
+wlG
+uhc
+wlG
+wlG
+wlG
 srp
 srp
 srp
@@ -84031,7 +84634,7 @@ sYP
 oZW
 oZW
 oZW
-kHi
+evE
 vJq
 xyp
 xyp
@@ -84215,13 +84818,13 @@ pXB
 pXB
 pXB
 srp
-srp
-wlG
-ehl
-wlG
 wlG
 wlG
 ehl
+wlG
+wlG
+wlG
+mEA
 wlG
 wlG
 wlG
@@ -84282,7 +84885,7 @@ hAg
 xuS
 rvq
 mpx
-dnq
+qMt
 kiE
 wXt
 hAW
@@ -84534,16 +85137,16 @@ srp
 gcB
 lWs
 uZw
-dTm
+xNH
 oxL
 ccG
 iAJ
-rLc
+pIc
 tmk
 rLc
 vVc
 ngo
-xsa
+udo
 iSi
 abm
 iSy
@@ -84791,16 +85394,16 @@ srp
 pXB
 ewI
 dRp
-ozT
+vZX
 ozT
 ewI
 pDa
 rus
-dnq
+otB
 dMH
 aYM
 cZj
-xsa
+hjG
 iSi
 abm
 iSy
@@ -85047,12 +85650,12 @@ srp
 srp
 pXB
 ewI
-dBQ
-dBQ
+eUE
+eUE
 ewI
 ewI
-dnq
-dnq
+otB
+otB
 wAG
 rAq
 aYM
@@ -85317,7 +85920,7 @@ xEx
 oZW
 oZW
 kHi
-vJq
+lyj
 xyp
 xyp
 kPZ
@@ -85560,8 +86163,8 @@ srp
 srp
 srp
 pXB
-lWs
-uZw
+vLq
+jWe
 dTm
 oxL
 vIf
@@ -85575,7 +86178,7 @@ vTs
 gUM
 fli
 eVc
-dGV
+hMF
 nSM
 edm
 iGZ
@@ -85818,9 +86421,9 @@ srp
 srp
 pXB
 ewI
-dBQ
-dBQ
-dBQ
+dxF
+lPR
+dxF
 ewI
 vbG
 rLc
@@ -86078,8 +86681,8 @@ dBQ
 uLL
 jxN
 sMN
-dBQ
-aYM
+gOg
+dAn
 qNT
 sQp
 qau
@@ -86088,7 +86691,7 @@ wue
 dZM
 jdO
 dVG
-dVG
+doG
 dGV
 wuM
 eoa
@@ -86331,11 +86934,11 @@ srp
 srp
 srp
 pXB
-dBQ
+knD
 nsr
 uEt
 ofI
-dBQ
+knD
 son
 pDe
 wAG
@@ -86588,7 +87191,7 @@ srp
 srp
 srp
 pXB
-dBQ
+knD
 eUu
 tYJ
 kBi
@@ -86845,14 +87448,14 @@ srp
 srp
 srp
 pXB
-dBQ
+vuy
 fkI
 ojr
 onW
-dBQ
+eUE
 fzA
 fzA
-dnq
+rks
 cBM
 mHM
 llY
@@ -87135,7 +87738,7 @@ deg
 bso
 whw
 tcr
-eQV
+oeU
 kmr
 tFx
 rGb
@@ -87392,7 +87995,7 @@ tcr
 pDl
 eyN
 tcr
-eQV
+oeU
 kmr
 mgq
 eit

--- a/_maps/map_files/Galactica/Galactica2.dmm
+++ b/_maps/map_files/Galactica/Galactica2.dmm
@@ -22720,6 +22720,7 @@
 /obj/machinery/camera/autoname{
 	dir = 8
 	},
+/obj/machinery/recharge_station,
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/bar{
 	name = "Night Club"
@@ -28743,6 +28744,10 @@
 "pfr" = (
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame3/central)
+"pfw" = (
+/obj/machinery/recharge_station,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/frame1/starboard)
 "pfC" = (
 /obj/structure/displaycase/trophy,
 /obj/machinery/airalarm/directional/west,
@@ -35168,6 +35173,10 @@
 	},
 /turf/open/floor/plating,
 /area/nsv/magazine/starboard)
+"sFF" = (
+/obj/machinery/recharge_station,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/frame2/port)
 "sFS" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -37836,6 +37845,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/recharge_station,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "tYC" = (
@@ -92596,7 +92606,7 @@ pXB
 ewU
 pXB
 xUX
-dWH
+sFF
 dWH
 bcP
 ugd
@@ -100091,7 +100101,7 @@ jhf
 hqk
 qaM
 fgw
-eKt
+pfw
 eDI
 xyC
 xyC

--- a/_maps/map_files/Galactica/Galactica2.dmm
+++ b/_maps/map_files/Galactica/Galactica2.dmm
@@ -177,6 +177,9 @@
 /obj/effect/turf_decal/tile/ship/half/orange,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons)
 "afe" = (
@@ -2089,6 +2092,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "bbk" = (
@@ -2694,6 +2700,13 @@
 /obj/machinery/deck_turret/powder_gate,
 /turf/open/floor/plating,
 /area/nsv/magazine/starboard)
+"boY" = (
+/obj/effect/turf_decal/tile/ship/full/blue,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/primary)
 "bpd" = (
 /obj/effect/landmark/start/bartender,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -7807,8 +7820,11 @@
 	pixel_y = -32;
 	req_one_access_txt = "69"
 	},
-/obj/effect/landmark/start/munitions_tech,
-/turf/open/floor/carpet/orange,
+/obj/effect/turf_decal/caution,
+/obj/machinery/camera/autoname{
+	dir = 10
+	},
+/turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "eig" = (
 /obj/machinery/light{
@@ -8109,6 +8125,9 @@
 	},
 /obj/effect/landmark/zebra_interlock_point,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/nsv/weapons)
 "eqJ" = (
@@ -12058,12 +12077,11 @@
 	})
 "gqS" = (
 /obj/effect/turf_decal/tile/ship/full/blue,
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "munidelivery"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
@@ -13443,7 +13461,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/carpet/orange,
+/turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "gXm" = (
 /turf/open/floor/carpet/blue,
@@ -13657,10 +13675,20 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame2/starboard)
 "hcC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
+/obj/structure/window/reinforced,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
 	},
-/turf/open/floor/carpet/orange,
+/obj/effect/turf_decal/ship/delivery/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 31
+	},
+/turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "hcE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -14257,13 +14285,15 @@
 /turf/open/floor/durasteel/techfloor_grid,
 /area/engine/engineering)
 "hvU" = (
-/obj/structure/plasticflaps,
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "munidelivery"
-	},
-/obj/structure/disposalpipe/segment{
+/obj/structure/disposaloutlet{
 	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/plasticflaps,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
@@ -15952,6 +15982,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet,
 /area/nsv/weapons)
 "iqR" = (
@@ -17216,6 +17249,16 @@
 /obj/machinery/status_display/supply,
 /turf/closed/wall/steel,
 /area/quartermaster/storage)
+"jfq" = (
+/obj/effect/turf_decal/ship/delivery/yellow,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/monotile/steel,
+/area/nsv/weapons)
 "jfu" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	req_access_txt = "12"
@@ -19136,6 +19179,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
@@ -21212,6 +21258,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons)
 "liQ" = (
@@ -22518,6 +22567,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet,
 /area/nsv/weapons)
 "lQb" = (
@@ -23421,6 +23473,9 @@
 	freq = 1400;
 	location = "Munitions"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "mqa" = (
@@ -23737,6 +23792,10 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/medical/medbay)
+"mxX" = (
+/obj/machinery/recharge_station,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/frame2/port)
 "myd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -24345,6 +24404,12 @@
 "mLj" = (
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/atmos)
+"mLJ" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet,
+/area/nsv/weapons)
 "mMj" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line,
@@ -25014,7 +25079,7 @@
 "nhK" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/start/munitions_tech,
-/turf/open/floor/carpet/orange,
+/turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "nhM" = (
 /turf/open/floor/plating{
@@ -25241,6 +25306,9 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/effect/landmark/zebra_interlock_point,
 /obj/item/radio/intercom/directional/north,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons)
 "npk" = (
@@ -26542,8 +26610,15 @@
 /turf/open/floor/durasteel/techfloor_grid,
 /area/engine/engineering/reactor_core)
 "oep" = (
-/obj/machinery/camera/autoname,
-/turf/open/floor/carpet/orange,
+/obj/machinery/door/window/brigdoor/westright{
+	dir = 2;
+	req_one_access_txt = "69"
+	},
+/obj/effect/turf_decal/ship/delivery/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "oeq" = (
 /obj/effect/turf_decal/stripes/line{
@@ -26811,6 +26886,13 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/science/robotics/lab)
+"ojM" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/hallway/nsv/deck2/primary)
 "oku" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible/layer2,
 /obj/structure/disposalpipe/segment{
@@ -26862,7 +26944,7 @@
 /obj/structure/munitions_trolley,
 /obj/machinery/light,
 /obj/item/radio/intercom/directional/south,
-/turf/open/floor/carpet/orange,
+/turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "omb" = (
 /obj/structure/lattice/catwalk/over/ship,
@@ -27427,6 +27509,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/ship/neutral,
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
 "ozp" = (
@@ -27839,6 +27924,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons)
 "oIE" = (
@@ -28207,11 +28295,12 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "oUu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
+/obj/effect/turf_decal/tile/ship/full/blue,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/open/floor/carpet/orange,
-/area/nsv/weapons)
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck2/primary)
 "oUy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -28744,10 +28833,6 @@
 "pfr" = (
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame3/central)
-"pfw" = (
-/obj/machinery/recharge_station,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/frame1/starboard)
 "pfC" = (
 /obj/structure/displaycase/trophy,
 /obj/machinery/airalarm/directional/west,
@@ -32644,6 +32729,9 @@
 "rpc" = (
 /obj/effect/turf_decal/tile/ship/full/blue,
 /obj/effect/landmark/nuclear_waste_spawner,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "rpj" = (
@@ -33283,6 +33371,12 @@
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame2/port)
+"rFR" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/monotile/dark,
+/area/nsv/weapons)
 "rGb" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -35173,10 +35267,6 @@
 	},
 /turf/open/floor/plating,
 /area/nsv/magazine/starboard)
-"sFF" = (
-/obj/machinery/recharge_station,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/frame2/port)
 "sFS" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -36578,10 +36668,11 @@
 /turf/open/floor/monotile/dark,
 /area/security/brig)
 "tnn" = (
-/obj/machinery/conveyor_switch/oneway{
-	id = "munidelivery"
+/obj/effect/turf_decal/tile/ship/half/orange,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/turf/open/floor/carpet/orange,
+/turf/open/floor/monotile/steel,
 /area/nsv/weapons)
 "tnr" = (
 /obj/machinery/conveyor{
@@ -37082,6 +37173,9 @@
 /obj/structure/table/wood/fancy,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet,
 /area/nsv/weapons)
@@ -40238,6 +40332,9 @@
 /obj/effect/turf_decal/tile/ship/orange{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons)
 "viq" = (
@@ -40574,6 +40671,10 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/monotile/steel,
 /area/storage/primary)
+"vsR" = (
+/obj/machinery/recharge_station,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/frame1/starboard)
 "vtt" = (
 /obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/chapel{
@@ -45494,6 +45595,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame2/starboard)
+"yfR" = (
+/obj/effect/turf_decal/tile/ship/half/neutral{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck2/primary)
 "yfS" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold/layer2{
 	dir = 4
@@ -92606,7 +92717,7 @@ pXB
 ewU
 pXB
 xUX
-sFF
+mxX
 dWH
 bcP
 ugd
@@ -96232,7 +96343,7 @@ aAQ
 biY
 xAd
 ntw
-xAd
+yfR
 xAd
 xAd
 sDJ
@@ -96487,12 +96598,12 @@ sYT
 lju
 gqS
 mpy
-rkV
+oUu
 kbY
-jaI
-jaI
-rkV
-jaI
+boY
+boY
+oUu
+boY
 rpc
 uFe
 ipU
@@ -96750,7 +96861,7 @@ hqf
 ppy
 lju
 qif
-qif
+ojM
 vjs
 otC
 ipU
@@ -97007,7 +97118,7 @@ vjs
 sqB
 vjs
 fZo
-oTH
+mLJ
 oTH
 ipU
 jse
@@ -97255,9 +97366,9 @@ qiB
 vGW
 vGW
 urI
-cId
+vjs
 hcC
-tnn
+urI
 sYT
 gza
 xBo
@@ -97512,8 +97623,8 @@ izU
 koD
 bgA
 jCJ
-sYT
-oUu
+cId
+mPx
 nhK
 xtE
 gza
@@ -98806,7 +98917,7 @@ sYT
 sYT
 oNu
 sYT
-agZ
+jfq
 agZ
 agZ
 sYT
@@ -99063,7 +99174,7 @@ urI
 urI
 qfd
 urI
-urI
+rFR
 urI
 aDc
 wVx
@@ -99577,7 +99688,7 @@ gzr
 ivn
 scN
 rMz
-qjl
+tnn
 urI
 cHC
 ioq
@@ -99834,7 +99945,7 @@ nyd
 nyd
 qrP
 rMz
-qjl
+tnn
 mPx
 aDc
 bgg
@@ -100101,7 +100212,7 @@ jhf
 hqk
 qaM
 fgw
-pfw
+vsR
 eDI
 xyC
 xyC
@@ -100348,7 +100459,7 @@ qwy
 urI
 qmV
 rMz
-qjl
+tnn
 jWg
 aDc
 wUD
@@ -100605,7 +100716,7 @@ roE
 roE
 oSq
 rMz
-qjl
+tnn
 jWg
 cHC
 edA
@@ -100862,7 +100973,7 @@ oqG
 oXF
 wwW
 rMz
-qjl
+tnn
 jWg
 cHC
 ioq
@@ -101119,7 +101230,7 @@ qRz
 qRz
 qRz
 tNI
-qjl
+tnn
 jWg
 aDc
 kRL


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes https://github.com/BeeStation/NSV13/issues/2506 and a host of other mapping errors. Also updates the security of security department by electrifying windows, doors and assigning correct permissions to external and internal security doors.

## Why It's Good For The Game

Fix Man Good. Prisoners escaping without first outsmarting sec, bad. Torps not properly arriving at munitions from gulag bad.

![muni output updated](https://github.com/BeeStation/NSV13/assets/75588150/35d9f597-9c21-4102-a04e-9cd212e6f626)


## Changelog
:cl:
add: Added wire nodes for all Sec Dept. doors and windows on the Galactica
add: Added an breathing air tank dispenser to atmos storage on the Galactica
add: Added 4 borg chargers to the lower deck of the Galactica in various locations.
fix: Added disposals output to gulag torp disposal pipe in munitions on the galactica.
fix: Fixed a couple mapping issues with the Galactica Xenobio
fix: Corrected Sec Dept. Airlock permissions on the Galactica
fix: Properly connected PDSR output piping
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
