### PR TITLE
[BUGFIX] FTL Navigation Console is no longer able to be used everywhere

### DIFF
--- a/nsv13/code/modules/overmap/starmap.dm
+++ b/nsv13/code/modules/overmap/starmap.dm
@@ -48,7 +48,8 @@
 		ui.set_autoupdate(TRUE)
 
 /obj/machinery/computer/ship/navigation/ui_act(action, params, datum/tgui/ui)
-	if(..() && !IsAdminGhost(usr))
+	. = ..()
+	if(. && !IsAdminGhost(usr))
 		return
 	if(!linked)
 		return

--- a/nsv13/code/modules/overmap/starmap.dm
+++ b/nsv13/code/modules/overmap/starmap.dm
@@ -28,9 +28,6 @@
 		return TRUE
 	return ..()
 
-/obj/machinery/computer/ship/navigation/ui_state(mob/user)
-	return GLOB.always_state
-
 /obj/machinery/computer/ship/navigation/public
 	name = "Starmap Console"
 	desc = "A computer which shows the current position of the ship in the universe."
@@ -51,8 +48,7 @@
 		ui.set_autoupdate(TRUE)
 
 /obj/machinery/computer/ship/navigation/ui_act(action, params, datum/tgui/ui)
-	.=..()
-	if(isobserver(usr) && !IsAdminGhost(usr))
+	if(..() && !IsAdminGhost(usr))
 		return
 	if(!linked)
 		return


### PR DESCRIPTION
## About The Pull Request

fixes #2045
removes the always_state override from the FTL console and adds a missing parent check to ui_act()

## Why It's Good For The Game

![930fa64abea7372f70f8ee7453da222d](https://github.com/BeeStation/NSV13/assets/39193182/91a93522-aca9-4a0d-8bbc-fead14af41d1)

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/NSV13/assets/39193182/78d80695-6e2b-427c-85c3-28daa4f45baf
##
Admin ghost interaction

https://github.com/BeeStation/NSV13/assets/39193182/1fff175a-434c-4462-9627-91d7b2a35f1c



</details>

## Changelog
:cl: tonty
fix: the FTL navigation console no longer grants hyperspecific telekinesis to people who use it
/:cl:
