### PR TITLE
Torp Factory 1.5

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -32,6 +32,11 @@
 				qdel(S)
 			else
 				S.be_replaced()
+	//NSV13 - stop runtiming
+	if(registered_z)
+		SSmobs.clients_by_zlevel[registered_z] -= src
+		registered_z = null
+	//NSV13 end
 	if(ranged_ability)
 		ranged_ability.remove_ranged_ability(src)
 	if(buckled)

--- a/code/modules/recycling/conveyor.dm
+++ b/code/modules/recycling/conveyor.dm
@@ -195,6 +195,11 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	if(!operating)
 		SSmove_manager.stop_looping(convayable, SSconveyors)
 		return
+	//NSV13 - account for potentially changing location between sig send and reaching this.
+	if(convayable.loc != source)
+		SSmove_manager.stop_looping(convayable, SSconveyors)
+		return
+	//NSV13 end.
 	start_conveying(convayable)
 
 /obj/machinery/conveyor/proc/conveyable_exit(datum/source, atom/convayable, direction)

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/automation.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/automation.dm
@@ -186,7 +186,7 @@
 				playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 0)
 				return
 			var/obj/item/ship_weapon/parts/missile/torpedo_part = held_components[1]
-			if(!(torpedo_part.fits_type && !istype(torpedo_target, torpedo_part.fits_type)) || torpedo_target.state != torpedo_part.target_state)
+			if((torpedo_part.fits_type && !istype(torpedo_target, torpedo_part.fits_type)) || torpedo_target.state != torpedo_part.target_state)
 				visible_message("<span class='notice'>[src] sighs.</span>")
 				playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 0)
 				return

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/automation.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/automation.dm
@@ -11,9 +11,9 @@
 	processing_flags = START_PROCESSING_MANUALLY //Does not process.
 	///Icon state the arm of this device will have
 	var/arm_icon_state = "welder3"
-	///An overlay for the machine that varies by its arm icon state. For some reason an item and not a overlay or any kind of effect.
-	var/obj/item/arm = null //This being an /obj makes me scream.
-	///List of valid munition types. This are SUPER DIRTY types. DO NOT TRUST THESE TYPES. If you are reading this, new coder, PLEASE keep a common ancestor if you want to access vars!!
+	///An overlay for the machine that varies by its arm icon state. For some reason an item and not an overlay or any kind of effect.
+	var/obj/item/arm = null //This being an /item makes me scream.
+	///List of valid munition types. These are SUPER DIRTY types. DO NOT TRUST THESE TYPES. If you are reading this, new coder, PLEASE keep a common ancestor if you want to access vars and have the things be basically the same!!
 	var/munition_types = list(/obj/item/ship_weapon/ammunition/missile/missile_casing, /obj/item/ship_weapon/ammunition/torpedo/torpedo_casing) //This is super bad but I don't feel like rewriting all of missile / torp casing code so it stays :)
 	///The target construction states of the missile
 	var/list/target_states = list(1, 7, 9)  //Who would magic number these even *after* having to reference them in machines too?? I am not cleaning up after you.. right now at least. -Delta
@@ -82,7 +82,7 @@
 
 /obj/machinery/missile_builder/Initialize(mapload)
 	. = ..()
-	arm = new /obj/item(src) //WHY IS THIS AN ITEM NOT AN OVERLAY or ANYTHING not /obj.
+	arm = new /obj/item(src) //WHY IS THIS AN ITEM (worse, basetype..) and not an overlay or something else that would make more sense?!
 	arm.icon = icon
 	arm.icon_state = arm_icon_state
 	vis_contents += arm

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/automation.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/automation.dm
@@ -21,6 +21,10 @@
 	var/turf/target_turf
 	///The timer that tracks how long the arm should be doing arm things.
 	var/active_arm_timer_id
+	///Next time a success sound can play.
+	var/next_success_sound = 0
+	///Next time a fail sound can play.
+	var/next_fail_sound = 0
 
 /obj/machinery/missile_builder/attackby(obj/item/I, mob/user, params)
 	if(default_unfasten_wrench(user, I))
@@ -106,6 +110,7 @@
  * * Does not return anything. SHOULD NOT RETURN ANYTHING.
 **/
 /obj/machinery/missile_builder/proc/attempt_assembler_action(turf/source, atom/movable/entering, old_loc, old_locs)
+	SIGNAL_HANDLER
 	if(QDELETED(entering)) //How would this happen? Who knows.. but this is NSV after all.
 		return
 	if(!isobj(entering) || iseffect(entering))
@@ -113,31 +118,41 @@
 	if(!(entering.type in munition_types))
 		visible_message("[src] shakes its arm melancholically.")
 		arm.shake_animation()
-		playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 0)
+		if(world.time >= next_fail_sound)
+			playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 0)
+			next_fail_sound = world.time + 0.2 SECONDS
 		return
 	switch(entering.type) //This is VERY BAD but they do not share a common type.
 		if(/obj/item/ship_weapon/ammunition/missile/missile_casing)
 			var/obj/item/ship_weapon/ammunition/missile/missile_casing/missile_target = entering
 			if(!(missile_target.state in target_states))
 				visible_message("<span class='notice'>[src] sighs.</span>")
-				playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 0)
+				if(world.time >= next_fail_sound)
+					playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 0)
+					next_fail_sound = world.time + 0.5 SECONDS
 				return
 			trigger_arm_animation()
 			missile_target.state++ //Next step!
 			missile_target.check_completion()
-			do_sparks(4, TRUE, missile_target)
-			playsound(src, 'sound/items/welder.ogg', 100, 1)
+			if(world.time >= next_success_sound)
+				do_sparks(4, TRUE, missile_target)
+				playsound(src, 'sound/items/welder.ogg', 100, 1)
+				next_success_sound = world.time + 0.2 SECONDS
 		if(/obj/item/ship_weapon/ammunition/torpedo/torpedo_casing)
 			var/obj/item/ship_weapon/ammunition/torpedo/torpedo_casing/torpedo_target = entering
 			if(!(torpedo_target.state in target_states))
 				visible_message("<span class='notice'>[src] sighs.</span>")
-				playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 0)
+				if(world.time >= next_fail_sound)
+					playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 0)
+					next_fail_sound = world.time + 0.5 SECONDS
 				return
 			trigger_arm_animation()
 			torpedo_target.state++ //Next step!
 			torpedo_target.check_completion()
-			do_sparks(4, TRUE, torpedo_target)
-			playsound(src, 'sound/items/welder.ogg', 100, 1)
+			if(world.time >= next_success_sound)
+				do_sparks(4, TRUE, torpedo_target)
+				playsound(src, 'sound/items/welder.ogg', 100, 1)
+				next_success_sound = world.time + 0.2 SECONDS
 		else
 			CRASH("Please stop handing the missile assemblers invalid types as valid ammunition. Type: [entering.type]. ALL valid casings must be missile or torpedo types.")
 
@@ -149,32 +164,38 @@
 		return
 	if(entering.loc != source)
 		return
-	if(length(held_components) > 0)
-		var/obj/held_component = held_components[1]
-		if(held_component.type == entering.type) //Please do throw these hungry machines some components.
-			var/obj/item/entering_item = entering
-			visible_message("<span class='notice'>[src] happily adds [entering_item] to its component storage.</span>")
+	if(tracked_component_type && tracked_component_type == entering.type) //Please do throw these hungry machines some components.
+		var/obj/item/entering_item = entering
+		visible_message("<span class='notice'>[src] happily adds [entering_item] to its component storage.</span>")
+		if(world.time >= next_success_sound)
 			playsound(src, 'sound/machines/ping.ogg', 50, 0)
-			entering_item.do_pickup_animation(src)
-			entering_item.forceMove(src)
-			held_components += entering_item
-			return
+			next_success_sound = world.time + 0.2 SECONDS
+		entering_item.do_pickup_animation(src)
+		entering_item.forceMove(src)
+		held_components += entering_item
+		return
 	if(!(entering.type in munition_types))
 		visible_message("[src] shakes its arm melancholically.")
 		arm.shake_animation()
-		playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 0)
+		if(world.time >= next_fail_sound)
+			playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 0)
+			next_fail_sound = world.time + 0.2 SECONDS
 		return
 	switch(entering.type) //This is VERY BAD but they do not share a common type.
 		if(/obj/item/ship_weapon/ammunition/missile/missile_casing)
 			var/obj/item/ship_weapon/ammunition/missile/missile_casing/missile_target = entering
 			if(!length(held_components))
 				visible_message("<span class='notice'>[src] sighs.</span>")
-				playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 0)
+				if(world.time >= next_fail_sound)
+					playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 0)
+					next_fail_sound = world.time + 0.5 SECONDS
 				return
 			var/obj/item/ship_weapon/parts/missile/missile_part = held_components[1]
 			if((missile_part.fits_type && !istype(missile_target, missile_part.fits_type)) || missile_target.state != missile_part.target_state)
 				visible_message("<span class='notice'>[src] sighs.</span>")
-				playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 0)
+				if(world.time >= next_fail_sound)
+					playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 0)
+					next_fail_sound = world.time + 0.5 SECONDS
 				return
 			trigger_arm_animation()
 			do_item_attack_animation(missile_target, used_item = missile_part)
@@ -183,18 +204,22 @@
 			missile_part.forceMove(missile_target)
 			held_components -= missile_part
 			missile_target.check_completion()
-			do_sparks(4, TRUE, missile_target)
-			playsound(src, 'sound/machines/ping.ogg', 50, 0)
+			if(world.time >= next_success_sound)
+				do_sparks(4, TRUE, missile_target)
+				playsound(src, 'sound/machines/ping.ogg', 50, 0)
+				next_success_sound = world.time + 0.2 SECONDS
 		if(/obj/item/ship_weapon/ammunition/torpedo/torpedo_casing)
 			var/obj/item/ship_weapon/ammunition/torpedo/torpedo_casing/torpedo_target = entering
 			if(!length(held_components))
-				visible_message("<span class='notice'>[src] sighs.</span>")
-				playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 0)
+				if(world.time >= next_fail_sound)
+					playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 0)
+					next_fail_sound = world.time + 0.5 SECONDS
 				return
 			var/obj/item/ship_weapon/parts/missile/torpedo_part = held_components[1]
 			if((torpedo_part.fits_type && !istype(torpedo_target, torpedo_part.fits_type)) || torpedo_target.state != torpedo_part.target_state)
-				visible_message("<span class='notice'>[src] sighs.</span>")
-				playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 0)
+				if(world.time >= next_fail_sound)
+					playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 0)
+					next_fail_sound = world.time + 0.5 SECONDS
 				return
 			trigger_arm_animation()
 			do_item_attack_animation(torpedo_target, used_item = torpedo_part)
@@ -203,8 +228,10 @@
 			torpedo_part.forceMove(torpedo_target)
 			held_components -= torpedo_part
 			torpedo_target.check_completion()
-			do_sparks(4, TRUE, torpedo_target)
-			playsound(src, 'sound/machines/ping.ogg', 50, 0)
+			if(world.time >= next_success_sound)
+				do_sparks(4, TRUE, torpedo_target)
+				playsound(src, 'sound/machines/ping.ogg', 50, 0)
+				next_success_sound = world.time + 0.2 SECONDS
 		else
 			CRASH("Please stop handing the missile assemblers invalid types as valid ammunition. Type: [entering.type]. ALL valid casings must be missile or torpedo types.")
 
@@ -229,8 +256,10 @@
 	desc = "An assembly arm which can slot a multitude of missile components into casings for you! Swipe it with an ID to release its stored components."
 	req_one_access = list(ACCESS_MUNITIONS)
 	circuit = /obj/item/circuitboard/machine/missile_builder/assembler
-	//Currently loaded missile components.
+	///Currently loaded missile components.
 	var/list/held_components = list()
