### PR TITLE
Updates the armour pumps to account for lag properly

### DIFF
--- a/nsv13/code/modules/overmap/armour/nano_pump.dm
+++ b/nsv13/code/modules/overmap/armour/nano_pump.dm
@@ -58,7 +58,7 @@
 	if(stress_shutdown)
 		. += "<span class='warning'>The system overload lights are flashing</span>"
 
-/obj/machinery/armour_plating_nanorepair_pump/process()
+/obj/machinery/armour_plating_nanorepair_pump/process(delta_time)
 	if(!OM)
 		OM = get_overmap()
 	if(online && is_operational && !stress_shutdown)
@@ -71,7 +71,7 @@
 				var/armour_integrity = (OM.armour_quadrants[quadrant]["current_armour"] / OM.armour_quadrants[quadrant]["max_armour"]) * 100
 				if(armour_integrity < 15)
 					armour_integrity = 15
-				armour_repair_amount = ((382 * NUM_E **(0.0764 * armour_integrity))/(50 + NUM_E ** (0.0764 * armour_integrity)) ** 2 ) * (apnw.repair_efficiency * (armour_allocation / 100)) * 6 //Don't ask
+				armour_repair_amount = delta_time * ((382 * NUM_E **(0.0764 * armour_integrity))/(50 + NUM_E ** (0.0764 * armour_integrity)) ** 2 ) * (apnw.repair_efficiency * (armour_allocation / 100)) * 6 //Don't ask
 				if(apnw.repair_resources >= (armour_repair_amount * weight_class))
 					OM.armour_quadrants[quadrant]["current_armour"] += armour_repair_amount
 					if(OM.armour_quadrants[quadrant]["current_armour"] > OM.armour_quadrants[quadrant]["max_armour"])
@@ -82,7 +82,7 @@
 			if(OM.obj_integrity < OM.max_integrity) //Structure Check
 				if(OM.structure_crit_no_return) //If we have crossed the point of no return, halt repairs
 					return
-				structure_repair_amount = ((2 + (weight_class / 10)) * apnw.repair_efficiency * structure_allocation) / 100
+				structure_repair_amount = delta_time * ((2 + (weight_class / 10)) * apnw.repair_efficiency * structure_allocation) / 100
 				if(apnw.repair_resources >= (structure_repair_amount * weight_class) * 1.5)
 					OM.obj_integrity += structure_repair_amount
 					if(OM.obj_integrity > OM.max_integrity)

--- a/nsv13/code/modules/overmap/armour/nano_pump.dm
+++ b/nsv13/code/modules/overmap/armour/nano_pump.dm
@@ -71,7 +71,7 @@
 				var/armour_integrity = (OM.armour_quadrants[quadrant]["current_armour"] / OM.armour_quadrants[quadrant]["max_armour"]) * 100
 				if(armour_integrity < 15)
 					armour_integrity = 15
-				armour_repair_amount = delta_time * ((382 * NUM_E **(0.0764 * armour_integrity))/(50 + NUM_E ** (0.0764 * armour_integrity)) ** 2 ) * (apnw.repair_efficiency * (armour_allocation / 100)) * 6 //Don't ask
+				armour_repair_amount = delta_time * ((382 * NUM_E **(0.0764 * armour_integrity))/(50 + NUM_E ** (0.0764 * armour_integrity)) ** 2 ) * (apnw.repair_efficiency * (armour_allocation / 100)) * 3 //Don't ask
 				if(apnw.repair_resources >= (armour_repair_amount * weight_class))
 					OM.armour_quadrants[quadrant]["current_armour"] += armour_repair_amount
 					if(OM.armour_quadrants[quadrant]["current_armour"] > OM.armour_quadrants[quadrant]["max_armour"])
@@ -82,7 +82,7 @@
 			if(OM.obj_integrity < OM.max_integrity) //Structure Check
 				if(OM.structure_crit_no_return) //If we have crossed the point of no return, halt repairs
 					return
-				structure_repair_amount = delta_time * ((2 + (weight_class / 10)) * apnw.repair_efficiency * structure_allocation) / 100
+				structure_repair_amount = delta_time * ((2 + (weight_class / 10)) * apnw.repair_efficiency * structure_allocation) / 200
 				if(apnw.repair_resources >= (structure_repair_amount * weight_class) * 1.5)
 					OM.obj_integrity += structure_repair_amount
 					if(OM.obj_integrity > OM.max_integrity)


### PR DESCRIPTION
## About The Pull Request

Adds delta_time to the armour pumps' process(), to avoid lag affecting the pump performance.

## Why It's Good For The Game

Now the pumps should actually work at the same speed all the time, most importantly not slowing down when there is game lag from things like big fleet battles and atmospherics processing during a firetorping.

## Changelog
:cl:
fix: Fixed armour pumps not accounting for game lag in their processing
/:cl:
