### PR TITLE
Fixes fighters not receiving relayed overmap alerts

### DIFF
--- a/nsv13/code/modules/antagonists/role_preference/role_antagonists.dm
+++ b/nsv13/code/modules/antagonists/role_preference/role_antagonists.dm
@@ -3,5 +3,5 @@
 	antag_datum = /datum/antagonist/bloodling
 
 /datum/role_preference/antagonist/pvp
-	name = "Galactic Conquest"
+	name = "Syndicate Crewmember (Galactic Conquest)"
 	antag_datum = /datum/antagonist/nukeop/syndi_crew

--- a/nsv13/code/modules/overmap/overmap.dm
+++ b/nsv13/code/modules/overmap/overmap.dm
@@ -821,10 +821,16 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 				SEND_SOUND(M, sound(S, repeat = loop, wait = 0, volume = 100))
 		if(message)
 			to_chat(M, message)
+	for(var/obj/structure/overmap/O as() in overmaps_in_ship) //Of course they get relayed the same message if they're in the same ship too
+		if(length(O.mobs_in_ship))
+			O.relay(args)
 
 /obj/structure/overmap/proc/stop_relay(channel) //Stops all playing sounds for crewmen on N channel.
 	for(var/mob/M as() in mobs_in_ship)
 		M.stop_sound_channel(channel)
+	for(var/obj/structure/overmap/O as() in overmaps_in_ship) //Of course they get relayed the same message if they're in the same ship too
+		if(length(O.mobs_in_ship))
+			O.stop_relay(args)
 
 /obj/structure/overmap/proc/relay_to_nearby(S, message, ignore_self=FALSE, sound_range=20, faction_check=FALSE) //Sends a sound + text message to nearby ships
 	for(var/obj/structure/overmap/ship as() in GLOB.overmap_objects) //Might be called in hyperspace or by fighters, so shouldn't use a system check.


### PR DESCRIPTION
## About The Pull Request

Also fixes the name of the Syndicate crew antagonist option to be more clear it's about Galactic Conquest.
Fixes #2456 

## Why It's Good For The Game

Yes

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: Fixed fighters not hearing overmap messages from their mothership.
spellcheck: Made it clear the Syndicate Crew antag preference is for PVP
/:cl: