### PR TITLE
NSV Materials Fix

### DIFF
--- a/nsv13/code/game/objects/items/custom_materials.dm
+++ b/nsv13/code/game/objects/items/custom_materials.dm
@@ -13,7 +13,7 @@ GLOBAL_LIST_INIT(duranium_recipes, list ( \
 	icon_state = "sheet-duranium"
 	item_state = "sheet-duranium"
 	sheettype = "duranium"
-	materials = list(/datum/material/iron = MINERAL_MATERIAL_AMOUNT*7/40, /datum/material/plasma = MINERAL_MATERIAL_AMOUNT/20, /datum/material/silver = MINERAL_MATERIAL_AMOUNT*3/20, /datum/material/titanium = MINERAL_MATERIAL_AMOUNT*5/8)
+	materials = list(/datum/material/iron = MINERAL_MATERIAL_AMOUNT*0.175, /datum/material/plasma = MINERAL_MATERIAL_AMOUNT*0.05, /datum/material/silver = MINERAL_MATERIAL_AMOUNT*0.15, /datum/material/titanium = MINERAL_MATERIAL_AMOUNT*0.625)
 	throwforce = 10
 	flags_1 = CONDUCT_1
 	resistance_flags = FIRE_PROOF
@@ -54,7 +54,7 @@ GLOBAL_LIST_INIT(durasteel_recipes, list ( \
 	icon_state = "sheet-durasteel"
 	item_state = "sheet-durasteel"
 	sheettype = "durasteel"
-	materials = list(/datum/material/iron = MINERAL_MATERIAL_AMOUNT/5, /datum/material/silver = MINERAL_MATERIAL_AMOUNT*3/20, /datum/material/titanium = MINERAL_MATERIAL_AMOUNT*12/20)
+	materials = list(/datum/material/iron = MINERAL_MATERIAL_AMOUNT*0.2, /datum/material/silver = MINERAL_MATERIAL_AMOUNT*0.15, /datum/material/titanium = MINERAL_MATERIAL_AMOUNT*0.65)
 	throwforce = 10
 	flags_1 = CONDUCT_1
 	resistance_flags = FIRE_PROOF

--- a/nsv13/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/nsv13/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -24,7 +24,7 @@
 	icon = 'nsv13/icons/obj/custom_tiles.dmi'
 	icon_state = "durasteel_tile"
 	force = 6
-	materials = list(/datum/material/iron = MINERAL_MATERIAL_AMOUNT*0.2*0.25, /datum/material/silver = MINERAL_MATERIAL_AMOUNT*0.15*0.25, /datum/material/titanium = MINERAL_MATERIAL_AMOUNT*0.65*0.25)
+	materials = list(/datum/material/iron = MINERAL_MATERIAL_AMOUNT*0.05, /datum/material/silver = MINERAL_MATERIAL_AMOUNT*0.0375, /datum/material/titanium = MINERAL_MATERIAL_AMOUNT*0.1625)
 	throwforce = 10
 	flags_1 = CONDUCT_1
 	turf_type = /turf/open/floor/durasteel
@@ -135,7 +135,7 @@
 	icon = 'nsv13/icons/turf/dark_carpet.dmi'
 	icon_state = "dark_carpet_tile"
 	resistance_flags = FLAMMABLE
-	materials = list(/datum/material/iron = MINERAL_MATERIAL_AMOUNT*0.2*0.25, /datum/material/silver = MINERAL_MATERIAL_AMOUNT*0.15*0.25, /datum/material/titanium = MINERAL_MATERIAL_AMOUNT*0.65*0.25)
+	materials = list(/datum/material/iron = MINERAL_MATERIAL_AMOUNT*0.05, /datum/material/silver = MINERAL_MATERIAL_AMOUNT*0.0375, /datum/material/titanium = MINERAL_MATERIAL_AMOUNT*0.1625)
 	turf_type = /turf/open/floor/carpet/ship
 
 /obj/item/stack/tile/carpet/ship/blue

--- a/nsv13/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/nsv13/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -24,7 +24,7 @@
 	icon = 'nsv13/icons/obj/custom_tiles.dmi'
 	icon_state = "durasteel_tile"
 	force = 6
-	materials = list(/datum/material/iron = MINERAL_MATERIAL_AMOUNT/20, /datum/material/silver = MINERAL_MATERIAL_AMOUNT*3/80, /datum/material/titanium = MINERAL_MATERIAL_AMOUNT*13/80)
+	materials = list(/datum/material/iron = MINERAL_MATERIAL_AMOUNT*0.2*0.25, /datum/material/silver = MINERAL_MATERIAL_AMOUNT*0.15*0.25, /datum/material/titanium = MINERAL_MATERIAL_AMOUNT*0.65*0.25)
 	throwforce = 10
 	flags_1 = CONDUCT_1
 	turf_type = /turf/open/floor/durasteel
@@ -135,6 +135,7 @@
 	icon = 'nsv13/icons/turf/dark_carpet.dmi'
 	icon_state = "dark_carpet_tile"
 	resistance_flags = FLAMMABLE
+	materials = list(/datum/material/iron = MINERAL_MATERIAL_AMOUNT*0.2*0.25, /datum/material/silver = MINERAL_MATERIAL_AMOUNT*0.15*0.25, /datum/material/titanium = MINERAL_MATERIAL_AMOUNT*0.65*0.25)
 	turf_type = /turf/open/floor/carpet/ship
 
 /obj/item/stack/tile/carpet/ship/blue

--- a/nsv13/code/modules/research/designs/smelting_designs.dm
+++ b/nsv13/code/modules/research/designs/smelting_designs.dm
@@ -12,7 +12,7 @@
 	name = "Durasteel alloy"
 	id = "durasteel"
 	build_type = SMELTER | PROTOLATHE
-	materials = list(/datum/material/iron = MINERAL_MATERIAL_AMOUNT, /datum/material/silver = MINERAL_MATERIAL_AMOUNT)
+	materials = list(/datum/material/iron = MINERAL_MATERIAL_AMOUNT*0.2, /datum/material/silver = MINERAL_MATERIAL_AMOUNT*0.15, /datum/material/titanium = MINERAL_MATERIAL_AMOUNT*0.65)
 	build_path = /obj/item/stack/sheet/durasteel
 	category = list("initial", "Stock Parts")
 	departmental_flags = DEPARTMENTAL_FLAG_CARGO | DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_ENGINEERING
@@ -22,7 +22,7 @@
 	name = "Duranium alloy"
 	id = "duranium"
 	build_type = SMELTER | PROTOLATHE
-	materials = list(/datum/material/iron = MINERAL_MATERIAL_AMOUNT, /datum/material/plasma = MINERAL_MATERIAL_AMOUNT/2, /datum/material/silver = MINERAL_MATERIAL_AMOUNT/2)
+	materials = list(/datum/material/iron = MINERAL_MATERIAL_AMOUNT*0.175, /datum/material/plasma = MINERAL_MATERIAL_AMOUNT*0.05, /datum/material/silver = MINERAL_MATERIAL_AMOUNT*0.15, /datum/material/titanium = MINERAL_MATERIAL_AMOUNT*0.625)
 	build_path = /obj/item/stack/sheet/duranium
 	category = list("initial", "Stock Parts")
 	departmental_flags = DEPARTMENTAL_FLAG_CARGO | DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_ENGINEERING


### PR DESCRIPTION
## About The Pull Request

makes the NSV material amounts look nicer in code
fixes the durasteel sheet material amount (it was missing a bit of titanium)
fixes the amount NSV materials cost in ORMs and lathes
adds material amounts to `tile/carpet/ship` (they are made of durasteel)

## Why It's Good For The Game

![fix man good](https://user-images.githubusercontent.com/23534908/222276620-9eb46bcf-ea6b-418c-beb1-4ba7c82a5f8d.gif)
and also I want to be able to recycle those floor tiles when I accidently make them

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/NSV13/assets/23534908/b7d94485-c4f4-4b72-88a8-9eb6425c5215)

</details>

## Changelog
:cl:
fix: You can now recycle nanoweave carpet tiles
fix: Fixed the amount that NSV materials cost in ORMs and lathes
/:cl: