### PR TITLE
Fixes overmap loop homing

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -820,7 +820,7 @@
 
 /obj/item/projectile/proc/process_homing() //Nsv13 - Enhanced the performance of this entire proc.
 	if(QDELETED(homing_target)) //NSV13 - Changed proc to be less performance intensive
-		if(homing_target) //Bla bla refclearing. Necessary evil. (Probably not worth the hassle of handling this via comsig so this here instead)
+		if(homing_target) //Bla bla refclearing. Necessary evil. (Probably not worth the hassle of handling this via comsig, so this is here instead)
 			homing_target = null
 		return FALSE //Hi, Delta from the past here, future one. We don't just disable homing entirely here because some projectiles might be able to reassess targets.
 	var/targetAngle

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -820,8 +820,14 @@
 
 /obj/item/projectile/proc/process_homing() //Nsv13 - Enhanced the performance of this entire proc.
 	if(QDELETED(homing_target)) //NSV13 - Changed proc to be less performance intensive
-		return FALSE
-	var/targetAngle = get_angle(src, homing_target)
+		if(homing_target) //Bla bla refclearing. Necessary evil. (Probably not worth the hassle of handling this via comsig so this here instead)
+			homing_target = null
+		return FALSE //Hi, Delta from the past here, future one. We don't just disable homing entirely here because some projectiles might be able to reassess targets.
+	var/targetAngle
+	if(z && SSmapping.level_trait(z, ZTRAIT_OVERMAP)) //This bit of performance cost should be worth making these track properly.
+		targetAngle = overmap_angle(src, homing_target)
+	else
+		targetAngle = get_angle(src, homing_target)
 	var/angle = closer_angle_difference(Angle, targetAngle)
 	next_homing_process = world.time + homing_delay
 	setAngle(Angle + CLAMP(angle, -homing_turn_speed, homing_turn_speed))

--- a/nsv13/code/modules/projectiles/overmap.dm
+++ b/nsv13/code/modules/projectiles/overmap.dm
@@ -3,9 +3,10 @@
 	var/valid_angle = 0 //Angle the projectile can track at
 	var/shotdown_effect_type = /obj/effect/temp_visual/impact_effect/torpedo
 
+//Hey look, all this logic doesn't work! I love finding these things.
 /obj/item/projectile/guided_munition/process_homing(atom/A)
 	. = ..()
 	var/simplify_Angle = SIMPLIFY_DEGREES(Angle)
-	var/simplify_targetAngle = SIMPLIFY_DEGREES(targetAngle)
+	var/simplify_targetAngle = SIMPLIFY_DEGREES(targetAngle) //<< This var is never actually modified because [local var] supercedes [obj var] unless src is used. Personally, I'm unsure if we actually WANT it fixed. ~Delta
 	if(simplify_targetAngle > simplify_Angle + valid_angle)
 		homing = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Essentially, homing projectiles on the overmap didn't take into account the z looping.
This makes them do that. Will probably never be free of running across things not yet configured for `overmap_angle()` & `overmap_dist()`

Also noticed something else broken but for now that's just getting annotation until I actually discuss it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
I'm not recording a video for this but it does do the thing on local.

## Changelog
:cl:
fix: Overmap projectiles now correctly home across z loop borders.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
