### PR TITLE
Species names are colored when examining / health analyzing

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -359,7 +359,7 @@ GENE SCANNER
 		else if(S.mutantstomach != initial(S.mutantstomach))
 			mutant = TRUE
 
-		to_chat(user, "<span class='info'>Species: [S.name][mutant ? "-derived mutant" : ""]</span>")
+		to_chat(user, "<span class='info'>Species: [H.species_examine_font()][S.name][mutant ? "-derived mutant" : ""]</font></span>") //NSV13 - species name is colored depending on special conditions.
 	to_chat(user, "<span class='info'>Body temperature: [round(M.bodytemperature-T0C,0.1)] &deg;C ([round(M.bodytemperature*1.8-459.67,0.1)] &deg;F)</span>")
 
 	// Time of death

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -359,7 +359,7 @@ GENE SCANNER
 		else if(S.mutantstomach != initial(S.mutantstomach))
 			mutant = TRUE
 
-		to_chat(user, "<span class='info'>Species: [H.species_examine_font()][S.name][mutant ? "-derived mutant" : ""]</font></span>") //NSV13 - species name is colored depending on special conditions.
+		to_chat(user, "<span class='info'>Species: <span class='[H.species_examine_font()]'>[S.name][mutant ? "-derived mutant" : ""]</span></span>") //NSV13 - species name is colored depending on special conditions.
 	to_chat(user, "<span class='info'>Body temperature: [round(M.bodytemperature-T0C,0.1)] &deg;C ([round(M.bodytemperature*1.8-459.67,0.1)] &deg;F)</span>")
 
 	// Time of death

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -24,7 +24,7 @@
 		display_name += "[compose_rank(src)]"
 	display_name += name
 	if(dna?.species && !skipface)
-		apparent_species = ", [species_examine_font()]\an [dna.species.name]</font>" //NSV13 - species name is colored depending on special conditions.
+		apparent_species = ", <span class='[species_examine_font()]'>\an [dna.species.name]</span>" //NSV13 - species name is colored depending on special conditions.
 	. = list("<span class='info'>*---------*\nThis is <EM>[!obscure_name ? display_name : "Unknown"][apparent_species]</EM>!")
 
 	//uniform

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -24,7 +24,7 @@
 		display_name += "[compose_rank(src)]"
 	display_name += name
 	if(dna?.species && !skipface)
-		apparent_species = ", \an [dna.species.name]"
+		apparent_species = ", [species_examine_font()]\an [dna.species.name]</font>" //NSV13 - species name is colored depending on special conditions.
 	. = list("<span class='info'>*---------*\nThis is <EM>[!obscure_name ? display_name : "Unknown"][apparent_species]</EM>!")
 
 	//uniform

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -210,29 +210,3 @@
 	destination.undershirt = undershirt
 	destination.socks = socks
 	destination.jumpsuit_style = jumpsuit_style
-
-//NSV13 begin - special colors for species names
-/**
- * # `species_examine_font()`
- *
- * This gets a humanoid's special examine font, which is used to color their species name during examine / health analyzing.
- * The first of these that applies is returned.
- * Returns:
- * * Metallic font if robotic
- * * Cyan if a toxinlover
- * * Purple if plasmaperson
- * * Rock / Brownish if a golem
- * * Green if none of the others apply (aka, generic organic)
-*/
-/mob/living/carbon/human/proc/species_examine_font()
-	if((MOB_ROBOTIC in mob_biotypes))
-		return "<font color='#aaa9ad'>"
-	if(HAS_TRAIT(src, TRAIT_TOXINLOVER))
-		return "<font color='#00ffff'>"
-	if(isplasmaman(src))
-		return "<font color='#800080'>"
-	if(isgolem(src))
-		return "<font color='#8b4513'>"
-	return "<font color='#18d855'>"
-
-//NSV13 end

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -210,3 +210,29 @@
 	destination.undershirt = undershirt
 	destination.socks = socks
 	destination.jumpsuit_style = jumpsuit_style
+
+//NSV13 begin - special colors for species names
+/**
+ * # `species_examine_font()`
+ *
+ * This gets a humanoid's special examine font, which is used to color their species name during examine / health analyzing.
+ * The first of these that applies is returned.
+ * Returns:
+ * * Metallic font if robotic
+ * * Cyan if a toxinlover
+ * * Purple if plasmaperson
+ * * Rock / Brownish if a golem
+ * * Green if none of the others apply (aka, generic organic)
+*/
+/mob/living/carbon/human/proc/species_examine_font()
+	if((MOB_ROBOTIC in mob_biotypes))
+		return "<font color='#aaa9ad'>"
+	if(HAS_TRAIT(src, TRAIT_TOXINLOVER))
+		return "<font color='#00ffff'>"
+	if(isplasmaman(src))
+		return "<font color='#800080'>"
+	if(isgolem(src))
+		return "<font color='#8b4513'>"
+	return "<font color='#18d855'>"
+
+//NSV13 end

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -175,6 +175,7 @@
 			H.throw_alert("nutrition", /atom/movable/screen/alert/etherealcharge, 3)
 			if(H.health > 10.5)
 				apply_damage(0.65, TOX, null, null, H)
+			brutemod = 1.9
 		else
 			H.throw_alert("nutrition", /atom/movable/screen/alert/etherealcharge, 4)
 			if(H.health > 10.5)

