### PR TITLE
Weird Atom Init Issues VS. One Lizard

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -290,8 +290,8 @@ SUBSYSTEM_DEF(mapping)
 	var/obj/structure/overmap/OM = instance_overmap(config.ship_type)
 	pass(OM)
 	// Free boarding overmap/mining level
-	add_new_zlevel("Overmap treadmill [++world.maxz]", ZTRAITS_OVERMAP)
-	OM.free_treadmills += world.maxz
+	var/datum/space_level/overmap_z1 = add_new_zlevel("Overmap treadmill [length(z_list)+1]", ZTRAITS_OVERMAP)
+	OM.free_treadmills += overmap_z1.z_value
 
 	LoadStationRoomTemplates()
 	LoadStationRooms()

--- a/nsv13/code/__DEFINES/overmap.dm
+++ b/nsv13/code/__DEFINES/overmap.dm
@@ -119,3 +119,6 @@ GLOBAL_LIST_INIT(overmap_impact_sounds, list('nsv13/sound/effects/ship/freespace
 #define SHIELD_ABSORB 1 //!Shield absorbed hit.
 #define SHIELD_FORCE_DEFLECT 2 //!Shield absorbed hit and is redirecting projectile with slightly turned vector.
 #define SHIELD_FORCE_REFLECT 3 //!Shield absorbed hit and is redirecting projectile in reverse direction.
+
+//Interior instancing comsig, aka cursed things.
+#define COMSIG_INTERIOR_DONE_LOADING "interior_done_loading"

--- a/nsv13/code/__HELPERS/overmap.dm
+++ b/nsv13/code/__HELPERS/overmap.dm
@@ -130,5 +130,5 @@ Another get_angle that works better with the looping edges of the overmap
  * Generates a new z level with behavior specific to overmaps and returns its space level datum.
  */
 /datum/controller/subsystem/mapping/proc/add_new_overmap_zlevel()
-	. = add_new_zlevel("Overmap treadmill [length(SSmapping.z_list)+1]", ZTRAITS_OVERMAP)
+	. = add_new_zlevel("Overmap treadmill [length(z_list)+1]", ZTRAITS_OVERMAP)
 	setup_map_transitions(.)

--- a/nsv13/code/__HELPERS/overmap.dm
+++ b/nsv13/code/__HELPERS/overmap.dm
@@ -126,3 +126,9 @@ Another get_angle that works better with the looping edges of the overmap
 	add_new_zlevel(name, traits)
 	SSatoms.InitializeAtoms(block(locate(1,1,world.maxz),locate(world.maxx,world.maxy,world.maxz)))
 	setup_map_transitions(z_list[world.maxz])
+/**
+ * Generates a new z level with behavior specific to overmaps and returns its space level datum.
+ */
+/datum/controller/subsystem/mapping/proc/add_new_overmap_zlevel()
+	. = add_new_zlevel("Overmap treadmill [length(SSmapping.z_list)+1]", ZTRAITS_OVERMAP)
+	setup_map_transitions(.)

--- a/nsv13/code/__HELPERS/overmap.dm
+++ b/nsv13/code/__HELPERS/overmap.dm
@@ -118,6 +118,10 @@ Another get_angle that works better with the looping edges of the overmap
 	else if(CX<0)
 		.+=360
 
+/**
+ * I am genuinely unsure what this is actually meant to do that normal z add does not do.
+* If ANYONE actually knows if there is some important reason the procs I changed used this please tell me ~Delta
+**/
 /datum/controller/subsystem/mapping/proc/add_new_initialized_zlevel(name, traits = list(), z_type = /datum/space_level, orbital_body_type)
 	add_new_zlevel(name, traits)
 	SSatoms.InitializeAtoms(block(locate(1,1,world.maxz),locate(world.maxx,world.maxy,world.maxz)))

--- a/nsv13/code/modules/overmap/fighters/fighters_launcher.dm
+++ b/nsv13/code/modules/overmap/fighters/fighters_launcher.dm
@@ -335,13 +335,26 @@
 		return FALSE
 	if(istype(OM, /obj/structure/overmap/asteroid))
 		var/obj/structure/overmap/asteroid/AS = OM
+		if(AS.interior_status == INTERIOR_READY)
+			return transfer_from_overmap(AS)
 		AS.interior_mode = INTERIOR_DYNAMIC // We don't actually want it to create one until we're ready but we do need entry points
-		AS.instance_interior()
-		AS.docking_points = AS.interior_entry_points
-		return transfer_from_overmap(OM)
+		DC.docking_cooldown = TRUE
+		RegisterSignal(AS, COMSIG_INTERIOR_DONE_LOADING, PROC_REF(on_dock_interior_load_finish))
+		SSstar_system.queue_for_interior_load(AS)
+		return TRUE //We have to assume this will end up being a correct docking.
 	if(mass < OM.mass)  //If theyre bigger than us and have docking points, and we want to dock.
 		return transfer_from_overmap(OM)
 	return FALSE
+
+///Listens for the interior loading to finish and finishes docking once it does.
+/obj/structure/overmap/small_craft/proc/on_dock_interior_load_finish(obj/structure/overmap/docking_target)
+	SIGNAL_HANDLER
+	UnregisterSignal(docking_target, COMSIG_INTERIOR_DONE_LOADING)
+	docking_target.docking_points = docking_target.interior_entry_points
+	var/obj/item/fighter_component/docking_computer/DC = loadout.get_slot(HARDPOINT_SLOT_DOCKING)
+	if(DC)
+		DC.docking_cooldown = FALSE
+	INVOKE_ASYNC(src, PROC_REF(transfer_from_overmap), docking_target)
 
 /obj/structure/overmap/small_craft/proc/transfer_from_overmap(obj/structure/overmap/OM)
 	if(!length(OM.docking_points))

--- a/nsv13/code/modules/overmap/overmap.dm
+++ b/nsv13/code/modules/overmap/overmap.dm
@@ -234,13 +234,13 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 	if(!_path)
 		_path = /obj/structure/overmap/nanotrasen/heavy_cruiser/starter
 	RETURN_TYPE(/obj/structure/overmap)
-	SSmapping.add_new_initialized_zlevel("Overmap ship level [++world.maxz]", ZTRAITS_OVERMAP)
+	var/datum/space_level/new_ship_z = SSmapping.add_new_zlevel("Overmap ship level [length(SSmapping.z_list)+1]", ZTRAITS_OVERMAP)
 	repopulate_sorted_areas()
-	smooth_zlevel(world.maxz)
-	log_game("Z-level [world.maxz] loaded for overmap treadmills.")
-	var/turf/exit = get_turf(locate(round(world.maxx * 0.5, 1), round(world.maxy * 0.5, 1), world.maxz)) //Plop them bang in the center of the system.
+	smooth_zlevel(new_ship_z.z_value)
+	log_game("Z-level [new_ship_z.z_value] loaded for overmap treadmills.")
+	var/turf/exit = get_turf(locate(round(world.maxx * 0.5, 1), round(world.maxy * 0.5, 1), new_ship_z.z_value)) //Plop them bang in the center of the system.
 	var/obj/structure/overmap/OM = new _path(exit) //Ship'll pick up the info it needs, so just domp eet at the exit turf.
-	OM.reserved_z = world.maxz
+	OM.reserved_z = new_ship_z.z_value
 	OM.overmap_flags |= OVERMAP_FLAG_ZLEVEL_CARRIER
 	OM.current_system = SSstar_system.find_system(OM)
 	if(OM.role == MAIN_OVERMAP) //If we're the main overmap, we'll cheat a lil' and apply our status to all of the Zs under "station"
@@ -444,12 +444,23 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 			interior_mode = (possible_interior_maps?.len) ? INTERIOR_EXCLUSIVE : NO_INTERIOR
 		//Allows small ships to have a small interior.
 		if(INTERIOR_DYNAMIC)
-			instance_interior()
-			post_load_interior()
+			RegisterSignal(src, COMSIG_INTERIOR_DONE_LOADING, PROC_REF(after_init_load_interior))
+			SSstar_system.queue_for_interior_load(src)
 
-	apply_weapons()
 	RegisterSignal(src, list(COMSIG_FTL_STATE_CHANGE, COMSIG_SHIP_KILLED), PROC_REF(dump_locks)) // Setup lockon handling
 	//We have a lot of types but not that many weapons per ship, so let's just worry about the ones we do have
+	if(interior_mode != INTERIOR_DYNAMIC)
+		apply_weapons()
+		for(var/firemode = 1; firemode <= MAX_POSSIBLE_FIREMODE; firemode++)
+			var/datum/ship_weapon/SW = weapon_types[firemode]
+			if(istype(SW) && (SW.allowed_roles & OVERMAP_USER_ROLE_GUNNER))
+				weapon_numkeys_map += firemode
+
+///Listens for when the interior is done initing and finishes up some variables when it is.
+/obj/structure/overmap/proc/after_init_load_interior()
+	SIGNAL_HANDLER
+	UnregisterSignal(src, COMSIG_INTERIOR_DONE_LOADING)
+	apply_weapons()
 	for(var/firemode = 1; firemode <= MAX_POSSIBLE_FIREMODE; firemode++)
 		var/datum/ship_weapon/SW = weapon_types[firemode]
 		if(istype(SW) && (SW.allowed_roles & OVERMAP_USER_ROLE_GUNNER))
@@ -969,8 +980,8 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 		return reserved_z
 	if(ftl_drive)
 		if(!free_treadmills?.len)
-			SSmapping.add_new_initialized_zlevel("Overmap treadmill [++world.maxz]", ZTRAITS_OVERMAP)
-			reserved_z = world.maxz
+			var/datum/space_level/new_level = SSmapping.add_new_zlevel("Overmap treadmill [length(SSmapping.z_list)+1]", ZTRAITS_OVERMAP)
+			reserved_z = new_level.z_value
 		else
 			var/_z = pick_n_take(free_treadmills)
 			reserved_z = _z

--- a/nsv13/code/modules/overmap/overmap.dm
+++ b/nsv13/code/modules/overmap/overmap.dm
@@ -235,6 +235,8 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 		_path = /obj/structure/overmap/nanotrasen/heavy_cruiser/starter
 	RETURN_TYPE(/obj/structure/overmap)
 	var/datum/space_level/new_ship_z = SSmapping.add_new_zlevel("Overmap ship level [length(SSmapping.z_list)+1]", ZTRAITS_OVERMAP)
+	if(!folder || !interior_map_files)
+		SSmapping.setup_map_transitions(new_ship_z) //We usually recalculate transitions later, but not if there's no interior.
 	repopulate_sorted_areas()
 	smooth_zlevel(new_ship_z.z_value)
 	log_game("Z-level [new_ship_z.z_value] loaded for overmap treadmills.")
@@ -980,7 +982,7 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 		return reserved_z
 	if(ftl_drive)
 		if(!free_treadmills?.len)
-			var/datum/space_level/new_level = SSmapping.add_new_zlevel("Overmap treadmill [length(SSmapping.z_list)+1]", ZTRAITS_OVERMAP)
+			var/datum/space_level/new_level = SSmapping.add_new_overmap_zlevel()
 			reserved_z = new_level.z_value
 		else
 			var/_z = pick_n_take(free_treadmills)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Sooo we have been having some very fun atom init issues popping up concerningly often, and given it tends to fix itself for a single tick (aswell as all only partially uninitialized atoms) if someone buys a shuttle / docks to an asteroid, my assumption is it has something to do with something SSmapping related. (Sabres?)

This messes with some components that touch this, namely some overmap z treadmill handling that was super cursed (still is, but a bit cleaner :)  ), and ship interior z loading which was not only very cursed but also caused SSatoms to yell occassionally when multiple things started to load their interiors in a short timeframe.

Treadmills use some slightly more proper z initialization (instead of using ++world.maxz for.. their names??), while interior initialization is now handled by a queue system that sends signals when it's done loading. (Notably, only for asteroids and ships using `instance_interior()`, boarding map loading (`ai_load_interior()`) remains unchanged.)

### As should be seen by the tag at the top, please only TM this for now, if at all. This might have consequences I am not quite aware of yet, since I'm messing with very complex things in this PR.

I'm not sure if this'll actually make the weird init issues stop, but it's my shot at them for the moment. We'll see if they still occur with this.
(According to someone in the comments this does resolve the issue, which I've never been able to trigger personally, so thats good).

Potentially fixes #2397 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I can't express my distaste for Atom Init partially breaking in enough words.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
Only partially tested for the moment, and fairly difficult to in-depth test too. Might ignite things.

## Changelog
:cl:
code: Ship interior loading now uses a queue system (for virtual z using things like Sabres & Asteroids)
code: Some overmap z generation handling is ever so slightly cleaner now.
fix: Should resolve certain atom init issues (that manifested as broken sparks, among many other things).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
