### PR TITLE
Lets borgs click on transport small craft to enter

### DIFF
--- a/nsv13/code/game/general_quarters/dropship.dm
+++ b/nsv13/code/game/general_quarters/dropship.dm
@@ -122,6 +122,10 @@
 		user.forceMove(T)
 	mobs_in_ship -= user
 
+/obj/structure/overmap/small_craft/transport/attack_robot(mob/user)
+	if(user.Adjacent(src))
+		return attack_hand(user)
+
 /obj/structure/overmap/small_craft/transport/attack_hand(mob/user)
 	if(allowed(user))
 		if(do_after(user, 2 SECONDS, target=src))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Allows cyborgs to click on TRANSPORT small craft to enter, instead of being forced to click and drag to get in. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's a bit annoying to click and drag every time you want to enter a Sabre, instead of just clicking once.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
tweak: borgs can now leftclick to enter transport small crafts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
