### PR TITLE
Makes asteroids not just replace every turf when generating ores

### DIFF
--- a/nsv13/code/modules/mining/asteroid.dm
+++ b/nsv13/code/modules/mining/asteroid.dm
@@ -130,8 +130,8 @@ GLOBAL_LIST_EMPTY(asteroid_spawn_markers)		//handles mining asteroids, kind of s
 		center = T
 	else
 		center = locate(T.x+(width/2), T.y+(height/2), T.z)
-	for(var/turf/closed/mineral/target_turf as() in RANGE_TURFS(rand(3,5), center)) //Give that boi a nice core.
-		if(prob(85)) //Bit of random distribution
+	for(var/turf/closed/mineral/target_turf as() in RANGE_TURFS(rand(4,6), center)) //Give that boi a nice core.
+		if(prob(80)) //Bit of random distribution
 			var/turf_type = pick(core_composition)
 			target_turf.ChangeTurf(turf_type) //Make the core itself
 	// add boundaries

--- a/nsv13/code/modules/mining/asteroid.dm
+++ b/nsv13/code/modules/mining/asteroid.dm
@@ -130,7 +130,7 @@ GLOBAL_LIST_EMPTY(asteroid_spawn_markers)		//handles mining asteroids, kind of s
 		center = T
 	else
 		center = locate(T.x+(width/2), T.y+(height/2), T.z)
-	for(var/turf/target_turf as() in RANGE_TURFS(rand(3,5), center)) //Give that boi a nice core.
+	for(var/turf/closed/mineral/target_turf as() in RANGE_TURFS(rand(3,5), center)) //Give that boi a nice core.
 		if(prob(85)) //Bit of random distribution
 			var/turf_type = pick(core_composition)
 			target_turf.ChangeTurf(turf_type) //Make the core itself


### PR DESCRIPTION
## About The Pull Request

Removes the age old problem of our cool unique asteroid ruin and space/floor turfs getting replaced with rock. Now the asteroid mineral generation only replaces rock turfs (I made the core size a bit bigger to compensate for this, and will probably lower the ore chance a bit more as well so it's not too much)

## Why It's Good For The Game

Stops ruins and gaps from being filled with rock when it's not needed.

## Testing Photographs and Procedure

## Changelog
:cl:
tweak: Changed asteroid ore spawning to respect asteroid maps more
/:cl:
