### PR TITLE
You can now emag the gravity generator (and fix it)

### DIFF
--- a/nsv13.dme
+++ b/nsv13.dme
@@ -4044,6 +4044,7 @@
 #include "nsv13\code\modules\overmap\weapons\weapons.dm"
 #include "nsv13\code\modules\paperwork\stamps.dm"
 #include "nsv13\code\modules\pixelshifting\pixelshifting.dm"
+#include "nsv13\code\modules\power\gravitygenerator_modular.dm"
 #include "nsv13\code\modules\power\lighting.dm"
 #include "nsv13\code\modules\power\power.dm"
 #include "nsv13\code\modules\power\stormdrive.dm"

--- a/nsv13/code/modules/power/gravitygenerator_modular.dm
+++ b/nsv13/code/modules/power/gravitygenerator_modular.dm
@@ -56,7 +56,7 @@
 	if(ishuman(user))
 		add_fibers(user) //Emagging this thing is close and personal work.
 	investigate_log("was emagged and will now generate 2G", INVESTIGATE_GRAVITY)
-	message_admins("The gravity generator was emagged by [user] (real name: [user.real_name])! [ADMIN_VERBOSEJMP(src)]")
+	message_admins("The gravity generator was emagged by [user] (real name: [user?.real_name])! [ADMIN_VERBOSEJMP(src)]")
 	return TRUE
 
 //Modular proc attachment

--- a/nsv13/code/modules/power/gravitygenerator_modular.dm
+++ b/nsv13/code/modules/power/gravitygenerator_modular.dm
@@ -42,7 +42,7 @@
 	if(!on)
 		to_chat(user, "<span class='notice'>[src] must be active to most efficiently override its controls.</span>")
 		return FALSE
-	to_chat(user, "<span class='notice'>You start messing eith [src]'s internals. This will take a moment to get done just right..")
+	to_chat(user, "<span class='notice'>You start messing eith [src]'s internals. This will take a moment to get done just right..</span>")
 	if(!do_after(user, 5 SECONDS, target = src, extra_checks = CALLBACK(src, PROC_REF(can_emag_generator))))
 		return FALSE
 	to_chat(user, "<span class='warning'>You override [src]'s safeties and crosswire it to double its target gravity.</span>")

--- a/nsv13/code/modules/power/gravitygenerator_modular.dm
+++ b/nsv13/code/modules/power/gravitygenerator_modular.dm
@@ -7,7 +7,7 @@
 	if(I?.tool_behaviour != TOOL_MULTITOOL)
 		return ..()
 	if(on || charge_count > 0 || charging_state == POWER_UP)
-		to_chat(user, "<span class='warning'>You should not mess with this device's circuitry while it is active!</span>")
+		to_chat(user, "<span class='warning'>You should not mess with [src]'s circuitry while it is active!</span>")
 		return TRUE
 	if(machine_stat & BROKEN)
 		to_chat(user, "<span class='notice'>Fix [src]'s chassis first.</span>")

--- a/nsv13/code/modules/power/gravitygenerator_modular.dm
+++ b/nsv13/code/modules/power/gravitygenerator_modular.dm
@@ -40,7 +40,7 @@
 	if(obj_flags & EMAGGED)
 		return FALSE
 	if(!on)
-		to_chat(user, "<span class='notice'>[src] must be active to most efficiently override its controls.</span>")
+		to_chat(user, "<span class='notice'>[src] must be active to override its controls.</span>")
 		return FALSE
 	to_chat(user, "<span class='notice'>You start messing with [src]'s internals. This will take a moment to get done just right..</span>")
 	if(!do_after(user, 5 SECONDS, target = src, extra_checks = CALLBACK(src, PROC_REF(can_emag_generator))))

--- a/nsv13/code/modules/power/gravitygenerator_modular.dm
+++ b/nsv13/code/modules/power/gravitygenerator_modular.dm
@@ -42,7 +42,7 @@
 	if(!on)
 		to_chat(user, "<span class='notice'>[src] must be active to most efficiently override its controls.</span>")
 		return FALSE
-	to_chat(user, "<span class='notice'>You start messing eith [src]'s internals. This will take a moment to get done just right..</span>")
+	to_chat(user, "<span class='notice'>You start messing with [src]'s internals. This will take a moment to get done just right..</span>")
 	if(!do_after(user, 5 SECONDS, target = src, extra_checks = CALLBACK(src, PROC_REF(can_emag_generator))))
 		return FALSE
 	to_chat(user, "<span class='warning'>You override [src]'s safeties and crosswire it to double its target gravity.</span>")

