### PR TITLE
Forces your screen icons back to their default positions when exiting overmap cameras

### DIFF
--- a/nsv13/code/modules/overmap/camera.dm
+++ b/nsv13/code/modules/overmap/camera.dm
@@ -74,6 +74,11 @@
 	if(M.client)
 		M.client.view_size.resetToDefault()
 		M.client.overmap_zoomout = 0
+		for(var/V in M.actions) //Reset action buttons to stop the screen from staying large
+			var/datum/action/A = V
+			var/atom/movable/screen/movable/action_button/B = A.button
+			B.moved = FALSE
+		M.update_action_buttons(TRUE)
 	var/mob/camera/ai_eye/remote/overmap_observer/eyeobj = M.remote_control
 	M.cancel_camera()
 	if(M.client) //Reset px, y


### PR DESCRIPTION
## About The Pull Request
Fixes a bug which allowed your view to stay zoomed out if you moved one of your action buttons while the overmap camera was open.

## Why It's Good For The Game

Fixes players having the problem and superpower of looking out 20 extra tiles on the ship map

## Changelog
:cl:
fix: Fixed your view getting stuck zoomed out after using overmap consoles or piloting
/:cl: