### PR TITLE
Makes it so the Aetherwhisp lasers have circuit boards and don't get deleted upon deconstruction.

### DIFF
--- a/nsv13/code/game/objects/items/nsv_circuitboards.dm
+++ b/nsv13/code/game/objects/items/nsv_circuitboards.dm
@@ -410,7 +410,7 @@
 
 // Laser AMS
 /obj/item/circuitboard/machine/laser_ams
-	name = "laser anti missile system (circuitboard)"
+	name = "laser AMS (circuitboard)"
 	build_path = /obj/machinery/ship_weapon/energy/ams
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
 	req_components = list(

--- a/nsv13/code/game/objects/items/nsv_circuitboards.dm
+++ b/nsv13/code/game/objects/items/nsv_circuitboards.dm
@@ -408,6 +408,42 @@
 		/obj/item/stock_parts/cell = 5,
 		/obj/item/stack/ore/bluespace_crystal = 5)
 
+// Laser AMS
+/obj/item/circuitboard/machine/laser_ams
+	name = "laser anti missile system (circuitboard)"
+	build_path = /obj/machinery/ship_weapon/energy/ams
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
+	req_components = list(
+		/obj/item/stack/sheet/glass = 5,
+		/obj/item/stock_parts/micro_laser = 5,
+		/obj/item/stock_parts/capacitor = 5,
+		/obj/item/stock_parts/cell = 5,
+		/obj/item/stack/ore/bluespace_crystal = 5)
+
+// Phase Cannon
+/obj/item/circuitboard/machine/phase_cannon
+	name = "phase cannon (circuitboard)"
+	build_path = /obj/machinery/ship_weapon/energy/beam
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
+	req_components = list(
+		/obj/item/stack/sheet/glass = 5,
+		/obj/item/stock_parts/micro_laser = 5,
+		/obj/item/stock_parts/capacitor = 5,
+		/obj/item/stock_parts/cell = 5,
+		/obj/item/stack/ore/bluespace_crystal = 5)
+
+// Burst Phaser
+/obj/item/circuitboard/machine/burst_phaser
+	name = "burst phaser MK2 (circuitboard)"
+	build_path = /obj/machinery/ship_weapon/energy
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
+	req_components = list(
+		/obj/item/stack/sheet/glass = 3,
+		/obj/item/stock_parts/micro_laser = 3,
+		/obj/item/stock_parts/capacitor = 3,
+		/obj/item/stock_parts/cell = 3,
+		/obj/item/stack/ore/bluespace_crystal = 3)
+
 // Smelter and console
 /obj/item/circuitboard/machine/processing_unit
 	name = "circuit board (furnace)"

--- a/nsv13/code/modules/munitions/ship_weapons/energy_weapons/laser_ams.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/energy_weapons/laser_ams.dm
@@ -5,6 +5,7 @@
 	icon_state = "missile_cannon"
 	fire_mode = FIRE_MODE_AMS_LASER //Shot automatically
 	ammo_type = /obj/item/ship_weapon/ammunition/railgun_ammo
+	circuit = /obj/item/circuitboard/machine/laser_ams
 	bound_width = 64
 	pixel_x = -32
 	pixel_y = -32

--- a/nsv13/code/modules/munitions/ship_weapons/energy_weapons/phaser.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/energy_weapons/phaser.dm
@@ -5,6 +5,7 @@
 	icon_state = "phase_cannon"
 	fire_mode = FIRE_MODE_RED_LASER //Shot by the pilot.
 	ammo_type = /obj/item/ship_weapon/ammunition/railgun_ammo
+	circuit = /obj/item/circuitboard/machine/burst_phaser
 	bound_width = 64
 	pixel_x = -32
 	pixel_y = -32
@@ -27,6 +28,7 @@
 	icon_state = "ion_cannon"
 	fire_mode = FIRE_MODE_BLUE_LASER
 	energy_weapon_type = /datum/ship_weapon/phaser
+	circuit = /obj/item/circuitboard/machine/phase_cannon
 	charge_rate = 600000 // At power level 5, requires 3MW per tick to charge
 	charge_per_shot = 4000000 // At power level 5, requires 20MW total to fire, takes about 12 seconds to gain 1 charge
 	max_charge = 8000000 // Store 2 charges


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR Fixes #2581
It does this by giving the phaser weapons circuit boards alongside stock parts required to construct them, I'm all ears for feedback as to what would be a fair amount of required components for them but currently they have the following requirements:

Laser AMS:
* 5 Sheets of Glass
* 5 Micro Lasers
* 5 Capacitors
* 5 Power Cells
* 5 Bluespace Crystals

Phase Cannon:
* 5 Sheets of Glass
* 5 Micro Lasers
* 5 Capacitors
* 5 Power Cells
* 5 Bluespace Crystals

Burst Phasers:
* 3 Sheets of Glass
* 3 Micro Lasers
* 3 Capacitors
* 3 Power Cells
* 3 Bluespace Crystals

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The ability to keep the round from having to end due to the phaser weapons being unable to be reconstructed the second they get destroyed is quite the good thing I would say.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Phase Cannon
![Skärmbild 2024-03-05 100743](https://github.com/BeeStation/NSV13/assets/59128051/b44c1b4a-3f69-4c35-8859-f4313b101db0)

Laser AMS (Board is now named laser AMS to shorten the lengthy name for the board down)
![Skärmbild 2024-03-05 100718](https://github.com/BeeStation/NSV13/assets/59128051/a334b550-5b0e-471b-b7e2-a66a99393b67)

Burst Phasers
![Skärmbild 2024-03-05 100645](https://github.com/BeeStation/NSV13/assets/59128051/a8696c9d-21ba-4320-a406-d52bf61b1d99)

</details>

## Changelog
:cl:
add: Gave the Aetherwhisp laser weaponry circuit boards so they don't get completely round removed when destroyed,
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
