### PR TITLE
Fixes Snake ammo sorters and integrity failsafe

### DIFF
--- a/_maps/map_files/Snake/snake_lower.dmm
+++ b/_maps/map_files/Snake/snake_lower.dmm
@@ -566,7 +566,7 @@
 "ce" = (
 /obj/machinery/ammo_sorter{
 	dir = 8;
-	id = "atlas1";
+	id = "snake";
 	name = "AP shells"
 	},
 /obj/item/ship_weapon/ammunition/naval_artillery/ap,
@@ -1812,7 +1812,8 @@
 /area/space/nearstation)
 "gK" = (
 /obj/machinery/computer/ammo_sorter{
-	dir = 1
+	dir = 1;
+	id = "snake"
 	},
 /obj/item/multitool,
 /turf/open/floor/engine,
@@ -5406,7 +5407,7 @@
 "ui" = (
 /obj/machinery/ammo_sorter{
 	dir = 8;
-	id = "atlas1";
+	id = "snake";
 	name = "Standard Shells #2"
 	},
 /obj/item/ship_weapon/ammunition/naval_artillery,
@@ -6210,7 +6211,7 @@
 "wC" = (
 /obj/machinery/ammo_sorter{
 	dir = 8;
-	id = "atlas1";
+	id = "snake";
 	name = "Gunpowder #2"
 	},
 /obj/item/powder_bag,
@@ -11118,7 +11119,7 @@
 "MW" = (
 /obj/machinery/ammo_sorter{
 	dir = 8;
-	id = "atlas1";
+	id = "snake";
 	name = "Standard Shells #1"
 	},
 /obj/item/ship_weapon/ammunition/naval_artillery,
@@ -13099,7 +13100,7 @@
 "TP" = (
 /obj/machinery/ammo_sorter{
 	dir = 8;
-	id = "atlas1";
+	id = "snake";
 	name = "Gunpowder #1"
 	},
 /obj/item/powder_bag,

--- a/nsv13/code/modules/overmap/types/nanotrasen.dm
+++ b/nsv13/code/modules/overmap/types/nanotrasen.dm
@@ -196,6 +196,7 @@
 
 /obj/structure/overmap/nanotrasen/patrol_cruiser/starter //Currently assigned to the Snake
 	role = MAIN_OVERMAP
+	obj_integrity = 1000
 	max_integrity = 1000
 	integrity_failure = 1000
 	bound_width = 64


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes Snake ammo sorters not being linked to the console. Also fixes a issue where the obj and max integrity of the ship weren't equal, triggering a failsafe (See screenshots)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Ammo sorters should start linked.


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>
Ammo sorters

![SnakeAmmoFix](https://github.com/BeeStation/NSV13/assets/95106800/a8c391c4-419f-4342-ad80-59761d7e1294)

Failsafe message

![SnakeFailsafe](https://github.com/BeeStation/NSV13/assets/95106800/ff779327-db94-4302-84f4-66e04c167915)


</details>

## Changelog
:cl:
fix: Ammo sorters on snake now start linked
fix: Prevents a failsafe from triggering every time the snake is loaded
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
