### PR TITLE
Roundstart Nucleum

### DIFF
--- a/_maps/map_files/Aetherwhisp/Aetherwhisp2.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp2.dmm
@@ -7158,7 +7158,7 @@
 /obj/machinery/air_sensor/atmos{
 	id_tag = "ftl_sensor"
 	},
-/turf/open/floor/engine/vacuum,
+/turf/open/floor/engine/nucleum,
 /area/engine/engine_smes)
 "eSC" = (
 /obj/machinery/light_switch/east,
@@ -11299,7 +11299,7 @@
 /obj/machinery/camera/autoname{
 	dir = 8
 	},
-/turf/open/floor/engine/vacuum,
+/turf/open/floor/engine/nucleum,
 /area/engine/engine_smes)
 "hEV" = (
 /obj/machinery/atmospherics/components/binary/pump/layer4{
@@ -19564,7 +19564,8 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/turf/closed/wall/r_wall/ship,
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
 /area/engine/engine_smes)
 "nzF" = (
 /obj/machinery/holopad,
@@ -23103,10 +23104,9 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos{
 	id_tag = "ftl_out";
-	internal_pressure_bound = 1000;
-	on = 0
+	internal_pressure_bound = 1000
 	},
-/turf/open/floor/engine/vacuum,
+/turf/open/floor/engine/nucleum,
 /area/engine/engine_smes)
 "pNP" = (
 /obj/machinery/door/firedoor/border_only/directional/west,
@@ -49382,7 +49382,7 @@ irp
 iOJ
 pvG
 pvG
-qCL
+vHd
 pMZ
 aiL
 njC
@@ -49896,7 +49896,7 @@ irp
 iOJ
 pvG
 pvG
-qCL
+vHd
 hER
 dbO
 qCe
@@ -50153,9 +50153,9 @@ irp
 wNs
 pvG
 vDP
-vDP
-vDP
-vDP
+alU
+alU
+alU
 vDP
 vDP
 vDP

--- a/_maps/map_files/Galactica/Galactica2.dmm
+++ b/_maps/map_files/Galactica/Galactica2.dmm
@@ -6112,7 +6112,7 @@
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
-/turf/open/floor/engine/vacuum,
+/turf/open/floor/engine/nucleum,
 /area/engine/engineering/reactor_core)
 "dko" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -6540,7 +6540,7 @@
 /obj/machinery/air_sensor/atmos{
 	id_tag = "nuclear_mix_sensor_3"
 	},
-/turf/open/floor/engine/vacuum,
+/turf/open/floor/engine/nucleum,
 /area/engine/engineering/reactor_core)
 "dwn" = (
 /obj/machinery/door/airlock/turbolift/ship{
@@ -14867,7 +14867,7 @@
 /turf/open/floor/durasteel/techfloor_grid,
 /area/maintenance/disposal)
 "hNt" = (
-/turf/open/floor/engine/vacuum,
+/turf/open/floor/engine/nucleum,
 /area/engine/engineering/reactor_core)
 "hNy" = (
 /obj/machinery/door/airlock/ship/maintenance{
@@ -18151,7 +18151,7 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos{
 	id = "nuclear_mix_in_3"
 	},
-/turf/open/floor/engine/vacuum,
+/turf/open/floor/engine/nucleum,
 /area/engine/engineering/reactor_core)
 "jBK" = (
 /obj/machinery/computer/station_alert{
@@ -37665,7 +37665,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/engine/vacuum,
+/turf/open/floor/engine/nucleum,
 /area/engine/engineering/reactor_core)
 "tTF" = (
 /obj/effect/spawner/room/threexfive,
@@ -38349,11 +38349,12 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible/layer4{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible/layer2{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/valve/digital/on/layer4{
+	dir = 8;
+	name = "To Fueltank"
 	},
 /turf/open/floor/durasteel/techfloor_grid,
 /area/engine/engineering/reactor_core)
@@ -40401,7 +40402,7 @@
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
-/turf/open/floor/engine/vacuum,
+/turf/open/floor/engine/nucleum,
 /area/engine/engineering/reactor_core)
 "vok" = (
 /obj/machinery/light{

--- a/_maps/map_files/Gladius/Gladius2.dmm
+++ b/_maps/map_files/Gladius/Gladius2.dmm
@@ -649,6 +649,9 @@
 /obj/effect/turf_decal/ship/techfloor{
 	dir = 5
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/open/floor/engine,
 /area/engine/engineering/ftl_room)
 "avB" = (
@@ -1236,14 +1239,12 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/storage)
 "aTA" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/brown/hidden{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/pipe/simple/brown/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel/ridged/steel,
@@ -2132,6 +2133,9 @@
 /area/nsv/weapons/gauss)
 "bwC" = (
 /obj/machinery/camera/autoname,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering/ftl_room)
 "bxf" = (
@@ -2286,8 +2290,11 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "bCO" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
+	},
+/obj/machinery/meter{
+	name = "FTL Waste to Cooler"
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering/ftl_room)
@@ -2888,6 +2895,13 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"bZZ" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/brown/visible,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering/ftl_room)
 "cal" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3086,6 +3100,9 @@
 /obj/effect/turf_decal/ship/techfloor{
 	dir = 9
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/open/floor/engine,
 /area/engine/engineering/ftl_room)
 "cfW" = (
@@ -3156,6 +3173,9 @@
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/ship/techfloor{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel/ridged/steel,
@@ -3302,7 +3322,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/brown/hidden{
+/obj/machinery/atmospherics/pipe/simple/brown/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel/ridged/steel,
@@ -4115,6 +4135,13 @@
 	},
 /turf/open/floor/durasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"cGo" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 8;
+	id = "nucleum_in"
+	},
+/turf/open/floor/engine/nucleum,
+/area/engine/engineering/ftl_room)
 "cGs" = (
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess{
 	name = "Maintenance Access Library"
@@ -4495,6 +4522,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/ship/techfloor{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/ridged/steel,
@@ -5226,10 +5256,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
+/obj/effect/turf_decal/ship/techfloor{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 5
 	},
-/obj/effect/turf_decal/ship/techfloor{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/ridged/steel,
@@ -6384,7 +6417,7 @@
 /turf/open/floor/plating/airless,
 /area/engine/atmos)
 "ecJ" = (
-/obj/machinery/atmospherics/pipe/simple/brown/hidden{
+/obj/machinery/atmospherics/pipe/simple/brown/visible{
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
@@ -6509,9 +6542,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering/ftl_room)
@@ -6972,6 +7007,9 @@
 /obj/effect/turf_decal/ship/techfloor{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/engine,
 /area/engine/engineering/ftl_room)
 "euH" = (
@@ -7065,7 +7103,7 @@
 /turf/open/floor/durasteel,
 /area/hydroponics/garden)
 "exY" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
+/obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -7124,7 +7162,7 @@
 /turf/open/floor/durasteel,
 /area/maintenance/nsv/deck2/frame1/starboard)
 "ezy" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
+/obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel/ridged/steel,
@@ -8111,7 +8149,7 @@
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "fbQ" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
+/obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -9334,6 +9372,7 @@
 "fDN" = (
 /obj/machinery/computer/ship/ftl_core,
 /obj/effect/turf_decal/ship/techfloor,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/engine/engineering/ftl_room)
 "fEg" = (
@@ -9953,6 +9992,16 @@
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/nsv/weapons/gauss)
+"fUO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
+	dir = 8;
+	name = "Nucleum Exhaust Cooler"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering/ftl_room)
 "fUQ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -10373,8 +10422,15 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "geF" = (
-/obj/machinery/atmospherics/pipe/manifold/green/hidden,
-/turf/open/floor/plasteel/ridged/steel,
+/obj/structure/cable/yellow,
+/obj/machinery/computer/monitor{
+	dir = 4;
+	name = "Reactor Grid power monitoring console"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
 /area/engine/engineering/ftl_room)
 "geN" = (
 /obj/machinery/mineral/stacking_machine{
@@ -10383,7 +10439,7 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "gfc" = (
-/obj/machinery/atmospherics/pipe/manifold/brown/hidden{
+/obj/machinery/atmospherics/pipe/manifold/brown/visible{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -11332,6 +11388,18 @@
 /obj/machinery/blackbox_recorder,
 /turf/open/floor/plasteel/grid/techfloor/grid/airless,
 /area/tcommsat/server)
+"gHH" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/ship/techfloor{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/ridged/steel,
+/area/engine/engineering/ftl_room)
 "gHO" = (
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/deck{
@@ -11790,7 +11858,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/modular_computer/console/preset/engineering,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
 /area/engine/engineering/ftl_room)
 "gWL" = (
 /obj/structure/disposalpipe/segment{
@@ -12087,6 +12159,12 @@
 	},
 /turf/open/floor/durasteel,
 /area/crew_quarters/locker)
+"hdw" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering/ftl_room)
 "hdB" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -12306,6 +12384,12 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"hjy" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering/ftl_room)
 "hjC" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/snacks/dough,
@@ -12690,6 +12774,9 @@
 /area/crew_quarters/bar)
 "hvE" = (
 /obj/effect/turf_decal/ship/techfloor{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -13872,11 +13959,11 @@
 /turf/open/floor/monotile/dark,
 /area/chapel/main)
 "ieU" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/brown/hidden{
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/pipe/simple/brown/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel/ridged/steel,
@@ -13942,7 +14029,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 5
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering/ftl_room)
 "igI" = (
@@ -14338,6 +14427,9 @@
 /obj/machinery/atmospherics/components/binary/drive_pylon,
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/ship/techfloor{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel/ridged/steel,
@@ -15925,15 +16017,13 @@
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "jlv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering/ftl_room)
 "jlH" = (
@@ -16381,11 +16471,27 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/airlock/ship/engineering{
 	name = "FTL Room";
 	req_one_access_txt = "10"
 	},
 /turf/open/floor/plasteel/dark,
+/area/engine/engineering/ftl_room)
+"jyZ" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/item/pipe_dispenser,
+/turf/open/floor/engine,
 /area/engine/engineering/ftl_room)
 "jza" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -16411,6 +16517,7 @@
 "jzO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/ship/techfloor,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/ftl_room)
 "jzZ" = (
@@ -16923,7 +17030,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "jPo" = (
-/obj/machinery/atmospherics/pipe/simple/brown/hidden{
+/obj/machinery/atmospherics/pipe/simple/brown/visible{
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
@@ -16940,8 +17047,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/atmospherics/pipe/simple/brown/hidden{
+/obj/machinery/atmospherics/pipe/simple/brown/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -16999,6 +17105,7 @@
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/ftl_room)
 "jSi" = (
@@ -17343,6 +17450,9 @@
 /area/library)
 "kcg" = (
 /obj/effect/turf_decal/ship/techfloor{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /turf/open/floor/engine,
@@ -17719,6 +17829,16 @@
 /obj/machinery/light,
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/kitchen)
+"koE" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering/ftl_room)
+"koX" = (
+/obj/machinery/atmospherics/pipe/simple/brown/visible,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering/ftl_room)
 "kpu" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/engine/n2o,
@@ -18159,7 +18279,8 @@
 /turf/closed/wall/ship,
 /area/engine/atmos)
 "kDJ" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/ftl_room)
 "kEq" = (
@@ -19164,6 +19285,9 @@
 /obj/effect/turf_decal/ship/techfloor{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/engine,
 /area/engine/engineering/ftl_room)
 "lkl" = (
@@ -19186,10 +19310,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/brown/hidden{
+/obj/effect/turf_decal/ship/techfloor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/brown/visible{
 	dir = 1
 	},
-/obj/effect/turf_decal/ship/techfloor{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/ridged/steel,
@@ -19711,6 +19838,7 @@
 /area/crew_quarters/toilet)
 "lBb" = (
 /obj/effect/turf_decal/ship/techfloor,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/engine/engineering/ftl_room)
 "lBn" = (
@@ -20756,6 +20884,12 @@
 /obj/effect/turf_decal/ship/techfloor{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/ftl_room)
 "mct" = (
@@ -21014,6 +21148,9 @@
 /obj/machinery/atmospherics/components/binary/drive_pylon,
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/ship/techfloor{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel/ridged/steel,
@@ -22012,6 +22149,9 @@
 /obj/effect/turf_decal/ship/techfloor{
 	dir = 10
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/open/floor/engine,
 /area/engine/engineering/ftl_room)
 "mJn" = (
@@ -22221,7 +22361,7 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/starboard)
 "mRS" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+/obj/machinery/atmospherics/pipe/layer_manifold/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -23017,10 +23157,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
+/obj/effect/turf_decal/ship/techfloor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 9
 	},
-/obj/effect/turf_decal/ship/techfloor{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/ridged/steel,
@@ -23661,6 +23804,7 @@
 /area/crew_quarters/toilet)
 "nIV" = (
 /obj/effect/turf_decal/ship/techfloor,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/ftl_room)
 "nJq" = (
@@ -24148,6 +24292,13 @@
 	},
 /turf/open/floor/durasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"nVk" = (
+/obj/machinery/atmospherics/components/binary/pump/layer4{
+	name = "Cooled FTL Waste to Scrubber";
+	on = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering/ftl_room)
 "nVr" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/grid/steel,
@@ -24276,6 +24427,13 @@
 	},
 /turf/open/floor/plasteel/grid/techfloor/grid/airless,
 /area/tcommsat/server)
+"nYs" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering/ftl_room)
 "nYx" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/monotile/dark,
@@ -25096,7 +25254,7 @@
 /turf/open/floor/plasteel/techmaint,
 /area/engine/engineering/reactor_core)
 "oxx" = (
-/obj/machinery/atmospherics/pipe/simple/brown/hidden{
+/obj/machinery/atmospherics/pipe/simple/brown/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -25240,6 +25398,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/ship/techfloor{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/ridged/steel,
@@ -25404,6 +25565,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"oGG" = (
+/obj/machinery/computer/atmos_control/tank/sm{
+	dir = 8;
+	input_tag = "nucleum_in";
+	name = "Nucleum Tank Monitor";
+	output_tag = "nucleum_out";
+	sensors = list("nucleum"="Nucleum")
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering/ftl_room)
 "oGK" = (
 /obj/structure/sink/kitchen{
 	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
@@ -25489,11 +25660,14 @@
 /turf/open/floor/monotile/dark,
 /area/storage/primary)
 "oJu" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering/ftl_room)
@@ -28974,8 +29148,8 @@
 /turf/open/floor/monotile/dark,
 /area/engine/engineering/reactor_control)
 "qDe" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/ftl_room)
 "qDx" = (
@@ -29394,6 +29568,20 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
+"qPR" = (
+/obj/machinery/light,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/computer/monitor{
+	dir = 4;
+	name = "Main Grid power monitoring console"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering/ftl_room)
 "qPU" = (
 /obj/structure/closet/radiation,
 /obj/structure/cable{
@@ -30138,6 +30326,11 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"rhk" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/visible,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/engineering/ftl_room)
 "rhH" = (
 /obj/effect/turf_decal/tile/ship/full/blue,
 /obj/machinery/light,
@@ -31238,11 +31431,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/brown/hidden{
+/obj/machinery/atmospherics/pipe/simple/brown/visible{
 	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering/ftl_room)
@@ -31252,7 +31445,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "rNx" = (
-/obj/machinery/atmospherics/pipe/manifold/brown/hidden{
+/obj/machinery/atmospherics/pipe/manifold/brown/visible{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -31950,7 +32143,7 @@
 /area/security/checkpoint/supply)
 "shM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/machinery/atmospherics/pipe/simple/brown/hidden{
+/obj/machinery/atmospherics/pipe/simple/brown/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -32520,6 +32713,13 @@
 /obj/item/dest_tagger,
 /turf/open/floor/monotile/dark,
 /area/quartermaster/sorting)
+"sxn" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering/ftl_room)
 "sxu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -32567,8 +32767,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/turf_decal/ship/techfloor{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/ridged/steel,
@@ -32965,7 +33167,10 @@
 "sJn" = (
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
-/turf/open/floor/plasteel/dark,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/engine,
 /area/engine/engineering/ftl_room)
 "sJo" = (
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -33040,6 +33245,9 @@
 /obj/effect/turf_decal/ship/techfloor{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/ftl_room)
 "sMI" = (
@@ -33053,7 +33261,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/brown/hidden{
+/obj/machinery/atmospherics/pipe/simple/brown/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel/ridged/steel,
@@ -34064,6 +34272,9 @@
 /obj/effect/turf_decal/ship/techfloor{
 	dir = 5
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/ftl_room)
 "tpd" = (
@@ -34948,6 +35159,24 @@
 	},
 /turf/open/floor/durasteel,
 /area/lawoffice)
+"tPW" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/ship/techfloor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/meter{
+	name = "FTL Pillar Input"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/ridged/steel,
+/area/engine/engineering/ftl_room)
 "tPX" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -35137,10 +35366,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/brown/hidden{
+/obj/effect/turf_decal/ship/techfloor{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/brown/visible{
 	dir = 6
 	},
-/obj/effect/turf_decal/ship/techfloor{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/ridged/steel,
@@ -35342,8 +35574,9 @@
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
 "udY" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/turf_decal/ship/techfloor,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/ftl_room)
 "ueg" = (
@@ -35803,16 +36036,32 @@
 /turf/open/floor/plating,
 /area/storage/tech)
 "utf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/ftl_room)
 "utD" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /turf/open/floor/plasteel/techmaint,
 /area/engine/engineering/reactor_core)
+"utH" = (
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_y = 6;
+	name = "Common Channel Intercom"
+	},
+/obj/item/radio/intercom{
+	pixel_y = -5;
+	name = "Engineering Channel Intercom";
+	frequency = 1357
+	},
+/turf/open/floor/engine,
+/area/engine/engineering/ftl_room)
 "uup" = (
 /obj/item/radio/intercom/directional/east,
 /obj/structure/lattice/catwalk/over/ship/dark,
@@ -36340,6 +36589,12 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/quartermaster/miningoffice)
+"uIu" = (
+/obj/machinery/air_sensor/atmos/nucleium_tank{
+	id_tag = "nucleum"
+	},
+/turf/open/floor/engine/nucleum,
+/area/engine/engineering/ftl_room)
 "uII" = (
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/monotile/dark,
@@ -36601,6 +36856,12 @@
 	},
 /turf/open/floor/plasteel/chapel,
 /area/chapel/main)
+"uSa" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nucleium_output{
+	id_tag = "nucleum_out"
+	},
+/turf/open/floor/engine/nucleum,
+/area/engine/engineering/ftl_room)
 "uSh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -36940,6 +37201,13 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"veB" = (
+/obj/machinery/atmospherics/pipe/manifold/green/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/ridged/steel,
+/area/engine/engineering/ftl_room)
 "veD" = (
 /obj/structure/closet/crate/coffin,
 /obj/item/reagent_containers/food/snacks/grown/poppy{
@@ -38438,7 +38706,9 @@
 /turf/open/floor/monotile/light,
 /area/crew_quarters/cryopods)
 "vXY" = (
-/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering/ftl_room)
 "vYb" = (
@@ -38648,6 +38918,12 @@
 	},
 /turf/open/floor/durasteel,
 /area/crew_quarters/locker)
+"wde" = (
+/obj/machinery/atmospherics/pipe/manifold/green/visible{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering/ftl_room)
 "wdr" = (
 /obj/structure/table,
 /obj/item/hatchet,
@@ -39403,6 +39679,32 @@
 /obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/cryopods)
+"wAO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/airlock/ship/engineering{
+	name = "Engineering Construction Storage";
+	req_one_access_txt = "10;24"
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/storage)
 "wAT" = (
 /obj/machinery/telecomms/broadcaster/preset_right,
 /turf/open/floor/circuit/airless,
@@ -39429,6 +39731,10 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
+"wCF" = (
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/engine,
+/area/engine/engineering/ftl_room)
 "wCH" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -40665,7 +40971,10 @@
 /turf/open/floor/plasteel/grid/steel,
 /area/hallway/secondary/exit/departure_lounge)
 "xof" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/machinery/atmospherics/pipe/simple/brown/visible,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering/ftl_room)
 "xox" = (
@@ -40899,9 +41208,9 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard/fore)
 "xuU" = (
-/obj/machinery/atmospherics/components/binary/temperature_gate{
-	dir = 4;
-	target_temperature = 293.15
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped{
+	dir = 8;
+	filter_type = "nucleium"
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering/ftl_room)
@@ -41037,6 +41346,10 @@
 	},
 /turf/open/floor/monotile/airless,
 /area/tcommsat/server)
+"xBr" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering/ftl_room)
 "xBt" = (
 /obj/structure/closet/crate,
 /obj/item/wrench/medical,
@@ -42213,11 +42526,27 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/security/checkpoint/engineering)
+"ylS" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/ship/techfloor{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/ridged/steel,
+/area/engine/engineering/ftl_room)
 "ylW" = (
 /turf/closed/wall/ship,
 /area/storage/art)
 "ymc" = (
-/obj/machinery/atmospherics/pipe/simple/brown/hidden,
+/obj/machinery/atmospherics/pipe/simple/brown/visible,
+/obj/machinery/meter{
+	name = "FTL Pillar Exhaust"
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering/ftl_room)
 "ymi" = (
@@ -57026,7 +57355,7 @@ jyU
 igx
 jPO
 syC
-geF
+ezy
 lkh
 pCV
 pCV
@@ -57280,7 +57609,7 @@ jJc
 fFD
 vGo
 hig
-mmi
+vXY
 oxx
 sMx
 ezy
@@ -57794,11 +58123,11 @@ btC
 btC
 xpz
 hig
-mmi
+vXY
 oxx
-sMx
+ylS
 jRX
-kDJ
+veB
 kDJ
 kDJ
 kDJ
@@ -58051,13 +58380,13 @@ jhd
 jhd
 gXH
 hig
-mmi
+vXY
 rNx
 tpb
 noA
-mcl
-mcl
-mcl
+tPW
+gHH
+gHH
 mcl
 lkt
 miM
@@ -58310,15 +58639,15 @@ ecj
 hig
 vXY
 ecJ
-ymc
-ymc
-ymc
+koX
+koX
+bZZ
 gfc
 ymc
-ymc
+xof
 rNj
-mmi
-mmi
+qSZ
+rCA
 mmi
 hig
 omb
@@ -58565,18 +58894,18 @@ vwN
 vwN
 ecj
 hig
-tLz
-mmi
-mmi
-mmi
-mmi
+wde
+xBr
+xBr
+xBr
+nYs
 xuU
 mmi
-mmi
+hjy
 oJu
-qSZ
-rCA
-ujF
+jyZ
+geF
+qPR
 hig
 iEd
 wsj
@@ -58822,17 +59151,17 @@ vwN
 vwN
 ecj
 hig
+vXY
+oGG
 mmi
-mmi
-mmi
-mmi
-mmi
+sCZ
+vXY
 bCO
 mmi
 mmi
 wXe
 gWC
-gWC
+hdw
 sJn
 hig
 knc
@@ -59079,18 +59408,18 @@ kZy
 wNe
 ecj
 hig
-mmi
-xof
-vTu
-vTu
-vTu
+sxn
+wCH
+wCH
+hig
+vXY
 mRS
-vTu
-vTu
+mmi
+mmi
 egy
-mmi
-mmi
-mmi
+utH
+pCV
+wCF
 hig
 tDQ
 aVM
@@ -59336,18 +59665,18 @@ ecj
 ecj
 ecj
 hig
-mmi
-mmi
-mmi
-sCZ
-mmi
-mmi
-mmi
-mmi
+cGo
+uIu
+uSa
+rhk
+exY
+fUO
+vTu
+nVk
 jlv
-mmi
-mmi
-mmi
+koE
+pCV
+pCV
 hig
 qop
 pYQ
@@ -59593,9 +59922,9 @@ umV
 ecj
 ecj
 hig
-hig
-hig
-hig
+wCH
+wCH
+wCH
 hig
 vcj
 wCH
@@ -60620,7 +60949,7 @@ kHT
 ecj
 ecj
 pWy
-vlW
+wAO
 iaa
 iaa
 uhi

--- a/_maps/map_files/Gladius/Gladius2.dmm
+++ b/_maps/map_files/Gladius/Gladius2.dmm
@@ -3401,6 +3401,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port/fore)
+"cnA" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering/ftl_room)
 "cnV" = (
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/plasteel/dark,
@@ -6375,6 +6384,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
+"eaY" = (
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/engine,
+/area/engine/engineering/ftl_room)
 "eba" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/techmaint,
@@ -10088,6 +10101,10 @@
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"fXF" = (
+/obj/structure/extinguisher_cabinet/east,
+/turf/open/floor/engine,
+/area/engine/engineering/ftl_room)
 "fYs" = (
 /obj/machinery/door/airlock/ship/public{
 	name = "Dressing Room";
@@ -12742,12 +12759,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /obj/machinery/door/airlock/ship/engineering{
 	name = "FTL Room";
 	req_one_access_txt = "10"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering/ftl_room)
@@ -17832,6 +17855,9 @@
 "koE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/engineering/ftl_room)
@@ -32127,6 +32153,10 @@
 /area/crew_quarters/dorms)
 "shr" = (
 /obj/machinery/airalarm/directional/north,
+/obj/machinery/door/airlock/ship/engineering{
+	name = "Engineering Construction Storage";
+	req_one_access_txt = "10;24"
+	},
 /turf/open/floor/plasteel/dark,
 /area/nsv/engine/corridor)
 "shB" = (
@@ -37173,6 +37203,12 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/starboard)
 "vcj" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /obj/machinery/door/airlock/ship/engineering{
 	name = "FTL Room";
 	req_one_access_txt = "10"
@@ -39699,10 +39735,6 @@
 	dir = 8
 	},
 /obj/effect/landmark/zebra_interlock_point,
-/obj/machinery/door/airlock/ship/engineering{
-	name = "Engineering Construction Storage";
-	req_one_access_txt = "10;24"
-	},
 /turf/open/floor/monotile/dark,
 /area/engine/storage)
 "wAT" = (
@@ -59151,7 +59183,7 @@ vwN
 vwN
 ecj
 hig
-vXY
+cnA
 oGG
 mmi
 sCZ
@@ -59675,8 +59707,8 @@ vTu
 nVk
 jlv
 koE
-pCV
-pCV
+eaY
+fXF
 hig
 qop
 pYQ

--- a/_maps/map_files/Tycoon/Tycoon2.dmm
+++ b/_maps/map_files/Tycoon/Tycoon2.dmm
@@ -45588,7 +45588,7 @@
 /obj/machinery/air_sensor/atmos{
 	id_tag = "FTLsensor"
 	},
-/turf/open/floor/engine/vacuum,
+/turf/open/floor/engine/nucleum,
 /area/engine/engineering/reactor_core)
 "kuw" = (
 /obj/machinery/light{
@@ -51391,7 +51391,7 @@
 	id_tag = "FTLoutput";
 	on = 0
 	},
-/turf/open/floor/engine/vacuum,
+/turf/open/floor/engine/nucleum,
 /area/engine/engineering/reactor_core)
 "tmT" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
@@ -52618,7 +52618,7 @@
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
-/turf/open/floor/engine/vacuum,
+/turf/open/floor/engine/nucleum,
 /area/engine/engineering/reactor_core)
 "vii" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{

--- a/nsv13/code/__DEFINES/atmospherics.dm
+++ b/nsv13/code/__DEFINES/atmospherics.dm
@@ -1,3 +1,4 @@
 #define ATMOS_GAS_MONITOR_INPUT_NUCLEIUM "nucleium_in"
 #define ATMOS_GAS_MONITOR_OUTPUT_NUCLEIUM "nucleium_out"
 #define ATMOS_GAS_MONITOR_SENSOR_NUCLEIUM "nucleium_sensor"
+#define ATMOS_TANK_NUCLEUM		"nucleum=750;TEMP=293.15"

--- a/nsv13/code/game/turfs/custom_turfs.dm
+++ b/nsv13/code/game/turfs/custom_turfs.dm
@@ -166,3 +166,7 @@
 		var/obj/structure/overmap/small_craft/OM = AM
 		return OM.check_overmap_elegibility(ignore_position = TRUE)
 	return ..()
+
+/turf/open/floor/engine/nucleum
+	name = "Nucleum Floor"
+	initial_gas_mix = ATMOS_TANK_NUCLEUM


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR creates an engineering turf for nucleum and adds that turf to the maps with the Thirring FTL Drive.

## Why It's Good For The Game

Crewmen can now start moving larger ships before the 10 minute mark. Mappers no longer have to tweak a variable.

## Changelog
:cl:
add: Added new nucleum preset engineering tile
add: Nucleum tank to the Gladius
tweak: Added nucleum gas to the nucleum tanks on the Gladius, Galactica, Tycoon and Aetherwhisp
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