--- a/nsv13.dme
+++ b/nsv13.dme
@@ -3914,6 +3914,7 @@
 #include "nsv13\code\modules\mob\living\carbon\carbon.dm"
 #include "nsv13\code\modules\mob\living\carbon\examine_tgui.dm"
 #include "nsv13\code\modules\mob\living\carbon\human\nsv_emotes.dm"
+#include "nsv13\code\modules\mob\living\carbon\human\nsv_human_helpers.dm"
 #include "nsv13\code\modules\mob\living\carbon\human\species_types\catgirl.dm"
 #include "nsv13\code\modules\mob\living\carbon\human\species_types\nanotrasen_knpc.dm"
 #include "nsv13\code\modules\mob\living\carbon\human\species_types\other_knpc.dm"

--- a/nsv13/code/modules/mob/living/carbon/human/nsv_human_helpers.dm
+++ b/nsv13/code/modules/mob/living/carbon/human/nsv_human_helpers.dm
@@ -1,0 +1,25 @@
+/**
+ * # `species_examine_font()`
+ *
+ * This gets a humanoid's special examine font, which is used to color their species name during examine / health analyzing.
+ * The first of these that applies is returned.
+ * Returns:
+ * * Metallic font if robotic
+ * * Cyan if a toxinlover
+ * * Yellow-ish if an Ethereal
+ * * Purple if plasmaperson
+ * * Rock / Brownish if a golem
+ * * Green if none of the others apply (aka, generic organic)
+*/
+/mob/living/carbon/human/proc/species_examine_font()
+	if((MOB_ROBOTIC in mob_biotypes))
+		return "<font color='#aaa9ad'>"
+	if(HAS_TRAIT(src, TRAIT_TOXINLOVER))
+		return "<font color='#00ffff'>"
+	if(isethereal(src))
+		return "<font color='#e0d31d'>"
+	if(isplasmaman(src))
+		return "<font color='#800080'>"
+	if(isgolem(src))
+		return "<font color='#8b4513'>"
+	return "<font color='#18d855'>"

--- a/nsv13/code/modules/mob/living/carbon/human/nsv_human_helpers.dm
+++ b/nsv13/code/modules/mob/living/carbon/human/nsv_human_helpers.dm
@@ -13,13 +13,13 @@
 */
 /mob/living/carbon/human/proc/species_examine_font()
 	if((MOB_ROBOTIC in mob_biotypes))
-		return "<font color='#aaa9ad'>"
+		return "sc_robotic"
 	if(HAS_TRAIT(src, TRAIT_TOXINLOVER))
-		return "<font color='#00ffff'>"
+		return "sc_toxlover"
 	if(isethereal(src))
-		return "<font color='#e0d31d'>"
+		return "sc_ethereal"
 	if(isplasmaman(src))
-		return "<font color='#800080'>"
+		return "sc_plasmaman"
 	if(isgolem(src))
-		return "<font color='#8b4513'>"
-	return "<font color='#18d855'>"
+		return "sc_golem"
+	return "sc_normal"

--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -582,3 +582,12 @@ em						{font-style: normal;	font-weight: bold;}
 .stat_infomation				{color: #e6a648;}
 
 .stat_br				        {color: #2ace53;}
+
+//NSV13 - species examine colors
+.sc_robotic {color: #aaa9ad;}
+.sc_toxlover {color: #00ffff;}
+.sc_ethereal {color: #e0d31d;}
+.sc_plasmaman {color: #c400c4}
+.sc_golem {color: #b34a00}
+.sc_normal {color: #18d855}
+//NSV13 end

--- a/tgui/packages/tgui-panel/styles/goon/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-light.scss
@@ -581,3 +581,12 @@ h1.alert, h2.alert		{color: #000000;}
 .stat_infomation				{color: #be8530;}
 
 .stat_br				        {color: #2ace53;}
+
+//NSV13 - species examine colors
+.sc_robotic {color: #8a898d;}
+.sc_toxlover {color: #1e89d1;}
+.sc_ethereal {color: #dda91a;}
+.sc_plasmaman {color: #aa03aa}
+.sc_golem {color: #8f3e05}
+.sc_normal {color: #029731}
+//NSV13 end


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title.
When examining an individual (assuming species is visible), or using a health analyzer on them, their species will be displayed in a color specific to special interactions the species may have.
Caught cases are robots, toxinlovers (oozelings primarily), ethereals, plasmamen, golems, and neither of the other five. The first case that is valid applies its color.
This is a port of https://github.com/Citadel-Station-13/Citadel-Station-13/pull/14783

Also fixes a random ethereal bug I stumbled upon (as I tend to do) that made starvation not increase brute vulnerability in a specific nutrition window.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Very small change with high impact on quick species quirk recognition.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
Updated

![grafik](https://github.com/BeeStation/NSV13/assets/46569814/267a120a-ab7b-4404-a4ba-e6aa493b5001)

![grafik](https://github.com/BeeStation/NSV13/assets/46569814/ff871a27-e02e-4849-9878-c4e7062efbf4)

## Changelog
:cl:
qol: Species names are now colored when examining / using health analyzers.
fix: Ethereal starvation no longer has a nutrition window where increased brute vulnerability was not handled.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
