### PR TITLE
AI tracking is no longer scared of naked people, and other fun stories.

### DIFF
--- a/code/datums/components/holomap.dm
+++ b/code/datums/components/holomap.dm
@@ -41,7 +41,7 @@
 /datum/component/holomap/proc/get_user()
 	RETURN_TYPE(/mob/living)
 	var/atom/movable/holder = parent
-	return (isliving(holder) || !isatom(holder)) ? holder : holder.loc
+	return (isliving(holder) || !isatom(holder)) ? holder : holder.loc //FIXME - This proc is terrible (and can runtime). Just save the user and track if they get del'd like a sane person. Why is this like this??????
 
 /datum/component/holomap/Initialize()
 	. = ..()

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -64,10 +64,23 @@
 	if(!target_name)
 		return
 
+	var/freshlist = FALSE //NSV13 - tracking bugs
 	if(!track.initialized)
 		trackable_mobs()
+		freshlist = TRUE //NSV13 - tracking bugs
 
+	//NSV13 - safer checks.
 	var/datum/weakref/target = (isnull(track.humans[target_name]) ? track.others[target_name] : track.humans[target_name])
+	if((isnull(target) || !istype(target))) //Uh oh!
+		if(freshlist) //Already accurate new list
+			return
+
+		trackable_mobs() //Target may be new.
+		target = (isnull(track.humans[target_name]) ? track.others[target_name] : track.humans[target_name])
+		if((isnull(target) || !istype(target)))
+			return
+	//NSV13 end.
+
 	ai_start_tracking(target.resolve())
 
 /mob/living/silicon/ai/proc/ai_start_tracking(mob/living/target) //starts ai tracking

--- a/nsv13/code/modules/mob/living/silicon/ai/track.dm
+++ b/nsv13/code/modules/mob/living/silicon/ai/track.dm
@@ -62,7 +62,7 @@ GLOBAL_DATUM_INIT(tracking_menu, /datum/track_menu, new)
 				var/mob/living/carbon/human/player = mob_poi
 				var/nanite_sensors = HAS_TRAIT(player, TRAIT_NANITE_SENSORS)
 				var/obj/item/clothing/under/uniform = player.w_uniform
-				if(nanite_sensors || uniform.sensor_mode >= SENSOR_VITALS)
+				if(nanite_sensors || (uniform && uniform.sensor_mode >= SENSOR_VITALS))
 					serialized["health"] = FLOOR((player.health / player.maxHealth * 100), 1)
 
 				var/obj/item/card/id/identification_card = mob_poi.get_idcard()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Turns out the AI tracking window breaks if anybody is naked. As in. Anyone within the entire camera visual grid the AI has access to. This is absolutely hilarious but also not working as intended. Maybe a fun april fools thing.

Additionally, fixes some lacking safety within AI tracking itself, which could stop working and / or runtime under certain circumstances (since it assumed the list it was working on was perfect, which, it wasn't). It should be more likely to work consistently now!

Fixes #2566 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
No.

## Changelog
:cl:
fix: The AI tracking window no longer breaks if anybody on the camera network is naked.
fix: As AI, tracking somebody with the crew monitor should be less likely to brick.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
