### PR TITLE
Fixes nucleium engine turfs not working

### DIFF
--- a/_maps/map_files/Aetherwhisp/Aetherwhisp2.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp2.dmm
@@ -7158,7 +7158,7 @@
 /obj/machinery/air_sensor/atmos{
 	id_tag = "ftl_sensor"
 	},
-/turf/open/floor/engine/nucleum,
+/turf/open/floor/engine/nucleium,
 /area/engine/engine_smes)
 "eSC" = (
 /obj/machinery/light_switch/east,
@@ -11299,7 +11299,7 @@
 /obj/machinery/camera/autoname{
 	dir = 8
 	},
-/turf/open/floor/engine/nucleum,
+/turf/open/floor/engine/nucleium,
 /area/engine/engine_smes)
 "hEV" = (
 /obj/machinery/atmospherics/components/binary/pump/layer4{
@@ -23106,7 +23106,7 @@
 	id_tag = "ftl_out";
 	internal_pressure_bound = 1000
 	},
-/turf/open/floor/engine/nucleum,
+/turf/open/floor/engine/nucleium,
 /area/engine/engine_smes)
 "pNP" = (
 /obj/machinery/door/firedoor/border_only/directional/west,

--- a/_maps/map_files/Galactica/Galactica2.dmm
+++ b/_maps/map_files/Galactica/Galactica2.dmm
@@ -6112,7 +6112,7 @@
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
-/turf/open/floor/engine/nucleum,
+/turf/open/floor/engine/nucleium,
 /area/engine/engineering/reactor_core)
 "dko" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -6540,7 +6540,7 @@
 /obj/machinery/air_sensor/atmos{
 	id_tag = "nuclear_mix_sensor_3"
 	},
-/turf/open/floor/engine/nucleum,
+/turf/open/floor/engine/nucleium,
 /area/engine/engineering/reactor_core)
 "dwn" = (
 /obj/machinery/door/airlock/turbolift/ship{
@@ -14867,7 +14867,7 @@
 /turf/open/floor/durasteel/techfloor_grid,
 /area/maintenance/disposal)
 "hNt" = (
-/turf/open/floor/engine/nucleum,
+/turf/open/floor/engine/nucleium,
 /area/engine/engineering/reactor_core)
 "hNy" = (
 /obj/machinery/door/airlock/ship/maintenance{
@@ -18151,7 +18151,7 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos{
 	id = "nuclear_mix_in_3"
 	},
-/turf/open/floor/engine/nucleum,
+/turf/open/floor/engine/nucleium,
 /area/engine/engineering/reactor_core)
 "jBK" = (
 /obj/machinery/computer/station_alert{
@@ -37665,7 +37665,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/engine/nucleum,
+/turf/open/floor/engine/nucleium,
 /area/engine/engineering/reactor_core)
 "tTF" = (
 /obj/effect/spawner/room/threexfive,
@@ -40402,7 +40402,7 @@
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
-/turf/open/floor/engine/nucleum,
+/turf/open/floor/engine/nucleium,
 /area/engine/engineering/reactor_core)
 "vok" = (
 /obj/machinery/light{

--- a/_maps/map_files/Gladius/Gladius2.dmm
+++ b/_maps/map_files/Gladius/Gladius2.dmm
@@ -4147,9 +4147,9 @@
 "cGo" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 8;
-	id = "nucleum_in"
+	id = "nucleium_in"
 	},
-/turf/open/floor/engine/nucleum,
+/turf/open/floor/engine/nucleium,
 /area/engine/engineering/ftl_room)
 "cGs" = (
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess{
@@ -10011,7 +10011,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
 	dir = 8;
-	name = "Nucleum Exhaust Cooler"
+	name = "Nucleium Exhaust Cooler"
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering/ftl_room)
@@ -25594,10 +25594,10 @@
 "oGG" = (
 /obj/machinery/computer/atmos_control/tank/sm{
 	dir = 8;
-	input_tag = "nucleum_in";
-	name = "Nucleum Tank Monitor";
-	output_tag = "nucleum_out";
-	sensors = list("nucleum"="Nucleum")
+	input_tag = "nucleium_in";
+	name = "Nucleium Tank Monitor";
+	output_tag = "nucleium_out";
+	sensors = list("nucleium"="Nucleium")
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering/ftl_room)
@@ -36621,9 +36621,9 @@
 /area/quartermaster/miningoffice)
 "uIu" = (
 /obj/machinery/air_sensor/atmos/nucleium_tank{
-	id_tag = "nucleum"
+	id_tag = "nucleium"
 	},
-/turf/open/floor/engine/nucleum,
+/turf/open/floor/engine/nucleium,
 /area/engine/engineering/ftl_room)
 "uII" = (
 /obj/machinery/newscaster/directional/west,
@@ -36888,9 +36888,9 @@
 /area/chapel/main)
 "uSa" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nucleium_output{
-	id_tag = "nucleum_out"
+	id_tag = "nucleium_out"
 	},
-/turf/open/floor/engine/nucleum,
+/turf/open/floor/engine/nucleium,
 /area/engine/engineering/ftl_room)
 "uSh" = (
 /obj/effect/turf_decal/stripes/line{

--- a/_maps/map_files/Tycoon/Tycoon2.dmm
+++ b/_maps/map_files/Tycoon/Tycoon2.dmm
@@ -45668,7 +45668,7 @@
 /obj/machinery/air_sensor/atmos{
 	id_tag = "FTLsensor"
 	},
-/turf/open/floor/engine/nucleum,
+/turf/open/floor/engine/nucleium,
 /area/engine/engineering/reactor_core)
 "kuw" = (
 /obj/machinery/light{
@@ -51535,7 +51535,7 @@
 	id_tag = "FTLoutput";
 	on = 0
 	},
-/turf/open/floor/engine/nucleum,
+/turf/open/floor/engine/nucleium,
 /area/engine/engineering/reactor_core)
 "tmT" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
@@ -52776,7 +52776,7 @@
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
-/turf/open/floor/engine/nucleum,
+/turf/open/floor/engine/nucleium,
 /area/engine/engineering/reactor_core)
 "vii" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{

--- a/nsv13/code/__DEFINES/atmospherics.dm
+++ b/nsv13/code/__DEFINES/atmospherics.dm
@@ -1,4 +1,4 @@
 #define ATMOS_GAS_MONITOR_INPUT_NUCLEIUM "nucleium_in"
 #define ATMOS_GAS_MONITOR_OUTPUT_NUCLEIUM "nucleium_out"
 #define ATMOS_GAS_MONITOR_SENSOR_NUCLEIUM "nucleium_sensor"
-#define ATMOS_TANK_NUCLEUM		"nucleum=750;TEMP=293.15"
+#define ATMOS_TANK_NUCLEIUM		"nucleium=750;TEMP=293.15"

--- a/nsv13/code/game/turfs/custom_turfs.dm
+++ b/nsv13/code/game/turfs/custom_turfs.dm
@@ -167,6 +167,6 @@
 		return OM.check_overmap_elegibility(ignore_position = TRUE)
 	return ..()
 
-/turf/open/floor/engine/nucleum
-	name = "Nucleum Floor"
-	initial_gas_mix = ATMOS_TANK_NUCLEUM
+/turf/open/floor/engine/nucleium
+	name = "Nucleium Floor"
+	initial_gas_mix = ATMOS_TANK_NUCLEIUM

--- a/tgui/packages/tgui/interfaces/StormdriveConsole.js
+++ b/tgui/packages/tgui/interfaces/StormdriveConsole.js
@@ -271,7 +271,7 @@ export const StormdriveConsole = (props, context) => {
                         {toFixed((data.pluoxium/data.total_moles) * 100) + ' %'}
                       </ProgressBar>
                     </LabeledList.Item>
-                    <LabeledList.Item label="Nucleum">
+                    <LabeledList.Item label="Nucleium">
                       <ProgressBar
                         value={(data.nucleium/data.total_moles) * 100}
                         minValue={0}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Soooo it appears someone or a few someones write "Nucleium" as "Nucleum", which has led to a few broken things, including a bunch of runtimes during atmos init for any ship with floors that are supposed to have nucleium, since.. nucleum doesn't exist.

This replaces every single mention of "nucleum" on any map / code with "nucleium" as I could just adjust the few lines that runtime, but keeping it that way would ensure someone reads an incorrect line & creates the same situation again.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
. .. .


## Changelog
:cl:
fix: Nucleium engine turfs now work. As may some other map cases of "nucleum" being used as incorrect term.
spellcheck: "nucleum" -> "nucleium"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
