### PR TITLE
Re-adds the basic plasma cutter back into its respective node.

### DIFF
--- a/_maps/map_files/Mining/nsv13/ruins/mining30.dmm
+++ b/_maps/map_files/Mining/nsv13/ruins/mining30.dmm
@@ -50,9 +50,6 @@
 	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
 	},
 /area/ruin/powered)
-"B" = (
-/turf/closed/mineral/random/high_chance,
-/area/ruin/powered)
 "C" = (
 /obj/effect/landmark/dropship_entry,
 /turf/template_noop,
@@ -861,14 +858,14 @@ L
 L
 L
 L
-B
+L
 L
 L
 W
 g
 G
 W
-B
+L
 L
 L
 b
@@ -902,16 +899,16 @@ L
 L
 L
 L
-B
-B
+L
+L
 L
 L
 W
 c
 G
 W
-B
-B
+L
+L
 L
 b
 b
@@ -944,8 +941,8 @@ L
 L
 L
 L
-B
-B
+L
+L
 L
 L
 Z
@@ -953,7 +950,7 @@ G
 G
 c
 L
-B
+L
 L
 L
 b
@@ -1122,7 +1119,7 @@ G
 c
 Z
 L
-B
+L
 L
 b
 b
@@ -1156,15 +1153,15 @@ L
 L
 L
 L
-B
+L
 a
 Z
 G
 G
 g
 p
-B
-B
+L
+L
 L
 b
 b
@@ -1197,16 +1194,16 @@ L
 L
 L
 L
-B
-B
+L
+L
 W
 Z
 G
 G
 G
 W
-B
-B
+L
+L
 L
 b
 b
@@ -1239,8 +1236,8 @@ L
 L
 L
 L
-B
-B
+L
+L
 W
 W
 W

--- a/_maps/map_files/Mining/nsv13/ruins/mining30.dmm
+++ b/_maps/map_files/Mining/nsv13/ruins/mining30.dmm
@@ -50,6 +50,9 @@
 	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
 	},
 /area/ruin/powered)
+"B" = (
+/turf/closed/mineral/random/high_chance,
+/area/ruin/powered)
 "C" = (
 /obj/effect/landmark/dropship_entry,
 /turf/template_noop,
@@ -858,14 +861,14 @@ L
 L
 L
 L
-L
+B
 L
 L
 W
 g
 G
 W
-L
+B
 L
 L
 b
@@ -899,16 +902,16 @@ L
 L
 L
 L
-L
-L
+B
+B
 L
 L
 W
 c
 G
 W
-L
-L
+B
+B
 L
 b
 b
@@ -941,8 +944,8 @@ L
 L
 L
 L
-L
-L
+B
+B
 L
 L
 Z
@@ -950,7 +953,7 @@ G
 G
 c
 L
-L
+B
 L
 L
 b
@@ -1119,7 +1122,7 @@ G
 c
 Z
 L
-L
+B
 L
 b
 b
@@ -1153,15 +1156,15 @@ L
 L
 L
 L
-L
+B
 a
 Z
 G
 G
 g
 p
-L
-L
+B
+B
 L
 b
 b
@@ -1194,16 +1197,16 @@ L
 L
 L
 L
-L
-L
+B
+B
 W
 Z
 G
 G
 G
 W
-L
-L
+B
+B
 L
 b
 b
@@ -1236,8 +1239,8 @@ L
 L
 L
 L
-L
-L
+B
+B
 W
 W
 W

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -745,7 +745,7 @@
 	display_name = "Mining Technology"
 	description = "Better than Efficiency V."
 	prereq_ids = list("engineering")
-	design_ids = list("drill", "superresonator", "triggermod", "damagemod", "cooldownmod", "rangemod", "hypermod", "ore_redemption", "mining_equipment_vendor", "exploration_equipment_vendor", "cargoexpress", "furnace", "furnace_console")
+	design_ids = list("drill", "superresonator", "triggermod", "damagemod", "cooldownmod", "rangemod", "hypermod", "plasmacutter", "ore_redemption", "mining_equipment_vendor", "exploration_equipment_vendor", "cargoexpress", "furnace", "furnace_console")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -745,7 +745,7 @@
 	display_name = "Mining Technology"
 	description = "Better than Efficiency V."
 	prereq_ids = list("engineering")
-	design_ids = list("drill", "superresonator", "triggermod", "damagemod", "cooldownmod", "rangemod", "hypermod", "plasmacutter", "ore_redemption", "mining_equipment_vendor", "exploration_equipment_vendor", "cargoexpress", "furnace", "furnace_console")
+	design_ids = list("drill", "superresonator", "triggermod", "damagemod", "cooldownmod", "rangemod", "hypermod", "ore_redemption", "mining_equipment_vendor", "exploration_equipment_vendor", "cargoexpress", "furnace", "furnace_console")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 


### PR DESCRIPTION
## About The Pull Request

Fixes the accidental deletion of the basic plasma cutter from the basic mining research node.

## Why It's Good For The Game

Fix man good.

## Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>


![l1riUcrJ73](https://github.com/BeeStation/NSV13/assets/123000630/3465399b-0e44-4919-9ff1-4405f6aa035d)

![image](https://github.com/BeeStation/NSV13/assets/123000630/88289070-bb0c-4b7d-8f4c-5941a2f52925)

</details>

## Changelog
:cl:
fix: re-added plasma cutter to mining tech node's item list
/:cl: