### PR TITLE
Sort projectiles fx.dm better

### DIFF
--- a/nsv13/code/datums/weapon_types.dm
+++ b/nsv13/code/datums/weapon_types.dm
@@ -125,6 +125,7 @@
 	range_modifier = 5
 	overmap_firing_sounds = list('nsv13/sound/effects/fighters/autocannon.ogg')
 
+
 //Energy Weapons
 
 /datum/ship_weapon/burst_phaser // Little red laser
@@ -293,8 +294,7 @@
 	special_fire_proc = /obj/structure/overmap/proc/secondary_fire
 	ai_fire_delay = 1 SECONDS
 
-//You don't ever actually select this. Crew act as gunners.
-
+///You don't ever actually select this. Crew act as gunners.
 /datum/ship_weapon/gauss
 	name = "Gauss guns"
 	default_projectile_type = /obj/item/projectile/bullet/gauss_slug
@@ -310,7 +310,7 @@
 	ai_fire_delay = 2 SECONDS
 	allowed_roles = OVERMAP_USER_ROLE_SECONDARY_GUNNER
 
-/datum/ship_weapon/pdc_mount // .50 cal flavored PDC bullets, which were previously just PDC flavored .50 cal turrets
+/datum/ship_weapon/pdc_mount //! .50 cal flavored PDC bullets, which were previously just PDC flavored .50 cal turrets
 	name = "PDC"
 	default_projectile_type = /obj/item/projectile/bullet/pdc_round
 	burst_size = 3

--- a/nsv13/code/modules/overmap/weapons/projectiles_fx.dm
+++ b/nsv13/code/modules/overmap/weapons/projectiles_fx.dm
@@ -373,7 +373,7 @@ Misc projectile types, effects, think of this as the special FX file.
 /obj/item/projectile/guided_munition/on_hit(atom/target, blocked = FALSE)
 	..()
 	if(!check_faction(target))
-		return FALSE 	 //Nsv13 - faction checking for overmaps. We're gonna just cut off real early and save some math if the IFF doesn't check out.
+		return FALSE 	 //Faction checking for overmaps. We're gonna just cut off real early and save some math if the IFF doesn't check out.
 	if(isovermap(target)) //Were we to explode on an actual overmap, this would oneshot the ship as it's a powerful explosion.
 		return BULLET_ACT_HIT
 	var/obj/item/projectile/P = target //This is hacky, refactor check_faction to unify both of these. I'm bodging it for now.

--- a/nsv13/code/modules/overmap/weapons/projectiles_fx.dm
+++ b/nsv13/code/modules/overmap/weapons/projectiles_fx.dm
@@ -25,7 +25,7 @@ Misc projectile types, effects, think of this as the special FX file.
 	flag = "overmap_heavy"
 	spread = 5
 
-/obj/item/projectile/bullet/mac_relayed_round	//Projectile relayed by all default MAC shells on overmap hit. No difference for AP / others as their values don't really matter on z level.
+/obj/item/projectile/bullet/mac_relayed_round	//!Projectile relayed by all default MAC shells on overmap hit. No difference for AP / others as their values don't really matter on z level.
 	icon = 'nsv13/icons/obj/projectiles_nsv.dmi'
 	icon_state = "railgun"
 	name = "artillery round"
@@ -82,32 +82,32 @@ Misc projectile types, effects, think of this as the special FX file.
 	homing_benefit_time = 2.5 SECONDS
 	homing_turn_speed = 30
 
-//Improvised ammunition, does terrible damage but is cheap to produce
+///Improvised ammunition, does terrible damage but is cheap to produce
 /obj/item/projectile/bullet/mac_round/cannonshot
 	name = "cannonball"
 	damage = 350
 	icon_state = "cannonshot"
 	flag = "overmap_medium"
 
-//You somehow loaded a magic entrapment ball into a cannon. This is your reward.
+///You somehow loaded a magic entrapment ball into a cannon. This is your reward.
 /obj/item/projectile/bullet/mac_round/cannonshot/admin
 	damage = 600
 	speed = 3
 	flag = "overmap_heavy"
 
-#define DIRTY_SHELL_TURF_SLUDGE_PROB 70	//Chance for sludge to spawn on a turf within the sludge range of the detonation turf. Detonation turf always gets an epicenter sludge.
-#define DIRTY_SHELL_SLUDGE_RANGE 3	//Un-random sludge event radius (for the shell detonating)
-#define DIRTY_SHELL_PELLET_PROB 80	//Chance for a pellet per tile from the outer circle
-#define DIRTY_SHELL_PELLET_RANGE 6	//Picks all turfs on the other circle of this range and uses them as possible targets for pellets.
+#define DIRTY_SHELL_TURF_SLUDGE_PROB 70	//!Chance for sludge to spawn on a turf within the sludge range of the detonation turf. Detonation turf always gets an epicenter sludge.
+#define DIRTY_SHELL_SLUDGE_RANGE 3	//!Un-random sludge event radius (for the shell detonating)
+#define DIRTY_SHELL_PELLET_PROB 80	//!Chance for a pellet per tile from the outer circle
+#define DIRTY_SHELL_PELLET_RANGE 6	//!Picks all turfs on the other circle of this range and uses them as possible targets for pellets.
 
