### PR TITLE
Holomap fix + AI gets one too

### DIFF
--- a/code/datums/components/holomap.dm
+++ b/code/datums/components/holomap.dm
@@ -99,10 +99,10 @@
 	return legend
 
 /datum/component/holomap/proc/activate_holomap(mob/user)
-	current_z_level = user.z
+	var/turf/current_turf = get_turf(user.client.eye)
+	current_z_level = current_turf.z
 	holomap_datum = new()
 	bogus = FALSE
-	var/turf/current_turf = get_turf(user)
 	if(!("[HOLOMAP_EXTRA_STATIONMAP]_[current_z_level]" in SSholomaps.extra_holomaps))
 		bogus = TRUE
 		holomap_datum.initialize_holomap_bogus()

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -168,6 +168,7 @@
 	builtInCamera = new (src)
 	builtInCamera.network = list("ss13")
 	//Nsv13
+	AddComponent(/datum/component/holomap)
 	for(var/stype in subtypesof(/datum/component/simple_teamchat/radio_dependent/squad))
 		AddComponent(stype, override = TRUE)
 	update_overmap() //AIs don't move, so we do this here.


### PR DESCRIPTION
## About The Pull Request

fixes #2517
Gives the AI a holomap
Makes the holomap locate on the client's eye position (this notably affects the AI and advanced camera consoles)

## Why It's Good For The Game

![fix man good](https://user-images.githubusercontent.com/23534908/222276620-9eb46bcf-ea6b-418c-beb1-4ba7c82a5f8d.gif)

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/NSV13/assets/23534908/221f6dc9-628e-45c5-8981-e8cdf53be990)

</details>

## Changelog
:cl:
fix: fixed the holomap not working when inside objects
tweak: The holomap cursor now shows the location of your camera
/:cl: