### PR TITLE
Allows you to choose which direction you lay down towards

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1167,7 +1167,18 @@
 			if(buckled.buckle_lying != -1)
 				lying = buckled.buckle_lying
 		if(!lying) //force them on the ground
-			lying = pick(90, 270)
+			//NSV13 - you get to choose if it's controlled.
+			if(!resting)
+				lying = pick(90, 270)
+			else
+				switch(dir)
+					if(WEST)
+						lying = 270
+					if(EAST)
+						lying = 90
+					else
+						lying = pick(90, 270)
+			//NSV13 end.
 	else
 		mobility_flags |= MOBILITY_STAND
 		lying = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. 
This lets you choose the direction you rest in if you lay down intentionally.
If you face west, you lay down westwards, if you face east, you lay down eastwards, otherwise you rest randomly as before.
Previously it would just always choose at random, which could be a bit annoying if you really wanted to lay down a particular way (50 50 rolls).
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
There's no reason for this to not have existed.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Changelog
:cl:
add: Your current direction now decides which way you will face when voluntarily resting.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
