### PR TITLE
Some more overmap fixes

### DIFF
--- a/nsv13/code/controllers/subsystem/starsystem.dm
+++ b/nsv13/code/controllers/subsystem/starsystem.dm
@@ -271,7 +271,6 @@ Returns a faction datum by its name (case insensitive!)
 	return system
 
 /datum/controller/subsystem/star_system/proc/spawn_ship(obj/structure/overmap/OM, datum/star_system/target_sys, center=FALSE)//Select Ship to Spawn and Location via Z-Trait
-	target_sys.system_contents += OM
 	if(target_sys.occupying_z)
 		var/turf/destination = null
 		if(center)
@@ -642,12 +641,12 @@ Returns a faction datum by its name (case insensitive!)
 	START_PROCESSING(SSfastprocess, src)
 
 /obj/effect/overmap_anomaly/singularity/process()
-	if(!z) //Not in nullspace
+	if(!z || !current_system) //Not in nullspace
 		if(length(affecting))
 			for(var/obj/structure/overmap/OM in affecting)
 				stop_affecting(OM)
 		return
-	for(var/obj/structure/overmap/OM as() in GLOB.overmap_objects) //Has to go through global overmaps due to anomalies not referencing their system - probably something to change one day.
+	for(var/obj/structure/overmap/OM in current_system.system_contents) //This list is not exclusively overmaps so no as() calls.
 		if(LAZYFIND(affecting, OM))
 			continue
 		if(OM.z != z)

--- a/nsv13/code/modules/overmap/FTL/ftl_jump.dm
+++ b/nsv13/code/modules/overmap/FTL/ftl_jump.dm
@@ -40,6 +40,9 @@
 	if(istype(OM, /obj/structure/overmap))
 		OM.current_system = src //Debugging purposes only
 		after_enter(OM)
+	else if(istype(OM, /obj/effect/overmap_anomaly))
+		var/obj/effect/overmap_anomaly/anomaly_OM = OM
+		anomaly_OM.current_system = src
 
 /datum/star_system/proc/after_enter(obj/structure/overmap/OM)
 	if(desc)

--- a/nsv13/code/modules/overmap/physics.dm
+++ b/nsv13/code/modules/overmap/physics.dm
@@ -595,8 +595,8 @@ This proc is to be used when someone gets stuck in an overmap ship, gauss, WHATE
 	var/turf/T = get_center()
 	if(!T) //Might be at map edge.
 		T = get_turf(src)
-	if(!T) //Abort.
-		return FALSE
+		if(!T) //Abort.
+			return FALSE
 	var/obj/item/projectile/proj = new proj_type(T)
 	if(ai_aim && !proj.can_home && !proj.hitscan)
 		target = calculate_intercept(target, proj, miss_chance=miss_chance, max_miss_distance=max_miss_distance)

--- a/nsv13/code/modules/overmap/physics.dm
+++ b/nsv13/code/modules/overmap/physics.dm
@@ -593,6 +593,10 @@ This proc is to be used when someone gets stuck in an overmap ship, gauss, WHATE
 	if(!z || QDELETED(src))
 		return FALSE
 	var/turf/T = get_center()
+	if(!T) //Might be at map edge.
+		T = get_turf(src)
+	if(!T) //Abort.
+		return FALSE
 	var/obj/item/projectile/proj = new proj_type(T)
 	if(ai_aim && !proj.can_home && !proj.hitscan)
 		target = calculate_intercept(target, proj, miss_chance=miss_chance, max_miss_distance=max_miss_distance)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
#2693 adjusts singularities to use the system contents to track affected, but fails to account for the fact not all contents of `system_contents` are overmap objects (as opposed to `GLOB.overmap_objects`).
This PR does similar but safer, while also reinforcing some sanity a bit (current_system was not 100% reliable at being set for anomalies and spawn_ship flooded system_contents with typepaths)

Also makes overmaps firing projectiles a bit less likely to runtime if they are near mapedge or were firing while being moved to nulspace.

This fixes #2701 (Well technically it is a testmerge breaking it but this does that part except without breaking).
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
This is tested on local.

## Changelog
:cl:
code: Singularities now use system contents in a safe way.
fix: Spawn_ship no longer floods system_contents with typepaths.
fix: Overmap firing should be a bit more resilient to turf-related oddities.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
