### PR TITLE
Particle Accelerator and Plutonium Sludge radiation buffs

### DIFF
--- a/code/modules/projectiles/projectile/energy/accelerator_particle.dm
+++ b/code/modules/projectiles/projectile/energy/accelerator_particle.dm
@@ -8,7 +8,7 @@
 	projectile_phasing = (ALL & (~PASSMOB) & (~PASSBLOB) & (~PASSANOMALY) & (~PASSMACHINE))
 	suppressed = SUPPRESSED_VERY //we don't want every machine that gets hit to spam chat
 	hitsound = null
-	irradiate = 60
+	irradiate = 600 //NSV13 -Multiplied this by 10
 	var/energy = 10
 	var/stop_dissipate = FALSE
 
@@ -18,14 +18,14 @@
 /obj/item/projectile/energy/accelerated_particle/weak
 	range = 8
 	energy = 5
-	irradiate = 30
+	irradiate = 300 //NSV13 -Multiplied this by 10
 	stop_dissipate = TRUE //because its supposed to keep the singu/tesla stable at the same size
 
 /obj/item/projectile/energy/accelerated_particle/strong
 	range = 15
 	energy = 15
-	irradiate = 90
+	irradiate = 900 //NSV13 -Multiplied this by 10
 /obj/item/projectile/energy/accelerated_particle/powerful
 	range = 20
 	energy = 50
-	irradiate = 300
+	irradiate = 3000 //NSV13 -Multiplied this by 10

--- a/nsv13/code/game/objects/effects/decals/plutonium_sludge.dm
+++ b/nsv13/code/game/objects/effects/decals/plutonium_sludge.dm
@@ -27,11 +27,11 @@
 	if(isliving(AM))
 		var/mob/living/L = AM
 		playsound(loc, 'sound/effects/gib_step.ogg', HAS_TRAIT(L, TRAIT_LIGHT_STEP) ? 20 : 50, 1)
-	radiation_pulse(src, 500, 5) //MORE RADS
+	radiation_pulse(src, 625, 5) //MORE RADS
 
 /obj/effect/decal/nuclear_waste/attackby(obj/item/tool, mob/user)
 	if(tool.tool_behaviour == TOOL_SHOVEL)
-		radiation_pulse(src, 1000, 5) //MORE RADS
+		radiation_pulse(src, 500, 5) //MORE RADS //The careful clearing of sludge should not give off as much radiation as casually running through it.
 		to_chat(user, "<span class='notice'>You start to clear [src]...</span>")
 		if(tool.use_tool(src, user, 50, volume=100))
 			to_chat(user, "<span class='notice'>You clear [src]. </span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR increases the radiation output of plutonium sludge by 12.5% when walking on it, and increases the radiation output of the particle accelerator projectile by 1000%.

## Why It's Good For The Game

People casually running through plutonium sludge should need to urgently seek help, but people who clear plutonium sludge should not receive as high a spike. In addition, standing in front of a particle accelerator that is capable of starting both nuclear reactors and singularities is probably not all that smart.

</details>

## Changelog
:cl:
balance: Increased radiation emission from Particle Accelerator particles and plutonium sludge.
/:cl:
