### PR TITLE
[Upstream] Atmos bots now display temperature in Kelvin

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/atmosbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/atmosbot.dm
@@ -293,7 +293,7 @@
 	if(!locked || issilicon(user) || IsAdminGhost(user))
 		dat += "Breach Pressure: <a href='?src=[REF(src)];set_breach_pressure=1'>[breached_pressure]</a><br>"
 		dat += "Temperature Control: <a href='?src=[REF(src)];toggle_temp_control=1'>[temperature_control?"Enabled":"Disabled"]</a><br>"
-		dat += "Temperature Target: <a href='?src=[REF(src)];set_ideal_temperature=[ideal_temperature]'>[ideal_temperature]C</a><br>"
+		dat += "Temperature Target: <a href='?src=[REF(src)];set_ideal_temperature=[ideal_temperature]'>[ideal_temperature]K</a><br>"
 		dat += "Gas Scrubbing Controls<br>"
 		for(var/gas_id in gasses)
 			var/gas_enabled = gasses[gas_id]
@@ -318,7 +318,7 @@
 			if("[G]" == gas_id)
 				gasses[G] = gasses[G] ? FALSE : TRUE
 	else if(href_list["set_ideal_temperature"])
-		var/new_temp = input(usr, "Set Target Temperature ([T0C] to [T20C + 20])", "Target Temperature") as num
+		var/new_temp = input(usr, "Set Target Temperature ([T0C]K to [T20C + 20]K)", "Target Temperature") as num
 		if(!isnum(new_temp) || new_temp < T0C || new_temp > T20C + 20)
 			return
 		ideal_temperature = new_temp


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ports from upstream the following PR:
* https://github.com/BeeStation/BeeStation-Hornet/pull/9261

That PR makes it so the atmos bot interface now shows the correct temperature unit, aka Kelvin rather than Celsius. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Make the people not be able to get confused about the high temperature!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![Skärmbild 2023-09-26 115559](https://github.com/BeeStation/NSV13/assets/59128051/437574f9-6a6d-47e3-abe2-5036d09ce85b)

![Skärmbild 2023-09-26 115609](https://github.com/BeeStation/NSV13/assets/59128051/c09a0db9-0a71-4286-bf1a-d7a4af9542df)

</details>

## Changelog
:cl:Haliris
spellcheck: fixed atmosbots displaying their temperature in Celsius rather than Kelvin.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
