### PR TITLE
[Upstream] Adds a small vignette that pops up when your laws are changed as AI.

### DIFF
--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -110,6 +110,11 @@
 	layer = BLIND_LAYER
 	plane = FULLSCREEN_PLANE
 
+/atom/movable/screen/fullscreen/law_change
+    icon_state = "law_change"
+    layer = BLIND_LAYER
+    plane = FULLSCREEN_PLANE
+
 /atom/movable/screen/fullscreen/curse
 	icon_state = "curse"
 	layer = CURSE_LAYER

--- a/code/modules/mob/living/silicon/laws.dm
+++ b/code/modules/mob/living/silicon/laws.dm
@@ -14,9 +14,12 @@
 	throw_alert("newlaw", /atom/movable/screen/alert/newlaw)
 	if(announce && last_lawchange_announce != world.time)
 		to_chat(src, "<b>Your laws have been changed.</b>")
+		overlay_fullscreen("law_change", /atom/movable/screen/fullscreen/law_change, 1)
 		// lawset modules cause this function to be executed multiple times in a tick, so we wait for the next tick in order to be able to see the entire lawset
 		addtimer(CALLBACK(src, PROC_REF(show_laws)), 0)
 		addtimer(CALLBACK(src, PROC_REF(deadchat_lawchange)), 0)
+		// Wait a tick and clear the vignette
+		addtimer(CALLBACK(src, PROC_REF(clear_fullscreen), "law_change"), 0.2 SECONDS)
 		last_lawchange_announce = world.time
 
 /mob/living/silicon/proc/set_law_sixsixsix(law, announce = TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ports https://github.com/BeeStation/BeeStation-Hornet/pull/9939

From the original PR,
Adds a small vignette that appears momentarily on the screen when laws are changed.
The vignette appears and then immediately fades out, similar to other notifier vignettes.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
~~Because having the only indicator for a law change being in the chat window can cause it to be easily missed. Especially in NSV, where an AI could be too busy flying the main ship or gunning to notice the message.~~
idk it looks cool


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

From the original PR

![IMG_0168](https://github.com/BeeStation/NSV13/assets/95106800/81f997ed-d65f-4c87-8c50-fc7fbcb3b30d)

![IMG_0169](https://github.com/BeeStation/NSV13/assets/95106800/ce38ce3c-8a00-4690-b833-91d66ef369f6)

</details>

## Changelog 
:cl: Harranhall
add: Added a vignette that appears momentarily when your laws are changed as AI.
imageadd: added the "law_change" fullscreen vignette.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