--- a/nsv13/code/modules/power/gravitygenerator_modular.dm
+++ b/nsv13/code/modules/power/gravitygenerator_modular.dm
@@ -1,0 +1,73 @@
+///This is the modular NSV file for gravity generators, to keep the base file more clear of conflicts.
+
+//Modular proc attachment
+/obj/machinery/gravity_generator/main/attackby(obj/item/I, mob/user, params)
+	if(!(obj_flags & EMAGGED))
+		return ..()
+	if(I?.tool_behaviour != TOOL_MULTITOOL)
+		return ..()
+	if(on || charge_count > 0 || charging_state == POWER_UP)
+		to_chat(user, "<span class='warning'>You should not mess with this device's circuitry while it is active!</span>")
+		return TRUE
+	if(machine_stat & BROKEN)
+		to_chat(user, "<span class='notice'>Fix [src]'s chassis first.</span>")
+		return TRUE
+	to_chat(user, "<span class='notice'>You start resetting [src]'s control circuits and safety protocols.</span>")
+	if(!do_after(user, 10 SECONDS, target = src, extra_checks = CALLBACK(src, PROC_REF(can_reset_generator))))
+		return TRUE
+	to_chat(user, "<span class='notice'>You reset [src]'s control circuits to default.</span>")
+	obj_flags &= (~EMAGGED)
+	change_setting(1)
+	ui_update()
+	if(ishuman(user))
+		add_fibers(user) //..Fixing this thing is ALSO close and personal work.
+	investigate_log("was reset while emagged and will now generate 1G", INVESTIGATE_GRAVITY)
+	return TRUE
+
+///Is this gravity generator in need of a reset right now, and is this a valid state for it to be reset in?
+/obj/machinery/gravity_generator/main/proc/can_reset_generator()
+	if(on || charge_count > 0 || charging_state == POWER_UP || !(obj_flags & EMAGGED) || (machine_stat & BROKEN))
+		return FALSE
+	return TRUE
+
+///Can this gravity generator be emagged right now?
+/obj/machinery/gravity_generator/main/proc/can_emag_generator()
+	if((obj_flags & EMAGGED) || !on)
+		return FALSE
+	return TRUE
+
+/obj/machinery/gravity_generator/main/emag_act(mob/user)
+	if(obj_flags & EMAGGED)
+		return FALSE
+	if(!on)
+		to_chat(user, "<span class='notice'>[src] must be active to most efficiently override its controls.</span>")
+		return FALSE
+	to_chat(user, "<span class='notice'>You start messing eith [src]'s internals. This will take a moment to get done just right..")
+	if(!do_after(user, 5 SECONDS, target = src, extra_checks = CALLBACK(src, PROC_REF(can_emag_generator))))
+		return FALSE
+	to_chat(user, "<span class='warning'>You override [src]'s safeties and crosswire it to double its target gravity.</span>")
+	charge_count = 0
+	set_state(0)
+	radiation_pulse(src, 1800) //You SHOULD wear protection when messing with this thing this badly.
+	obj_flags |= EMAGGED
+	change_setting(2) // :)
+	set_power(POWER_UP)
+	ui_update()
+	if(ishuman(user))
+		add_fibers(user) //Emagging this thing is close and personal work.
+	investigate_log("was emagged and will now generate 2G", INVESTIGATE_GRAVITY)
+	message_admins("The gravity generator was emagged by [user] (real name: [user.real_name])! [ADMIN_VERBOSEJMP(src)]")
+	return TRUE
+
+//Modular proc attachment
+/obj/machinery/gravity_generator/main/ui_data(mob/user)
+	. = ..()
+	.["emagged"] = (obj_flags & EMAGGED) ? TRUE : FALSE //Trinary for safety because bitfield checks do not return just a pure TRUE / FALSE.
+	.["theme"] = (obj_flags & EMAGGED) ? "syndicate " : "ntos"
+
+///Modular proc OVERRIDE
+/obj/machinery/gravity_generator/main/change_setting(value)
+	if(value != setting)
+		setting = value
+		if(on) //No reason to shake if grav is off.
+			shake_everyone()

--- a/tgui/packages/tgui/interfaces/GravityGenerator.js
+++ b/tgui/packages/tgui/interfaces/GravityGenerator.js
@@ -7,17 +7,27 @@ export const GravityGenerator = (props, context) => {
   const {
     charging_state,
     operational,
-  } = data;
+    emagged,
+    theme,
+  } = data; { /* NSV13 - added theme and emagged as vars*/ }
   return (
     <Window
       width={400}
-      height={600}>
+      height={600}
+      theme={theme}> {/* NSV13 - theme change on emag*/ }
       <Window.Content>
         {!operational && (
           <NoticeBox>
             No data available
           </NoticeBox>
         )}
+        {/* NSV13 - gravgen emag info*/ }
+        {!!operational && !!emagged && (
+          <NoticeBox danger>
+            {'ERR - GR&!%$$ %$&/(!%$) ?)!&$§ ERROR, #!&%# 2G'}
+          </NoticeBox>
+        )}
+        {/* NSV13 end*/ }
         {!!operational && charging_state !== 0 && (
           <NoticeBox danger>
             WARNING - Radiation detected


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title!
Using an emag on an active gravity generator after a few seconds of interaction will short out the generator and reboot it with some... slightly altered settings.
Very hazardous to do.
Inconveniencing for just about anyone once the generator is done charging (you should be gone by then), somewhat dangerous for people weak to high gravity.

To fix, take the generator offline (nondestructively) and carefully reset its firmware with a multitool.

Almost entirely modularized save for some changes to the JS, because I felt like writing modular code.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Ways for antagonists to antagonize without doing (almost) irreplaceable things ("space all the NACs haha!") are fun!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
No.

## Changelog
:cl:
add: The gravity generator now has an emag interaction (and a method to fix said interaction).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
