### PR TITLE
Fixes the issue where exiting tugs moves camera off-center

### DIFF
--- a/nsv13/code/modules/vehicles/_vehicle.dm
+++ b/nsv13/code/modules/vehicles/_vehicle.dm
@@ -75,6 +75,7 @@ MASSIVE THANKS TO MONSTER860 FOR HELP WITH THIS. HE EXPLAINED PHYSICS AND MATH T
 
 /obj/vehicle/sealed/car/realistic/after_remove_occupant(mob/M)
 	M.set_focus(M)
+	M?.client.AdjustView()
 
 /obj/vehicle/sealed/car/realistic/proc/toggle_brakes()
 	brakes = !brakes


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
What this PR does is the following:
Fixes #2449 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug fixes are good, even better when it's about the player camera!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/BeeStation/NSV13/assets/59128051/844f0618-d15f-4b1b-8daa-89a3e57914f1

</details>

## Changelog
:cl:
fix: Fixes an issue where exiting a tug would move your camera off-center if the tug had been moved.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
