### PR TITLE
Stops brooms from breaking through the bluespace barrier

### DIFF
--- a/code/game/objects/items/broom.dm
+++ b/code/game/objects/items/broom.dm
@@ -62,14 +62,19 @@
 	if (locate(/obj/structure/table) in target.contents)
 		return
 	var/i = 0
-	var/turf/target_turf = get_step(target, user.dir)
+	//NSV13 - Illegal movement through space and time.
+	var/movedir = user.dir
+	movedir &= ~UP
+	movedir &= ~DOWN
+	var/turf/target_turf = get_step(target, movedir)
+	//NSV13 endish
 	var/obj/machinery/disposal/bin/target_bin = locate(/obj/machinery/disposal/bin) in target_turf.contents
 	for(var/obj/item/garbage in target.contents)
 		if(!garbage.anchored)
 			if (target_bin)
 				garbage.forceMove(target_bin)
 			else
-				garbage.Move(target_turf, user.dir)
+				garbage.Move(target_turf, movedir) //NSV13 - mild arg adjustment
 			i++
 		if(i > 19)
 			break


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Brooms currently have some very "fancy" and "reasonable" behavior when somebody using them runs up stairs. Also known as "displacing things that are up the stairs by one z level, regardless of there not actually being another z to the ship. Through roofs, floors, and or the fabric of the universe itself.
This fixes that.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
No.

## Changelog
:cl:
fix: Brooms can no longer bluespace things into space.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
