### PR TITLE
Hammerhead, ram ahead

### DIFF
--- a/nsv13/code/__DEFINES/overmap.dm
+++ b/nsv13/code/__DEFINES/overmap.dm
@@ -114,6 +114,11 @@ GLOBAL_LIST_INIT(overmap_impact_sounds, list('nsv13/sound/effects/ship/freespace
 #define MASS_TITAN 150 //40+ Players - Large Capital Ships
 #define MASS_IMMOBILE 200 //Things that should not be moving. See: stations
 
+//Collision stuff
+#define OVERMAP_COLLISION_COOLDOWN 1 SECONDS //! Cooldown between collisions.
+#define OVERMAP_COLLISION_MAGNIFIER 4 //! All collision damage big enough to go into the damage calculation itself is multiplied by this.
+#define HAMMERHEAD_COLLISION_GUARD_ANGLE 55 //! Angle that determines maximum variance of collision angle to ship angle to count as "head" impact.
+
 //Fun tools
 #define SHIELD_NOEFFECT 0 //!Shield failed to absorb hit.
 #define SHIELD_ABSORB 1 //!Shield absorbed hit.

--- a/nsv13/code/modules/overmap/fighters/fighters_launcher.dm
+++ b/nsv13/code/modules/overmap/fighters/fighters_launcher.dm
@@ -157,7 +157,7 @@
 			linkup()
 
 /obj/structure/fighter_launcher/proc/shake_people(var/obj/structure/overmap/OM)
-	if(OM?.operators.len)
+	if(OM && length(OM.operators))
 		for(var/mob/M in OM.operators)
 			shake_with_inertia(M, 10, 1)
 			to_chat(M, "<span class='warning'>You feel a sudden jolt!</span>")

--- a/nsv13/code/modules/overmap/overmap.dm
+++ b/nsv13/code/modules/overmap/overmap.dm
@@ -31,6 +31,8 @@
 	var/sprite_size = 64 //Pixels. This represents 64x64 and allows for the bullets that you fire to align properly.
 	var/area_type = null //Set the type of the desired area you want a ship to link to, assuming it's not the main player ship.
 	var/impact_sound_cooldown = FALSE //Avoids infinite spamming of the ship taking damage.
+	///Handles cooldown between collisions to avoid certain very bad times :)
+	var/next_collision = 0
 	var/datum/star_system/current_system //What star_system are we currently in? Used for parallax.
 	var/resize = 0 //Factor by which we should shrink a ship down. 0 means don't shrink it.
 	var/list/docking_points = list() //Where we can land on this ship. Usually right at the edge of a z-level.
@@ -1005,3 +1007,14 @@ Proc to spool up a new Z-level for a player ship and assign it a treadmill.
 	if(ftl_drive)
 		return TRUE
 	return FALSE
+
+/**
+ * Handles special modifications or effects an overmap has for collisions.
+ * * other_ship = the ship this collides with.
+ * * impact_powers = the strength of the impact for (this ship, other ship). Done this way because list pointer allows inplace var access.
+ * * impact_angle = The angle of the impact.
+ *
+ * This does NOT return the modified impact powers, as it is not neccessary due to inplace handling!
+ */
+/obj/structure/overmap/proc/spec_collision_handling(obj/structure/overmap/other_ship, list/impact_powers, impact_angle)
+	return

--- a/nsv13/code/modules/overmap/physics.dm
+++ b/nsv13/code/modules/overmap/physics.dm
@@ -438,6 +438,15 @@ This proc is to be used when someone gets stuck in an overmap ship, gauss, WHATE
 		return
 	return ..()
 
+/**
+ * Handles collision between two overmap objects.
+ * * other = the object collided with.
+ * * c_response = ????
+ * * collision_velocity = UNUSED
+ *
+ * * BEAR IN MIND col_angle and velocity angles go COUNTERCLOCKWISE starting EAST while (overmap) angle itself goes CLOCKWISE starting NORTH!!!!!
+ * * ^ ^ ^ ^ THIS IS REALLY IMPORTANT
+ */
 /obj/structure/overmap/proc/collide(obj/structure/overmap/other, datum/collision_response/c_response, collision_velocity)
 	//No colliders. But we still get a lot of info anyways!
 	if(!c_response)
@@ -452,7 +461,7 @@ This proc is to be used when someone gets stuck in an overmap ship, gauss, WHATE
 		if(((cos(src.velocity.angle() - col_angle) * src_vel_mag) - (cos(other.velocity.angle() - col_angle) * other_vel_mag)) < 0)
 			return
 
-		// Elastic collision equations
+		// Elastic collision equations - I don't feel like rewriting these so I'll just change the damage calculation unrelated to the new velocities :) ~Delta
 		var/new_src_vel_x = ((																			\
 			(src_vel_mag * cos(src.velocity.angle() - col_angle) * (src.mass - other.mass)) +			\
 			(2 * other.mass * other_vel_mag * cos(other.velocity.angle() - col_angle))					\
@@ -473,20 +482,46 @@ This proc is to be used when someone gets stuck in an overmap ship, gauss, WHATE
 			(2 * src.mass * src_vel_mag * cos(src.velocity.angle() - col_angle))						\
 		) / (other.mass + src.mass)) * sin(col_angle) + (other_vel_mag * sin(other.velocity.angle() - col_angle) * sin(col_angle + 90))
 
+		//New calculations, go!
+
+		//Calculate vector forces when angled towards collision angle.
+
+		var/self_vector_angle_diff = ((col_angle - velocity.angle()) + 360) % 360 //Byond modulo allows negative values as outcome apparently. :)
+		var/self_ramvec = src_vel_mag * cos(self_vector_angle_diff)
+
+		var/other_vector_angle_diff = ((col_angle + 180 - other.velocity.angle()) + 360) % 360
+		var/other_ramvec = other_vel_mag * cos(other_vector_angle_diff)
+
+		var/total_force = (self_ramvec + other_ramvec) //Forces combined
+
+		if(world.time >= next_collision && total_force >= 2) //Magic!
+			total_force *= OVERMAP_COLLISION_MAGNIFIER //Arbitrary amplifier to collisions (used to be x5, for now x4 because of new math)
+			//Impact forces applied to each ship.
+			var/own_impact_power = CLAMP(other.mass / mass, 0.2, 10) * (total_force * 0.5) //I'm kind of scared of how the masses of big chonkers are going to interact so I'm capping this for now :)
+			var/other_impact_power = CLAMP(mass / other.mass, 0.2, 10) * (total_force * 0.5)
+			if(self_ramvec > other_ramvec)
+				own_impact_power *= 2 //The one having more impact force towards the ramming vector takes more damage.
+			else
+				other_impact_power *= 2
+			var/list/impact_powers = list(own_impact_power, other_impact_power) //List for inplace adjustments
+			var/modulated_col_angle = (col_angle + 360) % 360
+			spec_collision_handling(other, impact_powers, modulated_col_angle)
+			impact_powers = reverseList(impact_powers)
+			other.spec_collision_handling(src, impact_powers, ((modulated_col_angle + 180) % 360))
+			own_impact_power = impact_powers[2] //Remember, we turned this around!
+			other_impact_power = impact_powers[1]
+			if(own_impact_power > 0)
+				take_quadrant_hit(own_impact_power, quadrant_impact(other))
+			if(other_impact_power > 0)
+				other.take_quadrant_hit(other_impact_power, other.quadrant_impact(src))
+
+			next_collision = world.time + OVERMAP_COLLISION_COOLDOWN
+			log_game("[key_name(pilot)] has impacted an overmap ship into [other] \[Total collision force:[total_force]\]")
+			//Uncomment for debug :)
+			//message_admins("COLLISION DEBUG: own mag / ramvec: \[[src_vel_mag]|[self_ramvec]\]; other mag / remvec: \[[other_vel_mag]|[other_ramvec]\]; total force / own force / other force: \[[total_force]|[own_impact_power]|[other_impact_power]\]; Angles - collision angle / vector angle / angle diff / other vector angle / other angle diff: \[CA[col_angle]|VA[velocity.angle()]|AD[self_vector_angle_diff]|OVA[other.velocity.angle()]|OAD[other_vector_angle_diff]\]")
+
 		src.velocity._set(new_src_vel_x, new_src_vel_y)
 		other.velocity._set(new_other_vel_x, new_other_vel_y)
-
-		var/bonk = src_vel_mag//How much we got bonked
-		var/bonk2 = other_vel_mag //Vs how much they got bonked
-		//Prevent ultra spam.
-		if(!impact_sound_cooldown && (bonk > 2 || bonk2 > 2))
-			bonk *= 5 //The rammer gets an innate penalty, to discourage ramming metas.
-			bonk2 *= 5
-			take_quadrant_hit(bonk, quadrant_impact(other)) //This looks horrible, but trust me, it isn't! Probably!. Armour_quadrant.dm for more info
-			other.take_quadrant_hit(bonk2, quadrant_impact(src)) //This looks horrible, but trust me, it isn't! Probably!. Armour_quadrant.dm for more info
-
-			log_game("[key_name(pilot)] has impacted an overmap ship into [other] with velocity [bonk]")
-
 		return TRUE
 
 	//Update the colliders before we do any kind of calc.

--- a/nsv13/code/modules/overmap/types/nanotrasen.dm
+++ b/nsv13/code/modules/overmap/types/nanotrasen.dm
@@ -202,6 +202,14 @@
 	overmap_deletion_traits = DAMAGE_STARTS_COUNTDOWN
 	broadside = TRUE
 
+/obj/structure/overmap/nanotrasen/heavy_cruiser/starter/spec_collision_handling(obj/structure/overmap/other_ship, list/impact_powers, impact_angle)
+	var/modified_angle = 360 - ((angle + 630) % 360)
+	var/angle_diff = impact_angle - modified_angle
+	if(abs(angle_diff) > HAMMERHEAD_COLLISION_GUARD_ANGLE)
+		return
+	impact_powers[1] *= 0.5 // x 0.5 self damage
+	impact_powers[2] *= 2.5 // x 2.5 other damage
+
 /obj/structure/overmap/nanotrasen/heavy_cruiser/starter/apply_weapons()
 	weapon_types[FIRE_MODE_AMS] = new /datum/ship_weapon/vls(src)
 	weapon_types[FIRE_MODE_GAUSS] = new /datum/ship_weapon/gauss(src)

--- a/nsv13/code/modules/overmap/types/syndicate.dm
+++ b/nsv13/code/modules/overmap/types/syndicate.dm
@@ -180,6 +180,14 @@
 	combat_dice_type = /datum/combat_dice/destroyer
 	possible_interior_maps = list(/datum/map_template/boarding/destroyer)
 
+/obj/structure/overmap/syndicate/ai/destroyer/spec_collision_handling(obj/structure/overmap/other_ship, list/impact_powers, impact_angle)
+	var/modified_angle = 360 - ((angle + 630) % 360)
+	var/angle_diff = impact_angle - modified_angle
+	if(abs(angle_diff) > HAMMERHEAD_COLLISION_GUARD_ANGLE)
+		return
+	impact_powers[1] *= 0.5 // x 0.5 self damage
+	impact_powers[2] *= 2.5 // x 2.5 other damage
+
 /obj/structure/overmap/syndicate/ai/destroyer/elite
 	name = "Special Ops Torpedo Destroyer"
 	icon_state = "hammerhead_elite"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
After some "incidents" involving a Hammerhead class vessel, improvements have been made to their prow armor design which should result in more effective kinetic force ablation.
Unfortunately the Syndicate seems to have also gotten their hands on the design and has employed it on their own lines of Hammerheaded vessels.

The main part of this PR (or what it was supposed to be) is that Hammerheads (both NSV and the Syndicate ones) now have significantly more beneficial collision behavior when colliding head on.

However, while I was working on that, I also noticed that collision damage both never cared about mass (as opposed to the changelog comment), and also was very weirdly distributed (damage was calculated purely of each ship's own momentum, which means a stationary ship would always take 0 damage and a fast one would take a lot).

This reworks the damage calculation (but not the bounce) to take into account relative collision velocities, mass ratio, and potential other factors (see: Hammerhead).

Do note that while this makes collisions more useful if used by players (since those are usually the fast-side-colliding that would have nearly no benefits in the old system), it also may make low mass to high mass collisions VERY dangerous. There is a cap on the scaling, but if you ram something very heavy very fast in a Fighter, the outcome might not be good.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Hammerheads do have that ram for a reason!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
Bunch of testing went into this, but as always some things may sneak through.

## Changelog
:cl:
code: Reworked the overmap vs overmap ramming damage code.
balance: Hammerheads now have a frontal "guard angle" which supports head-on collisions.
fix: Fighters shouldn't runtime anymore if nobody is in them when they try to shake occupants.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
