### PR TITLE
Minor Nitpicks

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,12 +1,21 @@
 {
   "version": "0.2.0",
   "configurations": [
+
     {
       "type": "byond",
       "request": "launch",
       "name": "Launch DreamSeeker",
       "preLaunchTask": "Build All",
       "dmb": "${workspaceFolder}/${command:CurrentDMB}"
-    }
+    },
+	{
+		"type": "byond",
+		"request": "launch",
+		"name": "Launch DreamDaemon",
+		"preLaunchTask": "Build All",
+		"dmb": "${workspaceFolder}/${command:CurrentDMB}",
+		"dreamDaemon": true
+	  }
   ]
 }

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -31,6 +31,9 @@
 //#define VISUALIZE_ACTIVE_TURFS	//Highlights atmos active turfs in green
 #endif //ifdef TESTING
 
+// Enables a few verbs to help track down skin-related issues. Not production safe.
+//#define MACROTEST
+
 /// If this is uncommented, will profile mapload atom initializations
 // #define PROFILE_MAPLOAD_INIT_ATOM
 

--- a/code/modules/admin/verbs/macro_debug.dm
+++ b/code/modules/admin/verbs/macro_debug.dm
@@ -1,0 +1,68 @@
+//This file depends on #define MACROTEST. Otherwise it is not included.
+
+#warn !!UNSAFE!!: MacroTest Verbs Enabled, Do Not Merge.
+/client
+	var/x_mt_watchingfocus = FALSE
+	var/x_mt_winmon_enabled = FALSE
+	var/list/x_mt_winmon_packet //Lazylist
+
+/// Dumps the list of all macros. This should almost always be just default
+/client/verb/dump_macroset_ids()
+	set name = "mt Dump Macroset IDs"
+	set category = "_MACRO_TEST"
+	to_chat(usr, (winget(src, "", "macros") || "NULL (Bad. Incredibly. Incredibly bad.)"))
+	return
+
+/// List all children of default. Name for macros is their bound key.
+/client/verb/dump_set()
+	set name = "mt Dump bindings"
+	set category = "_MACRO_TEST"
+	to_chat(usr, (winget(src, "default.*" , "name")|| "NULL (Bad. Real bad.)"))
+
+/// A slightly more pleasant way to execute free wingets.
+/client/verb/arbitrary_winget(cmd as text)
+	set name = "awing"
+	set desc = "Run an arbitrary Winset call, Space-separated arguments."
+	set category = "_MACRO_TEST"
+	var/list/parts = splittext(cmd, " ")
+	to_chat(usr, (winget(src, parts[1], parts[2]) || "NULL (Bad Call?)"))
+
+/// A slightly more pleasant way to execute free winsets.
+/client/verb/arbitrary_winset(cmd as text)
+	set name = "aswin"
+	set desc = "Run an arbitrary Winset call, Space-separated arguments."
+	set category = "_MACRO_TEST"
+	var/list/parts = splittext(cmd, " ")
+	winset(src, parts[1], parts[2])
+	to_chat(usr, ("CALLED: winset({client:[src.ckey]}, \"[parts[1]]\",\"[parts[2]]\")"))
+
+/// Will dump the currently focused skin element to chat. Used for tracking down focus juggling issues.
+/client/verb/focuswatch()
+	set name = "mt toggle focus watch"
+	set category = "_MACRO_TEST"
+	if(x_mt_watchingfocus)
+		x_mt_watchingfocus = FALSE
+		return
+	else
+		x_mt_watchingfocus = TRUE
+		while(x_mt_watchingfocus)
+			// Live-report the element with focus.
+			to_chat(usr, (winget(src, "", "focus") || "NULL (Entire game defocused?)"))
+			sleep(0.5 SECONDS) //Every half second
+
+/client/verb/winmon(cmd as text|null)
+	set name = "winmon"
+	set desc = "Repeatedly run a winget to monitor it's value"
+	set category = "_MACRO_TEST"
+	if(x_mt_winmon_enabled || isnull(cmd))
+		x_mt_winmon_enabled = FALSE
+		return
+	else
+		x_mt_winmon_enabled = TRUE
+		var/list/parts = splittext(cmd, " ")
+		x_mt_winmon_packet = parts
+		while(x_mt_winmon_enabled)
+			// Repeatedly rerun the same winget to watch the value
+			var/winout = winget(src, x_mt_winmon_packet[1], x_mt_winmon_packet[2])
+			to_chat(usr, ( winout ? "WINMON:[winout]": "WINMON: NULL (Bad Call?)"))
+			sleep(0.5 SECONDS)

--- a/code/modules/keybindings/setup.dm
+++ b/code/modules/keybindings/setup.dm
@@ -36,6 +36,11 @@
 
 	erase_all_macros()
 
+	/// Is this client using Chat Relay/Legacy input mode. If so,
+	/// we need to be **VERY CAREFUL** about what keys we bind,
+	/// and we can't bind anything printable. -Francinum
+	var/using_chat_relay = (prefs.toggles2 & PREFTOGGLE_2_HOTKEYS)
+
 	var/list/macro_sets = SSinput.macro_sets
 	var/use_tgui_say = !prefs || (prefs.toggles2 & PREFTOGGLE_2_TGUI_SAY)
 	var/say = use_tgui_say ? tgui_say_create_open_command(SAY_CHANNEL) : "\".winset \\\"command=\\\".start_typing say\\\";command=.init_say;saywindow.is-visible=true;saywindow.input.focus=true\\\"\""
@@ -52,13 +57,16 @@
 			var/key = macro_set[k]
 			var/command = macro_set[key]
 			winset(src, "[setname]-[REF(key)]", "parent=[setname];name=[key];command=[command]")
-		winset(src, "[setname]-say", "parent=[setname];name=T;command=[say]")
-		winset(src, "[setname]-me", "parent=[setname];name=M;command=[me]")
-		winset(src, "[setname]-ooc", "parent=[setname];name=O;command=[ooc]")
-		if(use_tgui_say)
-			winset(src, "[setname]-radio", "parent=[setname];name=Y;command=[radio]")
-			winset(src, "[setname]-looc", "parent=[setname];name=L;command=[looc]") // NSV13 - Moves LOOC keybind to L from U
-			winset(src, "[setname]-close-tgui-say", "parent=[setname];name=Escape;command=[tgui_say_create_close_command()]")
+		// If we bind these, we're going to disable input relay.
+		// This *does* silently break TGUI-Say, but I doubt players who want to use this mode care. -Francinum
+		if(!using_chat_relay)
+			winset(src, "[setname]-say", "parent=[setname];name=T;command=[say]")
+			winset(src, "[setname]-me", "parent=[setname];name=M;command=[me]")
+			winset(src, "[setname]-ooc", "parent=[setname];name=O;command=[ooc]")
+			if(use_tgui_say)
+				winset(src, "[setname]-radio", "parent=[setname];name=Y;command=[radio]")
+				winset(src, "[setname]-looc", "parent=[setname];name=L;command=[looc]") // NSV13 - Moves LOOC keybind to L from U
+				winset(src, "[setname]-close-tgui-say", "parent=[setname];name=Escape;command=[tgui_say_create_close_command()]")
 
 	if(prefs.toggles2 & PREFTOGGLE_2_HOTKEYS)
 		winset(src, null, "input.focus=true input.background-color=[COLOR_INPUT_ENABLED] mainwindow.macro=default")

--- a/code/modules/keybindings/setup.dm
+++ b/code/modules/keybindings/setup.dm
@@ -59,7 +59,7 @@
 			winset(src, "[setname]-[REF(key)]", "parent=[setname];name=[key];command=[command]")
 		// If we bind these, we're going to disable input relay.
 		// This *does* silently break TGUI-Say, but I doubt players who want to use this mode care. -Francinum
-		if(!using_chat_relay)
+		if(using_chat_relay)
 			winset(src, "[setname]-say", "parent=[setname];name=T;command=[say]")
 			winset(src, "[setname]-me", "parent=[setname];name=M;command=[me]")
 			winset(src, "[setname]-ooc", "parent=[setname];name=O;command=[ooc]")

--- a/code/modules/keybindings/setup.dm
+++ b/code/modules/keybindings/setup.dm
@@ -39,7 +39,7 @@
 	/// Is this client using Chat Relay/Legacy input mode. If so,
 	/// we need to be **VERY CAREFUL** about what keys we bind,
 	/// and we can't bind anything printable. -Francinum
-	var/using_chat_relay = (prefs.toggles2 & PREFTOGGLE_2_HOTKEYS)
+	var/using_chat_relay = !(prefs.toggles2 & PREFTOGGLE_2_HOTKEYS)
 
 	var/list/macro_sets = SSinput.macro_sets
 	var/use_tgui_say = !prefs || (prefs.toggles2 & PREFTOGGLE_2_TGUI_SAY)
@@ -57,9 +57,9 @@
 			var/key = macro_set[k]
 			var/command = macro_set[key]
 			winset(src, "[setname]-[REF(key)]", "parent=[setname];name=[key];command=[command]")
-		// If we bind these, we're going to disable input relay.
-		// This *does* silently break TGUI-Say, but I doubt players who want to use this mode care. -Francinum
-		if(using_chat_relay)
+		// If we bind these, we're going to break the default command bar input relay behaviour.
+		// This *does* mean we outright ignore the tgui-say pref, but I doubt players who want to use this mode care. -Francinum
+		if(!using_chat_relay)
 			winset(src, "[setname]-say", "parent=[setname];name=T;command=[say]")
 			winset(src, "[setname]-me", "parent=[setname];name=M;command=[me]")
 			winset(src, "[setname]-ooc", "parent=[setname];name=O;command=[ooc]")

--- a/nsv13.dme
+++ b/nsv13.dme
@@ -4127,3 +4127,7 @@
 #ifdef DONATOR_ITEMS
 #include "nsv13\code\modules\donator\donator.dm"
 #endif
+
+#ifdef MACROTEST
+#include "code\modules\admin\verbs\macro_debug.dm"
+#endif


### PR DESCRIPTION
```
Fixes default/Legacy control
> This does *technically* mean that legacy can't use TGUI Say, but nobody using Legacy is going to care.

Adds macrotest debug tools

Adds Dream Daemon VSCode debug target
```
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Default input has been broken for 8 months since #2618, due to it directly binding printable keys on legacy users.

The only safe keys to hard-bind on legacy input users is in this random list from 2008.
https://www.byond.com/docs/notes/macro.html

This also comes with a set of janky tools for directly poking at the client skin. They aren't production safe and are behind a compile flag, `MACROTEST`

You can now compile targeting Dream Daemon, as god intended. (This boots faster and means your client doesn't try to crash itself when you hit a breakpoint)

## Why It's Good For The Game

I got nerd-sniped. I entered the VC as a cheap joke.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Nobody but me cares about this anyways.

</details>

## Changelog
:cl:
fix: Default/Legacy input now properly relays keys.
del: TGUI Say and Legacy Input are incompatible, Legacy will take precedence.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
