### PR TITLE
Adds special offers to overmap traders

### DIFF
--- a/nsv13/code/modules/overmap/traders.dm
+++ b/nsv13/code/modules/overmap/traders.dm
@@ -4,6 +4,7 @@
 	var/shortname = "DM" //Used in Brazil.
 	var/list/stonks = list() //The trader's inventory.
 	var/list/sold_items = list()
+	var/list/special_offers = list() //Items locked behind points
 	var/faction_type = null //What faction does the dude belong to.
 	var/system_type = "unaligned" //In what systems do they spawn?
 	//Fluff / voice stuff
@@ -48,11 +49,20 @@
 	yellow_pages_dat += "<font size = \"2\">"
 	for(var/itemPath in sold_items)
 		var/datum/trader_item/TI = new itemPath()
-		TI.price = rand(TI.price/2, TI.price*4)
-		TI.stock = rand(TI.stock/2, TI.stock*2) //How much we got in stock boys
+		TI.price = round(rand(TI.price/2, TI.price*4))
+		TI.stock = round(rand(TI.stock/2, TI.stock*2)) //How much we got in stock boys
 		stonks += TI
 		TI.owner = src
 		yellow_pages_dat += "[TI.stock]x [TI.name] ([TI.price] ea.) - <i>[TI.desc]</i><br /><br />"
+	for(var/itemPath in special_offers)
+		var/datum/trader_item/TI = new itemPath()
+		if(system_type == SSstar_system.find_main_overmap().faction && F.tickets >= TI.special_requirement) //Right now we use faction tickets to unlock better items
+			TI.name = "SPECIAL OFFER! " + TI.name //Advertising is very important
+			TI.price = round(rand((2*TI.price)/3, TI.price*2)) //These will be more expensive by default already and have less chaotic prices
+			TI.stock = round(rand(TI.stock/2, TI.stock*2))
+			stonks += TI
+			TI.owner = src
+			yellow_pages_dat += "SPECIAL OFFER! [TI.stock]x [TI.name] ([TI.price] ea.) - <i>[TI.desc]</i><br /><br />"
 	yellow_pages_dat += "</font>"
 
 /datum/trader_item
@@ -62,6 +72,7 @@
 	var/unlock_path = null
 	var/stock = 1 //How many of these items are usually stocked, this is randomized
 	var/owner = null
+	var/special_requirement //How many tickets do we need to unlock this item in the store?
 
 /datum/trader_item/proc/on_purchase(obj/structure/overmap/OM)
 	return OM.send_supplypod(unlock_path)
@@ -138,7 +149,15 @@
 	faction_type = FACTION_ID_NT
 	system_type = "nanotrasen"
 	image = "https://cdn.discordapp.com/attachments/701841640897380434/764557336684527637/unknown.png"
-	sold_items = list(/datum/trader_item/torpedo, /datum/trader_item/missile, /datum/trader_item/c45, /datum/trader_item/pdc, /datum/trader_item/deck_gun_autorepair, /datum/trader_item/yellow_pages)
+	sold_items = list(/datum/trader_item/torpedo, \
+	/datum/trader_item/missile, \
+	/datum/trader_item/c45, \
+	/datum/trader_item/pdc, \
+	/datum/trader_item/pdc_circuit, \
+	/datum/trader_item/deck_gun_autorepair, \
+	/datum/trader_item/yellow_pages)
+	special_offers = list(/datum/trader_item/firing_electronics, \
+	/datum/trader_item/vls_circuit)
 
 /datum/trader/armsdealer/syndicate
 	name = "DonkCo Warcrime Emporium"
@@ -147,8 +166,20 @@
 	faction_type = FACTION_ID_SYNDICATE
 	system_type = "syndicate"
 	//Top tier trader with the best items available.
-	sold_items = list(/datum/trader_item/hellfire,/datum/trader_item/torpedo, /datum/trader_item/missile, /datum/trader_item/c20r, /datum/trader_item/c45, /datum/trader_item/stechkin, \
-		/datum/trader_item/pdc, /datum/trader_item/fighter/syndicate, /datum/trader_item/overmap_shields, /datum/trader_item/deck_gun_autoelevator, /datum/trader_item/yellow_pages)
+	sold_items = list(/datum/trader_item/hellfire, \
+	/datum/trader_item/torpedo, \
+	/datum/trader_item/missile, \
+	/datum/trader_item/c20r, \
+	/datum/trader_item/c45, \
+	/datum/trader_item/stechkin, \
+	/datum/trader_item/pdc, \
+	/datum/trader_item/pdc_circuit, \
+	/datum/trader_item/fighter/syndicate, \
+	/datum/trader_item/overmap_shields, \
+	/datum/trader_item/deck_gun_autoelevator, \
+	/datum/trader_item/yellow_pages)
+	special_offers = list(/datum/trader_item/firing_electronics, \
+	/datum/trader_item/vls_circuit)
 	station_type = /obj/structure/overmap/trader/syndicate
 	image = "https://cdn.discordapp.com/attachments/728055734159540244/764570187357093928/unknown.png"
 	greetings = list("You've made it pretty far in, huh? We won't tell if you're buying...", "Freedom isn't free, buy a gun to secure yours.", "Excercise your right to bear arms now!")
@@ -180,7 +211,13 @@
 	"CzanekCorp here. We got a new shipment in, you down for talking turkey?",\
 	"CzanekCorp, we got repairs and goods on a budget, you in?")
 	on_purchase = list("Yes, we know the tazers aren't the safest, but if you don't like 'em, stop buying 'em, eh?", "Good doing business with you. Good luck out there, killer.", "About time we got somebody who knows what they're doing. Here, free shipping!", "No refunds, no returns!")
-	sold_items = list(/datum/trader_item/ship_repair,/datum/trader_item/fighter/light,/datum/trader_item/fighter/heavy,/datum/trader_item/fighter/utility, /datum/trader_item/taser, /datum/trader_item/taser_ammo, /datum/trader_item/yellow_pages)
+	sold_items = list(/datum/trader_item/ship_repair, \
+	/datum/trader_item/fighter/light, \
+	/datum/trader_item/fighter/heavy, \
+	/datum/trader_item/fighter/utility, \
+	/datum/trader_item/taser, \
+	/datum/trader_item/taser_ammo, \
+	/datum/trader_item/yellow_pages)
 	station_type = /obj/structure/overmap/trader/shipyard
 	image = "https://cdn.discordapp.com/attachments/701841640897380434/764540586732421120/unknown.png"
 
@@ -193,7 +230,14 @@
 	"Have you come to dig or pay?",\
 	"We got minerals for you, so long as you've got a deposit for us.")
 	on_purchase = list("Maybe next time, dig it up yourself lazy gits!", "Credits have been withdrawn, Supplies inbound.", "Czanek would approve of this.", "If you're too afraid to get these yourself, I'm almost scared to give them to you. But money is money.")
-	sold_items = list(/datum/trader_item/mining_point_card, /datum/trader_item/gold, /datum/trader_item/diamond, /datum/trader_item/uranium, /datum/trader_item/silver, /datum/trader_item/bluespace_crystal, /datum/trader_item/titanium, /datum/trader_item/yellow_pages)
+	sold_items = list(/datum/trader_item/mining_point_card, \
+	/datum/trader_item/gold, \
+	/datum/trader_item/diamond, \
+	/datum/trader_item/uranium, \
+	/datum/trader_item/silver, \
+	/datum/trader_item/bluespace_crystal, \
+	/datum/trader_item/titanium, \
+	/datum/trader_item/yellow_pages)
 	station_type = /obj/structure/overmap/trader
 	image = "https://cdn.discordapp.com/attachments/612668662977134592/859132739147792444/unknown.png"   //I don't wanna do this but I'm also not going to break the mold as to make it hopefully easier in future to fix.
 
@@ -210,7 +254,16 @@
 	desc = "Corporate approved aftermarket shipyard."
 	shortname = "MHE"
 	faction_type = FACTION_ID_NT
-	sold_items = list(/datum/trader_item/ship_repair/tier2, /datum/trader_item/flak,/datum/trader_item/fighter/light,/datum/trader_item/fighter/heavy,/datum/trader_item/fighter/utility, /datum/trader_item/fighter/judgement, /datum/trader_item/fighter/prototype, /datum/trader_item/railgun_disk, /datum/trader_item/yellow_pages)
+	sold_items = list(/datum/trader_item/ship_repair/tier2, \
+	/datum/trader_item/flak, \
+	/datum/trader_item/fighter/light, \
+	/datum/trader_item/fighter/heavy, \
+	/datum/trader_item/fighter/utility, \
+	/datum/trader_item/fighter/judgement, \
+	/datum/trader_item/fighter/prototype, \
+	/datum/trader_item/railgun_disk, \
+	/datum/trader_item/yellow_pages)
+	special_offers = list(/datum/trader_item/ship_repair/tier3)
 	station_type = /obj/structure/overmap/trader/shipyard
 
 // HIM

--- a/nsv13/code/modules/overmap/traders_items.dm
+++ b/nsv13/code/modules/overmap/traders_items.dm
@@ -188,7 +188,7 @@
 	desc = "Essential electronics for building most modern naval weapons."
 	price = 20000
 	stock = 2
-	unlock_path = /obj/item/circuitboard/machine/vls
+	unlock_path = /obj/item/ship_weapon/parts/firing_electronics
 	special_requirement = 500 //Kick their ass!!!
 
 /datum/trader_item/pdc_circuit

--- a/nsv13/code/modules/overmap/traders_items.dm
+++ b/nsv13/code/modules/overmap/traders_items.dm
@@ -77,6 +77,15 @@
 	repair_amount = 50
 	stock = 2
 
+/datum/trader_item/ship_repair/tier3
+	name = "Deluxe ship repair"
+	desc = "A complete repair job of all of your ship's hull and armour, because you've earned it!"
+	price = 2000
+	failure_chance = 0
+	repair_amount = 100
+	stock = 1
+	special_requirement = 400 //Prove those scars are worth the cost
+
 /datum/trader_item/ship_repair/on_purchase(obj/structure/overmap/OM)
 	OM.repair_all_quadrants(repair_amount, failure_chance)
 
@@ -166,17 +175,40 @@
 		/obj/item/ship_weapon/parts/loading_tray,\
 	)
 
+/datum/trader_item/vls_circuit
+	name = "VLS tube circuit board"
+	desc = "The critical component for expanding your missile complement!"
+	price = 5000
+	stock = 10
+	unlock_path = /obj/item/circuitboard/machine/vls
+	special_requirement = 100 //At least put some effort into it
+
+/datum/trader_item/firing_electronics
+	name = "Firing Electronics"
+	desc = "Essential electronics for building most modern naval weapons."
+	price = 20000
+	stock = 2
+	unlock_path = /obj/item/circuitboard/machine/vls
+	special_requirement = 500 //Kick their ass!!!
+
+/datum/trader_item/pdc_circuit
+	name = "PDC mount circuit board"
+	desc = "Not enough point defense? Just build more!"
+	price = 2500
+	stock = 4
+	unlock_path = /obj/item/circuitboard/machine/pdc_mount
+
 /datum/trader_item/torpedo
 	name = "Standard Torpedo"
 	desc = "A standard torpedo for ship to ship combat."
-	price = 1000
-	stock = 10
+	price = 900 //Price is 1000 per in cargo
+	stock = 15
 	unlock_path = /obj/item/ship_weapon/ammunition/torpedo
 
 /datum/trader_item/missile
 	name = "Standard Missile"
 	desc = "A standard missile for ship to ship combat."
-	price = 500
+	price = 500 //Price in cargo is 833 per, this is a real steal
 	stock = 20
 	unlock_path = /obj/item/ship_weapon/ammunition/missile
 
@@ -211,8 +243,8 @@
 /datum/trader_item/pdc
 	name = "PDC Ammo Box"
 	desc = "PDC rounds for use in ship to ship guns."
-	price = 800
-	stock = 10
+	price = 175 //cost of buying in cargo is 200 per box
+	stock = 20
 	unlock_path = /obj/item/ammo_box/magazine/nsv/pdc
 
 /datum/trader_item/anti_air


### PR DESCRIPTION
## About The Pull Request

Adds the special offer category of trader item, notably including **firing electronics** and full repairs.
I've also made PDC mount boards available without a specific limit, we can change this later if it's a problem.
These offers will require a certain threshold of faction points to be reached, after which they become available in their respective stores. Special offer prices will have less fluctuation, but are generally more expensive by default.

## Why It's Good For The Game

This has been a plan for a while now, though some of the gun dynamics will obviously change with 2.0 which will likely include a partial rework of the balance of this as well.

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/NSV13/assets/43698041/3f9d2e53-5244-4be3-90ca-34b3dd66b2b9)

## Changelog
:cl:
add: Added special offers to traders, which have to be unlocked with faction ticket points
balance: Made gun parts available for purchase at Whiterapids' Munitions
/:cl: