### PR TITLE
[WIP] Make big ships feel tankier

### DIFF
--- a/nsv13/code/modules/overmap/armour/nano_pump.dm
+++ b/nsv13/code/modules/overmap/armour/nano_pump.dm
@@ -65,7 +65,9 @@
 		idle_power_usage = 0 //reset power use
 		var/weight_class = OM.mass
 		if(weight_class >= MASS_TITAN)
-			weight_class = 10 //Because someone changed how mass classes work
+			weight_class = 90 //Because someone changed how mass classes work //Undoing this because a repair rate of .13% is aweful. maths out instead to .5% per pump per secondish
+		if(weight_class >= MASS_LARGE)
+			weight_class = 50  //Copying above because a repair rate of .19% Feels aweful as an engineer. maths out to .5% per pump per secondish
 		if(armour_allocation)
 			if(OM.armour_quadrants[quadrant]["current_armour"] < OM.armour_quadrants[quadrant]["max_armour"]) //Armour Check
 				var/armour_integrity = (OM.armour_quadrants[quadrant]["current_armour"] / OM.armour_quadrants[quadrant]["max_armour"]) * 100
@@ -84,6 +86,7 @@
 					return
 				structure_repair_amount = ((2 + (weight_class / 10)) * apnw.repair_efficiency * structure_allocation) / 100
 				if(apnw.repair_resources >= (structure_repair_amount * weight_class) * 1.5)
+					//message_admins("repaired [structure_repair_amount]") // Admeme message for mathing help
 					OM.obj_integrity += structure_repair_amount
 					if(OM.obj_integrity > OM.max_integrity)
 						OM.obj_integrity = OM.max_integrity


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

So big ships felt weak as they entered SScrit quickly and struggled to exit SS crit. This addresses that.

Atlas unchanged repair rate: .27% per pump at max (For reference)
Whips unchanged repair rate: .33% per pump at max (for reference)

Galactical changed repair rate: .13%> .51% per pump at max. Easily lowerable after review of live rounds
Tycoon&&Gladius changed repair rate: .19%> .50% per pump at max. Easily lowerable after review of live rounds

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

beeg ships should consistently feel beeg and not just fold like a deck of cards. This attempt to address it via pumps

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
tweak: Pumps bonked to provide bigger ships better values
balance: Beeg ships should now feel Beeg
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
