### PR TITLE
Makes shields hits only spawn one visual (which is actually aligned with the ship)

### DIFF
--- a/nsv13/code/modules/overmap/shieldgen.dm
+++ b/nsv13/code/modules/overmap/shieldgen.dm
@@ -338,7 +338,7 @@
 
 /obj/effect/temp_visual/overmap_shield_hit
 	name = "Shield hit"
-	icon = 'nsv13/icons/overmap/shieldhit.dmi';
+	icon = 'nsv13/icons/overmap/shieldhit.dmi'
 	icon_state = "shieldhit"
 	duration = 0.75 SECONDS
 	layer = ABOVE_MOB_LAYER+0.1
@@ -349,17 +349,18 @@
 /obj/effect/temp_visual/overmap_shield_hit/Initialize(mapload, obj/structure/overmap/OM)
 	. = ..()
 	//Scale up the shield hit icon to roughly fit the overmap ship that owns us.
-	if(!OM)
+	if(!OM || !istype(OM))
+		log_runtime("Shield hit effect was made with no ship!")
 		return INITIALIZE_HINT_QDEL
-	overmap = OM
 	var/matrix/desired = new()
-	var/icon/I = icon(overmap.icon)
+	var/icon/I = icon(OM.icon)
 	var/resize_x = I.Width()/96
 	var/resize_y = I.Height()/96
 	desired.Scale(resize_x,resize_y)
-	desired.Turn(overmap.angle)
+	desired.Turn(OM.angle)
 	transform = desired
-	overmap.vis_contents += src
+	OM.vis_contents |= src
+	overmap = OM
 
 /obj/effect/temp_visual/overmap_shield_hit/Destroy()
 	overmap?.vis_contents -= src

--- a/nsv13/code/modules/overmap/shieldgen.dm
+++ b/nsv13/code/modules/overmap/shieldgen.dm
@@ -343,7 +343,7 @@
 	duration = 0.75 SECONDS
 	layer = ABOVE_MOB_LAYER+0.1
 	animate_movement = NO_STEPS // Override the inbuilt movement engine to avoid bouncing
-	appearance_flags = TILE_BOUND | PIXEL_SCALE
+	vis_flags = VIS_INHERIT_ID
 	var/obj/structure/overmap/overmap
 
 /obj/effect/temp_visual/overmap_shield_hit/Initialize(mapload, obj/structure/overmap/OM)
@@ -357,13 +357,19 @@
 	var/resize_x = I.Width()/96
 	var/resize_y = I.Height()/96
 	desired.Scale(resize_x,resize_y)
-	desired.Turn(OM.angle)
 	transform = desired
-	OM.vis_contents |= src
+	//Don't even ask, this makes it fit on the ship sprite properly most of the time
+	if(I.Width() <= 48)
+		pixel_x = -24
+		pixel_y = -24
+	else
+		pixel_x += round(I.Width()/16, 1)
+		pixel_y += pixel_x*round(I.Height()/32, 1)
+	OM.overlays.Add(src) //Otherwise it won't animate with the ship nicely
 	overmap = OM
 
 /obj/effect/temp_visual/overmap_shield_hit/Destroy()
-	overmap?.vis_contents -= src
+	overmap?.overlays.Remove(src)
 	overmap = null
 	return ..()
 

--- a/nsv13/code/modules/overmap/weapons/damage.dm
+++ b/nsv13/code/modules/overmap/weapons/damage.dm
@@ -23,7 +23,7 @@ Bullet reactions
 		if(shield_result)
 			var/damage_sound = pick('nsv13/sound/effects/ship/damage/shield_hit.ogg', 'nsv13/sound/effects/ship/damage/shield_hit2.ogg')
 			if(!impact_sound_cooldown)
-				new /obj/effect/temp_visual/overmap_shield_hit(get_turf(src), src)
+				new /obj/effect/temp_visual/overmap_shield_hit(src, src)
 				relay(damage_sound)
 				if(P.damage >= 15) //Flak begone
 					shake_everyone(5)


### PR DESCRIPTION
## About The Pull Request

Title, fixes an age old bug

## Why It's Good For The Game
Intended behaviour

## Testing Photographs and Procedure
I'm not making a recording for 5 seconds of shield footage sorry
Update: At this point I've tested it so much I did honestly consider making an "Aetherwhisp getting attacked by pirates ASMR" video

## Changelog
:cl:
fix: Fixed shield sprites leaving doubles when the ship gets hit
/:cl:
