### PR TITLE
AI vox announcements can be heard by the entire ship

### DIFF
--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -129,10 +129,10 @@
 	message_admins("[key_name(src)] made a vocal announcement with the following message: [message].")
 
 	for(var/word in words)
-		play_vox_word(word, src.get_virtual_z_level(), null)
+		play_vox_word(word, src.get_virtual_z_level(), null, src.get_overmap()) //NSV13
 
 
-/proc/play_vox_word(word, z_level, mob/only_listener)
+/proc/play_vox_word(word, z_level, mob/only_listener, obj/structure/overmap/OM) //NSV13 lets announcements be heard by the entire ship
 
 	word = lowertext(word)
 
@@ -144,12 +144,17 @@
 
  		// If there is no single listener, broadcast to everyone in the same z level
 		if(!only_listener)
-			// Play voice for all mobs in the z level
-			for(var/mob/M in GLOB.player_list)
-				if(M.client && M.can_hear() && (M.client.prefs.toggles & PREFTOGGLE_SOUND_ANNOUNCEMENTS))
-					var/turf/T = get_turf(M)
-					if(T.get_virtual_z_level() == z_level)
-						SEND_SOUND(M, voice)
+			if(!OM) //NSV13 START
+				// Play voice for all mobs in the z level
+				for(var/mob/M in GLOB.player_list)
+					if(M.client && M.can_hear() && (M.client.prefs.toggles & PREFTOGGLE_SOUND_ANNOUNCEMENTS))
+						var/turf/T = get_turf(M)
+						if(T.get_virtual_z_level() == z_level)
+							SEND_SOUND(M, voice)
+			else
+				for(var/mob/M as() in OM.mobs_in_ship)
+					if(M.client && M.can_hear() && (M.client.prefs.toggles & PREFTOGGLE_SOUND_ANNOUNCEMENTS))
+						SEND_SOUND(M, voice) //NSV13 END
 		else
 			SEND_SOUND(only_listener, voice)
 		return 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Currently, vox announcements work by only letting players on the same Z level as the AI hear them. This PR changes that by making AI vox announcements send sound to every player on a ships mobs_on_ship list, letting players on different Z levels be able to hear them

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
AI announcements should be heard by the entire crew, not just one floor.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
tweak: AI vox announcements now work on the entire ship, instead of on a single Z level
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
