### PR TITLE
Tweaks some of randy's code

### DIFF
--- a/nsv13/code/modules/cargo/space_catalog.dm
+++ b/nsv13/code/modules/cargo/space_catalog.dm
@@ -29,6 +29,8 @@
 
 	nearby_traders = list()
 	for(var/datum/trader/T as() in SSstar_system.traders)
+		if(istype(T, /datum/trader/randy))
+			continue
 		if(T.system.sector != my_system.sector)
 			continue
 		if(my_system.dist(T.system) > TOO_FAR)

--- a/nsv13/code/modules/overmap/traders.dm
+++ b/nsv13/code/modules/overmap/traders.dm
@@ -54,7 +54,6 @@
 		TI.owner = src
 		yellow_pages_dat += "[TI.stock]x [TI.name] ([TI.price] ea.) - <i>[TI.desc]</i><br /><br />"
 	yellow_pages_dat += "</font>"
-	return FALSE
 
 /datum/trader_item
 	var/name = "Stonks"
@@ -226,6 +225,10 @@
 	//Pick 5 random items and construct fresh trader_items for it.
 	var/iter = 5
 	for(var/x in sold_items)
+		sold_items -= x
+		qdel(x)
+	for(var/x in stonks)
+		stonks -= x
 		qdel(x)
 	sold_items = list()
 	while(iter)
@@ -234,12 +237,17 @@
 		var/obj/item/a_gift/anything/generator = new
 		var/initialtype = generator.get_gift_type()
 		var/obj/item/soldtype = new initialtype
+		if(!soldtype) //spawned something that deleted itself, try again
+			log_runtime("Randy failed to spawn [initialtype]!")
+			qdel(item)
+			iter++
+			continue
 		item.unlock_path = initialtype
 		item.name = soldtype.name
 		item.desc = soldtype.desc
 		item.price = rand(1000, 100000000)
-		item.stock = 2
-		item.stock = rand(item.stock/2, item.stock*2)
+		item.stock = rand(1, 5)
+		item.owner = src
 		qdel(soldtype)
 		sold_items += item
 


### PR DESCRIPTION
## About The Pull Request

Investigating the disappearance of Zeta Reticuli has lead me to Randy Random as the most likely culprit, yet I'm still uncertain whether this fix will be enough.
Basically added some extra safety checks to the way random items are picked and scrubbed Randy's address from the yellow pages (it is more fun if you can't see what's in his shop before arriving after all)

## Why It's Good For The Game

Hopefully fixes an issue and adds more tension to visiting Randy

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>
I didn't test this
</details>

## Changelog
:cl:
del: Removed Randy from the yellow pages
tweak: Tweaked some of Randy's item generation code
/:cl: