### PR TITLE
Coffee machines for all Galactic Conquest maps & Syndicate coffee mood

### DIFF
--- a/_maps/map_files/Instanced/map_files/Babylon2.dmm
+++ b/_maps/map_files/Instanced/map_files/Babylon2.dmm
@@ -3792,10 +3792,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/pvp)
-"dEI" = (
-/obj/item/storage/fancy/coffee_condi_display,
-/turf/closed/wall/steel,
-/area/maintenance/pvp)
 "dEK" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel/dark,
@@ -13574,7 +13570,7 @@
 /obj/machinery/power/apc/auto_name/west{
 	req_access = list(150)
 	},
-/obj/machinery/coffeemaker,
+/obj/machinery/coffeemaker/pendulum,
 /turf/open/floor/plasteel/tech/grid,
 /area/bridge/pvp)
 "mks" = (
@@ -15475,10 +15471,6 @@
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/plasteel/tech/grid,
 /area/hallway/pvp)
-"nSX" = (
-/obj/item/storage/fancy/coffee_condi_display,
-/turf/open/floor/plasteel/tech/grid,
-/area/crew_quarters/bar/pvp)
 "nTd" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -25515,6 +25507,7 @@
 "wZP" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/coffee_condi_display,
+/obj/item/storage/box/coffeepack/robusta,
 /turf/open/floor/plasteel/tech/grid,
 /area/bridge/pvp)
 "xaj" = (
@@ -65893,8 +65886,8 @@ fJp
 pRY
 fJp
 fJp
-nSX
-dEI
+fJp
+enS
 uFX
 iSv
 iIO

--- a/_maps/map_files/Instanced/map_files/Babylon2.dmm
+++ b/_maps/map_files/Instanced/map_files/Babylon2.dmm
@@ -3792,6 +3792,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/pvp)
+"dEI" = (
+/obj/item/storage/fancy/coffee_condi_display,
+/turf/closed/wall/steel,
+/area/maintenance/pvp)
 "dEK" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel/dark,
@@ -11919,7 +11923,6 @@
 /area/quartermaster/pvp)
 "kIH" = (
 /obj/structure/table/wood,
-/obj/item/modular_computer/laptop/preset/civillian,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
@@ -11929,6 +11932,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/coffeemaker,
 /turf/open/floor/mineral/plastitanium/red,
 /area/crew_quarters/bar/pvp)
 "kJu" = (
@@ -13570,6 +13574,7 @@
 /obj/machinery/power/apc/auto_name/west{
 	req_access = list(150)
 	},
+/obj/machinery/coffeemaker,
 /turf/open/floor/plasteel/tech/grid,
 /area/bridge/pvp)
 "mks" = (
@@ -15470,6 +15475,10 @@
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/plasteel/tech/grid,
 /area/hallway/pvp)
+"nSX" = (
+/obj/item/storage/fancy/coffee_condi_display,
+/turf/open/floor/plasteel/tech/grid,
+/area/crew_quarters/bar/pvp)
 "nTd" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -20407,6 +20416,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/tech/grid,
 /area/engine/engineering/pvp)
+"svI" = (
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/item/clothing/mask/cigarette/cigar,
+/obj/item/nullrod/fedora,
+/turf/open/floor/mineral/plastitanium/red,
+/area/crew_quarters/bar/pvp)
 "sxc" = (
 /turf/open/floor/plasteel,
 /area/quartermaster/pvp)
@@ -23724,13 +23744,12 @@
 /area/bridge/pvp)
 "voB" = (
 /obj/structure/table/wood,
-/obj/item/clothing/mask/cigarette/cigar,
-/obj/item/nullrod/fedora,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/item/modular_computer/laptop/preset/civillian,
 /turf/open/floor/mineral/plastitanium/red,
 /area/crew_quarters/bar/pvp)
 "vqc" = (
@@ -24218,6 +24237,11 @@
 	},
 /turf/open/floor/wood,
 /area/hallway/pvp)
+"vPc" = (
+/obj/structure/table/wood,
+/obj/item/storage/fancy/coffee_condi_display,
+/turf/open/floor/mineral/plastitanium/red,
+/area/crew_quarters/bar/pvp)
 "vPe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -25488,6 +25512,11 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/pvp)
+"wZP" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/fancy/coffee_condi_display,
+/turf/open/floor/plasteel/tech/grid,
+/area/bridge/pvp)
 "xaj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -62230,7 +62259,7 @@ iAi
 jxM
 pwS
 iUo
-fGT
+wZP
 mjG
 qxQ
 oUp
@@ -65345,10 +65374,10 @@ eJJ
 vfV
 rpt
 pPA
-pPA
+svI
 voB
 kIH
-fHk
+vPc
 fJp
 fJp
 enS
@@ -65864,8 +65893,8 @@ fJp
 pRY
 fJp
 fJp
-fJp
-enS
+nSX
+dEI
 uFX
 iSv
 iIO

--- a/_maps/map_files/Instanced/map_files/Hammurabi1.dmm
+++ b/_maps/map_files/Instanced/map_files/Hammurabi1.dmm
@@ -390,6 +390,11 @@
 "mv" = (
 /turf/closed/wall/r_wall,
 /area/hammurabi/maintenance/secondary)
+"na" = (
+/obj/structure/table/wood,
+/obj/item/storage/fancy/coffee_condi_display,
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi/bar)
 "nk" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -794,6 +799,11 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/plating,
 /area/hammurabi/maintenance/secondary)
+"AB" = (
+/obj/structure/table/wood,
+/obj/machinery/coffeemaker,
+/turf/open/floor/mineral/plastitanium/red,
+/area/hammurabi/bar)
 "AR" = (
 /obj/machinery/vending/boozeomat/syndicate_access{
 	payment_department = "SYN"
@@ -28547,7 +28557,7 @@ mv
 mv
 kw
 aG
-Tk
+AB
 EU
 UR
 ki
@@ -28804,7 +28814,7 @@ mv
 AR
 UR
 UR
-Tk
+na
 EU
 UR
 ki

--- a/_maps/map_files/Instanced/map_files/SpaceSHIP.dmm
+++ b/_maps/map_files/Instanced/map_files/SpaceSHIP.dmm
@@ -7389,6 +7389,11 @@
 	},
 /turf/open/floor/carpet/red,
 /area/nsv/hanger/pvp/marine)
+"rn" = (
+/obj/structure/table/reinforced,
+/obj/machinery/coffeemaker,
+/turf/open/floor/wood,
+/area/crew_quarters/bar/pvp)
 "ro" = (
 /obj/machinery/camera/syndicate{
 	c_tag = "Chief Medical Officer's Office";
@@ -21708,6 +21713,11 @@
 	},
 /turf/open/floor/durasteel/lino,
 /area/crew_quarters/heads/captain/pvp/admiral)
+"Zv" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/fancy/coffee_condi_display,
+/turf/open/floor/wood,
+/area/crew_quarters/bar/pvp)
 "Zw" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
@@ -61218,8 +61228,8 @@ jg
 fx
 WN
 jg
-jg
-jg
+rn
+Zv
 oY
 Ae
 jn

--- a/nsv13/code/datums/mood_events/nsv_events.dm
+++ b/nsv13/code/datums/mood_events/nsv_events.dm
@@ -43,6 +43,11 @@
 	mood_change = 10
 	timeout = 10 MINUTES
 
+/datum/mood_event/drink_navy_coffee/add_effects(list/faction)
+	if("Syndicate" in faction)
+		description = "<span class='nicegreen'><b>THAT SHIT TASTED FUCKING DELICIOUS LET'S GO FUCK SOME NANOTRASEN SHIPS UP, NAVY FOR LIFE WOOOOOO!!</b></span>\n"
+
+
 /datum/mood_event/cheers
 	description = "<span class='nicegreen'>Cheers! ¡Salud! Kanpai! Prost! Skål! Santé! Sláinte! Saúde!</span>\n"
 	mood_change = 3

--- a/nsv13/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/nsv13/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -27,7 +27,7 @@
 	M.dizziness = max(0,M.dizziness-5)
 	M.drowsyness = max(0,M.drowsyness-3)
 	M.AdjustSleeping(-40, FALSE)
-	SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "navy_coffee", /datum/mood_event/drink_navy_coffee)
+	SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "navy_coffee", /datum/mood_event/drink_navy_coffee, M.faction)
 	..()
 	. = 1
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds coffee machines to all PVP maps and alters the mood event depending on the drinkers faction
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The Syndicate shouldn't want to blow themselves up whenever they drink coffee.


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>
Dark Astraeus

![SPACEcoffee](https://github.com/BeeStation/NSV13/assets/95106800/e8280f94-4c27-4e6d-970c-f342126d8c71)

Babylon

![BabyCoffee](https://github.com/BeeStation/NSV13/assets/95106800/4cd8725d-7547-463f-ae9a-9a9d8ef24244)

![BabyCoffee3](https://github.com/BeeStation/NSV13/assets/95106800/ab00d01e-0974-4378-affa-08819f329520)


Hammurabi


![HammurabiCoffee](https://github.com/BeeStation/NSV13/assets/95106800/606043b0-d4e3-4ad0-973c-fcc7d48b9167)

Mood event

![SyndiCoffee](https://github.com/BeeStation/NSV13/assets/95106800/8e381560-2c70-4cbc-9ba1-9c3aef61253b)

</details>

## Changelog
:cl:
add: Added coffee machines to PVP ships
tweak: Syndicate coffee drinkers now get a altered mood event
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
