### PR TITLE
simplemobs can no longer drive tugs (1984)

### DIFF
--- a/code/modules/vehicles/sealed.dm
+++ b/code/modules/vehicles/sealed.dm
@@ -46,6 +46,9 @@
 /obj/vehicle/sealed/proc/mob_enter(mob/M, silent = FALSE)
 	if(!istype(M))
 		return FALSE
+	if(!M.IsAdvancedToolUser()) //NSV13 - simple mobs cant get in car anymore
+		to_chat(M, "<span class='warning'>You don't have the dexterity to climb in [src]!</span>")
+		return
 	if(!silent)
 		M.visible_message("<span class='notice'>[M] climbs into \the [src]!</span>")
 	M.forceMove(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes #581

## Why It's Good For The Game

no more simple mobs driving car 
![1984 (1)](https://github.com/BeeStation/NSV13/assets/89947174/5dc27767-5907-4f52-927e-7fa072e56d64)

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/NSV13/assets/89947174/36247b9a-57b6-45dd-9d90-e1a1b7c72b71)
![image](https://github.com/BeeStation/NSV13/assets/89947174/4d787924-bd4c-4552-b7e8-15b1ba098007)


</details>

## Changelog
:cl:
fix: simplemods can no longer drive tugs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
