### PR TITLE
Fixes FTL pylons getting stuck in the shutdown state

### DIFF
--- a/nsv13/code/modules/overmap/FTL/components/drive.dm
+++ b/nsv13/code/modules/overmap/FTL/components/drive.dm
@@ -363,6 +363,8 @@ Preset classes of FTL drive with pre-programmed behaviours
 	jump_speed_pylon = initial(jump_speed_pylon)
 	if(shutdown_pylons)
 		for(var/obj/machinery/atmospherics/components/binary/drive_pylon/P as() in pylons)
+			if(P.pylon_state == PYLON_STATE_OFFLINE || P.pylon_state == PYLON_STATE_SHUTDOWN)
+				continue
 			P.set_state(PYLON_STATE_SHUTDOWN)
 	cooldown = TRUE
 	addtimer(CALLBACK(src, PROC_REF(post_cooldown), auto_spool_enabled), FTL_COOLDOWN)

--- a/nsv13/code/modules/overmap/FTL/components/drive_pylon.dm
+++ b/nsv13/code/modules/overmap/FTL/components/drive_pylon.dm
@@ -387,16 +387,9 @@
 	else
 		to_chat(user, "<span class='info'>You don't think it would be wise to touch this right now.</span>")
 
-
-#undef PYLON_STATE_OFFLINE
-#undef PYLON_STATE_STARTING
-#undef PYLON_STATE_WARMUP
-#undef PYLON_STATE_SPOOLING
-#undef PYLON_STATE_ACTIVE
-#undef PYLON_STATE_SHUTDOWN
-
 #undef MAX_WASTE_OUTPUT_PRESSURE
 #undef MAX_WASTE_STORAGE_PRESSURE
+#undef WASTE_GAS_HEAT
 
 #undef PYLON_ACTIVE_EXPONENT
 #undef POWER_FAIL_TOLERANCE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. If you hit "Shutdown" on the drive (or something else caused the main computer to powerdown), any pylons that weren't active would be set into the "shutdown" state despite already being offline, leading to them being unable to exit the state.
This keeps already disabled pylons offline instead (as they should be), avoiding the issue.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
No.

## Changelog
:cl:
fix: Thirring Drive Pylons should no longer be able to get stuck in the "shutting down" state.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
