### PR TITLE
Oops (Fixes midround additional overmap zlevel space tiles)

### DIFF
--- a/nsv13/code/__HELPERS/overmap.dm
+++ b/nsv13/code/__HELPERS/overmap.dm
@@ -119,16 +119,24 @@ Another get_angle that works better with the looping edges of the overmap
 		.+=360
 
 /**
- * I am genuinely unsure what this is actually meant to do that normal z add does not do.
-* If ANYONE actually knows if there is some important reason the procs I changed used this please tell me ~Delta
-**/
+ * Loads a new z level and initializes the empty space, which is neccessary outside of initial initializations.
+ */
 /datum/controller/subsystem/mapping/proc/add_new_initialized_zlevel(name, traits = list(), z_type = /datum/space_level, orbital_body_type)
 	add_new_zlevel(name, traits)
 	SSatoms.InitializeAtoms(block(locate(1,1,world.maxz),locate(world.maxx,world.maxy,world.maxz)))
 	setup_map_transitions(z_list[world.maxz])
+
 /**
- * Generates a new z level with behavior specific to overmaps and returns its space level datum.
+ * Generates a new z level with behavior specific to overmaps and returns its space level datum. Does not init space tiles by itself.
  */
 /datum/controller/subsystem/mapping/proc/add_new_overmap_zlevel()
 	. = add_new_zlevel("Overmap treadmill [length(z_list)+1]", ZTRAITS_OVERMAP)
+	setup_map_transitions(.)
+
+/**
+ * Same as add_new_overmap_zlevel, but also initializes space. Should be the one used post initial inits.
+ */
+/datum/controller/subsystem/mapping/proc/add_new_initialized_overmap_zlevel()
+	. = add_new_zlevel("Overmap treadmill [length(z_list)+1]", ZTRAITS_OVERMAP)
+	SSatoms.InitializeAtoms(block(locate(1,1,world.maxz),locate(world.maxx,world.maxy,world.maxz)))
 	setup_map_transitions(.)

--- a/nsv13/code/modules/overmap/overmap.dm
+++ b/nsv13/code/modules/overmap/overmap.dm
@@ -985,7 +985,7 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 		return reserved_z
 	if(ftl_drive)
 		if(!free_treadmills?.len)
-			var/datum/space_level/new_level = SSmapping.add_new_overmap_zlevel()
+			var/datum/space_level/new_level = SSmapping.add_new_initialized_overmap_zlevel()
 			reserved_z = new_level.z_value
 		else
 			var/_z = pick_n_take(free_treadmills)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
While fixing stuff, I may have foolishly omitted a certain proc from my overmap z loading thinking it wasn't neccessary since things worked fine in testing. Except it is, for empty zlevels loaded midround.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Space oopsies bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
No.

## Changelog
:cl:
fix: Space tiles on midround-created overmap zlevels should behave normally again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
