### PR TITLE
A small pass over the Atlas and Tycoon for various things

### DIFF
--- a/_maps/map_files/Atlas/atlas.dmm
+++ b/_maps/map_files/Atlas/atlas.dmm
@@ -4945,10 +4945,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=hmains1";
-	location = "hmains3"
-	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "pm" = (
@@ -9385,8 +9381,8 @@
 /area/security/main)
 "Eb" = (
 /obj/machinery/door/airlock/ship/external/glass{
-	req_one_access_txt = "31; 48";
-	name = "Mining Hangar Access"
+	name = "Mining Hangar Access";
+	req_one_access_txt = "31; 48"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10576,8 +10572,8 @@
 /area/maintenance/nsv/deck2/port)
 "Im" = (
 /obj/machinery/meter/atmos{
-	target_layer = 4;
-	name = "Scrubber loop gas flow meter"
+	name = "Scrubber loop gas flow meter";
+	target_layer = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -12120,8 +12116,8 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/meter/atmos/distro_loop{
-	target_layer = 2;
-	name = "Distribution loop gas flow meter"
+	name = "Distribution loop gas flow meter";
+	target_layer = 2
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -13956,8 +13952,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/ship/external/glass{
-	req_one_access_txt = "31; 48";
-	name = "Mining Hangar Access"
+	name = "Mining Hangar Access";
+	req_one_access_txt = "31; 48"
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/miningoffice)
@@ -15423,6 +15419,10 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/ship/blue,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=hmains1";
+	location = "hmains3"
+	},
 /turf/open/floor/durasteel/alt,
 /area/hallway/nsv/deck2/primary)
 "XF" = (

--- a/_maps/map_files/Atlas/atlas2.dmm
+++ b/_maps/map_files/Atlas/atlas2.dmm
@@ -337,7 +337,7 @@
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
 "bK" = (
 /obj/structure/cable{
@@ -758,8 +758,8 @@
 /obj/structure/table/reinforced,
 /obj/structure/railing,
 /obj/machinery/fax{
-	name = "Bridge Fax Machine";
-	fax_name = "Bridge"
+	fax_name = "Bridge";
+	name = "Bridge Fax Machine"
 	},
 /turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
@@ -877,7 +877,7 @@
 "dX" = (
 /obj/machinery/vending/boozeomat,
 /turf/closed/wall/steel,
-/area/crew_quarters/heads/xo)
+/area/crew_quarters/heads/captain)
 "dY" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/structure/cable{
@@ -889,7 +889,7 @@
 /area/crew_quarters/bar/mess_hall)
 "eb" = (
 /obj/item/kirbyplants/photosynthetic,
-/obj/structure/pool_ladder,
+/obj/machinery/light/small,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms)
 "ec" = (
@@ -1625,6 +1625,13 @@
 	},
 /turf/open/floor/durasteel/techfloor,
 /area/ai_monitored/turret_protected/aisat)
+"hi" = (
+/obj/structure/hull_plate,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/engine/airless,
+/area/nsv/weapons/gauss/battery/deck2/port)
 "hk" = (
 /obj/structure/sign/ship/deck,
 /turf/closed/wall/steel,
@@ -1989,8 +1996,8 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/sorting/mail{
-	sortType = 10;
-	dir = 8
+	dir = 8;
+	sortType = 10
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
@@ -2130,6 +2137,12 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
+"jh" = (
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/medical/morgue)
 "ji" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -2633,10 +2646,9 @@
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/ai)
 "le" = (
-/obj/structure/hull_plate,
-/obj/structure/hull_plate,
-/turf/open/floor/engine/airless,
-/area/space/nearstation)
+/obj/machinery/pool_filter,
+/turf/open/indestructible/sound/pool/end,
+/area/crew_quarters/bar/mess_hall)
 "lf" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	dir = 4;
@@ -2712,7 +2724,6 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat)
 "lw" = (
-/obj/machinery/pool_filter,
 /obj/machinery/airalarm/directional/north,
 /turf/open/indestructible/sound/pool/end,
 /area/crew_quarters/bar/mess_hall)
@@ -3732,8 +3743,8 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/sorting/mail{
-	sortType = 5;
-	dir = 4
+	dir = 4;
+	sortType = 5
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -3913,7 +3924,7 @@
 /obj/machinery/smartfridge{
 	name = "public botany fridge"
 	},
-/turf/closed/wall/r_wall,
+/turf/closed/wall/steel,
 /area/hydroponics)
 "rm" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -4703,6 +4714,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/turf_decal/tile/ship/half/green{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
 "uR" = (
@@ -4805,7 +4819,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
 "vf" = (
 /obj/structure/table/glass,
@@ -5250,6 +5264,9 @@
 /obj/item/storage/box/pinpointer_pairs,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/xo)
+"xk" = (
+/turf/open/floor/plating,
+/area/hallway/nsv/deck1/hallway)
 "xl" = (
 /obj/machinery/camera/autoname,
 /turf/open/indestructible/sound/pool/end,
@@ -6897,6 +6914,9 @@
 /obj/machinery/door/airlock/ship/external/glass{
 	name = "Auxiliary Shuttle Dock"
 	},
+/obj/effect/turf_decal/tile/ship/half/green{
+	dir = 1
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
 "Ev" = (
@@ -7445,6 +7465,13 @@
 /obj/structure/lattice/catwalk/over/ship,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
+"Ha" = (
+/obj/structure/hull_plate,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/engine/airless,
+/area/crew_quarters/heads/captain)
 "Hb" = (
 /obj/machinery/turretid{
 	control_area = /area/ai_monitored/turret_protected/ai_upload;
@@ -7652,6 +7679,9 @@
 /area/security/detectives_office)
 "HN" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/effect/turf_decal/tile/ship/half/green{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
 "HP" = (
@@ -7826,7 +7856,7 @@
 /area/space/nearstation)
 "Iy" = (
 /turf/closed/wall/steel,
-/area/crew_quarters/dorms)
+/area/hydroponics)
 "Iz" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -8156,6 +8186,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/tile/ship/half/green{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
 "JO" = (
@@ -8563,7 +8596,7 @@
 	dir = 8
 	},
 /obj/machinery/advanced_airlock_controller/directional/north,
-/turf/open/floor/monotile/steel,
+/turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
 "Lt" = (
 /obj/effect/turf_decal/tile/ship/green,
@@ -8675,9 +8708,6 @@
 "LR" = (
 /obj/structure/bed/pod,
 /obj/item/bedsheet/black,
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -8954,6 +8984,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "Nb" = (
@@ -9429,8 +9460,9 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
 "OI" = (
-/obj/structure/pool_ladder,
-/turf/closed/wall/r_wall,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/curtain/obscuring/grey,
+/turf/open/floor/plating,
 /area/crew_quarters/dorms)
 "OM" = (
 /obj/machinery/door/airlock/ship/public/glass{
@@ -9593,6 +9625,7 @@
 "PC" = (
 /obj/machinery/biogenerator,
 /obj/effect/turf_decal/tile/ship/half/green,
+/obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
 "PE" = (
@@ -10368,7 +10401,6 @@
 /area/hallway/nsv/deck1/hallway)
 "Tw" = (
 /obj/machinery/seed_extractor,
-/obj/machinery/computer/ship/viewscreen,
 /obj/machinery/camera/autoname,
 /obj/effect/turf_decal/tile/ship/half/green,
 /turf/open/floor/monotile/steel,
@@ -10764,7 +10796,7 @@
 "UV" = (
 /obj/structure/hull_plate,
 /obj/machinery/camera/autoname{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/engine/airless,
 /area/nsv/weapons/gauss/battery/deck2/port)
@@ -10898,8 +10930,8 @@
 /area/maintenance/nsv/deck1/starboard)
 "VI" = (
 /obj/machinery/airalarm/all_access{
-	pixel_y = 25;
-	mode = 5
+	mode = 5;
+	pixel_y = 25
 	},
 /obj/item/paper/fluff/awaymissions{
 	default_raw_text = "<center>Remember to turn on the Air Alarm- Engineering</center>";
@@ -11018,7 +11050,7 @@
 /area/security/detectives_office)
 "Wv" = (
 /obj/machinery/smartfridge,
-/turf/closed/wall/r_wall,
+/turf/closed/wall/steel,
 /area/hydroponics)
 "WC" = (
 /obj/effect/decal/cleanable/glitter/white{
@@ -11338,7 +11370,7 @@
 /obj/machinery/door/airlock/ship/external/glass{
 	name = "Arrivals Shuttle Dock"
 	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
 "XX" = (
 /obj/structure/chair/office{
@@ -11633,7 +11665,7 @@
 /area/hallway/nsv/deck1/hallway)
 "Zs" = (
 /obj/machinery/squad_vendor,
-/turf/closed/wall/r_wall,
+/turf/closed/wall/steel,
 /area/hydroponics)
 "Zt" = (
 /obj/machinery/computer/security/telescreen/ce{
@@ -43216,7 +43248,7 @@ qO
 tz
 Ea
 UE
-UE
+UV
 UE
 UE
 UE
@@ -43253,7 +43285,7 @@ dv
 mK
 Rg
 cL
-cL
+Cf
 cL
 cL
 cL
@@ -43510,8 +43542,8 @@ dv
 mK
 Rg
 cL
-cL
-cL
+SP
+Zp
 cL
 cL
 cL
@@ -43733,7 +43765,7 @@ UE
 UE
 UE
 UE
-UV
+UE
 Ea
 SX
 vu
@@ -43988,7 +44020,7 @@ MF
 Ea
 lX
 Ea
-UE
+hi
 UE
 UE
 Ea
@@ -44281,9 +44313,9 @@ dv
 mK
 Rg
 cx
-cx
-cx
-cx
+vc
+vc
+vc
 cx
 cL
 cL
@@ -45016,7 +45048,7 @@ Dr
 DB
 FI
 pG
-mz
+uG
 gi
 Uc
 xv
@@ -45273,7 +45305,7 @@ NK
 NK
 Bi
 NK
-mz
+uG
 lp
 qu
 qu
@@ -45530,8 +45562,8 @@ NK
 Yj
 Yj
 NK
-mz
-mz
+uG
+uG
 QK
 xw
 lM
@@ -45788,7 +45820,7 @@ sS
 yA
 GK
 YP
-mz
+uG
 uG
 YB
 fl
@@ -46045,7 +46077,7 @@ Ce
 Yj
 NK
 Jl
-mz
+uG
 LX
 uI
 aB
@@ -46302,7 +46334,7 @@ Yj
 Yj
 NK
 qs
-mz
+uG
 oo
 vZ
 aB
@@ -47073,7 +47105,7 @@ KS
 pR
 OM
 Ic
-KS
+Iy
 ZA
 bm
 sV
@@ -47096,7 +47128,7 @@ ZN
 MQ
 wu
 FE
-cH
+WJ
 DQ
 vD
 DQ
@@ -47368,7 +47400,7 @@ Xg
 ph
 dQ
 XN
-NU
+jh
 mt
 hN
 SV
@@ -47601,7 +47633,7 @@ AC
 dS
 Fc
 dl
-SH
+at
 RC
 PE
 Ka
@@ -47858,7 +47890,7 @@ cU
 KK
 mv
 Ad
-SH
+at
 CE
 LT
 zW
@@ -48115,7 +48147,7 @@ Ti
 Ao
 kM
 FF
-SH
+at
 iD
 GT
 El
@@ -48124,7 +48156,7 @@ at
 od
 Dx
 Ca
-cH
+WJ
 VJ
 Ek
 LN
@@ -48355,9 +48387,9 @@ CW
 LL
 HI
 KS
-KS
-KS
-KS
+Iy
+Iy
+Iy
 Zs
 Pf
 hJ
@@ -48372,7 +48404,7 @@ SH
 lN
 eC
 xi
-SH
+at
 Km
 Qd
 mr
@@ -48381,7 +48413,7 @@ at
 IW
 Hg
 sc
-cH
+WJ
 kE
 zH
 PU
@@ -48629,7 +48661,7 @@ SH
 Xl
 Ey
 SH
-SH
+at
 at
 vK
 Uq
@@ -48638,7 +48670,7 @@ Am
 yq
 Rw
 Bk
-cH
+WJ
 Ay
 Lh
 IX
@@ -48868,7 +48900,7 @@ HI
 ok
 PO
 Oj
-bS
+le
 Yr
 sJ
 mC
@@ -48886,7 +48918,7 @@ Oj
 mK
 mK
 mK
-mK
+Ha
 mK
 mK
 mK
@@ -48895,7 +48927,7 @@ Am
 PT
 kc
 sc
-cH
+WJ
 xT
 iF
 zn
@@ -49647,10 +49679,10 @@ ka
 ry
 Kn
 km
-Iy
-Iy
+xf
+xf
 ME
-Iy
+xf
 xf
 xf
 yg
@@ -50184,7 +50216,7 @@ Am
 Am
 Lo
 Am
-Am
+xk
 Am
 Am
 cx
@@ -50422,7 +50454,7 @@ xf
 Ar
 LR
 eb
-OI
+xf
 xf
 mK
 mK
@@ -50677,9 +50709,9 @@ xf
 sh
 xf
 xf
+OI
+OI
 xf
-OI
-OI
 mK
 mK
 mK
@@ -50934,9 +50966,9 @@ xf
 Ve
 ub
 xf
-xf
-xf
-xf
+vc
+vc
+lx
 mK
 mK
 mK
@@ -51441,13 +51473,13 @@ lx
 lx
 lx
 lx
+vc
+vc
+vc
+xf
+xf
+xf
 mK
-le
-mK
-xf
-xf
-xf
-xf
 mK
 mK
 mK
@@ -51963,10 +51995,10 @@ mK
 mK
 mK
 mK
-mK
-mK
-mK
-mK
+vc
+vc
+vc
+vc
 mK
 mK
 mK
@@ -52216,11 +52248,11 @@ jv
 mK
 mK
 mK
-mK
-mK
-mK
-mK
-mK
+vc
+vc
+vc
+vc
+vc
 mK
 mK
 mK

--- a/_maps/map_files/Tycoon/Tycoon1.dmm
+++ b/_maps/map_files/Tycoon/Tycoon1.dmm
@@ -1105,6 +1105,7 @@
 /area/space/nearstation)
 "dc" = (
 /obj/structure/table/glass,
+/obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/circuit/red,
 /area/ai_monitored/turret_protected/ai_upload)
 "dd" = (
@@ -2468,6 +2469,7 @@
 	},
 /obj/structure/chair/stool,
 /mob/living/simple_animal/hostile/retaliate/goose,
+/obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
@@ -2484,6 +2486,7 @@
 	name = "Mining Equipment";
 	req_one_access_txt = "48"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/quartermaster/miningdock)
 "go" = (
@@ -5371,6 +5374,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
@@ -5411,6 +5415,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
+/obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile/steel,
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
@@ -6910,6 +6915,7 @@
 	name = "Mining Equipment";
 	req_one_access_txt = "48"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/quartermaster/miningdock)
 "Dz" = (
@@ -7237,6 +7243,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
@@ -7638,6 +7645,7 @@
 	name = "Mining Equipment";
 	req_one_access_txt = "48"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/quartermaster/miningdock)
 "Nx" = (
@@ -7797,6 +7805,10 @@
 /obj/machinery/turnstile/xo,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
+"Qc" = (
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/monotile/steel,
+/area/quartermaster/miningdock)
 "Qg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -8107,6 +8119,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile/dark,
 /area/teleporter)
 "TL" = (
@@ -8369,6 +8382,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
@@ -43566,7 +43580,7 @@ zW
 sj
 wk
 QC
-Ml
+Qc
 VI
 Jp
 Qn
@@ -45818,7 +45832,7 @@ af
 ax
 ax
 ij
-hn
+aC
 mq
 mu
 cX

--- a/_maps/map_files/Tycoon/Tycoon2.dmm
+++ b/_maps/map_files/Tycoon/Tycoon2.dmm
@@ -555,6 +555,7 @@
 /obj/structure/fluff/support_beam{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/nsv/hanger/deck2)
 "abF" = (
@@ -1815,6 +1816,7 @@
 /obj/structure/fluff/support_beam{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/nsv/hanger/deck2)
 "aeF" = (
@@ -2408,6 +2410,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/nsv/hanger/deck2)
 "agc" = (
@@ -2620,6 +2623,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms/nsv/dorms_1)
 "agB" = (
@@ -3565,6 +3569,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile/steel,
 /area/medical/medbay/central)
 "aiW" = (
@@ -3912,21 +3917,6 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar)
-"ajV" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/obj/effect/turf_decal/ship/delivery/yellow,
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck2/frame1/central)
 "ajW" = (
 /obj/machinery/dna_scannernew,
 /turf/open/floor/monotile/light,
@@ -4196,6 +4186,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/medical/morgue)
 "akz" = (
@@ -4461,12 +4452,10 @@
 /turf/open/floor/monotile/light,
 /area/medical/virology)
 "akZ" = (
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
+/obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile/light,
 /area/medical/virology)
 "ala" = (
@@ -5041,6 +5030,7 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
 	},
+/obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "aml" = (
@@ -6085,10 +6075,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
 	},
 /obj/item/circuitboard/machine/anti_air,
 /obj/item/circuitboard/machine/anti_air,
@@ -7159,6 +7145,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "asy" = (
@@ -7229,6 +7216,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
+/obj/machinery/vending/wardrobe/atmos_wardrobe,
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "asN" = (
@@ -7583,10 +7571,6 @@
 "atZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/camera/autoname{
-	c_tag = "Atmos - Airlock #2";
-	dir = 8
-	},
 /obj/machinery/advanced_airlock_controller/directional/west,
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -7657,6 +7641,7 @@
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Library"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/library)
 "aun" = (
@@ -7856,9 +7841,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "auT" = (
@@ -7867,6 +7850,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/washing_machine,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "auU" = (
@@ -7972,7 +7958,7 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "ave" = (
-/turf/open/floor/monotile/dark,
+/turf/open/floor/plasteel/ridged,
 /area/crew_quarters/dorms/nsv/dorms_1)
 "avf" = (
 /obj/structure/chair/stool{
@@ -8150,6 +8136,7 @@
 "awa" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/reactor/pump/rbmk_output,
+/obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/durasteel/lino,
 /area/engine/engineering/reactor_control)
 "awc" = (
@@ -8576,6 +8563,7 @@
 	dir = 8
 	},
 /obj/machinery/vending/wardrobe/engi_wardrobe,
+/obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile/dark,
 /area/engine/storage_shared)
 "ayZ" = (
@@ -9596,10 +9584,6 @@
 /turf/open/floor/durasteel,
 /area/engine/engineering)
 "aBA" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/door/firedoor/border_only,
@@ -10461,6 +10445,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/tcommsat/computer)
 "aDY" = (
@@ -10953,6 +10938,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "aFc" = (
@@ -10966,6 +10952,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "aFd" = (
@@ -10979,6 +10966,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "aFe" = (
@@ -11275,6 +11263,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/durasteel,
 /area/security/prison)
 "aFD" = (
@@ -11675,6 +11664,7 @@
 	dir = 1
 	},
 /obj/machinery/turnstile,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/security/prison)
 "aGC" = (
@@ -13209,6 +13199,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons/fore)
 "aKj" = (
@@ -14187,6 +14178,9 @@
 /area/nsv/hanger/deck2)
 "aMo" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on,
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/science/server)
 "aMp" = (
@@ -15939,6 +15933,9 @@
 	name = "Engineering Security Post";
 	req_access_txt = "2"
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile/dark,
 /area/security/checkpoint/engineering)
 "aQn" = (
@@ -16446,6 +16443,8 @@
 	id_tag = "erp1";
 	name = "Showers"
 	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/dorms/nsv/dorms_1)
 "aRo" = (
@@ -16516,7 +16515,7 @@
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms/nsv/dorms_2)
 "aRy" = (
-/turf/open/floor/monotile/dark,
+/turf/open/floor/plasteel/ridged,
 /area/crew_quarters/dorms/nsv/dorms_2)
 "aRz" = (
 /turf/open/floor/monotile/light,
@@ -16526,6 +16525,8 @@
 	id_tag = "erp2";
 	name = "Showers"
 	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/dorms/nsv/dorms_2)
 "aRB" = (
@@ -16622,6 +16623,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "aRL" = (
@@ -17292,6 +17294,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/machinery/light,
 /turf/open/floor/monotile/steel,
 /area/nsv/hanger/deck2)
 "aTy" = (
@@ -17596,6 +17599,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/medical/morgue)
 "aUl" = (
@@ -18159,6 +18163,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/tcommsat/computer)
 "aVy" = (
@@ -19407,6 +19412,13 @@
 /area/security/prison)
 "aYg" = (
 /obj/structure/curtain/obscuring/grey,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/security/prison)
 "aYh" = (
@@ -19485,6 +19497,9 @@
 "aYs" = (
 /obj/structure/table/reinforced,
 /obj/item/binoculars,
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
 /turf/open/floor/monotile/steel,
 /area/security/warden)
 "aYt" = (
@@ -19841,6 +19856,7 @@
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Library"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/library)
 "aZn" = (
@@ -19853,6 +19869,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "aZo" = (
@@ -20214,6 +20231,7 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
 "bae" = (
@@ -22074,8 +22092,8 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/machinery/airalarm{
-	pixel_y = 23
+/obj/machinery/firealarm{
+	pixel_y = 24
 	},
 /turf/open/floor/monotile/dark,
 /area/gateway)
@@ -22649,12 +22667,6 @@
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame2/port)
 "beG" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
@@ -23486,7 +23498,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/camera/autoname,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/monotile/dark,
 /area/science/server)
@@ -23521,13 +23532,11 @@
 /turf/open/floor/monotile/steel,
 /area/science/xenobiology)
 "bgr" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
 /obj/machinery/camera/autoname,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile/dark,
 /area/science/xenobiology)
 "bgs" = (
@@ -23551,9 +23560,6 @@
 /turf/open/floor/monotile/steel,
 /area/security/prison)
 "bgu" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
 /obj/machinery/camera/autoname,
 /obj/machinery/keycard_auth{
 	pixel_x = -25;
@@ -23723,9 +23729,6 @@
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2)
 "bgQ" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/machinery/squad_vendor{
 	density = 0;
 	name = "Baker Squad Vendor";
@@ -23985,10 +23988,6 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "bhw" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/door/firedoor/border_only,
@@ -23996,6 +23995,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/zebra_interlock_point,
+/obj/effect/turf_decal/ship/delivery/yellow,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "bhx" = (
@@ -25385,23 +25385,6 @@
 /obj/machinery/light,
 /turf/open/floor/monotile/dark,
 /area/engine/break_room)
-"bkl" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck2/frame1/central)
 "bkn" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/light{
@@ -26717,6 +26700,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/janitor)
 "bne" = (
@@ -26814,6 +26798,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/plasticflaps/opaque,
+/obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "bnt" = (
@@ -27317,6 +27302,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/janitor)
 "boA" = (
@@ -27918,6 +27904,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/extinguisher_cabinet/south,
 /turf/open/floor/monotile/dark,
 /area/science)
 "bpH" = (
@@ -28104,12 +28091,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
+/obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile/dark,
 /area/chapel/main)
 "bpX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
 "bpY" = (
@@ -29673,6 +29660,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/ship/delivery/yellow,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "bth" = (
@@ -30546,6 +30535,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/ship/delivery/yellow,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/security/brig)
 "buJ" = (
@@ -30630,6 +30620,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/ship/delivery/yellow,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/security/brig)
 "buO" = (
@@ -32791,13 +32782,13 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/ship/delivery/yellow,
 /turf/open/floor/monotile/dark,
 /area/security/brig)
 "bzh" = (
@@ -33206,7 +33197,6 @@
 "bzY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
 "bzZ" = (
@@ -33465,6 +33455,7 @@
 /obj/machinery/turnstile{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/security/brig)
 "bAG" = (
@@ -33541,6 +33532,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms/nsv/dorms_2)
 "bAN" = (
@@ -33612,6 +33604,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/security/brig)
 "bAR" = (
@@ -33788,6 +33781,9 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/monotile/steel,
 /area/nsv/hanger/deck2)
 "bBp" = (
@@ -34053,6 +34049,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/zebra_interlock_point,
+/obj/effect/turf_decal/ship/delivery/yellow,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
 "bBM" = (
@@ -34721,21 +34718,6 @@
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
-/area/security/brig)
-"bDc" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/monotile/steel,
 /area/security/brig)
 "bDd" = (
 /obj/structure/cable{
@@ -35591,6 +35573,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/durasteel,
 /area/security/prison)
 "bED" = (
@@ -35668,6 +35651,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/turnstile,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/security/prison)
 "bEJ" = (
@@ -35902,6 +35886,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "bFe" = (
@@ -36049,6 +36034,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "bFr" = (
@@ -39854,12 +39840,6 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "cfx" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
@@ -40511,6 +40491,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/durasteel,
 /area/security/prison)
 "cYZ" = (
@@ -40623,6 +40604,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"diS" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/computer/ship/viewscreen,
+/turf/open/space/basic,
+/area/engine/atmos)
 "djJ" = (
 /obj/structure/closet/crate{
 	opened = 1
@@ -40710,7 +40696,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/structure/window/reinforced,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/nsv/weapons/gauss)
 "dud" = (
@@ -41387,6 +41372,7 @@
 /obj/structure/table,
 /obj/item/clothing/suit/hazardvest,
 /obj/item/clothing/mask/breath,
+/obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile/dark,
 /area/gateway)
 "esn" = (
@@ -41767,6 +41753,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "eRG" = (
@@ -41930,6 +41917,12 @@
 	},
 /turf/open/space/basic,
 /area/engine/atmos)
+"few" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/monotile/steel,
+/area/crew_quarters/heads/hos)
 "fex" = (
 /obj/structure/punching_bag,
 /obj/machinery/light_switch{
@@ -42015,8 +42008,20 @@
 	codes_txt = "patrol;next_patrol=loc3";
 	location = "loc2"
 	},
+/obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
+"fnR" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/monotile/steel,
+/area/security/brig)
 "foc" = (
 /obj/structure/closet/lasertag/red,
 /obj/machinery/newscaster{
@@ -42147,7 +42152,8 @@
 /area/nsv/weapons/fore)
 "fAz" = (
 /obj/machinery/door/airlock/ship/external/glass{
-	name = "Atmospherics Airlock"
+	name = "Atmospherics Airlock";
+	req_access_txt = "24"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -42662,6 +42668,11 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/engine/atmos)
+"gpO" = (
+/obj/structure/lattice,
+/obj/structure/grille/broken,
+/turf/open/space/basic,
+/area/space/nearstation)
 "gqp" = (
 /obj/machinery/newscaster,
 /turf/closed/wall/ship,
@@ -43435,7 +43446,6 @@
 /area/maintenance/starboard/fore)
 "htk" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
 "htl" = (
@@ -44336,6 +44346,8 @@
 	name = "Hangar Bay";
 	req_one_access_txt = "79"
 	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/monotile/steel,
 /area/nsv/hanger/deck2)
 "iJg" = (
@@ -45703,9 +45715,6 @@
 /turf/open/floor/plasteel/techmaint,
 /area/maintenance/starboard)
 "kwI" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
@@ -45715,6 +45724,7 @@
 /obj/machinery/advanced_airlock_controller{
 	pixel_y = 24
 	},
+/obj/machinery/light,
 /turf/open/floor/durasteel,
 /area/engine/engineering/reactor_core)
 "kyA" = (
@@ -46344,6 +46354,9 @@
 /obj/machinery/door/airlock/ship{
 	name = "Squad Staging Area"
 	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/monotile/steel,
 /area/nsv/hanger/deck2)
 "lpP" = (
@@ -46745,6 +46758,7 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
 "lVx" = (
@@ -47709,6 +47723,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/durasteel,
 /area/security/prison)
 "nmN" = (
@@ -48346,6 +48361,10 @@
 	},
 /turf/open/floor/plasteel/grid/steel,
 /area/engine/engineering/reactor_core)
+"oiN" = (
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/monotile/dark,
+/area/science/xenobiology)
 "ojM" = (
 /obj/structure/closet/crate/secure/loot,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -48883,6 +48902,11 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/quartermaster/qm)
+"pjr" = (
+/obj/structure/chair,
+/obj/machinery/computer/ship/viewscreen,
+/turf/open/floor/monotile/steel,
+/area/hallway/secondary/exit)
 "pjN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -48892,6 +48916,10 @@
 /obj/machinery/light_switch/south,
 /turf/open/floor/durasteel/lino,
 /area/engine/engineering/reactor_control)
+"pkh" = (
+/obj/machinery/computer/ship/viewscreen,
+/turf/open/floor/carpet/ship,
+/area/quartermaster/qm)
 "pkk" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/structure/cable{
@@ -49106,18 +49134,14 @@
 /turf/open/floor/plasteel/techmaint,
 /area/maintenance/starboard)
 "pBK" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/turf/open/floor/monotile/steel,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/effect/turf_decal/ship/delivery/yellow,
+/turf/open/floor/monotile/dark,
 /area/security/brig)
 "pBU" = (
 /obj/effect/landmark/xeno_spawn,
@@ -49278,6 +49302,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/durasteel,
 /area/security/prison)
 "pLb" = (
@@ -49432,9 +49457,6 @@
 /turf/open/floor/plasteel/techmaint,
 /area/maintenance/starboard)
 "qcm" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/lazylift/master/aircraft_elevator,
 /turf/open/floor/monotile/dark,
 /area/shuttle/turbolift/shaft)
@@ -50268,6 +50290,14 @@
 "rpx" = (
 /turf/open/floor/durasteel/lino,
 /area/engine/engineering/reactor_control)
+"rpL" = (
+/obj/structure/reagent_dispensers/foamtank/hull_repair_juice,
+/obj/item/extinguisher/advanced/hull_repair_juice,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/ridged/steel,
+/area/engine/engineering)
 "rrq" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank - CO2";
@@ -50376,6 +50406,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/durasteel/techfloor{
 	initial_gas_mix = "TEMP=2.7"
 	},
@@ -50777,6 +50808,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/medical/medbay/zone2{
 	name = "Intensive care unit"
@@ -51239,10 +51271,10 @@
 /area/medical/medbay/lobby)
 "sIU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/light{
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
+/obj/machinery/camera/autoname{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "sJI" = (
@@ -51545,6 +51577,7 @@
 	name = "Dropship Bay";
 	req_one_access_txt = "79"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2)
 "tnm" = (
@@ -51580,6 +51613,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/ship/delivery/yellow,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/security/brig)
 "tpo" = (
@@ -51793,6 +51827,8 @@
 	name = "Hangar Bay";
 	req_one_access_txt = "79"
 	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/monotile/steel,
 /area/nsv/hanger/deck2)
 "tDf" = (
@@ -52409,6 +52445,12 @@
 	},
 /turf/open/floor/durasteel/techfloor,
 /area/nsv/weapons/gauss)
+"uAr" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/monotile/dark,
+/area/shuttle/turbolift/shaft)
 "uBx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
@@ -52612,7 +52654,8 @@
 	},
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/machinery/door/airlock/ship/external/glass{
-	name = "Atmospherics Airlock"
+	name = "Atmospherics Airlock";
+	req_access_txt = "24"
 	},
 /turf/open/floor/plating/airless,
 /area/engine/atmos)
@@ -53273,7 +53316,6 @@
 "vYP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/curtain/obscuring/grey,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/chapel/main)
 "vYQ" = (
@@ -54002,6 +54044,13 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons/fore)
+"xgT" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/obj/machinery/computer/ship/viewscreen,
+/turf/open/floor/monotile/dark,
+/area/medical/morgue)
 "xhI" = (
 /obj/effect/spawner/lootdrop/maintenance/six,
 /turf/open/floor/plating,
@@ -54246,6 +54295,16 @@
 /obj/effect/spawner/lootdrop/gloves,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"xzJ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/security/brig)
 "xAD" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -70712,7 +70771,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+jLQ
 aaa
 aBf
 aHd
@@ -70969,7 +71028,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+wIM
 aaa
 aEG
 aHf
@@ -71226,7 +71285,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+wIM
 aaa
 aEG
 aHm
@@ -71473,18 +71532,18 @@ aaa
 aaa
 aaa
 aaa
+wIM
+gpO
+wIM
+wIM
+wIM
+jLQ
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+wIM
+wIM
+gpO
+wIM
+jLQ
 aEG
 aHn
 aYc
@@ -71730,17 +71789,17 @@ aaa
 aaa
 aaa
 aaa
+wIM
+aaa
+aaa
+aaa
+jLQ
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jLQ
 aaa
 aBf
 aHp
@@ -71987,7 +72046,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+wIM
 aaa
 jLQ
 jLQ
@@ -72244,7 +72303,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+gpO
 aaa
 jLQ
 aac
@@ -72303,7 +72362,7 @@ aXi
 alK
 lRd
 bih
-aeI
+oiN
 aeI
 nLp
 bJM
@@ -72501,8 +72560,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+wIM
+jLQ
 jLQ
 aac
 abX
@@ -72758,7 +72817,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+jLQ
 aaa
 jLQ
 aac
@@ -73043,8 +73102,8 @@ bfJ
 cvM
 buP
 wMk
-bDc
-bkJ
+pBK
+fnR
 bly
 bGu
 bkJ
@@ -73272,7 +73331,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+wIM
 aaa
 jLQ
 aac
@@ -73301,7 +73360,7 @@ biF
 buT
 bxY
 bzg
-biF
+xzJ
 biF
 bBG
 biF
@@ -73529,8 +73588,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+wIM
+jLQ
 avl
 aac
 adT
@@ -73786,7 +73845,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+wIM
 aaa
 jLQ
 aac
@@ -74043,7 +74102,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+wIM
 aaa
 jLQ
 aac
@@ -74300,7 +74359,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+gpO
 aaa
 jLQ
 aac
@@ -74557,8 +74616,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+wIM
+jLQ
 jLQ
 aac
 arx
@@ -74814,7 +74873,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+wIM
 aaa
 jLQ
 aac
@@ -76117,7 +76176,7 @@ pHV
 eBC
 cNV
 aZa
-aGE
+few
 bCZ
 aQM
 bej
@@ -77906,7 +77965,7 @@ ahm
 abK
 ahJ
 ahm
-ahQ
+xgT
 ahQ
 ahQ
 ahQ
@@ -87140,7 +87199,7 @@ cOK
 kuw
 xsc
 fbx
-bip
+uAr
 bip
 bip
 bip
@@ -87460,7 +87519,7 @@ aaa
 aaa
 aaa
 aOe
-aeF
+pjr
 bcH
 aNp
 aNo
@@ -88168,7 +88227,7 @@ cOK
 keO
 xsc
 fbx
-bip
+uAr
 bip
 bip
 bip
@@ -92051,7 +92110,7 @@ bzZ
 agm
 agm
 vHy
-ajV
+beG
 aZS
 beG
 aad
@@ -92789,9 +92848,9 @@ tCu
 tMg
 tCu
 tCu
-cOK
-cOK
-cOK
+tCu
+tCu
+tCu
 cOK
 cOK
 cOK
@@ -92837,7 +92896,7 @@ acn
 acn
 acn
 acn
-bkl
+cfx
 acn
 lPA
 aPn
@@ -93039,7 +93098,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+wIM
 aaa
 ksH
 nNs
@@ -93296,8 +93355,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+wIM
+jLQ
 moR
 enx
 tux
@@ -93364,7 +93423,7 @@ ajg
 ajm
 ajo
 ajs
-aka
+pkh
 aka
 bGD
 aka
@@ -93553,7 +93612,7 @@ aaa
 aaa
 aaa
 aaa
-bAe
+wIM
 aaa
 moR
 fvp
@@ -93808,9 +93867,9 @@ aaa
 aaa
 aaa
 aaa
+bAe
 aaa
-aaa
-aaa
+wIM
 aaa
 moR
 aup
@@ -94067,8 +94126,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+wIM
+jLQ
 ksH
 auk
 tux
@@ -94324,7 +94383,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+wIM
 aaa
 ksH
 rel
@@ -94581,7 +94640,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+wIM
 aaa
 ksH
 khE
@@ -94838,8 +94897,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+wIM
+jLQ
 moR
 iLl
 gUD
@@ -95095,7 +95154,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+wIM
 aaa
 moR
 iLl
@@ -95352,7 +95411,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+wIM
 aaa
 moR
 iLl
@@ -95609,8 +95668,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+wIM
+jLQ
 moR
 iLl
 jld
@@ -95866,7 +95925,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+wIM
 aaa
 moR
 iLl
@@ -96123,7 +96182,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+jLQ
 aaa
 ksH
 uee
@@ -96383,9 +96442,9 @@ asL
 asL
 asL
 ksH
-anN
+ksH
 jbU
-anN
+ksH
 haf
 haf
 haf
@@ -100548,7 +100607,7 @@ ucr
 asG
 rhe
 rhe
-rhe
+hus
 rhe
 vfz
 iJr
@@ -101568,7 +101627,7 @@ azB
 ncc
 sfd
 aoW
-rhe
+diS
 rhe
 rhe
 rhe
@@ -101787,7 +101846,7 @@ aHL
 amx
 kgt
 qIc
-qIc
+rpL
 sny
 hbj
 qho


### PR DESCRIPTION
## About The Pull Request

Placed some more viewscreens around the Tycoon, removed the accidental ladders in the Atlas dorms, Added some extra grilles outside of often breached areas. Also installed a wire under the engineering security outpost door.
Some firelocks were also missing zebra interlock helpers, and I tweaked one or two other things as I saw them too.

## Why It's Good For The Game

Fixing problems is nice, having more available viewscreens helps other crew stay aware of combat better.

## Changelog
:cl:
add: Added more viewscreens in Tycoon's departments.
fix: Removed pool ladders from Atlas dorms.
fix: Fixed the Tycoon engineering security outpost not starting connected.
/:cl: