### PR TITLE
Fixes the "You are Dead" tgui window popup

### DIFF
--- a/code/modules/mob/dead/observer/logout.dm
+++ b/code/modules/mob/dead/observer/logout.dm
@@ -2,7 +2,7 @@
 	update_z(null)
 	if (client)
 		client.images -= (GLOB.ghost_images_default+GLOB.ghost_images_simple)
-		client.tgui_panel?.clear_dead_popup()
+		//client.tgui_panel?.clear_dead_popup() - NSV13 - commented out because this is a bad place to do that and also client is commonly already gone when this proc is called.
 
 	if(observetarget)
 		if(ismob(observetarget))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -571,6 +571,10 @@
 			for(var/S in mind.spell_list)
 				var/obj/effect/proc_holder/spell/spell = S
 				spell.updateButtonIcon()
+		//NSV13 - clear that popup.
+		if(client)
+			client.tgui_panel?.clear_dead_popup()
+		//NSV13 end.
 
 /mob/living/proc/remove_CC(should_update_mobility = TRUE)
 	SetStun(0, FALSE)

--- a/code/modules/mob/living/login.dm
+++ b/code/modules/mob/living/login.dm
@@ -30,3 +30,7 @@
 	var/datum/antagonist/hivemind/hivemind = mind.has_antag_datum(/datum/antagonist/hivemind)
 	if(hivemind)
 		hivemind.regain_images()
+	//NSV13 - clear the dead alert.
+	if(stat != DEAD)
+		client?.tgui_panel?.clear_dead_popup()
+	//NSV13 end.

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -899,7 +899,11 @@
 ///Force get the ghost from the mind
 /mob/proc/grab_ghost(force)
 	if(mind)
-		return mind.grab_ghost(force = force)
+		//NSV13 - clear dead popup if alive.
+		. = mind.grab_ghost(force = force)
+		if(stat != DEAD && client)
+			client.tgui_panel?.clear_dead_popup()
+		//NSV13 end
 
 ///Notify a ghost that it's body is being cloned
 /mob/proc/notify_ghost_cloning(var/message = "Someone is trying to revive you. Re-enter your corpse if you want to be revived!", var/sound = 'sound/effects/genetics.ogg', var/atom/source = null, flashwindow)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title.
At the moment, it shows up but is never properly cleared because usually client is already null when the ghost's logout is called, and even if it wasn't that would be a bad place to clear it.
This moves the procs to clear that message to revival, ghost grabbing, and the mob Login() proc, the latter two only being triggered if the mob is actually alive, which should be much more reliable.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->


## Changelog
:cl:
fix: The "You are Dead" chat window popup should now be properly removed when you are not dead.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
