### PR TITLE
Fixes Shells are not appropriately handling the presence of powder bags.

### DIFF
--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
@@ -58,6 +58,11 @@
 		spawn_frame(TRUE)
 		qdel(src)
 
+/obj/machinery/ship_weapon/deck_turret/Destroy()
+	for( var/obj/item/ship_weapon/ammunition/naval_artillery/shell in ammo )
+		shell.speed = initial( shell.speed ) // Reset on turret destruction
+	return ..()
+
 /obj/machinery/ship_weapon/deck_turret/spawn_frame(disassembled)
 	if(!disassembled)
 		QDEL_LIST(component_parts)
@@ -114,6 +119,7 @@
 			visible_message("<span class='warning'>Unable to perform operation right now, please wait.</span>")
 			return FALSE
 		loading = TRUE
+		core.payload_gate.pack_shell()
 		if(load_sound)
 			playsound(A.loc, load_sound, 100, 1)
 		playsound(A.loc, 'sound/machines/click.ogg', 50, 1)
@@ -168,7 +174,7 @@
 		if(core.payload_gate.shell)
 			data["can_pack"] = TRUE
 			data["loaded"] = core.payload_gate.shell.name || "Nothing"
-			data["speed"] = core.payload_gate.shell.speed || 0
+			data["speed"] = core.payload_gate.shell.speed + core.payload_gate.calculated_power || 0
 		else
 			data["can_pack"] = FALSE
 			data["loaded"] = "Nothing"
@@ -295,8 +301,6 @@
 	set waitfor = FALSE
 	playsound(src.loc, 'nsv13/sound/effects/ship/freespace2/m_lock.wav', 100, 1)
 	icon_state = "[initial(icon_state)]_sealed"
-	qdel(bag)
-	bag = null
 	sleep(1 SECONDS)
 	icon_state = initial(icon_state)
 
@@ -669,6 +673,7 @@
 	var/ammo_type = /obj/item/ship_weapon/ammunition/naval_artillery
 	var/loading = FALSE
 	var/load_delay = 8 SECONDS
+	var/calculated_power = 0
 
 /obj/machinery/deck_turret/payload_gate/MouseDrop_T(obj/item/A, mob/user)
 	. = ..()
@@ -715,6 +720,12 @@
 		loaded = FALSE
 		shell = null
 
+/obj/machinery/deck_turret/payload_gate/proc/pack_shell()
+	shell.speed = CLAMP(shell.speed + calculated_power, NAC_MIN_POWDER_LOAD, NAC_MAX_POWDER_LOAD)
+	calculated_power = 0
+	for ( var/obj/item/powder_bag/bag in contents )
+		qdel( bag )
+
 ///Shorthand for moving shell to turf
 /obj/machinery/deck_turret/payload_gate/proc/unload()
 	if(!shell)
@@ -732,9 +743,10 @@
 /obj/machinery/deck_turret/payload_gate/proc/chamber(obj/machinery/deck_turret/powder_gate/source)
 	if(!shell || !source?.bag)
 		return FALSE
-	shell.speed += source.bag.power
 	shell.name = "Packed [initial(shell.name)]"
-	shell.speed = CLAMP(shell.speed, NAC_MIN_POWDER_LOAD, NAC_MAX_POWDER_LOAD)
+	calculated_power += source.bag.power
+	source.bag.forceMove( src ) // In case of deconstruction or destruction, gunpowder is saved until the shell is loaded
+	source.bag = null
 	source.pack()
 	return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a long standing issue where gunpowder is being packed directly into the shell by powder gates, allowing "pre-loading" to occur where it shouldn't via deconstruction. Feeding the shell now modifies its speed directly before it's sent to the weapon turret. 

If you're loading and using the deck turret under normal conditions, nothing changes. 

## Why It's Good For The Game

Fixes https://github.com/BeeStation/NSV13/issues/1385

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/NSV13/assets/22532898/2bdfeac7-16ac-4c9d-9247-1bb935eddd19

Since gunpowder will be held in the payload gate until used, dismantling it will return your gunpowder without modifying the shell 

![image](https://github.com/BeeStation/NSV13/assets/22532898/f099ca55-4682-4e60-a506-8f3847a0d945)


</details>

## Changelog
:cl:
fix: Fixed shells are not appropriately handling the presence of powder bags
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
