### PR TITLE
Relayed BSA is more 'fun' and also random fixes.

### DIFF
--- a/_maps/map_files/Eclipse/Eclipse1.dmm
+++ b/_maps/map_files/Eclipse/Eclipse1.dmm
@@ -262,7 +262,7 @@
 "bp" = (
 /obj/structure/closet/crate/large,
 /obj/effect/spawner/lootdrop/maintenance/four,
-/obj/item/robot_module/borgi,
+/obj/item/borg/upgrade/transform/borgi,
 /turf/open/floor/plasteel/dark/side,
 /area/construction)
 "br" = (

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -51,7 +51,7 @@
 	destination.dna.features = features.Copy()
 	destination.dna.real_name = real_name
 	destination.dna.temporary_mutations = temporary_mutations.Copy()
-	destination.flavour_text = destination.client.prefs.active_character.flavor_text //Update the flavor_text to use new dna text //NSV13
+	destination.flavour_text = holder ? holder.flavour_text : "" //Update the flavor_text to use new dna text //NSV13
 	if(transfer_SE)
 		destination.dna.mutation_index = mutation_index
 		destination.dna.default_mutation_genes = default_mutation_genes

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -37,6 +37,11 @@
 
 	var/list/dent_decals
 
+	//NSV13 - avoid runtiming from doafter stack.
+	///Is this wall currently being interacted with (cleaned / deconned / etc)
+	var/interacting = FALSE
+	//NSV13 end
+
 /turf/closed/wall/Initialize(mapload)
 	. = ..()
 	if(is_station_level(z))
@@ -175,13 +180,24 @@
 	if(!isturf(user.loc))
 		return	//can't do this stuff whilst inside objects and such
 
+
+	if(interacting) //NSV 13 - the doafters in here can change the type of the turf, which WILL runtime if you let them stack.
+		return
+
 	add_fingerprint(user)
 
 	var/turf/T = user.loc	//get user's location for delay checks
 
+	//NSV13 - src type changes which must be accounted for here.
+	interacting = TRUE
 	//the istype cascade has been spread among various procs for easy overriding
-	if(try_clean(W, user, T) || try_wallmount(W, user, T) || try_decon(W, user, T) || try_destroy(W, user, T))
+	if(try_clean(W, user, T) || try_wallmount(W, user, T))
+		interacting = FALSE
 		return
+	if(try_decon(W, user, T) || try_destroy(W, user, T))
+		return //interacting is NOT set here because if either of these two is TRUE, this is no longer of the same type.
+	interacting = FALSE
+	//NSV13 end.
 
 	return ..()
 

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -195,7 +195,9 @@
 		interacting = FALSE
 		return
 	if(try_decon(W, user, T) || try_destroy(W, user, T))
-		return //interacting is NOT set here because if either of these two is TRUE, this is no longer of the same type.
+		if(istype(src, /turf/closed/wall)) //I hate this.
+			interacting = FALSE //Set interacting only if the wall is still a wall.
+		return
 	interacting = FALSE
 	//NSV13 end.
 

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -474,7 +474,12 @@
 		if(clipboard.pen)
 			holding = clipboard.pen
 
-	data["held_item_details"] = holding?.get_writing_implement_details()
+	//NSV13 - Old part here runtimes.
+	if(holding)
+		data["held_item_details"] = holding.get_writing_implement_details()
+	else
+		data["held_item_details"] = null //Overriding old data, otherwise data would not get changed.
+	//NSV13 end.
 
 	// If the paper is on an unwritable noticeboard, clear the held item details so it's read-only.
 	if(istype(loc, /obj/structure/noticeboard))

--- a/nsv13/code/modules/munitions/ship_weapons/energy_weapons/bsa.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/energy_weapons/bsa.dm
@@ -205,6 +205,7 @@
 	impact_type = /obj/effect/projectile/impact/bsa
 	movement_type = FLYING
 	projectile_piercing = ALL
+	relay_projectile_type = /obj/item/projectile/beam/laser/heavylaser/bsa/relayed
 
 /obj/effect/projectile/muzzle/bsa
 	alpha = 0
@@ -216,3 +217,13 @@
 /obj/effect/projectile/impact/bsa
 	name = "bsa"
 	icon_state = "bsa_impact"
+
+/obj/item/projectile/beam/laser/heavylaser/bsa/relayed
+	projectile_piercing = PASSGLASS|PASSGRILLE|PASSTABLE
+
+/obj/item/projectile/beam/laser/heavylaser/bsa/relayed/on_hit(atom/target, blocked)
+	. = ..()
+	if(isliving(target))
+		var/mob/living/goodbye = target
+		goodbye.dust(TRUE, FALSE)
+	explosion(get_turf(target), 6, 8, 9, 12, ignorecap = TRUE, flame_range = 6) //I have to keep myself from letting it just truncate ships because thats a bit annoying to fix for the receiving side, even if accurate to appearance.

--- a/nsv13/code/modules/overmap/traders.dm
+++ b/nsv13/code/modules/overmap/traders.dm
@@ -284,24 +284,24 @@
 		stonks -= x
 		qdel(x)
 	sold_items = list()
-	while(iter)
+	var/fails = 0
+	while(iter && fails < 10)
 		iter--
 		var/datum/trader_item/item = new
 		var/obj/item/a_gift/anything/generator = new
-		var/initialtype = generator.get_gift_type()
-		var/obj/item/soldtype = new initialtype
-		if(!soldtype) //spawned something that deleted itself, try again
-			log_runtime("Randy failed to spawn [initialtype]!")
+		var/obj/item/initialtype = generator.get_gift_type() //If you put any non-items in here I will haunt you.
+		if(!initialtype) //failed to select something, try again
+			log_runtime("Randy failed to select an item!")
 			qdel(item)
 			iter++
+			fails++ //DO NOT loop forever.
 			continue
 		item.unlock_path = initialtype
-		item.name = soldtype.name
-		item.desc = soldtype.desc
+		item.name = initial(initialtype.name)
+		item.desc = initial(initialtype.desc)
 		item.price = rand(1000, 100000000)
 		item.stock = rand(1, 5)
 		item.owner = src
-		qdel(soldtype)
 		sold_items += item
 
 	var/datum/trader_item/yellow_pages/pages = new

--- a/nsv13/code/modules/power/stormdrive.dm
+++ b/nsv13/code/modules/power/stormdrive.dm
@@ -586,7 +586,7 @@ Control Rods
 	var/datum/gas_mixture/air1 = airs[1]
 	var/nucleium_power_reduction = 0
 
-	var/fuel_check = ((air1.get_moles(GAS_PLASMA) + air1.get_moles(GAS_CONSTRICTED_PLASMA) + air1.get_moles(GAS_TRITIUM)) / air1.total_moles()) * 100
+	var/fuel_check = air1.total_moles() <= 0 ? 0 : ((air1.get_moles(GAS_PLASMA) + air1.get_moles(GAS_CONSTRICTED_PLASMA) + air1.get_moles(GAS_TRITIUM)) / air1.total_moles()) * 100
 	if(air1.total_moles() >= reaction_rate && fuel_check >= 12.5) //1:8 ratio
 		var/datum/gas_mixture/reaction_chamber_gases = air1.remove(reaction_rate)
 

--- a/nsv13/code/modules/squads/squad_manager.dm
+++ b/nsv13/code/modules/squads/squad_manager.dm
@@ -52,7 +52,7 @@ GLOBAL_DATUM_INIT(squad_manager, /datum/squad_manager, new)
 // Try to find a squad that's not already tasked that can do the job
 /datum/squad_manager/proc/assign_squad(role)
 	var/datum/squad/assigned = role_squad_map[role]
-	if(assigned && length(assigned.members))
+	if(istype(assigned) && length(assigned.members))
 		assigned.lowpop_retasked = TRUE
 		assigned.access_enabled = TRUE // They won't be much help without this
 		return

--- a/nsv13/code/modules/squads/squad_manager.dm
+++ b/nsv13/code/modules/squads/squad_manager.dm
@@ -51,12 +51,14 @@ GLOBAL_DATUM_INIT(squad_manager, /datum/squad_manager, new)
 
 // Try to find a squad that's not already tasked that can do the job
 /datum/squad_manager/proc/assign_squad(role)
-	var/datum/squad/assigned = role_squad_map[role]
-	if(istype(assigned) && length(assigned.members))
-		assigned.lowpop_retasked = TRUE
-		assigned.access_enabled = TRUE // They won't be much help without this
-		return
-
+	var/list/assigned_list = role_squad_map[role]
+	if(length(assigned_list))
+		for(var/datum/squad/assigned in assigned_list)
+			if(!istype(assigned) || !length(assigned.members))
+				continue
+			assigned.lowpop_retasked = TRUE
+			assigned.access_enabled = TRUE // They won't be much help without this
+			return
 	//Prefer DC squads by default. Make sure there are people in them and we haven't tasked them already
 	var/list/possible = role_squad_map[DC_SQUAD]
 	for(var/datum/squad/S in possible)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
While the (true) BSA has a lot of oomph on the overmap itself, its actual effects when relayed are somewhat less interesting as it's effectively just a hitscan-penning NAC that leaves no trace once it passed. This gives it a large explosion and some rather unpleasant effects on direct hits instead.
I considered letting it actually truncate ships & spacing a line, but given we do have pvp content on the overmap sometimes (or if some bus contains a foe with a BSA), that'd be a bit rude . Also is similar to the effects when *someone* fires the thing with the shutters closed.

Also fixes a lot of random things that runtime since I test with pause on runtime enabled and also look at logs sometimes. Sidetracking my beloved.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Explosions are nice.

Also fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
No.

## Changelog
:cl:
balance: The BSA now goes kaboom when relayed instead of being essentially a ghost NAC shell.
fix: The Eclipse no longer spawns a borg module that should never exist outside of mobs.
fix: DNA no longer has some super weird code for flavor text, instead copying the one of the source mob.
tweak: You can no longer stack interactions on walls. This is to prevent a runtime from actions that modify the type of them (deconstruction mainly).
fix: Paper no longer runtimes if you do not have a pen in hand (???).
fix: Traders no longer do some cursed things to create their trade items, instead using the all-powerful initial().
fix: The stormdrive no longer runtimes if it has zero gas in it.
fix: Some squad assignment stuff shouldn't try to use a list as datum anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