-//Dirty shell: Stage 1 - overmap projectile
+///Dirty shell: Stage 1 - overmap projectile
 /obj/item/projectile/bullet/mac_round/dirty
 	damage = 150
 	name = "dirty artillery round"
 	relay_projectile_type = /obj/item/projectile/bullet/delayed_prime/dirty_shell_stage_two
 
 
-//Delayed priming projectile parent type - useful for a few different kinds of projectiles so why not.
+///Delayed priming projectile parent type - useful for a few different kinds of projectiles so why not.
 /obj/item/projectile/bullet/delayed_prime
 	icon = 'nsv13/icons/obj/projectiles_nsv.dmi'
 	icon_state = "railgun"
@@ -117,7 +117,7 @@ Misc projectile types, effects, think of this as the special FX file.
 	movement_type = FLYING
 	projectile_piercing = ALL
 	damage = 45		//It's on a z now, lets not instakill people / objects this happens to hit.
-	var/penetration_fuze = 1	//Will pen through this many things considered valid for reducing this before arming. Can overpenetrate if it happens to pen through windows or other things with not enough resistance.
+	var/penetration_fuze = 1	//!Will pen through this many things considered valid for reducing this before arming. Can overpenetrate if it happens to pen through windows or other things with not enough resistance.
 
 /obj/item/projectile/bullet/delayed_prime/on_hit(atom/target, blocked)
 	. = ..()
@@ -140,7 +140,7 @@ Misc projectile types, effects, think of this as the special FX file.
 /obj/item/projectile/bullet/delayed_prime/proc/release_payload(atom/detonation_location)
 	return
 
-//Dirty shell: Stage 2 - z level sludge payload projectile
+///Dirty shell: Stage 2 - z level sludge payload projectile
 /obj/item/projectile/bullet/delayed_prime/dirty_shell_stage_two
 	name = "dirty artillery round"
 	icon_state = "railgun"
@@ -186,7 +186,7 @@ Misc projectile types, effects, think of this as the special FX file.
 		P.fire()
 
 
-//Dirty Shell: Stage 3 - spread of irradiating pellets
+///Dirty Shell: Stage 3 - spread of irradiating pellets
 /obj/item/projectile/energy/nuclear_particle/dirty_shell_stage_three
 	irradiate = 300	//Less radiation than the "true" gumballs
 	name = "irradiated pellet"
@@ -477,7 +477,7 @@ Misc projectile types, effects, think of this as the special FX file.
 	var/ai_disruption = 30
 	var/ai_disruption_cap = 120
 
-//Player-accessible version of the above. Weaker because reverse engineered ~~and balance~~
+///Player-accessible version of parent. Weaker because reverse engineered ~~and balance~~
 /obj/item/projectile/guided_munition/torpedo/disruptor/prototype
 	name = "prototype disruption torpedo"
 	ai_disruption = 15 //Do you like stuncombat? Well the AI doesn't.
@@ -572,7 +572,7 @@ Misc projectile types, effects, think of this as the special FX file.
 	muzzle_type = /obj/effect/projectile/muzzle/xray
 	impact_type = /obj/effect/projectile/impact/xray
 
-//Designed to be spammed like crazy, but can be buffed to do extremely solid damage when you overclock the guns.
+///Designed to be spammed like crazy, but can be buffed to do extremely solid damage when you overclock the guns.
 /obj/item/projectile/beam/laser/phaser
 	damage = 30
 	flag = "overmap_medium"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Should make it a bit less likely that people (like me) overlook some procs that were far away from their datum.
Also turns some comments into doc comments. Only single character changes this time, no moving of comments (so code style stays the same as before). This now works because the extension is now fixed and propperly handles //! marked same line doc comments. (On the other hand, it might have broken /// above line doc comments? I don't think that really matters for this PR tho.)
Also adds like one additional empty line somewhere for separation.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes code easier to read.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>
VSCode tells me that the removals are all code movements instead of actual removal.
![image](https://github.com/BeeStation/NSV13/assets/54814353/dd0ccdca-49c4-49eb-b33c-0850c05e0b7f)

</details>

## Changelog
:cl:
refactor: projectiles_fx.dm should now be slightly more readable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