+	///Currently tracked type for autopickup
+	var/tracked_component_type = null
 
 /obj/machinery/missile_builder/assembler/examine(mob/user)
 	. = ..()
@@ -255,11 +284,13 @@
 		to_chat(user, "<span class='notice'>You slot [I] into [src], ready for construction.</span>")
 		I.forceMove(src)
 		held_components += I
+		tracked_component_type = I.type
 	if(istype(I, /obj/item/card/id) && allowed(user))
 		to_chat(user, "<span class='warning'>You dump [src]'s contents out.</span>")
 		for(var/obj/item/X in held_components)
 			X.forceMove(get_turf(src))
 			held_components -= X
+		tracked_component_type = null
 
 /obj/machinery/missile_builder/assembler/MouseDrop_T(obj/structure/A, mob/user)
 	. = ..()

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/automation.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/automation.dm
@@ -236,8 +236,8 @@
 			listofitems[path]["amount"]++
 		else
 			listofitems[path] = list("name" = C.name, "amount" = 1)
-		for(var/i in listofitems)
-			. += "<span class='notice'>[listofitems[i]["name"]] x[listofitems[i]["amount"]]</span>"
+	for(var/i in listofitems)
+		. += "<span class='notice'>[listofitems[i]["name"]] x[listofitems[i]["amount"]]</span>"
 
 /obj/machinery/missile_builder/assembler/attackby(obj/item/I, mob/living/user, params)
 	. = ..()

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/automation.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/automation.dm
@@ -150,10 +150,12 @@
 	if(length(held_components) > 0)
 		var/obj/held_component = held_components[1]
 		if(held_component.type == entering.type) //Please do throw these hungry machines some components.
-			visible_message("<span class='notice'>[src] happily adds [entering] to its component storage.</span>")
+			var/obj/item/entering_item = entering
+			visible_message("<span class='notice'>[src] happily adds [entering_item] to its component storage.</span>")
 			playsound(src, 'sound/machines/ping.ogg', 50, 0)
-			entering.forceMove(src)
-			held_components += entering
+			entering_item.do_pickup_animation(src)
+			entering_item.forceMove(src)
+			held_components += entering_item
 			return
 	if(!(entering.type in munition_types))
 		visible_message("[src] shakes its arm melancholically.")
@@ -173,6 +175,8 @@
 				playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 0)
 				return
 			trigger_arm_animation()
+			do_item_attack_animation(missile_target, used_item = missile_part)
+
 			missile_target.state++ //Next step!
 			missile_part.forceMove(missile_target)
 			held_components -= missile_part
@@ -191,6 +195,8 @@
 				playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 0)
 				return
 			trigger_arm_animation()
+			do_item_attack_animation(torpedo_target, used_item = torpedo_part)
+
 			torpedo_target.state++ //Next step!
 			torpedo_part.forceMove(torpedo_target)
 			held_components -= torpedo_part

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/automation.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/automation.dm
@@ -125,7 +125,7 @@
 			trigger_arm_animation()
 			missile_target.state++ //Next step!
 			missile_target.check_completion()
-			do_sparks(10, TRUE, missile_target)
+			do_sparks(4, TRUE, missile_target)
 			playsound(src, 'sound/items/welder.ogg', 100, 1)
 		if(/obj/item/ship_weapon/ammunition/torpedo/torpedo_casing)
 			var/obj/item/ship_weapon/ammunition/torpedo/torpedo_casing/torpedo_target = entering
@@ -136,7 +136,7 @@
 			trigger_arm_animation()
 			torpedo_target.state++ //Next step!
 			torpedo_target.check_completion()
-			do_sparks(10, TRUE, torpedo_target)
+			do_sparks(4, TRUE, torpedo_target)
 			playsound(src, 'sound/items/welder.ogg', 100, 1)
 		else
 			CRASH("Please stop handing the missile assemblers invalid types as valid ammunition. Type: [entering.type]. ALL valid casings must be missile or torpedo types.")
@@ -177,7 +177,7 @@
 			missile_part.forceMove(missile_target)
 			held_components -= missile_part
 			missile_target.check_completion()
-			do_sparks(10, TRUE, missile_target)
+			do_sparks(4, TRUE, missile_target)
 			playsound(src, 'sound/machines/ping.ogg', 50, 0)
 		if(/obj/item/ship_weapon/ammunition/torpedo/torpedo_casing)
 			var/obj/item/ship_weapon/ammunition/torpedo/torpedo_casing/torpedo_target = entering
@@ -195,7 +195,7 @@
 			torpedo_part.forceMove(torpedo_target)
 			held_components -= torpedo_part
 			torpedo_target.check_completion()
-			do_sparks(10, TRUE, torpedo_target)
+			do_sparks(4, TRUE, torpedo_target)
 			playsound(src, 'sound/machines/ping.ogg', 50, 0)
 		else
 			CRASH("Please stop handing the missile assemblers invalid types as valid ammunition. Type: [entering.type]. ALL valid casings must be missile or torpedo types.")

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/automation.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/automation.dm
@@ -147,6 +147,8 @@
 		return
 	if(!isobj(entering) || iseffect(entering))
 		return
+	if(entering.loc != source)
+		return
 	if(length(held_components) > 0)
 		var/obj/held_component = held_components[1]
 		if(held_component.type == entering.type) //Please do throw these hungry machines some components.

--- a/nsv13/code/modules/overmap/FTL/components/drive.dm
+++ b/nsv13/code/modules/overmap/FTL/components/drive.dm
@@ -55,7 +55,7 @@
 	radio.keyslot = new radio_key
 	radio.listening = 0
 	radio.recalculateChannels()
-	soundloop = new(list(src), FALSE, FALSE, CHANNEL_FTL_MANIFOLD, TRUE)
+	soundloop = new(src, FALSE, FALSE, CHANNEL_FTL_MANIFOLD, TRUE)
 	STOP_PROCESSING(SSmachines, src)
 	return INITIALIZE_HINT_LATELOAD
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Lets face it, the munitions torp automation right now has a tendency to be more trouble than it's worth. The machines are very clunky to handle, only work half the time (which neccessitated slower belts despite having been thrown into faster processing), and are incredibly processing inefficient.

This PR reworks almost everything that was related to the torp / missile assemblers, cleaning up code, making it magnitudes less expensive to idle (seriously the processing & iteration was horrible)
The machines now do not process at all, instead operating on their watched turf being entered by something they care about, and only then springing to action. This reduces their dry load to 0, and makes them only have any kind of performance requirement when things actually appear, which they also only have to iterate on once as opposed to every process() even if invalid.


They also now pick up components of the type last manually (by hand) inserted, should they pass the tile the assembler is watching.

https://github.com/BeeStation/NSV13/assets/46569814/3837f8a9-0829-4421-8ff5-1af86797b8ce


It is recommended to only keep a single type of component per assembler as there is no reason to have more than one right now, but if there is more than one, the one currently in first place (that will be applied next) is the one it will grab parts of.

In general, they also react MUCH faster thanks to being signal-based (superfast) instead of processing (guh)


Look at it go!

https://github.com/BeeStation/NSV13/assets/46569814/1bfa1df0-0a4e-4e6a-bee0-da9af8523e6a


It could run on normal belts now instead of the slowed belt subtype (hell you can throw components past it and the assembler will catch them), however I didn't feel like editing the maps.

Also fixes two random bugs, one with the FTL Thirring Computer soundloop that has been broken since it was added, and a random GC failure with clients_by_z which did not account for mob deletions.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Torp automation has been left somewhat neglected and lacking effective usefulness. This improves functionality, making a well-supplied assembly line a torpedo (or missile) powerhouse.

Also fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
Already in the PR desc body itself.

## Changelog
:cl:
refactor: The Torp and Missile factory automation machinery has been rewritten almost entirely to make it less clunky and more fun.
add: Automated Assemblers will now pick up components of the last manually inserted type if they pass in front of them!
fix: The Thirring Drive Core sound loop you have never heard before works now!
fix: The client_by_z list shouldn't be getting flooded with nulls anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
