### PR TITLE
Hangar Armory Tweaks Hammerhead

### DIFF
--- a/_maps/map_files/Hammerhead/Hammerhead.dmm
+++ b/_maps/map_files/Hammerhead/Hammerhead.dmm
@@ -12332,7 +12332,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "aNs" = (
 /obj/effect/turf_decal/tile/purple{
@@ -13635,7 +13635,7 @@
 "aRP" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/start/captain,
-/turf/open/floor/wood,
+/turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "aRQ" = (
 /obj/machinery/airalarm/directional/west,
@@ -16646,11 +16646,13 @@
 	departmentType = 4;
 	pixel_x = -32
 	},
-/obj/structure/table/glass,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/wood,
+/obj/machinery/modular_computer/console/preset/command{
+	dir = 1
+	},
+/turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "bbq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
@@ -29130,11 +29132,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "hsA" = (
-/obj/structure/table/glass,
-/obj/item/paper_bin{
-	pixel_y = 3
+/obj/machinery/computer/communications{
+	dir = 1
 	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "hsL" = (
 /obj/structure/disposalpipe/segment{
@@ -51543,6 +51544,12 @@
 /obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/durasteel,
 /area/science/robotics/lab)
+"vzl" = (
+/obj/machinery/computer/security{
+	dir = 1
+	},
+/turf/open/floor/carpet/royalblue,
+/area/crew_quarters/heads/captain)
 "vzz" = (
 /obj/machinery/door/airlock/ship/external{
 	req_one_access_txt = "13"
@@ -55407,7 +55414,10 @@
 /area/hallway/secondary/entry)
 "xWt" = (
 /obj/structure/table/glass,
-/turf/open/floor/wood,
+/obj/item/paper_bin{
+	pixel_y = 3
+	},
+/turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "xWy" = (
 /obj/structure/closet/crate,
@@ -115464,7 +115474,7 @@ qdI
 aOA
 anU
 xWt
-xWt
+vzl
 bbs
 aJh
 bbJ

--- a/_maps/map_files/Hammerhead/Hammerhead.dmm
+++ b/_maps/map_files/Hammerhead/Hammerhead.dmm
@@ -2442,7 +2442,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/durasteel,
+/turf/open/floor/durasteel/alt,
 /area/nsv/hanger)
 "aig" = (
 /obj/structure/table/wood,
@@ -10337,7 +10337,7 @@
 	name = "Pilot Ready Room";
 	req_access_txt = "71"
 	},
-/turf/open/floor/durasteel,
+/turf/open/floor/durasteel/alt,
 /area/nsv/hanger)
 "aHg" = (
 /obj/effect/turf_decal/stripes/red/line,
@@ -11347,7 +11347,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/durasteel/eris_techfloor_alt,
 /area/nsv/hanger)
 "aKB" = (
 /obj/machinery/airalarm/directional/north,
@@ -11711,7 +11711,13 @@
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/heads/captain/private)
 "aLD" = (
-/obj/structure/reagent_dispensers/fueltank/cryogenic_fuel,
+/obj/structure/table/reinforced,
+/obj/item/ammo_box/magazine/nsv/light_cannon,
+/obj/item/ammo_box/magazine/nsv/light_cannon,
+/obj/item/ammo_box/magazine/nsv/light_cannon,
+/obj/item/ammo_box/magazine/nsv/light_cannon,
+/obj/item/ammo_box/magazine/nsv/light_cannon,
+/obj/item/ammo_box/magazine/nsv/light_cannon,
 /turf/open/floor/durasteel/eris_techfloor_alt,
 /area/nsv/hanger)
 "aLF" = (
@@ -16772,9 +16778,7 @@
 "bbI" = (
 /obj/machinery/computer/lore_terminal,
 /obj/structure/munitions_trolley,
-/obj/item/ammo_box/magazine/nsv/heavy_cannon,
-/obj/item/ammo_box/magazine/nsv/heavy_cannon,
-/turf/open/floor/durasteel/eris_techfloor_alt,
+/turf/open/floor/durasteel/alt,
 /area/nsv/hanger)
 "bbJ" = (
 /obj/structure/chair,
@@ -21387,6 +21391,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
+/obj/structure/reagent_dispensers/fueltank/cryogenic_fuel,
 /turf/open/floor/plating,
 /area/nsv/hanger)
 "cpM" = (
@@ -22496,7 +22501,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/pilot,
-/turf/open/floor/durasteel,
+/turf/open/floor/durasteel/alt,
 /area/nsv/hanger)
 "dcg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -24565,7 +24570,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/pilot,
-/turf/open/floor/durasteel,
+/turf/open/floor/durasteel/alt,
 /area/nsv/hanger)
 "esM" = (
 /obj/effect/landmark/patrol_node{
@@ -25630,6 +25635,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/structure/reagent_dispensers/fueltank/cryogenic_fuel,
 /turf/open/floor/plating,
 /area/nsv/hanger)
 "fbB" = (
@@ -26212,6 +26218,9 @@
 	},
 /turf/open/floor/wood,
 /area/library/lounge)
+"fwF" = (
+/turf/open/floor/durasteel/alt,
+/area/nsv/hanger)
 "fwI" = (
 /obj/machinery/light{
 	dir = 8
@@ -27515,13 +27524,7 @@
 "gqM" = (
 /obj/machinery/computer/ship/viewscreen,
 /obj/structure/munitions_trolley,
-/obj/item/ammo_box/magazine/nsv/light_cannon,
-/obj/item/ammo_box/magazine/nsv/light_cannon,
-/obj/item/ammo_box/magazine/nsv/light_cannon,
-/obj/item/ammo_box/magazine/nsv/light_cannon,
-/obj/item/ammo_box/magazine/nsv/light_cannon,
-/obj/item/ammo_box/magazine/nsv/light_cannon,
-/turf/open/floor/durasteel/eris_techfloor_alt,
+/turf/open/floor/durasteel/alt,
 /area/nsv/hanger)
 "gre" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -27554,7 +27557,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/turf/open/floor/durasteel,
+/turf/open/floor/durasteel/alt,
 /area/nsv/hanger)
 "grU" = (
 /obj/structure/cable{
@@ -36082,7 +36085,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
-/turf/open/floor/durasteel,
+/turf/open/floor/durasteel/alt,
 /area/nsv/hanger)
 "lUN" = (
 /obj/structure/disposalpipe/segment{
@@ -38569,7 +38572,7 @@
 	name = "Pilot Ready Room";
 	req_access_txt = "71"
 	},
-/turf/open/floor/durasteel,
+/turf/open/floor/durasteel/alt,
 /area/nsv/hanger)
 "nuR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -40557,7 +40560,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/durasteel,
+/turf/open/floor/durasteel/alt,
 /area/nsv/hanger)
 "oDR" = (
 /obj/structure/lattice/catwalk,
@@ -43705,8 +43708,10 @@
 /turf/open/floor/engine/o2,
 /area/engine/atmos)
 "qEO" = (
-/obj/structure/reagent_dispensers/fueltank/cryogenic_fuel,
 /obj/machinery/firealarm/directional/north,
+/obj/structure/table/reinforced,
+/obj/item/ammo_box/magazine/nsv/heavy_cannon,
+/obj/item/ammo_box/magazine/nsv/heavy_cannon,
 /turf/open/floor/durasteel/eris_techfloor_alt,
 /area/nsv/hanger)
 "qEV" = (
@@ -45010,7 +45015,7 @@
 "rwp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/durasteel,
+/turf/open/floor/durasteel/alt,
 /area/nsv/hanger)
 "rws" = (
 /obj/machinery/light/small,
@@ -51255,7 +51260,7 @@
 /area/crew_quarters/bar)
 "vpl" = (
 /obj/effect/landmark/start/pilot,
-/turf/open/floor/durasteel,
+/turf/open/floor/durasteel/alt,
 /area/nsv/hanger)
 "vpo" = (
 /obj/machinery/door/airlock/ship/maintenance{
@@ -51572,7 +51577,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/durasteel,
+/turf/open/floor/durasteel/alt,
 /area/nsv/hanger)
 "vAQ" = (
 /obj/machinery/camera/autoname{
@@ -55241,7 +55246,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
 	},
-/turf/open/floor/durasteel,
+/turf/open/floor/durasteel/alt,
 /area/nsv/hanger)
 "xRZ" = (
 /obj/effect/landmark/start/security_officer,
@@ -97726,12 +97731,12 @@ ecH
 kjB
 kah
 gqM
-hmw
+fwF
 aMy
-hmw
+brd
 lUH
 xRM
-jnZ
+rwp
 aHe
 rwp
 grQ
@@ -97983,12 +97988,12 @@ ecH
 kjB
 kah
 bbI
-hmw
+fwF
 aMy
-hmw
+brd
 oDG
 aid
-brd
+fwF
 nuC
 vpl
 dcf


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes tile color and slightly moves munitions to make it obvious that the munitions trolleys are there.

## Why It's Good For The Game

The trolleys will no longer be buried under fighter cannon ammo while being on similarly colored tiles. Thus they will be visible for easy use.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>

![Capture2](https://github.com/user-attachments/assets/31ff2292-29fa-469b-818d-df1883750b57)

</details>

## Changelog
:cl:
tweak: Hammerhead hangar munitions trolleys now visible.
tweak: Hammerhead Capt. Office now has Command and Communications Consoles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
