### PR TITLE
Fixes runtime error when destroying and building gauss turrets

### DIFF
--- a/nsv13/code/game/objects/items/nsv_circuitboards.dm
+++ b/nsv13/code/game/objects/items/nsv_circuitboards.dm
@@ -316,6 +316,7 @@
 /obj/item/circuitboard/machine/gauss_turret
 	name = "gauss gun turret (circuitboard)"
 	build_path = /obj/machinery/ship_weapon/gauss_gun
+	req_components = list()
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
 
 /obj/item/circuitboard/machine/gauss_turret/Destroy(force=FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR fixes a runtime error I encountered while trying to recreate another bug that was reported a few weeks back. 

The runtime error in question was this:

![Skärmbild 2024-02-29 101248](https://github.com/BeeStation/NSV13/assets/59128051/7adc39f6-fe0a-4807-9d17-7dbdbdfd2362)

I fixed it by giving the machine board for the gauss turret an empty req_components list.
Side effect of fixing it seemed to make the turret itself now leave behind a wired machine frame alongside the board instead of just the board.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes it less resource consuming to rebuild a destroyed gauss turret since it now leaves behind the machine frame that had been used to build it.
Makes the construction and destruction of the gauss turret not produce a runtime error.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Go hit a gauss turret until it's destroyed.

![Skärmbild 2024-02-29 110751](https://github.com/BeeStation/NSV13/assets/59128051/8f614ead-5c1b-40c9-9e3c-1f708e013431)

</details>

## Changelog
:cl:
fix: The destruction of a gauss turret now leaves behind the machine frame that had been used to construct it.
code: Gave the machine board of the gauss turret a req_components list with nothing inside it to prevent a runtime error from occurring.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
