### PR TITLE
Round extension and enemy spawning tweaks

### DIFF
--- a/nsv13/code/controllers/subsystem/overmap_mode.dm
+++ b/nsv13/code/controllers/subsystem/overmap_mode.dm
@@ -330,11 +330,8 @@ SUBSYSTEM_DEF(overmap_mode)
 	*/
 
 	var/datum/star_system/rubicon = SSstar_system.system_by_id("Rubicon")
-	if(get_active_player_count(TRUE,TRUE,FALSE) > 10)
-		if(length(rubicon.enemies_in_system))
-			mode.objectives += new /datum/overmap_objective/clear_system/rubicon
-		else //If Rubicon is empty we go to Dolos
-			mode.objectives += new /datum/overmap_objective/clear_system/dolos
+	if(get_active_player_count(TRUE,TRUE,FALSE) > 10 && length(rubicon.enemies_in_system)) //Make sure there are enemies to fight
+		mode.objectives += new /datum/overmap_objective/clear_system/rubicon
 	else
 		mode.objectives += new /datum/overmap_objective/tickets
 		for(var/datum/faction/F in SSstar_system.factions)

--- a/nsv13/code/controllers/subsystem/overmap_mode.dm
+++ b/nsv13/code/controllers/subsystem/overmap_mode.dm
@@ -273,14 +273,18 @@ SUBSYSTEM_DEF(overmap_mode)
 	*/
 
 	var/text = "<b>[GLOB.station_name]</b>, <br>You have been assigned the following mission by <b>[capitalize(mode.starting_faction)]</b> and are expected to complete it with all due haste. Please ensure your crew is properly informed of your objectives and delegate tasks accordingly."
-	var/title = "Mission Briefing: [random_capital_letter()][random_capital_letter()][random_capital_letter()]-[GLOB.round_id]"
+	var/static/title = ""
+	if(!announced_objectives)
+		title += "Mission Briefing: [random_capital_letter()][random_capital_letter()][random_capital_letter()]-[GLOB.round_id]"
+	else //Add an extension if this isn't roundstart
+		title += "-Ext."
 
 	text = "[text] <br><br> [mode.brief] <br><br> Objectives:"
 
 	for(var/datum/overmap_objective/O in mode.objectives)
 		text = "[text] <br> - [O.brief]"
 
-		if ( !SSovermap_mode.announced_objectives ) // Prevents duplicate report spam when assigning additional objectives
+		if(!SSovermap_mode.announced_objectives)  // Prevents duplicate report spam when assigning additional objectives
 			O.print_objective_report()
 
 	print_command_report(text, title, TRUE)
@@ -325,10 +329,18 @@ SUBSYSTEM_DEF(overmap_mode)
 		mode.objectives += new /datum/overmap_objective/tickets
 	*/
 
-	if(get_active_player_count(TRUE,TRUE,FALSE) > 4)
-		mode.objectives += new /datum/overmap_objective/clear_system/rubicon
+	var/datum/star_system/rubicon = SSstar_system.system_by_id("Rubicon")
+	if(get_active_player_count(TRUE,TRUE,FALSE) > 10)
+		if(length(rubicon.enemies_in_system))
+			mode.objectives += new /datum/overmap_objective/clear_system/rubicon
+		else //If Rubicon is empty we go to Dolos
+			mode.objectives += new /datum/overmap_objective/clear_system/dolos
 	else
 		mode.objectives += new /datum/overmap_objective/tickets
+		for(var/datum/faction/F in SSstar_system.factions)
+			F.send_fleet(custom_difficulty = (mode.difficulty + 1)) //Extension is more challenging
+			escalation += 1
+			message_admins("Overmap difficulty has been increased by 1!")
 
 	instance_objectives()
 

--- a/nsv13/code/datums/starsystem_manager.dm
+++ b/nsv13/code/datums/starsystem_manager.dm
@@ -49,10 +49,12 @@
 		sys_inf["visited"] = 0
 		sys_inf["hidden"] = (SS.sector != current_sector)
 		var/label = ""
+		if(SS.hidden)
+			label += " HIDDEN"
 		if(SS.is_hypergate)
 			label += " HYPERGATE"
 		if(SS.is_capital && !label)
-			label = "CAPITAL"
+			label = " CAPITAL"
 		if(SS.trader && SS.sector != 3) //Use shortnames in brazil for readability
 			label = " [SS.trader.name]"
 		if(SS.trader && SS.sector == 3) //Use shortnames in brazil for readability
@@ -220,6 +222,11 @@
 				usr.client.debug_variables(target)
 			if(command == "Delete")
 				usr.client.cmd_admin_delete(target)
+		if("hideSystem")
+			var/datum/star_system/target = locate(params["sys_id"])
+			if(!istype(target))
+				return
+			target.hidden = !target.hidden
 		if("systemVV")
 			var/datum/star_system/target = locate(params["sys_id"])
 			if(!istype(target))

--- a/nsv13/code/game/gamemodes/overmap/objectives/rubicon.dm
+++ b/nsv13/code/game/gamemodes/overmap/objectives/rubicon.dm
@@ -26,6 +26,7 @@
 	desc = "Defeat all enemies in the [system_name] system"
 	brief = desc
 	target_system = SSstar_system.system_by_id(system_name)
+	target_system.hidden = FALSE
 	RegisterSignal(SSstar_system.find_main_overmap(), COMSIG_SHIP_KILLED_FLEET, PROC_REF(check_completion))
 
 /datum/overmap_objective/clear_system/check_completion()
@@ -38,8 +39,9 @@
 /datum/overmap_objective/clear_system/rubicon
 	system_name = "Rubicon"
 	extension_supported = TRUE
-	required_players = 4
+	required_players = 10
 
 /datum/overmap_objective/clear_system/dolos
 	system_name = "Dolos Remnants"
-	required_players = 4
+	extension_supported = TRUE //Only if Rubicon is not available
+	required_players = 10

--- a/nsv13/code/modules/overmap/factions.dm
+++ b/nsv13/code/modules/overmap/factions.dm
@@ -74,7 +74,7 @@ Set up relationships.
 	if(main_ship)
 		current_system = SSstar_system.ships[main_ship]["current_system"]
 	var/list/possible_spawns = list()
-	for(var/datum/star_system/starsys in SSstar_system.systems)
+	for(var/datum/star_system/starsys in SSstar_system.neutral_zone_systems) //Neutral zone to prevent overcrowding the Syndicate and friendly sectors
 		if(starsys != current_system && !starsys.hidden && (lowertext(starsys.alignment) == lowertext(src.name) || starsys.alignment == "unaligned" || starsys.alignment == "uncharted")) //Find one of our base systems and try to send a fleet out from there.
 			possible_spawns += starsys
 	if(!possible_spawns.len && !override)

--- a/tgui/packages/tgui/interfaces/StarsystemManager.js
+++ b/tgui/packages/tgui/interfaces/StarsystemManager.js
@@ -46,13 +46,17 @@ export const StarsystemManager = (props, context) => {
     return (
       <Section title={`${system.name}`}>
         <Button
-          content={"Send Fleet"}
+          content={"Send fleet"}
           icon={"hammer"}
           onClick={() => act('createFleet', { sys_id: system.sys_id })} />
         <Button
           content={"Create object"}
           icon={"sun"}
           onClick={() => act('createObject', { sys_id: system.sys_id })} />
+        <Button
+          content={"Hide/Unhide system"}
+          icon={"eye-slash"}
+          onClick={() => act('hideSystem', { sys_id: system.sys_id })} />
         <Button
           content={"Variables"}
           icon={"eye"}


### PR DESCRIPTION
## About The Pull Request

When the round extension mission is given, it will now check if Rubicon is already cleared and assign Dolos as the objective instead. I've also raised the requirement for these missions to 10, since four players will usually have a harder time getting a successful Rubicon mission.
On top of this I've automatically made the clear system objective unhide the target system, made enemy fleet spawning only happen in sector 2 (So no more empty starmaps because all of the ships spawned in the Syndicate sector) and adjusted the way briefings are generated to make it clear which paper is the extension objective and to maintain more consistency between the papers.
Also adds a hide/unhide button to the starsystem manager, and a label for systems that are hidden (see picture for preview)

## Why It's Good For The Game

These are quality of life features for admins, and increases the challenge for people who want to keep fighting after a successful mission.

## Testing Photographs and Procedure
I don't have a video but I did actually test this
Preview of hidden system on the starsystem manager:
![image](https://github.com/BeeStation/NSV13/assets/43698041/6cfa3d25-b840-49f4-83dd-2d5e56230f37)

## Changelog
:cl:
add: Added the option to get another ticket objective if Rubicon is already cleared
tweak: Increased Rubicon objective player requirement to 10
tweak: Mission briefing names will now be consistent in a round
balance: Fleets will now be stronger after the main mission is done
admin: Added button to hide/unhide a system on the starsystem manager
admin: Automatically unhides systems selected for the "clear system" objective
/:cl: