### PR TITLE
Prevents Kadesh from being boarded

### DIFF
--- a/nsv13/code/modules/overmap/types/syndicate.dm
+++ b/nsv13/code/modules/overmap/types/syndicate.dm
@@ -457,6 +457,7 @@
 	missiles = 8
 	torpedoes = 0
 	combat_dice_type = /datum/combat_dice/cruiser
+	possible_interior_maps = list()
 
 /obj/structure/overmap/syndicate/ai/kadesh/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Kadesh cruisers currently don't undefine the default boarding map, which allows them to be unintentionally boarded. This PR fixes that.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Ships that don't have an assigned map should not get boarded
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: fixed Kadesh cruisers from being boarded
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
