### PR TITLE
fix auto recall warnings not made during combat

### DIFF
--- a/nsv13/code/controllers/subsystem/overmap_mode.dm
+++ b/nsv13/code/controllers/subsystem/overmap_mode.dm
@@ -241,12 +241,7 @@ SUBSYSTEM_DEF(overmap_mode)
 						else // I don't know what happened but let's go around again
 							objective_reminder_stacks = 0
 				else
-					var/obj/structure/overmap/OM = SSstar_system.find_main_overmap()
 					var/datum/star_system/S = SSstar_system.return_system
-					if(length(OM.current_system?.enemies_in_system))
-						if(objective_reminder_stacks == 3)
-							priority_announce("Auto-recall to [S.name] will occur once you are out of combat.", "[mode.reminder_origin]")
-						return // Don't send them home while there are enemies to kill
 					switch(objective_reminder_stacks) //Less Stacks Here, Prevent The Post-Round Stalling
 						if(1)
 							priority_announce("Auto-recall to [S.name] will occur in [(mode.objective_reminder_interval * 2) / 600] Minutes.", "[mode.reminder_origin]")
@@ -255,6 +250,10 @@ SUBSYSTEM_DEF(overmap_mode)
 							priority_announce("Auto-recall to [S.name] will occur in [(mode.objective_reminder_interval * 1) / 600] Minutes.", "[mode.reminder_origin]")
 
 						else
+							var/obj/structure/overmap/OM = SSstar_system.find_main_overmap()
+							if(length(OM.current_system?.enemies_in_system))
+								priority_announce("Auto-recall to [S.name] will occur once you are out of combat.", "[mode.reminder_origin]")
+								return // Don't send them home while there are enemies to kill
 							priority_announce("Auto-recall to [S.name] activated, additional objective aborted.", "[mode.reminder_origin]")
 							mode.victory()
 


### PR DESCRIPTION
The reminder stacks were increased but the increase would not be commnunicated to the players if they were in combat during it, leading to auto recall announcements being missable.

fixes #2672

## Why It's Good For The Game

Players not knowing that auto recall is approaching is bad because surprise auto recall is lame. This makes  sure that the time is always available to the players.


## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
Admin completed initial objectives, voted for extension, set next_objective_reminder low enough to get a reminder (got a reminder), spawned in a pirate fleet in current system, set next_objective_reminder low again, (got a reminder), set it low again (got the "recall delayed due to combat message"), waited 10 minutes, got auto recalled. (I believe the 10 minutes wait after the recall is delayed are not related to this PR.)
## Changelog
:cl:
fix: Auto recall reminders now also get sent during combat
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
