### PR TITLE
Makes windows have damage overlays - Fixes #675

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -360,7 +360,7 @@
 		cut_overlay(crack_overlay)
 		if(ratio > 75)
 			return
-		crack_overlay = mutable_appearance('icons/obj/structures.dmi', "damage[ratio]", (layer+0.1)) //NSV13 - made layer in front of windows
+		crack_overlay = mutable_appearance('icons/obj/structures.dmi', "damage[ratio]", -(layer+0.1))
 		add_overlay(crack_overlay)
 
 /obj/structure/window/temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -360,7 +360,7 @@
 		cut_overlay(crack_overlay)
 		if(ratio > 75)
 			return
-		crack_overlay = mutable_appearance('icons/obj/structures.dmi', "damage[ratio]", -(layer+0.1))
+		crack_overlay = mutable_appearance('icons/obj/structures.dmi', "damage[ratio]", (layer+0.1)) //NSV13 - made layer in front of windows
 		add_overlay(crack_overlay)
 
 /obj/structure/window/temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)

--- a/nsv13/code/game/turfs/legacy_smooth.dm
+++ b/nsv13/code/game/turfs/legacy_smooth.dm
@@ -58,6 +58,7 @@
 		else
 			I = image(icon, "[basestate][connections[i]]", dir = 1<<(i-1))
 		overlays += I
+	update_icon()
 
 /obj/structure/window/proc/can_visually_connect_to(obj/structure/S)
 	return istype(S, src)

--- a/nsv13/code/game/turfs/legacy_smooth.dm
+++ b/nsv13/code/game/turfs/legacy_smooth.dm
@@ -42,6 +42,8 @@
 /obj/structure/window/legacy_smooth()
 	//A little cludge here, since I don't know how it will work with slim windows. Most likely VERY wrong.
 	//this way it will only update full-tile ones
+	if(QDELETED(src))
+		return
 	. = ..()
 	if(!can_visually_connect())
 		icon_state = initial(icon_state)
@@ -58,7 +60,16 @@
 		else
 			I = image(icon, "[basestate][connections[i]]", dir = 1<<(i-1))
 		overlays += I
-	update_icon()
+
+	if(!fulltile)
+		return
+	var/ratio = obj_integrity / max_integrity
+	ratio = CEILING(ratio*4, 1) * 25
+	cut_overlay(crack_overlay)
+	if(ratio > 75)
+		return
+	crack_overlay = mutable_appearance('icons/obj/structures.dmi', "damage[ratio]", (layer+0.1)) //NSV13 - made layer in front of windows
+	add_overlay(crack_overlay)
 
 /obj/structure/window/proc/can_visually_connect_to(obj/structure/S)
 	return istype(S, src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #675 by making the damage sprites for legacy_smoothed windows appear

## Why It's Good For The Game
You can tell when windows are damaged?

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![Screenshot 2023-09-24 161838](https://github.com/BeeStation/NSV13/assets/17987483/827d9eb4-a8e6-4d16-8f9d-22a97ab8f3c6)

</details>

## Changelog
:cl:
fix: fixed window damage overlay
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
