### PR TITLE
Fixes broadside cannon direction recognition

### DIFF
--- a/nsv13/code/__HELPERS/misc.dm
+++ b/nsv13/code/__HELPERS/misc.dm
@@ -14,7 +14,8 @@
 
 ///Whether the angle is on the port or starboard side of the ship (facing north or south on the map)
 /proc/angle2dir_ship(angle)
-	if(0 < angle && angle < 180)
+	var/modulated_angle = (((angle % 360) + 360) % 360)
+	if(modulated_angle <= 180)
 		return SOUTH
 	else
 		return NORTH


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The proc deciding which broadside cannon to fire assumes things about the angle variable that aren't true.
This makes the proc more reliable, which makes the correct cannon fire all the time instead of only until angle goes above 360 or below 0.

Fixes #2648 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Changelog
:cl:
fix: Broadside cannons should now always fire on the correct side.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
