### PR TITLE
[Upstream] Ecto Sniffer improvements

### DIFF
--- a/code/game/machinery/ecto_sniffer.dm
+++ b/code/game/machinery/ecto_sniffer.dm
@@ -13,18 +13,19 @@
 	var/sensor_enabled = TRUE
 	///List of ckeys containing players who have recently activated the device, players on this list are prohibited from activating the device untill their residue decays.
 	var/list/ectoplasmic_residues = list()
-	var/obj/item/radio/radio //NSV13 - Ecto Sniffer Radio Yelling
+	///Internal radio
+	var/obj/item/radio/radio
+	///Cooldown for radio, prevents spam
+	COOLDOWN_DECLARE(radio_cooldown)
 
 /obj/machinery/ecto_sniffer/Initialize()
 	. = ..()
 	wires = new/datum/wires/ecto_sniffer(src)
-	//NSV13 - Ecto Sniffer Radio Yelling - Start
 	radio = new(src)
 	radio.keyslot = new /obj/item/encryptionkey/headset_sci
 	radio.subspace_transmission = TRUE
 	radio.canhear_range = 0
 	radio.recalculateChannels()
-	//NSV13 - Ecto Sniffer Radio Yelling - Stop
 
 /obj/machinery/ecto_sniffer/attack_ghost(mob/user)
 	if(!on || !sensor_enabled || !is_operational)
@@ -37,15 +38,19 @@
 	if(is_banned_from(user.ckey, ROLE_POSIBRAIN))
 		to_chat(user, "<span class='warning'>Central Command outlawed your soul from interacting with the living...</span>")
 		return
+
 	activate(user)
 
 /obj/machinery/ecto_sniffer/proc/activate(mob/activator)
 	flick("ecto_sniffer_flick", src)
 	playsound(loc, 'sound/machines/ectoscope_beep.ogg', 25)
-	//NSV13 - Ecto Sniffer Radio Yelling - Start
-	var/msg = "[src] beeps, detecting ectoplasm! There may be additional positronic brain matrices available!"
-	radio.talk_into(src, msg, RADIO_CHANNEL_SCIENCE)
-	//NSV13 - Ecto Sniffer Radio Yelling - Stop
+
+	if(COOLDOWN_FINISHED(src, radio_cooldown))
+		COOLDOWN_START(src, radio_cooldown, 3 MINUTES)
+		radio.talk_into(src, "Ectoplasm has been detected! There may be additional positronic brain matrices available!", RADIO_CHANNEL_SCIENCE)
+	else
+		visible_message("<span class='notice'>[src] has detected ectoplasm! There may be additional positronic brain matrices available!</span>")
+
 	use_power(10)
 	if(activator?.ckey)
 		ectoplasmic_residues[activator.ckey] = TRUE
@@ -82,7 +87,7 @@
 
 /obj/machinery/ecto_sniffer/Destroy()
 	QDEL_NULL(wires)
-	QDEL_NULL(radio) //NSV13 - Ecto Sniffer Radio Yelling
+	QDEL_NULL(radio)
 	ectoplasmic_residues = null
 	. = ..()
 

--- a/code/game/machinery/ecto_sniffer.dm
+++ b/code/game/machinery/ecto_sniffer.dm
@@ -44,7 +44,6 @@
 	playsound(loc, 'sound/machines/ectoscope_beep.ogg', 25)
 	//NSV13 - Ecto Sniffer Radio Yelling - Start
 	var/msg = "[src] beeps, detecting ectoplasm! There may be additional positronic brain matrices available!"
-	visible_message("<span class='notice'>[msg]</span>")
 	radio.talk_into(src, msg, RADIO_CHANNEL_SCIENCE)
 	//NSV13 - Ecto Sniffer Radio Yelling - Stop
 	use_power(10)

--- a/code/game/machinery/ecto_sniffer.dm
+++ b/code/game/machinery/ecto_sniffer.dm
@@ -44,6 +44,7 @@
 	playsound(loc, 'sound/machines/ectoscope_beep.ogg', 25)
 	//NSV13 - Ecto Sniffer Radio Yelling - Start
 	var/msg = "[src] beeps, detecting ectoplasm! There may be additional positronic brain matrices available!"
+	visible_message("<span class='notice'>[msg]</span>")
 	radio.talk_into(src, msg, RADIO_CHANNEL_SCIENCE)
 	//NSV13 - Ecto Sniffer Radio Yelling - Stop
 	use_power(10)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ports https://github.com/BeeStation/BeeStation-Hornet/pull/9024
Modifications include the addition of the 3 minute global-cooldown to prevent radio spam, but we still keep the 30 second one for local visible_message.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes the ectosniffer on ships that don't have science comms (Eclipse) able to send visible messages to crew around it

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![EctoSnifferEclipse](https://github.com/BeeStation/NSV13/assets/95106800/4017138b-e890-4e14-8c47-8177802e18e7)


</details>

## Changelog WhereAmO, recouped by mystery3525
:cl:
tweak: Ecto Sniffer has a cooldown for radio messages, and can now send visible_messages
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
