### PR TITLE
Fixes borgs duplicating ammunition with the munition clamp upgrade

### DIFF
--- a/nsv13/code/modules/munitions/ship_weapons/_ship_weapon.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/_ship_weapon.dm
@@ -267,6 +267,9 @@
 		to_chat(user, "<span class='notice'>You start to load [A] into [src].</span>")
 		loading = TRUE
 		if(do_after(user, load_delay, target = src))
+			if ( !user_has_payload( A, user ) )
+				loading = FALSE
+				return FALSE
 			if(mag_load_sound)
 				playsound(src, mag_load_sound, 100, 1)
 
@@ -290,6 +293,19 @@
 		to_chat(user, "<span class='warning'>You can't load [A] into [src]!</span>")
 
 	return FALSE
+
+/obj/machinery/ship_weapon/proc/user_has_payload(obj/item/A, mob/user) // Searches humans and borgs for gunpowder before depositing
+	if ( !user )
+		return FALSE
+
+	// Prove you're not human
+	if ( istype( user, /mob/living/silicon/robot ) )
+		// Give me your hands
+		var/obj/item/borg/apparatus/munitions/hands = locate( /obj/item/borg/apparatus/munitions ) in user.contents
+		if ( !hands?.stored )
+			return FALSE
+
+	return TRUE
 
 /**
  * If we're not magazine-fed, eject round(s) from the weapon.

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
@@ -328,13 +328,26 @@
 	if(locate(/obj/machinery/deck_turret/autoelevator) in orange(2, src))
 		temp /= 2
 	if(do_after(user, temp, target = src))
-		if(user)
+		if(user_has_payload(A, user))
 			to_chat(user, "<span class='notice'>You load [A] into [src].</span>")
 			bag = A
 			bag.forceMove(src)
 			icon_state = "[initial(icon_state)]_loaded"
 			playsound(src.loc, 'nsv13/sound/effects/ship/mac_load.ogg', 100, 1)
 	loading = FALSE
+
+/obj/machinery/deck_turret/powder_gate/proc/user_has_payload(obj/item/A, mob/user) // Searches humans and borgs for gunpowder before depositing
+	if ( !user )
+		return FALSE
+
+	// Prove you're not human
+	if ( istype( user, /mob/living/silicon/robot ) )
+		// Give me your hands
+		var/obj/item/borg/apparatus/munitions/hands = locate( /obj/item/borg/apparatus/munitions ) in user.contents
+		if ( !hands?.stored )
+			return FALSE
+
+	return TRUE
 
 /obj/item/powder_bag
 	name = "gunpowder bag"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes borg contents not being checked when interacting with multiple powder racks or PDC racks. Normally when `do_after` removes contents from a human's hands it cancels all other pending `do_after`s. With borg munition clamps their hands do not change, so without refactors their contents will be checked in post by the machine. 

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
No fun allowed. Fixes https://github.com/BeeStation/NSV13/issues/2616

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/NSV13/assets/22532898/4fd528b9-fb6d-4ad2-8788-b323441bdd2a



</details>

## Changelog
:cl:
fix: fix borgs duplicating ammunition in deck turret and PDC 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
