### PR TITLE
Removes firing electronics as a PDC component and adds circuit board name consistency

### DIFF
--- a/nsv13/code/game/objects/items/nsv_circuitboards.dm
+++ b/nsv13/code/game/objects/items/nsv_circuitboards.dm
@@ -1,44 +1,44 @@
 ////CIC consoles////
 
 /obj/item/circuitboard/computer/ship/helm
-	name = "circuit board (helm computer)"
+	name = "helm computer (Computer Board)"
 	build_path = /obj/machinery/computer/ship/helm
 
 /obj/item/circuitboard/computer/ship/tactical_computer
-	name = "circuit board (tactical computer)"
+	name = "tactical console (Computer Board)"
 	build_path = /obj/machinery/computer/ship/tactical
 
 //Dradis
 /obj/item/circuitboard/computer/ship/dradis
-	name = "circuit board (dradis computer)"
+	name = "Dradis console (Computer Board)"
 	build_path = /obj/machinery/computer/ship/dradis
 
 /obj/item/circuitboard/computer/ship/dradis/mining
-	name = "circuit board (mining dradis computer)"
+	name = "mining Dradis console (Computer Board)"
 	build_path = /obj/machinery/computer/ship/dradis/mining
 
 /obj/item/circuitboard/computer/ship/dradis/cargo
-	name = "circuit board (cargo dradis computer)"
+	name = "cargo Dradis computer (Computer Board)"
 	build_path = /obj/machinery/computer/ship/dradis/minor/cargo
 
 //FTL nav
 /obj/item/circuitboard/computer/ship/navigation
-	name = "circuit board (FTL Navigation console)"
+	name = "FTL navigation console (Computer Board)"
 	build_path = /obj/machinery/computer/ship/navigation
 
 //Secondary ID console
 /obj/item/circuitboard/computer/card/secondary_ship_id_console
-	name = "circuit board (secondary ID console)"
+	name = "secondary ID console (Computer Board)"
 	build_path = /obj/machinery/computer/secondary_ship_id_console
 
 /obj/item/circuitboard/computer/card/secondary_ship_id_console/syndicate
-	name = "circiut board (Syndicate ID console)"
+	name = "Syndicate ID console (Computer Board)"
 	build_path = /obj/machinery/computer/secondary_ship_id_console/syndicate
 
 ////Security////
 
 /obj/item/circuitboard/computer/security/syndicate
-	name = "circuit board (Syndicate camera console)"
+	name = "Syndicate camera console (Computer Board)"
 	build_path = /obj/machinery/computer/security/syndicate
 
 ////Science////
@@ -59,15 +59,15 @@
 ////Munitions consoles////
 
 /obj/item/circuitboard/computer/ship/munitions_computer
-	name = "circuit board (munitions control computer)"
+	name = "munitions control computer (Computer Board)"
 	build_path = /obj/machinery/computer/ship/munitions_computer
 
 /obj/item/circuitboard/computer/ship/ordnance_computer
-	name = "circuit board (ordnance computer)"
+	name = "ordnance monitoring console (Computer Board)"
 	build_path = /obj/machinery/computer/ship/ordnance
 
 /obj/item/circuitboard/computer/ams
-	name = "AMS control console (computer)"
+	name = "AMS control console (Computer Board)"
 	build_path = /obj/machinery/computer/ams
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
 
@@ -77,7 +77,7 @@
 	return ..()
 
 /obj/item/circuitboard/computer/anti_air
-	name = "Anti-air turret console (circuit)"
+	name = "anti-air turret console (Computer Board)"
 	build_path = /obj/machinery/computer/anti_air
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
 
@@ -87,19 +87,19 @@
 	return ..()
 
 /obj/item/circuitboard/computer/ship/fighter_controller
-	name = "circuit board (fighter control computer)"
+	name = "fighter control computer (Computer Board)"
 	build_path = /obj/machinery/computer/ship/fighter_controller
 
 //Mag-cat control console
 /obj/item/circuitboard/computer/ship/fighter_launcher
-	name = "circuit board (Mag-cat control console)"
+	name = "mag-cat control console (Computer Board)"
 	build_path = /obj/machinery/computer/ship/fighter_launcher
 
 ////SHIP GUNS////
 
-//50 Cal. guns
+//50 Cal. guns, currently not used
 /obj/item/circuitboard/machine/anti_air
-	name = "PDC turret (circuitboard)"
+	name = "PDC turret (Machine Board)"
 	req_components = list(
 		/obj/item/stack/sheet/mineral/titanium = 20,
 		/obj/item/stack/sheet/mineral/copper = 10,
@@ -114,7 +114,7 @@
 	return ..()
 
 /obj/item/circuitboard/machine/anti_air/heavy
-	name = "RPDC (circuitboard)"
+	name = "RPDC (Machine Board)"
 	req_components = list(
 		/obj/item/stack/sheet/mineral/titanium = 40,
 		/obj/item/stack/sheet/mineral/copper = 40,
@@ -123,36 +123,39 @@
 		/obj/item/stack/cable_coil = 5)
 	build_path = /obj/machinery/ship_weapon/anti_air/heavy
 
-//PDC and flak boards, currently not used
+//PDC and flak boards
 #define PATH_PDC /obj/machinery/ship_weapon/pdc_mount
 #define PATH_FLAK  /obj/machinery/ship_weapon/pdc_mount/flak
 
 /obj/item/circuitboard/machine/pdc_mount
-	name = "circuit board (pdc mount)"
+	name = "PDC loading rack (Machine Board)"
 	desc = "You can use a screwdriver to switch between PDC and flak."
 	req_components = list(
 		/obj/item/stock_parts/manipulator = 4,
 		/obj/item/stock_parts/capacitor = 2,
 		/obj/item/stock_parts/matter_bin = 3,
-		/obj/item/ship_weapon/parts/firing_electronics = 1
 	)
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
+	build_path = PATH_PDC
 
+/*  //Not using flak right now
 /obj/item/circuitboard/machine/pdc_mount/Initialize(mapload)
 	. = ..()
 	if(!build_path)
 		if(prob(50))
-			name = "PDC Loading Rack (Machine Board)"
+			name = "PDC loading rack (Machine Board)"
 			build_path = PATH_PDC
 		else
-			name = "Flak Loading Rack (Machine Board)"
+			name = "Flak loading rack (Machine Board)"
 			build_path = PATH_FLAK
+*/
 
 /obj/item/circuitboard/machine/pdc_mount/Destroy(force=FALSE)
 	if(!force)
 		return QDEL_HINT_LETMELIVE
 	return ..()
 
+/* Flak isn't used right now
 /obj/item/circuitboard/machine/pdc_mount/attackby(obj/item/I, mob/user, params)
 	if(I.tool_behaviour == TOOL_SCREWDRIVER)
 		var/obj/item/circuitboard/new_type
@@ -169,10 +172,7 @@
 		I.play_tool_sound(src)
 		to_chat(user, "<span class='notice'>You change the circuitboard setting to \"[new_setting]\".</span>")
 		return
-
-/obj/item/circuitboard/machine/pdc_mount
-	name = "PDC Mount (Machine Board)"
-	build_path = PATH_PDC
+*/
 
 /obj/item/circuitboard/machine/pdc_mount/flak
 	name = "Flak Loading Rack (Machine Board)"
@@ -183,7 +183,7 @@
 
 //Deck Gun
 /obj/item/circuitboard/machine/deck_turret
-	name = "deck gun turret (circuitboard)"
+	name = "deck gun turret (Machine Board)"
 	req_components = list()
 	build_path = /obj/machinery/ship_weapon/deck_turret
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
@@ -197,7 +197,7 @@
 	return ..()
 
 /obj/item/circuitboard/computer/deckgun
-	name = "Deck gun loading computer (circuit)"
+	name = "deck gun loading computer (Machine Board)"
 	build_path = /obj/machinery/computer/deckgun
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
 
@@ -207,7 +207,7 @@
 	return ..()
 
 /obj/item/circuitboard/machine/deck_gun
-	name = "Deck gun core (circuitboard)"
+	name = "deck gun core (Machine Board)"
 	req_components = list(
 		/obj/item/stack/sheet/mineral/titanium = 10,
 		/obj/item/stack/cable_coil = 5)
@@ -221,7 +221,7 @@
 	return ..()
 
 /obj/item/circuitboard/machine/deck_gun/powder
-	name = "Deck gun powder gate (circuitboard)"
+	name = "deck gun powder gate (Machine Board)"
 	req_components = list(
 		/obj/item/stack/sheet/iron = 20,
 		/obj/item/stack/sheet/mineral/copper = 20,
@@ -230,7 +230,7 @@
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
 
 /obj/item/circuitboard/machine/deck_gun/payload
-	name = "Deck gun payload gate (circuitboard)"
+	name = "deck gun payload gate (Machine Board)"
 	req_components = list(
 		/obj/item/stack/sheet/iron = 20,
 		/obj/item/stack/sheet/mineral/titanium = 5,
@@ -244,7 +244,7 @@
 // Inertial dampeners
 
 /obj/item/circuitboard/machine/inertial_dampener
-	name = "inertial dampener (circuitboard)"
+	name = "inertial dampener (Machine Board)"
 	req_components = list(
 		/obj/item/stock_parts/scanning_module = 2,
 		/obj/item/stack/ore/bluespace_crystal = 2,
@@ -255,7 +255,7 @@
 
 //Upgrades
 /obj/item/circuitboard/machine/deck_gun/autoelevator
-	name = "Deck gun auto-elevator (circuitboard)"
+	name = "deck gun auto-elevator (Machine Board)"
 	req_components = list(
 		/obj/item/stack/sheet/mineral/titanium = 40,
 		/obj/item/stack/sheet/mineral/copper = 20,
@@ -264,7 +264,7 @@
 	build_path = /obj/machinery/deck_turret/autoelevator
 
 /obj/item/circuitboard/machine/deck_gun/autorepair
-	name = "Deck gun auto-repair module (circuitboard)"
+	name = "deck gun auto-repair module (Machine Board)"
 	req_components = list(
 		/obj/item/stack/sheet/mineral/titanium = 40,
 		/obj/item/stack/sheet/mineral/copper = 20,
@@ -275,30 +275,30 @@
 
 //Missile factory
 /obj/item/circuitboard/machine/missile_builder
-	name = "Seegson model 'Ford' robotic autowrench (board)"
+	name = "Seegson model 'Ford' robotic autowrench (Machine Board)"
 	build_path = /obj/machinery/missile_builder
 	req_components = list()
 	needs_anchored = FALSE
 
 /obj/item/circuitboard/machine/missile_builder/wirer
-	name = "Seegson model 'Ford' robotic autowirer (board)"
+	name = "Seegson model 'Ford' robotic autowirer (Machine Board)"
 	build_path = /obj/machinery/missile_builder/wirer
 
 /obj/item/circuitboard/machine/missile_builder/welder
-	name = "Seegson model 'Ford' robotic autowelder (board)"
+	name = "Seegson model 'Ford' robotic autowelder (Machine Board)"
 	build_path = /obj/machinery/missile_builder/welder
 
 /obj/item/circuitboard/machine/missile_builder/screwdriver
-	name = "Seegson model 'Ford' robotic bolt driver (board)"
+	name = "Seegson model 'Ford' robotic bolt driver (Machine Board)"
 	build_path = /obj/machinery/missile_builder/screwdriver
 
 /obj/item/circuitboard/machine/missile_builder/assembler
-	name = "Seegson model 'Ford' robotic missile assembly arm (board)"
+	name = "Seegson model 'Ford' robotic missile assembly arm (Machine Board)"
 	build_path = /obj/machinery/missile_builder/assembler
 
 //Missile system
 /obj/item/circuitboard/machine/vls
-	name = "M14 VLS Tube (Circuitboard)"
+	name = "M14 VLS Tube (Machine Board)"
 	build_path = /obj/machinery/ship_weapon/vls
 	req_components = list(
 		/obj/item/stack/sheet/mineral/titanium = 20,
@@ -314,7 +314,7 @@
 
 //Gauss guns
 /obj/item/circuitboard/machine/gauss_turret
-	name = "gauss gun turret (circuitboard)"
+	name = "Gauss gun turret (Machine Board)"
 	build_path = /obj/machinery/ship_weapon/gauss_gun
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
 
@@ -324,12 +324,12 @@
 	return ..()
 
 /obj/item/circuitboard/computer/iff
-	name = "IFF Console (circuit)"
+	name = "IFF Console (Machine Board)"
 	build_path = /obj/machinery/computer/iff_console
 
 //Coffee Machine - Navy's Lifeblood
 /obj/item/circuitboard/machine/coffeemaker
-	name = "Coffeemaker (Machine Board)"
+	name = "coffeemaker (Machine Board)"
 	icon_state = "service"
 	build_path = /obj/machinery/coffeemaker
 	req_components = list(
@@ -354,7 +354,7 @@
 //Plasma Caster and Loader
 
 /obj/item/circuitboard/machine/plasma_loader
-	name = "Phoron Gas Regulator (Machine Board)"
+	name = "phoron gas regulator (Machine Board)"
 	build_path = /obj/machinery/atmospherics/components/unary/plasma_loader
 	var/pipe_layer = PIPING_LAYER_DEFAULT
 	req_components = list(
@@ -372,7 +372,7 @@
 	. += "<span class='notice'>It is set to layer [pipe_layer].</span>"
 
 /obj/item/circuitboard/machine/plasma_caster
-	name = "circuit board (plasma caster)"
+	name = "plasma caster (Machine Board)"
 	desc = "My faithful...stand firm!"
 	req_components = list(
 		/obj/item/stack/sheet/mineral/titanium = 25,
@@ -389,7 +389,7 @@
 
 // Laser PD console
 /obj/item/circuitboard/computer/laser_pd
-	name = "point defense laser console (circuit)"
+	name = "point defense laser console (Machine Board)"
 	build_path = /obj/machinery/computer/laser_pd
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
 
@@ -400,7 +400,7 @@
 
 // Laser PD
 /obj/item/circuitboard/machine/laser_pd
-	name = "point defense laser turret (circuitboard)"
+	name = "point defense laser turret (Machine Board)"
 	build_path = /obj/machinery/ship_weapon/energy/laser_pd
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
 	req_components = list(
@@ -410,7 +410,7 @@
 
 // Smelter and console
 /obj/item/circuitboard/machine/processing_unit
-	name = "circuit board (furnace)"
+	name = "furnace (Machine Board)"
 	desc = "It melts and purifies ores."
 	req_components = list(
 		/obj/item/stock_parts/micro_laser = 1,
@@ -420,7 +420,7 @@
 	build_path = /obj/machinery/mineral/processing_unit
 
 /obj/item/circuitboard/machine/processing_unit_console
-	name = "circuit board (furnace console)"
+	name = "furnace console (Machine Board)"
 	desc = "Circuit for a furnace control console."
 	req_components = list(
 		/obj/item/stack/sheet/glass = 1,
@@ -430,7 +430,7 @@
 
 //Non-magic chem dispenser
 /obj/item/circuitboard/machine/refillable_chem_dispenser
-	name = "refillable chem dispenser (machine board)"
+	name = "refillable chem dispenser (Machine Board)"
 	icon_state = "medical"
 	build_path = /obj/machinery/refillable_chem_dispenser
 	req_components = list(
@@ -446,7 +446,7 @@
 
 //Bot navbeacon
 /obj/item/circuitboard/machine/navbeacon
-	name = "Bot Navigational Beacon"
+	name = "Bot Navigational Beacon Machine Board"
 	icon_state = "science"
 	build_path = /obj/machinery/navbeacon
 	req_components = list()


### PR DESCRIPTION
## About The Pull Request

It does those things in the title, now we can build PDC with just the mount board instead of needing firing electronics as well, as intended in the munitions shop update
Also commented out the ability to switch to flak boards since they are not meant to be available right now.

## Why It's Good For The Game

This is how I though it worked already anyway and also consistent naming is cool and good.

## Changelog
:cl:
del: Removed the requirement for firing electronics from PDC
del: Removed the option to switch PDC to flak boards as they are not in use
spellcheck: Fixed inconsistencies in NSV circuitboard names
/:cl:
