### PR TITLE
Gladius locker and hanger lift fixes

### DIFF
--- a/_maps/map_files/Gladius/Gladius1.dmm
+++ b/_maps/map_files/Gladius/Gladius1.dmm
@@ -3700,6 +3700,10 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/gateway)
+"bRw" = (
+/obj/machinery/lazylift_button,
+/turf/closed/wall/r_wall/ship,
+/area/shuttle/turbolift/tertiary)
 "bRS" = (
 /obj/effect/turf_decal/tile/ship/half/blue{
 	dir = 1
@@ -72863,7 +72867,7 @@ wsg
 eqI
 gVj
 gVj
-eqI
+bRw
 eqI
 pJj
 pJj

--- a/_maps/map_files/Gladius/Gladius1.dmm
+++ b/_maps/map_files/Gladius/Gladius1.dmm
@@ -32230,10 +32230,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/closet/secure_closet/brig{
-	id = "brig3";
-	name = "Cell 3 Locker"
-	},
+/obj/structure/closet/secure_closet/genpop,
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "oZR" = (

--- a/_maps/map_files/Gladius/Gladius2.dmm
+++ b/_maps/map_files/Gladius/Gladius2.dmm
@@ -10592,6 +10592,9 @@
 /area/crew_quarters/bar)
 "glm" = (
 /obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/maintenance/nsv/deck2/starboard/aft)
 "glx" = (
@@ -11740,6 +11743,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/visible/layer2,
 /turf/open/floor/plasteel/grid/steel,
 /area/engine/atmos)
+"gVh" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/turbolift/tertiary)
 "gVj" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
@@ -34384,6 +34394,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/monotile/dark,
 /area/nsv/engine/corridor)
+"tAt" = (
+/obj/machinery/lazylift_button,
+/turf/closed/wall/ship,
+/area/shuttle/turbolift/tertiary)
 "tAz" = (
 /obj/machinery/light{
 	dir = 4
@@ -62674,7 +62688,7 @@ lEY
 lEY
 lEY
 hnm
-cEl
+gVh
 qjq
 xmk
 gnw
@@ -63448,7 +63462,7 @@ khJ
 khJ
 jBH
 dnn
-khJ
+tAt
 khJ
 dJe
 dJe


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a lift button and lights to the Mining Hanger lift and replaces the normal lockers in the brig with genpop lockers
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Lifts should have buttons
Fixes #2529

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![GladiusButton](https://github.com/BeeStation/NSV13/assets/95106800/af6cf08f-fccb-47fe-8c03-292b28f4c1e3)


</details>

## Changelog
:cl:
add: Added lift button to Gladius mining hanger 
fix: fixed Gladius cell lockers not being genpop lockers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
