### PR TITLE
Syndicate (AI) boarding has a tell again

### DIFF
--- a/nsv13/code/modules/overmap/boarding/boarding.dm
+++ b/nsv13/code/modules/overmap/boarding/boarding.dm
@@ -37,10 +37,6 @@
 		candidates = pollCandidatesForMob("Do you want to play as a boarding team member?", ROLE_OPERATIVE, null, ROLE_OPERATIVE, 10 SECONDS, src)
 	//No candidates? Well! Guess you get to deal with some KNPCs :))))))
 	if(!length(candidates))
-		switch(faction_selection)
-			if("syndicate")
-				relay('nsv13/sound/effects/ship/boarding_pod.ogg', "<span class='userdanger'>You can hear several tethers attaching to the ship.</span>")
-			else //No other special cases exist but this is a switch anyways to support them in the future (pirates have no tell)
 		return spawn_knpcs(amount, faction_selection)
 	return spawn_player_boarders(candidates, target, amount, faction_selection)
 
@@ -110,6 +106,11 @@
 	if(!LZ)
 		message_admins("KNPC boarder spawn aborted. This ship does not support KNPCs (add some patrol nodes!)")
 		throw EXCEPTION("KNPC boarder spawn aborted. This ship does not support KNPCs (add some patrol nodes!)")
+
+	switch(faction_selection)
+		if("syndicate")
+			relay('nsv13/sound/effects/ship/boarding_pod.ogg', "<span class='userdanger'>You can hear several tethers attaching to the ship.</span>")
+		else //No other special cases exist but this is a switch anyways to support them in the future (pirates have no tell)
 
 	var/obj/structure/closet/supplypod/syndicate_odst/toLaunch = new()
 	var/shippingLane = GLOB.areas_by_type[/area/centcom/supplypod/supplypod_temp_holding]

--- a/nsv13/code/modules/overmap/boarding/boarding.dm
+++ b/nsv13/code/modules/overmap/boarding/boarding.dm
@@ -37,6 +37,10 @@
 		candidates = pollCandidatesForMob("Do you want to play as a boarding team member?", ROLE_OPERATIVE, null, ROLE_OPERATIVE, 10 SECONDS, src)
 	//No candidates? Well! Guess you get to deal with some KNPCs :))))))
 	if(!length(candidates))
+		switch(faction_selection)
+			if("syndicate")
+				relay('nsv13/sound/effects/ship/boarding_pod.ogg', "<span class='userdanger'>You can hear several tethers attaching to the ship.</span>")
+			else //No other special cases exist but this is a switch anyways to support them in the future (pirates have no tell)
 		return spawn_knpcs(amount, faction_selection)
 	return spawn_player_boarders(candidates, target, amount, faction_selection)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
At some point somewhen, something changed boarding code which made it so the usual tell when getting boarded by syndies (the sound & message) would only display if you had player boarders. Not only is this kinda metagamey, but also just straight up a bug.
I'd have given pirates the sound back too, but apparently it's intended for them to not have one these days, so quiet they stay.

(It felt so wrong not to have one of the more ptsd inducing sounds of NSV play when it should)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
No.

## Changelog
:cl:
fix: Syndicate AI boarders no longer silently breach your hull.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
