### PR TITLE
[Experimental] Large ship durability increase

### DIFF
--- a/nsv13/code/modules/overmap/types/nanotrasen.dm
+++ b/nsv13/code/modules/overmap/types/nanotrasen.dm
@@ -226,18 +226,18 @@
 
 /obj/structure/overmap/nanotrasen/battlecruiser/starter //Currently assigned to Tycoon and Gladius
 	role = MAIN_OVERMAP
-	obj_integrity = 1400
-	max_integrity = 1400
+	obj_integrity = 1600
+	max_integrity = 1600
 	starting_system = "Staging" //Required for all player ships
-	armor = list("overmap_light" = 95, "overmap_medium" = 60, "overmap_heavy" = 20)
+	armor = list("overmap_light" = 95, "overmap_medium" = 75, "overmap_heavy" = 50) //Cruisers should be able to take substantially more damage than Frigates and destroyers
 	overmap_deletion_traits = DAMAGE_STARTS_COUNTDOWN
 
 /obj/structure/overmap/nanotrasen/battleship/starter //Galactica
 	role = MAIN_OVERMAP //Player controlled variant
-	obj_integrity = 2150
-	max_integrity = 2150
+	obj_integrity = 2400
+	max_integrity = 2400
 	starting_system = "Staging" //Required for all player ships
-	armor = list("overmap_light" = 95, "overmap_medium" = 75, "overmap_heavy" = 25)
+	armor = list("overmap_light" = 98, "overmap_medium" = 95, "overmap_heavy" = 65) //This ship is a dreadnaught, is armored accordingly and should largely not care about lighter munitions.
 	overmap_deletion_traits = DAMAGE_STARTS_COUNTDOWN
 
 /obj/structure/overmap/nanotrasen/serendipity/starter

--- a/nsv13/code/modules/overmap/types/nanotrasen.dm
+++ b/nsv13/code/modules/overmap/types/nanotrasen.dm
@@ -229,7 +229,7 @@
 	obj_integrity = 1600
 	max_integrity = 1600
 	starting_system = "Staging" //Required for all player ships
-	armor = list("overmap_light" = 95, "overmap_medium" = 75, "overmap_heavy" = 50) //Cruisers should be able to take substantially more damage than Frigates and destroyers
+	armor = list("overmap_light" = 95, "overmap_medium" = 67, "overmap_heavy" = 35) //Cruisers should be able to take substantially more damage than Frigates and destroyers
 	overmap_deletion_traits = DAMAGE_STARTS_COUNTDOWN
 
 /obj/structure/overmap/nanotrasen/battleship/starter //Galactica
@@ -237,7 +237,7 @@
 	obj_integrity = 2400
 	max_integrity = 2400
 	starting_system = "Staging" //Required for all player ships
-	armor = list("overmap_light" = 98, "overmap_medium" = 95, "overmap_heavy" = 65) //This ship is a dreadnaught, is armored accordingly and should largely not care about lighter munitions.
+	armor = list("overmap_light" = 98, "overmap_medium" = 85, "overmap_heavy" = 45) //This ship is a dreadnaught, is armored accordingly and should largely not care about lighter munitions.
 	overmap_deletion_traits = DAMAGE_STARTS_COUNTDOWN
 
 /obj/structure/overmap/nanotrasen/serendipity/starter


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR moderately increases the health and substantially increases the armor of the Tycoon, Gladius, and Galactica. This is entirely a buff, and does not touch other ships at all.

## Why It's Good For The Game

Larger ships should be able to take a lot more punishment. Ideally, this will encourage more stand-and-fight type engagements with the ships that are large enough to actually take said punishment in the first place.

Cruisers will now have 50% more medium armor and 400% more heavy armor than Atlas class vessels, enabling them to actually tank hits vice needing to somehow avoid them all with a much larger and slower hull.

Our sole dreadnaught will largely be immune to munitions that are not torpedoes or heavy munitions, enabling it to play like the dreadnaught it actually is.

## Changelog
:cl:
balance: Increased the armor and health of Tycoon, Gladius, and Galactica
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
