### PR TITLE
[Upstream] Patches up the jankiness of LOOC

### DIFF
--- a/code/__DEFINES/bans.dm
+++ b/code/__DEFINES/bans.dm
@@ -1,0 +1,1 @@
+#define BAN_OOC "OOC"

--- a/code/modules/client/verbs/looc.dm
+++ b/code/modules/client/verbs/looc.dm
@@ -3,128 +3,108 @@
 //GLOBAL_VAR_INIT(looc_allowed, 1) //commenting this out might break something but w/e, replaced by one in global config by nsv13
 
 /client/verb/looc(msg as text)
-    set name = "LOOC"
-    set desc = "Local OOC, seen only by those in view."
-    set category = "OOC"
+	set name = "LOOC"
+	set desc = "Local OOC, seen only by those in view."
+	set category = "OOC"
 
-    if(GLOB.say_disabled)    //This is here to try to identify lag problems
-        to_chat(usr, "<span class='danger'> Speech is currently admin-disabled.</span>")
-        return
+	if(GLOB.say_disabled)    //This is here to try to identify lag problems
+		to_chat(usr, "<span class='danger'> Speech is currently admin-disabled.</span>")
+		return
 
-    if(!mob)        return
-    if(!mob.ckey)   return
+	if(!mob?.ckey)
+		return
 
-    msg = copytext(sanitize(msg), 1, MAX_MESSAGE_LEN)
-    var/raw_msg = msg
+	msg = trim(sanitize(msg), MAX_MESSAGE_LEN)
+	if(!length(msg))
+		return
 
-    if(!msg)
-        return
+	var/raw_msg = msg
 
-    if(!(prefs.chat_toggles & CHAT_LOOC)) //nsv13 - toggles -> chat_toggles, CHAT_OOC -> CHAT_LOOC
-        to_chat(src, "<span class='danger'>You have LOOC muted.</span>")
-        return
+	if(!(prefs.chat_toggles & CHAT_LOOC)) //nsv13 - toggles -> chat_toggles, CHAT_OOC -> CHAT_LOOC
+		to_chat(src, "<span class='danger'>You have LOOC muted.</span>")
+		return
 
-    if(is_banned_from(mob.ckey, "OOC"))
-        to_chat(src, "<span class='danger'>You have been banned from OOC and LOOC.</span>")
-        return
+	if(is_banned_from(mob.ckey, BAN_OOC))
+		to_chat(src, "<span class='danger'>You have been banned from OOC and LOOC.</span>")
+		return
 
-    if(!holder)
-        if(!GLOB.looc_allowed) //nsv13 - ooc_allowed -> looc_allowed
-            to_chat(src, "<span class='danger'>LOOC is globally muted.</span>")
-            return
-        if(!GLOB.dooc_allowed && (mob.stat == DEAD))
-            to_chat(usr, "<span class='danger'>LOOC for dead mobs has been turned off.</span>")
-            return
-        if(prefs.muted & MUTE_LOOC) //nsv13 - MUTE_OOC -> MUTE_LOOC
-            to_chat(src, "<span class='danger'>You cannot use LOOC (muted).</span>")
-            return
-        if(handle_spam_prevention(msg,MUTE_LOOC)) //nsv13 - MUTE_OOC -> MUTE_LOOC
-            return
-        if(findtext(msg, "byond://"))
-            to_chat(src, "<B>Advertising other servers is not allowed.</B>")
-            log_admin("[key_name(src)] has attempted to advertise in LOOC: [msg]")
-            return
-        if(mob.stat)
-            to_chat(src, "<span class='danger'>You cannot salt in LOOC while unconscious or dead.</span>")
-            return
-        if(istype(mob, /mob/dead))
-            to_chat(src, "<span class='danger'>You cannot use LOOC while ghosting.</span>")
-            return
+	if(!holder)
+		if(!GLOB.looc_allowed) //nsv13 - ooc_allowed -> looc_allowed
+			to_chat(src, "<span class='danger'>LOOC is globally muted.</span>")
+			return
+		if(!GLOB.dooc_allowed && (mob.stat == DEAD))
+			to_chat(usr, "<span class='danger'>LOOC for dead mobs has been turned off.</span>")
+			return
+		if(prefs.muted & MUTE_LOOC) //nsv13 - MUTE_OOC -> MUTE_LOOC
+			to_chat(src, "<span class='danger'>You cannot use LOOC (muted).</span>")
+			return
+		if(handle_spam_prevention(msg, MUTE_LOOC)) //nsv13 - MUTE_OOC -> MUTE_LOOC
+			return
+		if(findtext(msg, "byond://"))
+			to_chat(src, "<span class='bold danger'>Advertising other servers is not allowed.</span>")
+			log_admin("[key_name(src)] has attempted to advertise in LOOC: [msg]")
+			return
+		if(mob.stat)
+			to_chat(src, "<span class='danger'>You cannot salt in LOOC while unconscious or dead.</span>")
+			return
+		if(isdead(mob))
+			to_chat(src, "<span class='danger'>You cannot use LOOC while ghosting.</span>")
+			return
 
-        if(OOC_FILTER_CHECK(raw_msg))
-            to_chat(src, "<span class='warning'>That message contained a word prohibited in OOC chat! Consider reviewing the server rules.\n<span replaceRegex='show_filtered_ooc_chat'>\"[raw_msg]\"</span></span>")
-            return
+		if(OOC_FILTER_CHECK(raw_msg))
+			to_chat(src, "<span class='warning'>That message contained a word prohibited in OOC chat! Consider reviewing the server rules.\n<span replaceRegex='show_filtered_ooc_chat'>\"[raw_msg]\"</span></span>")
+			return
 
-    msg = emoji_parse(msg)
+	msg = emoji_parse(msg)
 
-    mob.log_talk(raw_msg, LOG_OOC, tag="LOOC")
+	mob.log_talk(raw_msg, LOG_OOC, tag="LOOC")
 
-    var/list/heard = hearers(7, get_top_level_mob(src.mob))
-
+	// Search everything in the view for anything that might be a mob, or contain a mob.
+	var/list/client/targets = list()
+	var/list/turf/in_view = list()
 	//NSV13 - AI QoL - Start
 	//so the ai can post looc text
-    if(istype(mob, /mob/living/silicon/ai))
-        var/mob/living/silicon/ai/ai = mob
-        heard = hearers(7, get_top_level_mob(ai.eyeobj))
-	//so the ai can see looc text
-    for(var/mob/living/silicon/ai/ai as anything in GLOB.ai_list)
-        if(ai.client && !(ai in heard) && (ai.eyeobj in heard))
-            heard += ai
+	if(istype(mob, /mob/living/silicon/ai))
+		var/mob/living/silicon/ai/ai = mob
+		for(var/turf/viewed_turf in view(get_turf(ai.eyeobj)))
+			in_view[viewed_turf] = TRUE
+	else
+		for(var/turf/viewed_turf in view(get_turf(mob)))
+			in_view[viewed_turf] = TRUE
 	//NSV13 - AI QoL - Stop
+	for(var/client/client in GLOB.clients)
+		if(!client.mob || !(client.prefs.chat_toggles & CHAT_LOOC) || (client in GLOB.admins)) //nsv13 - toggles -> chat_toggles, CHAT_OOC -> CHAT_LOOC
+			continue
+		//NSV13 - LOOC AI Stuff - Start
+		if(istype(client.mob, /mob/living/silicon/ai))
+			var/mob/living/silicon/ai/ai = client.mob
+			if(in_view[get_turf(ai.eyeobj)])
+				targets |= client
+				to_chat(client, "<span class='looc'><span class='prefix'>LOOC:</span> <EM><span class='name'>[mob.name]</span>:</EM> <span class='message'>[msg]</span></span>", avoid_highlighting = (client == src))
+		else if(in_view[get_turf(client.mob)]) //NSV13 - LOOC AI Stuff - Stop
+			targets |= client
+			to_chat(client, "<span class='looc'><span class='prefix'>LOOC:</span> <EM><span class='name'>[mob.name]</span>:</EM> <span class='message'>[msg]</span></span>", avoid_highlighting = (client == src))
 
-    for(var/mob/M as() in heard)
-        if(!M.client)
-            continue
-        var/client/C = M.client
-        if (C in GLOB.admins)
-            continue //they are handled after that
-
-        if (isobserver(M))
-            continue //Also handled later.
-
-        if(C.prefs.chat_toggles & CHAT_LOOC) //nsv13 - toggles -> chat_toggles, CHAT_OOC -> CHAT_LOOC
-//            var/display_name = src.key
-//            if(holder)
-//                if(holder.fakekey)
-//                    if(C.holder)
-//                        display_name = "[holder.fakekey]/([src.key])"
-//                else
-//                    display_name = holder.fakekey
-            to_chat(C,"<span class='looc'><span class='prefix'>LOOC:</span> <EM>[src.mob.name]:</EM> <span class='message'>[msg]</span></span>")
-
-    for(var/client/C in GLOB.admins)
-        if(C.prefs.chat_toggles & CHAT_LOOC) //nsv13 - toggles -> chat_toggles, CHAT_OOC -> CHAT_LOOC
-            var/prefix = "(R)LOOC"
-            if (C.mob in heard)
-                prefix = "LOOC"
-            to_chat(C,"<span class='looc'>[ADMIN_FLW(usr)]<span class='prefix'>[prefix]:</span> <EM>[src.key]/[src.mob.name]:</EM> <span class='message'>[msg]</span></span>")
+	for(var/client/client in GLOB.admins)
+		if(!(client.prefs.chat_toggles & CHAT_LOOC)) //nsv13 - toggles -> chat_toggles, CHAT_OOC -> CHAT_LOOC
+			continue
+		var/prefix = "[(client in targets) ? "" : "(R)"]LOOC"
+		to_chat(client, "<span class='looc'><span class='prefix'>[prefix]:</span> <EM>[ADMIN_LOOKUPFLW(mob)]:</EM> <span class='message'>[msg]</span></span>", avoid_highlighting = (client == src))
 
 /proc/toggle_looc(toggle = null) //nsv13 - adds a toggle for looc
-    if(toggle != null) //if we're specifically en/disabling looc
-        if(toggle != GLOB.looc_allowed)
-            GLOB.looc_allowed = toggle
-        else
-            return
-    else //otherwise just toggle it
-        GLOB.looc_allowed = !GLOB.looc_allowed
+	if(toggle != null) //if we're specifically en/disabling looc
+		if(toggle != GLOB.looc_allowed)
+			GLOB.looc_allowed = toggle
+		else
+			return
+	else //otherwise just toggle it
+		GLOB.looc_allowed = !GLOB.looc_allowed
 
 /proc/log_looc(text)
-    if (CONFIG_GET(flag/log_ooc))
-        WRITE_FILE(GLOB.world_game_log, "\[[time_stamp()]]LOOC: [text]")
+	if (CONFIG_GET(flag/log_ooc))
+		WRITE_FILE(GLOB.world_game_log, "\[[time_stamp()]]LOOC: [text]")
 
 ////////////////////FLAVOUR TEXT NSV13////////////////////
 /mob
 	var/flavour_text = ""
 //NSV13 - flavour text - Don't think this thing actually does anything - END
-
-/mob/proc/get_top_level_mob()
-    if(istype(src.loc,/mob)&&src.loc!=src)
-        var/mob/M=src.loc
-        return M.get_top_level_mob()
-    return src
-
-/proc/get_top_level_mob(var/mob/S)
-    if(istype(S.loc,/mob)&&S.loc!=S)
-        var/mob/M=S.loc
-        return M.get_top_level_mob()
-    return S

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -25,7 +25,7 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 		if(prefs.muted & MUTE_OOC)
 			to_chat(src, "<span class='danger'>You cannot use OOC (muted).</span>")
 			return
-	if(is_banned_from(ckey, "OOC"))
+	if(is_banned_from(ckey, BAN_OOC))
 		to_chat(src, "<span class='danger'>You have been banned from OOC.</span>")
 		return
 	if(QDELETED(src))

--- a/nsv13.dme
+++ b/nsv13.dme
@@ -38,6 +38,7 @@
 #include "code\__DEFINES\atmospherics.dm"
 #include "code\__DEFINES\atom_hud.dm"
 #include "code\__DEFINES\balloon_alert.dm"
+#include "code\__DEFINES\bans.dm"
 #include "code\__DEFINES\bitfields.dm"
 #include "code\__DEFINES\bodyparts.dm"
 #include "code\__DEFINES\bot_defines.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Pulls the following PRs from upstream
* https://github.com/BeeStation/BeeStation-Hornet/pull/9407
This PR patches up the jankiness with LOOC, allowing mobs inside containers to hear LOOC and allows...apparently observers to hear LOOC but does not allow them to talk over LOOC.

* https://github.com/BeeStation/BeeStation-Hornet/pull/9572 (Fixes some stuff the first PR caused)

Oh yeah managed to keep the AI LOOC stuff in the code as well so that is compatible with this almost up to date version of beestation LOOC
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Tries to keep the LOOC code somewhat up to date with Beestation's version of it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/BeeStation/NSV13/assets/59128051/2bcdbf8c-fab1-48ba-ba59-05850494bc5d


</details>

## Changelog
:cl:Absolucy
fix: LOOC is much less janky now. You can properly both hear LOOC as a ghost, and both hear and talk on LOOC while inside another object (including cases such as split personalities, recalled holoparasites, desynchronized mobs, jaunting mobs)!
fix: Fixed admins seeing LOOC message senders as themselves rather the actual sender
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
