### PR TITLE
Lets admins set system clear objectives and refactors extended mission code

### DIFF
--- a/nsv13/code/controllers/subsystem/overmap_mode.dm
+++ b/nsv13/code/controllers/subsystem/overmap_mode.dm
@@ -325,7 +325,7 @@ SUBSYSTEM_DEF(overmap_mode)
 	*/
 
 	if(get_active_player_count(TRUE,TRUE,FALSE) > 4)
-		mode.objective += new /datum/overmap_objective/clear_system/rubicon
+		mode.objectives += new /datum/overmap_objective/clear_system/rubicon
 	else
 		mode.objectives += new /datum/overmap_objective/tickets
 

--- a/nsv13/code/controllers/subsystem/overmap_mode.dm
+++ b/nsv13/code/controllers/subsystem/overmap_mode.dm
@@ -500,7 +500,7 @@ SUBSYSTEM_DEF(overmap_mode)
 /datum/overmap_objective/custom
 	name = "Custom"
 
-/datum/overmap_objective/custom/New(var/passed_input) //Receive the string and make it brief/desc
+/datum/overmap_objective/custom/New(passed_input) //Receive the string and make it brief/desc
 	.=..()
 	desc = passed_input
 	brief = passed_input
@@ -559,7 +559,7 @@ SUBSYSTEM_DEF(overmap_mode)
 				message_admins("Post Initilisation Overmap Gamemode Changes Not Currently Supported") //SoonTM
 				return
 			var/list/gamemode_pool = subtypesof(/datum/overmap_gamemode)
-			var/datum/overmap_gamemode/S = input("Select Overmap Gamemode", "Change Overmap Gamemode") as null|anything in gamemode_pool
+			var/datum/overmap_gamemode/S = input(usr, "Select Overmap Gamemode", "Change Overmap Gamemode") as null|anything in gamemode_pool
 			if(isnull(S))
 				return
 			if(SSovermap_mode.mode_initialised)
@@ -571,11 +571,14 @@ SUBSYSTEM_DEF(overmap_mode)
 				message_admins("[key_name_admin(usr)] has changed the overmap gamemode to [initial(S.name)]")
 			return
 		if("add_objective")
-			var/list/objectives_pool = subtypesof(/datum/overmap_objective)
-			var/datum/overmap_objective/S = input("Select objective to add", "Add Objective") as null|anything in objectives_pool
+			var/list/objectives_pool = (subtypesof(/datum/overmap_objective) - /datum/overmap_objective/custom)
+			var/datum/overmap_objective/S = input(usr, "Select objective to add", "Add Objective") as null|anything in objectives_pool
 			if(isnull(S))
 				return
-			SSovermap_mode.mode.objectives += new S()
+			var/extra
+			if(ispath(S,/datum/overmap_objective/clear_system))
+				extra = input(usr, "Select a target system", "Select System") as null|anything in SSstar_system.systems
+			SSovermap_mode.mode.objectives += new S(extra)
 			SSovermap_mode.instance_objectives()
 			return
 		if("add_custom_objective")

--- a/nsv13/code/controllers/subsystem/overmap_mode.dm
+++ b/nsv13/code/controllers/subsystem/overmap_mode.dm
@@ -305,6 +305,7 @@ SUBSYSTEM_DEF(overmap_mode)
 	for(var/datum/overmap_objective/O in mode.objectives)
 		O.ignore_check = TRUE //We no longer care about checking these objective against completeion
 
+	/* This doesn't work and I don't have the time to refactor all of it right now so on the TODO pile it goes!
 	var/list/extension_pool = subtypesof(/datum/overmap_objective)
 	var/players = get_active_player_count(TRUE, TRUE, FALSE) //Number of living, non-AFK players including non-humanoids
 	for(var/datum/overmap_objective/O in extension_pool)
@@ -320,6 +321,12 @@ SUBSYSTEM_DEF(overmap_mode)
 		mode.objectives += new selected
 	else
 		message_admins("No additional objective candidates! Defaulting to tickets")
+		mode.objectives += new /datum/overmap_objective/tickets
+	*/
+
+	if(get_active_player_count(TRUE,TRUE,FALSE) > 4)
+		mode.objective += new /datum/overmap_objective/clear_system/rubicon
+	else
 		mode.objectives += new /datum/overmap_objective/tickets
 
 	instance_objectives()

--- a/nsv13/code/game/gamemodes/overmap/objectives/rubicon.dm
+++ b/nsv13/code/game/gamemodes/overmap/objectives/rubicon.dm
@@ -8,6 +8,22 @@
 	var/system_name
 	var/datum/star_system/target_system
 
+/datum/overmap_objective/clear_system/New(datum/star_system/passed_input)
+	.=..()
+	if(passed_input)
+		system_name = passed_input.name
+	if(!system_name)
+		message_admins("No name given!")
+		for(var/datum/star_system/S in SSstar_system.neutral_zone_systems)
+			if(S.hidden)
+				continue
+			message_admins("length check")
+			if(length(S.enemies_in_system))
+				system_name = S.name
+				message_admins("Found system [S]: [system_name]!")
+				break
+			continue
+
 /datum/overmap_objective/clear_system/instance()
 	.=..()
 	desc = "Defeat all enemies in the [system_name] system"

--- a/nsv13/code/game/gamemodes/overmap/objectives/rubicon.dm
+++ b/nsv13/code/game/gamemodes/overmap/objectives/rubicon.dm
@@ -13,14 +13,11 @@
 	if(passed_input)
 		system_name = passed_input.name
 	if(!system_name)
-		message_admins("No name given!")
 		for(var/datum/star_system/S in SSstar_system.neutral_zone_systems)
 			if(S.hidden)
 				continue
-			message_admins("length check")
 			if(length(S.enemies_in_system))
 				system_name = S.name
-				message_admins("Found system [S]: [system_name]!")
 				break
 			continue
 


### PR DESCRIPTION
## About The Pull Request

Adds the ability for admins to set the target system for a system clearing objective with the overmap gamemode controller.
If you (or most likely the game) for some reason did *not* select a system, it will instead select a random sector 2 system with enemies in it.

## Why It's Good For The Game

This was originally going to be a PR to fix the round extension mission selection system. And while it does technically fix the issue of randomly selected clear missions not functioning, that is still a problem I intend to fix in this PR as well. (Later:) I just made a lazy fix for that now but it should work as originally intended.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>
I did test this
</details>

## Changelog
:cl:
fix: Fixed random clear missions not having a system
refactor: Removed the unintended ability for the mission extension to select any random objective
admin: Made it possible for admins to select a target for the "clear system" objective
/:cl: