### PR TITLE
Adds some NSV13 clothes to the torp shop

### DIFF
--- a/nsv13.dme
+++ b/nsv13.dme
@@ -3870,6 +3870,8 @@
 #include "nsv13\code\modules\client\loadout\loadout_colorizers.dm"
 #include "nsv13\code\modules\client\loadout\loadout_donator.dm"
 #include "nsv13\code\modules\client\loadout\loadout_general.dm"
+#include "nsv13\code\modules\client\loadout\loadout_hat.dm"
+#include "nsv13\code\modules\client\loadout\loadout_suit.dm"
 #include "nsv13\code\modules\client\loadout\loadout_uniform.dm"
 #include "nsv13\code\modules\clothing\custom_clothes.dm"
 #include "nsv13\code\modules\clothing\custom_outfits.dm"

--- a/nsv13/code/modules/client/loadout/loadout_hat.dm
+++ b/nsv13/code/modules/client/loadout/loadout_hat.dm
@@ -1,0 +1,4 @@
+/datum/gear/hat/sun
+	display_name = "headband of the rising sun"
+	path = /obj/item/clothing/head/ship/rising_sun
+	allowed_roles = list(JOB_NAME_MUNITIONSTECHNICIAN, JOB_NAME_MASTERATARMS, JOB_NAME_PILOT, JOB_NAME_AIRTRAFFICCONTROLLER)

--- a/nsv13/code/modules/client/loadout/loadout_suit.dm
+++ b/nsv13/code/modules/client/loadout/loadout_suit.dm
@@ -1,0 +1,8 @@
+/datum/gear/suit/jacket/utility
+	display_name = "Utility jacket"
+	path = /obj/item/clothing/suit/ship/assistant_jacket
+
+/datum/gear/suit/peacevest
+	display_name = "Peacekeeper vest"
+	path = /obj/item/clothing/suit/ship/peacekeeper
+	allowed_roles = list(JOB_NAME_SECURITYOFFICER)

--- a/nsv13/code/modules/client/loadout/loadout_uniform.dm
+++ b/nsv13/code/modules/client/loadout/loadout_uniform.dm
@@ -2,3 +2,10 @@
 	display_name = "skirt, black"
 	path = /obj/item/clothing/under/dress/skirt
 
+/datum/gear/uniform/rank/assistant/utility
+	display_name = "Utilitarian coveralls"
+	path = /obj/item/clothing/under/ship/assistant
+
+/datum/gear/uniform/rank/security/spacecop
+	display_name = "Space cop uniform"
+	path = /obj/item/clothing/under/ship/peacekeeper

--- a/nsv13/code/modules/clothing/custom_clothes.dm
+++ b/nsv13/code/modules/clothing/custom_clothes.dm
@@ -72,7 +72,7 @@
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 10, "bio" = 0, "rad" = 10, "fire" = 10, "acid" = 10)
 
 /obj/item/clothing/suit/ship/peacekeeper
-	name = "Peacekeer vest"
+	name = "Peacekeeper vest"
 	icon_state = "peacekeeper_vest"
 	item_state = "peacekeeper_vest"
 	desc = "A nanoweave vest capable of impeding most small arms fire as well as improvised weapons. It bears the logo of the North Star peacekeeper force"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a few clothing items exclusive to NSV to the torp shop. Currently adds the old and unused assistant uniform and jacket, space cop uniform, a unused peacekeeper armor vest and the headband of the rising sun.


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Adds more cosmetic options, and puts some unused items back in the game.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


![TorpShopAssistant](https://github.com/BeeStation/NSV13/assets/95106800/189d6a70-bd9e-4fa0-9060-1e264d64203e)


Utilitarian coveralls and jacket


![TorpShopSecurity](https://github.com/BeeStation/NSV13/assets/95106800/932bf4b0-0f49-476e-ab20-3558f25cb1c6)


Space cop uniform and peacekeeper vest


</details>

## Changelog
:cl:
add: Added some nsv clothes to the torp shop
spellcheck: fixed a typo in peacekeer vest
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
