### PR TITLE
Properly registers small craft in overmap ships and fixes sscrit explosions

### DIFF
--- a/code/modules/unit_tests/get_overmap.dm
+++ b/code/modules/unit_tests/get_overmap.dm
@@ -68,31 +68,11 @@
 	sabre.enter(dummy)
 	dummy.update_overmap()
 	TEST_ASSERT_EQUAL(dummy.get_overmap(), sabre, "The mob's overmap was not the sabre")
-*/
 
-/datum/unit_test/fighter_pilot_overmap/Destroy()
+/datum/unit_test/sabre_occupant_overmap/Destroy()
 	QDEL_NULL(dummy)
 	. = ..()
-
-/// A fighter inside a larger ship should have its get_overmap return the ship
-/datum/unit_test/fighter_on_ship
-	var/obj/structure/overmap/small_craft/combat/light/fighter = null
-
-/datum/unit_test/fighter_on_ship/Run()
-	for(var/obj/structure/overmap/small_craft/combat/light/OM as() in SSstar_system.find_main_overmap().overmaps_in_ship)
-		fighter = OM
-		break
-
-	if(!fighter)
-		var/turf/center = SSmapping.get_station_center()
-		ASSERT(center)
-		fighter = new (center)
-
-	TEST_ASSERT_EQUAL(fighter.get_overmap(), SSstar_system.find_main_overmap(), "The fighter's overmap was not the ship")
-
-/datum/unit_test/fighter_on_ship/Destroy()
-	QDEL_NULL(fighter)
-	. = ..()
+*/
 
 /// A fighter that leaves and re-enters a larger ship should have its get_overmap return null while in space, and the ship when back on the ship
 /datum/unit_test/fighter_docking

--- a/nsv13/code/modules/overmap/fighters/_fighters.dm
+++ b/nsv13/code/modules/overmap/fighters/_fighters.dm
@@ -470,7 +470,9 @@ Been a mess since 2018, we'll fix it someday (probably)
 		dradis = new dradis_type(src) //Fighters need a way to find their way home.
 		dradis.linked = src
 	set_light(4)
-	obj_integrity = max_integrity
+	var/obj/structure/overmap/OM = loc.get_overmap()
+	if(OM) //Actually register that we are inside the ship when spawned
+		OM.overmaps_in_ship |= src
 	RegisterSignal(src, COMSIG_MOVABLE_MOVED, PROC_REF(handle_moved)) //Used to smoothly transition from ship to overmap
 	var/obj/item/fighter_component/engine/engineGoesLast = null
 	if(build_components.len)

--- a/nsv13/code/modules/overmap/fighters/fighters_launcher.dm
+++ b/nsv13/code/modules/overmap/fighters/fighters_launcher.dm
@@ -358,7 +358,7 @@
 	forceMove(T)
 	if(current_system)
 		current_system.remove_ship(src, T)
-	OM.overmaps_in_ship += src
+	OM.overmaps_in_ship |= src
 	bound_width = initial(bound_width)
 	bound_height = initial(bound_height)
 	DC.docking_mode = FALSE

--- a/nsv13/code/modules/overmap/overmap.dm
+++ b/nsv13/code/modules/overmap/overmap.dm
@@ -823,14 +823,14 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 			to_chat(M, message)
 	for(var/obj/structure/overmap/O as() in overmaps_in_ship) //Of course they get relayed the same message if they're in the same ship too
 		if(length(O.mobs_in_ship))
-			O.relay(args)
+			O.relay(S,message,loop,channel)
 
 /obj/structure/overmap/proc/stop_relay(channel) //Stops all playing sounds for crewmen on N channel.
 	for(var/mob/M as() in mobs_in_ship)
 		M.stop_sound_channel(channel)
 	for(var/obj/structure/overmap/O as() in overmaps_in_ship) //Of course they get relayed the same message if they're in the same ship too
 		if(length(O.mobs_in_ship))
-			O.stop_relay(args)
+			O.stop_relay(channel)
 
 /obj/structure/overmap/proc/relay_to_nearby(S, message, ignore_self=FALSE, sound_range=20, faction_check=FALSE) //Sends a sound + text message to nearby ships
 	for(var/obj/structure/overmap/ship as() in GLOB.overmap_objects) //Might be called in hyperspace or by fighters, so shouldn't use a system check.

--- a/nsv13/code/modules/overmap/weapons/damage.dm
+++ b/nsv13/code/modules/overmap/weapons/damage.dm
@@ -268,5 +268,5 @@ Bullet reactions
 /obj/effect/temp_visual/explosion_telegraph/Destroy()
 	var/turf/T = get_turf(src)
 	var/damage_level = ((damage_amount <= 20) ? 1 : ((damage_amount <= 75) ? 2 : ((damage_amount <= 150) ? 3 : 4)))
-	explosion(T,damage_level == 4 ? 0 : 2,round(damage_level*1.75),round(damage_level*2.25))
+	explosion(T,damage_level == 4 ? 2 : 0,round(damage_level*1.75),round(damage_level*2.25))
 	return ..()


### PR DESCRIPTION
## About The Pull Request

Fixes small craft not being relayed messages from their parent ships due to not being added to `overmaps_in_ship` on initialization. Also makes devastation from sscrit explosions work properly instead of being inverted.

## Why It's Good For The Game

Makes things work as intended

## Changelog
:cl:
fix: Fixed superstructure crit explosions being too powerful for small hits
fix: Fixed fighters and sabres not being relayed overmap messages
/:cl: