### PR TITLE
Fixes jaws of life airlock interactions & tiny bit of beebase cleanup

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1091,6 +1091,7 @@
 		//NSV13 end
 		if(isElectrified() && C?.siemens_coefficient)
 			shock(user,100)
+
 		if(locked)
 			to_chat(user, "<span class='warning'>The bolts are down, it won't budge!</span>")
 			return

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1085,9 +1085,12 @@
 		note = C
 		update_icon()
 	else if(HAS_TRAIT(C, TRAIT_DOOR_PRYER) && user.a_intent != INTENT_HARM)
+		//NSV13 - please don't make jaws of life inferior to crowbars.
+		if(C.tool_behaviour == TOOL_CROWBAR && !security_level && (panel_open && ((obj_flags & EMAGGED) || (density && welded && !operating && !hasPower() && !locked) || charge)))
+			try_to_crowbar(C, user)
+		//NSV13 end
 		if(isElectrified() && C?.siemens_coefficient)
 			shock(user,100)
-
 		if(locked)
 			to_chat(user, "<span class='warning'>The bolts are down, it won't budge!</span>")
 			return
@@ -1179,33 +1182,6 @@
 				to_chat(user, "<span class='warning'>You need to be wielding the fire axe to do that!</span>")
 				return
 		INVOKE_ASYNC(src, (density ? PROC_REF(open) : PROC_REF(close)), 2)
-
-	if(HAS_TRAIT(I, TRAIT_DOOR_PRYER)) //NSV13 - kept the ability to use crowbars and stuff on doors
-		if(isElectrified())
-			shock(user,100)//it's like sticking a forck in a power socket
-			return
-
-		if(!density)//already open
-			return
-
-		if(locked)
-			to_chat(user, "<span class='warning'>The bolts are down, it won't budge!</span>")
-			return
-
-		if(welded)
-			to_chat(user, "<span class='warning'>It's welded, it won't budge!</span>")
-			return
-
-		var/time_to_open = 5
-		if(hasPower() && !prying_so_hard)
-			time_to_open = 50
-			playsound(src, 'sound/machines/airlock_alien_prying.ogg', 100, TRUE) //is it aliens or just the CE being a dick?
-			prying_so_hard = TRUE
-			if(do_after(user, time_to_open, TRUE, src))
-				open(2)
-				if(density && !open(2))
-					to_chat(user, "<span class='warning'>Despite your attempts, [src] refuses to open.</span>")
-			prying_so_hard = FALSE
 
 /obj/machinery/door/airlock/open(forced=0)
 	if( operating || welded || locked )


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
At some point airlock attackby got changed which led to aggressively door prying items to gain priority over normal interactions.
This, in the case of jaws of life, led to them being unable to dismantle doors by prying out the airlock electronics, aswell as caused the inability to remove door charges (never seen).
As jaws of life should be capable of all the work a crowbar could do, this adds an exception to the aggressively prying capable item check which passes the item to normal crowbarring interactions instead, if any of the conditions for special interaction is fulfilled and the item has crowbar tool behavior.

Also fixes a leftover from a beebase which led to jaws (& similar) prying code being present twice, one of which would be unreachable.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Changelog
:cl:
fix: Jaws of life can now deconstruct doors like a crowbar could.
code: Cleans up some leftover code that remained after a beebase.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
