### PR TITLE
Galactic Fixes

### DIFF
--- a/_maps/map_files/Galactica/Galactica1.dmm
+++ b/_maps/map_files/Galactica/Galactica1.dmm
@@ -1109,10 +1109,10 @@
 /area/maintenance/nsv/deck1/starboard)
 "cO" = (
 /obj/structure/table/reinforced,
-/obj/machinery/cell_charger{
-	pixel_y = 4
-	},
 /obj/effect/turf_decal/tile/ship/full/blue,
+/obj/machinery/keycard_auth{
+	pixel_y = 3
+	},
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "cP" = (
@@ -2148,10 +2148,10 @@
 /obj/effect/turf_decal/tile/ship/half/blue{
 	dir = 8
 	},
-/obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/ship/nt_floor_logo{
 	icon_state = "0,1"
 	},
+/obj/machinery/conquest_beacon/nanotrasen,
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "fJ" = (
@@ -9132,7 +9132,9 @@
 "xR" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/ship/half/red,
-/obj/item/storage/box/boardingpins,
+/obj/machinery/keycard_auth{
+	pixel_y = 3
+	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/heads/hos)
 "xT" = (
@@ -10510,14 +10512,20 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAP)
 "Bm" = (
-/obj/machinery/modular_computer/console/preset/command{
-	dir = 8
-	},
 /obj/structure/window/reinforced{
 	dir = 4;
 	layer = 2.9
 	},
 /obj/effect/turf_decal/tile/ship/full/blue,
+/obj/machinery/computer/ship/viewscreen{
+	density = 1;
+	desc = "A large computer which shows an exterior view of the ship.";
+	dir = 8;
+	icon = 'icons/obj/computer.dmi';
+	icon_state = "computer";
+	name = "Seegson model S viewscreen";
+	pixel_y = 1
+	},
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "Bn" = (
@@ -13489,16 +13497,10 @@
 	dir = 4;
 	layer = 2.9
 	},
-/obj/machinery/computer/ship/viewscreen{
-	density = 1;
-	desc = "A large computer which shows an exterior view of the ship.";
-	dir = 8;
-	icon = 'icons/obj/computer.dmi';
-	icon_state = "computer";
-	name = "Seegson model S viewscreen";
-	pixel_y = 1
-	},
 /obj/effect/turf_decal/tile/ship/full/blue,
+/obj/machinery/modular_computer/console/preset/command{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "IH" = (
@@ -14327,6 +14329,7 @@
 "KE" = (
 /obj/effect/turf_decal/ship/nt_floor_logo,
 /obj/item/beacon,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/light,
 /area/bridge/cic)
 "KF" = (
@@ -14632,6 +14635,8 @@
 /area/space/nearstation)
 "Lq" = (
 /obj/effect/turf_decal/tile/ship/red,
+/obj/structure/table/reinforced,
+/obj/item/storage/box/boardingpins,
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/heads/hos)
 "Lr" = (
@@ -15309,12 +15314,6 @@
 /obj/machinery/advanced_airlock_controller/directional/east,
 /turf/open/floor/durasteel/techfloor,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"Nj" = (
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/turf/open/floor/fakespace,
-/area/crew_quarters/heads/hos)
 "Nk" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -16871,6 +16870,10 @@
 "Rf" = (
 /obj/machinery/computer/card/minor/cmo{
 	dir = 4
+	},
+/obj/machinery/keycard_auth{
+	pixel_y = 3;
+	pixel_x = -28
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo)
@@ -57737,8 +57740,8 @@ mZ
 em
 fp
 Xg
-Xg
 pb
+Xg
 pb
 Xg
 Xg
@@ -65937,7 +65940,7 @@ oc
 oc
 KW
 sA
-Nj
+sA
 sA
 ue
 RI

--- a/_maps/map_files/Galactica/Galactica1.dmm
+++ b/_maps/map_files/Galactica/Galactica1.dmm
@@ -10657,6 +10657,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/vending/clothing,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "BD" = (

--- a/_maps/map_files/Galactica/Galactica1.dmm
+++ b/_maps/map_files/Galactica/Galactica1.dmm
@@ -467,6 +467,15 @@
 	},
 /turf/open/floor/plating,
 /area/security/brig)
+"be" = (
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 1
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck1/frame1/central)
 "bf" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	req_one_access_txt = "13"
@@ -590,8 +599,7 @@
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "by" = (
-/obj/effect/turf_decal/tile/ship/green,
-/obj/effect/turf_decal/tile/ship/green{
+/obj/effect/turf_decal/tile/ship/half/blue{
 	dir = 4
 	},
 /turf/open/floor/durasteel,
@@ -785,6 +793,33 @@
 	},
 /turf/open/floor/durasteel/techfloor,
 /area/ai_monitored/turret_protected/ai)
+"bU" = (
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 8
+	},
+/obj/structure/sign/directions/evac{
+	dir = 4;
+	pixel_y = 22;
+	pixel_x = -30
+	},
+/obj/structure/sign/directions/medical{
+	pixel_y = 28;
+	pixel_x = -30
+	},
+/obj/structure/sign/directions/science{
+	pixel_y = 34;
+	pixel_x = -30
+	},
+/obj/structure/sign/directions/engineering{
+	dir = 8;
+	pixel_y = 40;
+	pixel_x = -30
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck1/frame1/central)
 "bV" = (
 /obj/structure/sign/ship/securearea{
 	dir = 1
@@ -849,11 +884,11 @@
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "cd" = (
-/obj/effect/turf_decal/tile/ship/half/green{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/half/blue{
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/frame1/central)
@@ -898,8 +933,31 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/nsv/deck1/port/fore)
+"cl" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 1
+	},
+/obj/structure/sign/directions/command{
+	pixel_y = 24;
+	dir = 4;
+	pixel_x = -30
+	},
+/obj/structure/sign/directions/security{
+	pixel_y = 30;
+	pixel_x = -30
+	},
+/obj/structure/sign/directions/supply{
+	pixel_y = 36;
+	pixel_x = -30
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck1/frame1/central)
 "cm" = (
-/turf/open/floor/engine,
+/obj/effect/turf_decal/tile/ship/half/yellow,
+/turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/frame1/central)
 "cn" = (
 /obj/machinery/door/airlock/ship/maintenance{
@@ -1318,6 +1376,15 @@
 	},
 /turf/open/floor/carpet/red,
 /area/engine/break_room)
+"dp" = (
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 4
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck1/frame1/central)
 "dq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -1450,14 +1517,14 @@
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
 "dN" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/camera/autoname,
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 4
+	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck1/frame1/central)
 "dO" = (
@@ -1488,9 +1555,6 @@
 /turf/open/floor/engine,
 /area/maintenance/nsv/deck1/port)
 "dT" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -1556,6 +1620,16 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/monotile/light,
 /area/medical/virology)
+"ec" = (
+/obj/machinery/camera/autoname,
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 4
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck1/frame1/central)
 "ed" = (
 /obj/structure/sign/ship/deck,
 /turf/closed/wall/r_wall,
@@ -1605,13 +1679,13 @@
 /turf/open/floor/monotile/dark,
 /area/medical/surgery)
 "ej" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
+/obj/structure/extinguisher_cabinet/north,
 /obj/effect/turf_decal/tile/ship/green{
 	dir = 1
 	},
-/obj/structure/extinguisher_cabinet/north,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 4
+	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck1/frame1/central)
 "ek" = (
@@ -2196,6 +2270,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port/fore)
+"fQ" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 1
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck1/frame1/central)
 "fR" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
@@ -2404,6 +2490,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/monotile/steel,
 /area/ai_monitored/security/armory)
+"gs" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/effect/turf_decal/tile/ship/half/blue{
+	dir = 1
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck1/frame1/central)
 "gt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -2656,11 +2749,11 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/maintenance/nsv/deck1/port)
 "gY" = (
-/obj/effect/turf_decal/tile/ship/half/green{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/ship/half/blue{
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/frame1/central)
@@ -2872,12 +2965,6 @@
 /turf/open/floor/plating,
 /area/mine/laborcamp/security)
 "hD" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -3851,6 +3938,13 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/quartermaster/office)
+"jX" = (
+/obj/structure/extinguisher_cabinet/east,
+/obj/effect/turf_decal/tile/ship/half/blue{
+	dir = 4
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck1/frame1/central)
 "jY" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -3860,6 +3954,27 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/service)
+"jZ" = (
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 4
+	},
+/obj/structure/sign/directions/command{
+	pixel_y = 24;
+	dir = 4
+	},
+/obj/structure/sign/directions/security{
+	pixel_y = 30;
+	dir = 4
+	},
+/obj/structure/sign/directions/supply{
+	pixel_y = 36;
+	dir = 4
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck1/frame1/central)
 "ka" = (
 /turf/open/floor/plating,
 /area/science/robotics)
@@ -3889,6 +4004,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard/fore)
+"kf" = (
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 8
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck1/frame1/central)
 "kg" = (
 /obj/structure/sign/ship/deck,
 /turf/closed/wall/steel,
@@ -3973,14 +4094,14 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/hangar)
 "ks" = (
-/obj/structure/sign/directions/command{
+/obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/purple{
 	dir = 4
 	},
-/obj/structure/sign/directions/evac{
-	dir = 8;
-	pixel_y = -8
-	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/durasteel,
 /area/hallway/nsv/deck1/frame1/central)
 "kt" = (
 /obj/effect/turf_decal/stripes/corner,
@@ -4086,21 +4207,15 @@
 /turf/open/floor/monotile/steel,
 /area/ai_monitored/security/armory)
 "kG" = (
-/obj/effect/turf_decal/tile/ship/green{
+/obj/effect/turf_decal/tile/ship/purple{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
-/turf/open/floor/engine,
+/turf/open/floor/durasteel,
 /area/hallway/nsv/deck1/frame1/central)
 "kI" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/turf_decal/tile/ship/half/green{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
 	},
 /obj/machinery/door/airlock/ship/external/glass{
 	name = "command ferry dock";
@@ -4250,15 +4365,11 @@
 /turf/open/openspace,
 /area/security/brig)
 "kY" = (
-/obj/effect/turf_decal/tile/ship/half/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
+/obj/effect/turf_decal/tile/ship/half/purple{
 	dir = 8
 	},
-/obj/effect/landmark/latejoin,
-/turf/open/floor/monotile/steel,
-/area/crew_quarters/dorms)
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck1/frame1/central)
 "kZ" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/stripes/line,
@@ -4294,6 +4405,13 @@
 /mob/living/simple_animal/bot/secbot/armsky,
 /turf/open/floor/monotile/steel,
 /area/ai_monitored/security/armory)
+"lf" = (
+/obj/effect/turf_decal/tile/ship/half/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/yellow,
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck1/frame1/central)
 "lg" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only/directional/west,
@@ -5059,27 +5177,27 @@
 /turf/open/floor/monotile/dark,
 /area/medical/genetics)
 "nb" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/durasteel,
-/area/hallway/nsv/deck1/frame1/central)
-"nc" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/ship/green{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 4
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck1/frame1/central)
+"nc" = (
 /obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 4
+	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck1/frame1/central)
 "nd" = (
@@ -5204,13 +5322,13 @@
 /turf/closed/wall/steel,
 /area/medical/genetics)
 "nr" = (
-/obj/effect/turf_decal/tile/ship/green,
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/blue,
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck1/frame1/central)
 "ns" = (
@@ -5357,10 +5475,11 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port/fore)
 "nJ" = (
-/obj/effect/turf_decal/tile/ship/half/green{
+/obj/effect/turf_decal/tile/ship/blue{
 	dir = 4
 	},
-/turf/open/floor/monotile/dark,
+/obj/effect/turf_decal/tile/ship/blue,
+/turf/open/floor/durasteel,
 /area/hallway/nsv/deck1/frame1/central)
 "nK" = (
 /obj/structure/disposalpipe/segment,
@@ -5509,6 +5628,7 @@
 /obj/effect/turf_decal/tile/ship/half/neutral{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/ship/half/purple,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/frame1/central)
 "ol" = (
@@ -5809,6 +5929,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/cmo)
+"pc" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 4
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck1/frame1/central)
 "pd" = (
 /obj/structure/rack,
 /obj/item/ammo_box/magazine/peacekeeper,
@@ -5944,6 +6074,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
+"pq" = (
+/obj/machinery/camera/autoname,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 4
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck1/frame1/central)
 "pr" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -5974,7 +6114,7 @@
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/frame1/central)
 "pt" = (
-/obj/effect/turf_decal/tile/ship/half/green{
+/obj/effect/turf_decal/tile/ship/half/blue{
 	dir = 8
 	},
 /turf/open/floor/monotile/steel,
@@ -6460,6 +6600,9 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/ship/half/yellow{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/frame1/central)
 "qG" = (
@@ -6643,14 +6786,14 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "rf" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 4
 	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck1/frame1/central)
@@ -6795,11 +6938,11 @@
 /turf/open/floor/durasteel,
 /area/engine/break_room)
 "rv" = (
-/obj/effect/turf_decal/tile/ship/green,
-/obj/effect/turf_decal/tile/ship/green{
+/obj/structure/extinguisher_cabinet/east,
+/obj/effect/turf_decal/tile/ship/blue{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet/east,
+/obj/effect/turf_decal/tile/ship/blue,
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck1/frame1/central)
 "rw" = (
@@ -6847,6 +6990,12 @@
 /area/maintenance/nsv/deck1/starboard/aft)
 "rD" = (
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/ship/half/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/science/xenobiology)
 "rF" = (
@@ -7441,6 +7590,13 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/medical/virology)
+"td" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/half/purple,
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck1/frame1/central)
 "tf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -8032,8 +8188,8 @@
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "uD" = (
-/obj/effect/turf_decal/tile/ship/half/green,
 /obj/machinery/light,
+/obj/effect/turf_decal/tile/ship/half/brown,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/frame1/central)
 "uE" = (
@@ -8184,15 +8340,12 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "uX" = (
-/obj/structure/sign/directions/medical{
-	dir = 8;
-	pixel_y = -8
-	},
-/obj/structure/sign/directions/security{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/effect/turf_decal/tile/ship/half/purple{
 	dir = 1
 	},
-/turf/closed/wall/r_wall,
-/area/science/xenobiology)
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck1/frame1/central)
 "uY" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/turbolift/primary)
@@ -8209,10 +8362,22 @@
 /turf/open/floor/monotile/dark,
 /area/engine/break_room)
 "va" = (
-/obj/effect/turf_decal/tile/ship/green{
+/obj/effect/turf_decal/tile/ship/half/yellow{
 	dir = 1
 	},
-/turf/open/floor/engine,
+/obj/structure/sign/directions/command{
+	pixel_y = 24;
+	dir = 4
+	},
+/obj/structure/sign/directions/security{
+	pixel_y = 30;
+	dir = 4
+	},
+/obj/structure/sign/directions/supply{
+	pixel_y = 36;
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/frame1/central)
 "vb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -8252,7 +8417,7 @@
 /area/mine/laborcamp/security)
 "vj" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	name = "Morgue";
+	name = "Medical Passageway";
 	req_one_access_txt = "5"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -8308,11 +8473,25 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/ai_monitored/turret_protected/AIsatextAP)
 "vr" = (
-/obj/structure/sign/directions/engineering{
-	dir = 8
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 1
 	},
-/turf/closed/wall/r_wall,
-/area/maintenance/nsv/deck1/port)
+/obj/structure/sign/directions/command{
+	pixel_y = 24;
+	dir = 4;
+	pixel_x = -30
+	},
+/obj/structure/sign/directions/security{
+	pixel_y = 30;
+	dir = 1;
+	pixel_x = -30
+	},
+/obj/structure/sign/directions/supply{
+	pixel_y = 36;
+	pixel_x = -30
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck1/frame1/central)
 "vs" = (
 /obj/effect/turf_decal/tile/ship/half/neutral{
 	dir = 8
@@ -8434,6 +8613,7 @@
 /obj/machinery/camera/autoname{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/ship/half/blue,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/frame1/central)
 "vN" = (
@@ -8617,11 +8797,13 @@
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
 "wq" = (
-/obj/effect/turf_decal/tile/ship/half/green,
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/green{
 	dir = 4
 	},
-/turf/open/floor/monotile/dark,
+/turf/open/floor/durasteel,
 /area/hallway/nsv/deck1/frame1/central)
 "wr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -8679,6 +8861,9 @@
 	},
 /turf/open/floor/durasteel,
 /area/crew_quarters/dorms)
+"wz" = (
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck1/frame1/central)
 "wA" = (
 /obj/machinery/door/poddoor/shutters/ship{
 	id = "riot_storage";
@@ -8797,6 +8982,12 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/maintenance/nsv/deck1/starboard/aft)
+"wR" = (
+/obj/effect/turf_decal/tile/ship/half/blue{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck1/frame1/central)
 "wS" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -8843,22 +9034,28 @@
 	},
 /turf/open/floor/circuit/red/anim,
 /area/maintenance/nsv/deck1/port)
+"xc" = (
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/half/yellow{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck1/frame1/central)
 "xd" = (
 /obj/structure/hull_plate,
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
 "xe" = (
-/obj/effect/turf_decal/tile/ship/green,
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/junction/flip,
-/turf/open/floor/durasteel,
+/obj/structure/lattice/catwalk/over/ship,
+/turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/frame1/central)
 "xf" = (
 /obj/structure/cable/yellow,
@@ -8901,6 +9098,17 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
+"xl" = (
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/camera/autoname,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 4
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck1/frame1/central)
 "xm" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -8942,11 +9150,11 @@
 /turf/open/floor/carpet/purple,
 /area/science/xenobiology)
 "xs" = (
-/obj/effect/turf_decal/tile/ship/green,
-/obj/effect/turf_decal/tile/ship/green{
+/obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/tile/ship/yellow,
+/obj/effect/turf_decal/tile/ship/yellow{
 	dir = 8
 	},
-/obj/item/radio/intercom/directional/south,
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck1/frame1/central)
 "xt" = (
@@ -9039,6 +9247,15 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
+"xE" = (
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 8
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck1/frame1/central)
 "xF" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -9126,6 +9343,31 @@
 	},
 /turf/open/floor/durasteel/lino,
 /area/ai_monitored/nuke_storage)
+"xP" = (
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 4
+	},
+/obj/structure/sign/directions/evac{
+	dir = 4;
+	pixel_y = 22
+	},
+/obj/structure/sign/directions/medical{
+	dir = 4;
+	pixel_y = 28
+	},
+/obj/structure/sign/directions/science{
+	pixel_y = 34;
+	dir = 4
+	},
+/obj/structure/sign/directions/engineering{
+	dir = 8;
+	pixel_y = 40
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck1/frame1/central)
 "xQ" = (
 /turf/open/floor/durasteel,
 /area/engine/break_room)
@@ -9137,6 +9379,15 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/heads/hos)
+"xS" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/half/purple{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck1/frame1/central)
 "xT" = (
 /obj/structure/grille,
 /turf/open/floor/engine/airless,
@@ -9148,10 +9399,6 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port/fore)
 "xV" = (
-/obj/effect/turf_decal/tile/ship/green,
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -9160,6 +9407,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/ship/half/blue{
+	dir = 4
 	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck1/frame1/central)
@@ -9302,13 +9552,6 @@
 /turf/closed/wall/steel,
 /area/quartermaster/storage)
 "yq" = (
-/obj/machinery/door/airlock/ship{
-	name = "Moritorium";
-	req_one_access_txt = "5"
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/effect/landmark/zebra_interlock_point,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -9321,7 +9564,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/turf/open/floor/monotile/steel,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/medical/morgue)
 "yr" = (
 /obj/structure/cable/yellow{
@@ -9424,13 +9668,13 @@
 	},
 /area/maintenance/nsv/deck1/starboard)
 "yE" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
+/obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/tile/ship/yellow{
 	dir = 1
 	},
-/obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 4
+	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck1/frame1/central)
 "yF" = (
@@ -9531,7 +9775,7 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "yS" = (
-/obj/effect/turf_decal/tile/ship/half/green{
+/obj/effect/turf_decal/tile/ship/half/blue{
 	dir = 1
 	},
 /turf/open/floor/monotile/dark,
@@ -9613,15 +9857,12 @@
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/frame1/central)
 "zb" = (
-/obj/structure/sign/directions/medical{
-	dir = 4
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 8
 	},
-/obj/structure/sign/directions/command{
-	dir = 4;
-	pixel_y = -8
-	},
-/turf/closed/wall/steel,
-/area/maintenance/nsv/deck1/central)
+/obj/effect/turf_decal/tile/ship/purple,
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck1/frame1/central)
 "zd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/monotile/steel,
@@ -10065,7 +10306,7 @@
 /turf/open/floor/engine/airless,
 /area/ai_monitored/turret_protected/AIsatextAP)
 "zY" = (
-/obj/effect/turf_decal/tile/ship/green{
+/obj/effect/turf_decal/tile/ship/blue{
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
@@ -10225,6 +10466,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/half/blue{
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/frame1/central)
@@ -11203,10 +11447,29 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/maintenance/nsv/deck1/port)
 "CZ" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 8
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 1
 	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 4
+	},
+/obj/structure/sign/directions/evac{
+	dir = 4;
+	pixel_y = 22
+	},
+/obj/structure/sign/directions/medical{
+	dir = 4;
+	pixel_y = 28
+	},
+/obj/structure/sign/directions/science{
+	pixel_y = 34;
+	dir = 4
+	},
+/obj/structure/sign/directions/engineering{
+	dir = 8;
+	pixel_y = 40
+	},
+/turf/open/floor/durasteel,
 /area/hallway/nsv/deck1/frame1/central)
 "Da" = (
 /obj/structure/table/reinforced,
@@ -11295,6 +11558,15 @@
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile/dark,
 /area/engine/break_room)
+"Dm" = (
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 8
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck1/frame1/central)
 "Dn" = (
 /turf/closed/wall/steel,
 /area/maintenance/nsv/deck1/starboard/fore)
@@ -11346,6 +11618,12 @@
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile/dark,
 /area/security/brig)
+"Du" = (
+/obj/effect/turf_decal/tile/ship/half/purple{
+	dir = 1
+	},
+/turf/open/floor/monotile/dark,
+/area/science/xenobiology)
 "Dv" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -11385,15 +11663,15 @@
 /turf/open/floor/plating,
 /area/storage/tech)
 "Dz" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable{
 	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 4
 	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck1/frame1/central)
@@ -11780,12 +12058,12 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port/fore)
 "Ez" = (
-/obj/effect/turf_decal/tile/ship/green,
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/purple,
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 8
 	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck1/frame1/central)
@@ -12194,11 +12472,11 @@
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "FC" = (
-/obj/effect/turf_decal/tile/ship/green,
-/obj/effect/turf_decal/tile/ship/green{
+/obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/tile/ship/blue{
 	dir = 4
 	},
-/obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/tile/ship/blue,
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck1/frame1/central)
 "FD" = (
@@ -12390,8 +12668,11 @@
 /turf/open/floor/durasteel,
 /area/crew_quarters/dorms)
 "FY" = (
-/obj/effect/turf_decal/tile/ship/green,
-/turf/open/floor/engine,
+/obj/effect/turf_decal/tile/ship/yellow,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 8
+	},
+/turf/open/floor/durasteel,
 /area/hallway/nsv/deck1/frame1/central)
 "FZ" = (
 /turf/open/floor/monotile/steel,
@@ -12486,10 +12767,10 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
 "Gi" = (
-/obj/effect/turf_decal/tile/ship/half/green,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/ship/half/brown,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/frame1/central)
 "Gj" = (
@@ -12565,7 +12846,7 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "Gt" = (
-/obj/effect/turf_decal/tile/ship/green,
+/obj/effect/turf_decal/tile/ship/half/brown,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/frame1/central)
 "Gu" = (
@@ -12599,11 +12880,14 @@
 /turf/open/floor/plasteel/freezer,
 /area/medical/virology)
 "Gy" = (
-/obj/effect/turf_decal/tile/ship/green,
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 8
+/obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 1
 	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 4
+	},
+/turf/open/floor/durasteel,
 /area/hallway/nsv/deck1/frame1/central)
 "Gz" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer2{
@@ -12700,14 +12984,14 @@
 /turf/open/floor/circuit/red/anim,
 /area/maintenance/nsv/deck1/port)
 "GK" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 4
 	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck1/frame1/central)
@@ -13258,6 +13542,21 @@
 	},
 /turf/open/floor/engine/airless,
 /area/ai_monitored/turret_protected/AIsatextAP)
+"Ib" = (
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Medical Deck 1 Lobby"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/monotile/steel,
+/area/medical/medbay/zone2)
 "Id" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Isolation A";
@@ -13285,13 +13584,13 @@
 /turf/open/floor/monotile/steel,
 /area/medical/virology)
 "If" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
+/obj/machinery/camera/autoname,
+/obj/effect/turf_decal/tile/ship/blue{
 	dir = 1
 	},
-/obj/machinery/camera/autoname,
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 4
+	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck1/frame1/central)
 "Ig" = (
@@ -13652,6 +13951,18 @@
 	},
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
+"Jb" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 4
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck1/frame1/central)
 "Jc" = (
 /obj/machinery/computer/ship/dradis/minor/console,
 /obj/structure/window/reinforced{
@@ -13660,6 +13971,13 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
+"Jd" = (
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/yellow,
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck1/frame1/central)
 "Je" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -13735,13 +14053,13 @@
 /turf/closed/wall/r_wall,
 /area/security/warden)
 "Jm" = (
-/obj/effect/turf_decal/tile/ship/green{
+/obj/structure/extinguisher_cabinet/west,
+/obj/effect/turf_decal/tile/ship/purple{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/ship/green{
+/obj/effect/turf_decal/tile/ship/purple{
 	dir = 1
 	},
-/obj/structure/extinguisher_cabinet/west,
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck1/frame1/central)
 "Jn" = (
@@ -13865,11 +14183,14 @@
 /turf/open/floor/monotile/dark,
 /area/security/warden)
 "Jz" = (
-/obj/structure/sign/directions/engineering{
-	dir = 8
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 1
 	},
-/turf/closed/wall/r_wall,
-/area/science/xenobiology)
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 4
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck1/frame1/central)
 "JA" = (
 /obj/structure/rack,
 /obj/item/storage/box/firingpins{
@@ -13978,9 +14299,6 @@
 /obj/effect/turf_decal/tile/ship/half/neutral{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
 /obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
@@ -13997,6 +14315,13 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/medical/morgue)
+"JQ" = (
+/obj/effect/turf_decal/tile/ship/half/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/purple,
+/turf/open/floor/monotile/dark,
+/area/science/xenobiology)
 "JR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -14026,18 +14351,18 @@
 /turf/open/floor/monotile/steel,
 /area/quartermaster/office)
 "JU" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 4
+	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck1/frame1/central)
 "JV" = (
@@ -14076,14 +14401,14 @@
 /turf/open/floor/monotile/steel,
 /area/ai_monitored/security/armory)
 "JZ" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
 /obj/machinery/camera/autoname{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 1
 	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck1/frame1/central)
@@ -14150,11 +14475,11 @@
 /turf/open/openspace,
 /area/medical/medbay/zone2)
 "Ki" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/frame1/central)
@@ -14655,9 +14980,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
 /obj/machinery/door/airlock/ship/external/glass{
 	name = "command ferry dock";
 	req_one_access_txt = "19"
@@ -14854,6 +15176,27 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/medical/medbay/zone2)
+"LQ" = (
+/obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 4
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck1/frame1/central)
+"LR" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/effect/turf_decal/tile/ship/half/blue{
+	dir = 1
+	},
+/obj/structure/sign/directions/plaque/munitions{
+	dir = 4;
+	pixel_y = 30
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck1/frame1/central)
 "LS" = (
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/plating,
@@ -14953,13 +15296,10 @@
 /turf/open/floor/durasteel/techfloor,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "Mf" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/ship/purple{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck1/frame1/central)
 "Mg" = (
@@ -15097,6 +15437,9 @@
 /area/maintenance/nsv/deck1/starboard/aft)
 "MB" = (
 /obj/effect/turf_decal/tile/ship/half/neutral,
+/obj/effect/turf_decal/tile/ship/half/purple{
+	dir = 1
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/frame1/central)
 "MC" = (
@@ -15118,11 +15461,11 @@
 /turf/open/floor/carpet/purple,
 /area/science/xenobiology)
 "MD" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
+/obj/effect/turf_decal/tile/ship/blue{
 	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 4
 	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck1/frame1/central)
@@ -15355,12 +15698,10 @@
 /turf/closed/wall/r_wall,
 /area/security/warden)
 "Np" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 8
-	},
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/ship/half/yellow,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/frame1/central)
 "Nq" = (
@@ -15662,6 +16003,26 @@
 /obj/machinery/suit_storage_unit/radsuit,
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
+"Oa" = (
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 8
+	},
+/obj/structure/sign/directions/plaque/munitions{
+	pixel_y = 30;
+	pixel_x = -32
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck1/frame1/central)
+"Ob" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/half/yellow,
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck1/frame1/central)
 "Oc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -15776,6 +16137,15 @@
 "Ot" = (
 /turf/open/floor/durasteel,
 /area/engine/storage_shared)
+"Ou" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/half/blue{
+	dir = 4
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck1/frame1/central)
 "Ov" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/ship/preopen{
@@ -15789,6 +16159,13 @@
 /obj/structure/lattice,
 /turf/open/openspace,
 /area/medical/medbay/zone2)
+"Ox" = (
+/obj/effect/turf_decal/tile/ship/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/brown,
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck1/frame1/central)
 "Oy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -16629,6 +17006,10 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/trunk/multiz/down,
+/obj/effect/turf_decal/tile/ship/blue,
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/frame1/central)
 "QB" = (
@@ -16918,16 +17299,16 @@
 /turf/open/floor/plating,
 /area/bridge/cic)
 "Rm" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 4
 	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck1/frame1/central)
@@ -17063,13 +17444,13 @@
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
 "RE" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
+/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/tile/ship/blue{
 	dir = 1
 	},
-/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 4
+	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck1/frame1/central)
 "RF" = (
@@ -17103,11 +17484,11 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "RL" = (
-/obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/machinery/camera/autoname,
+/obj/effect/turf_decal/tile/ship/half/yellow{
+	dir = 1
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/frame1/central)
 "RM" = (
@@ -17141,11 +17522,11 @@
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/frame1/central)
 "RQ" = (
-/obj/effect/turf_decal/tile/ship/green,
-/obj/effect/turf_decal/tile/ship/green{
+/obj/structure/extinguisher_cabinet/south,
+/obj/effect/turf_decal/tile/ship/purple{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet/south,
+/obj/effect/turf_decal/tile/ship/purple,
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck1/frame1/central)
 "RR" = (
@@ -17372,8 +17753,8 @@
 /turf/open/openspace/airless,
 /area/space/nearstation)
 "Su" = (
-/obj/effect/turf_decal/tile/ship/green,
-/obj/effect/turf_decal/tile/ship/green{
+/obj/effect/turf_decal/tile/ship/brown,
+/obj/effect/turf_decal/tile/ship/brown{
 	dir = 8
 	},
 /turf/open/floor/durasteel,
@@ -17400,11 +17781,30 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port/fore)
 "Sz" = (
-/obj/effect/turf_decal/tile/ship/half/green{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/half/purple{
+	dir = 8
+	},
+/obj/structure/sign/directions/evac{
+	dir = 8;
+	pixel_y = 22;
+	pixel_x = -30
+	},
+/obj/structure/sign/directions/medical{
+	dir = 1;
+	pixel_y = 28;
+	pixel_x = -30
+	},
+/obj/structure/sign/directions/science{
+	pixel_y = 34;
+	pixel_x = -30
+	},
+/obj/structure/sign/directions/engineering{
+	dir = 8;
+	pixel_y = 40;
+	pixel_x = -30
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/frame1/central)
@@ -17515,10 +17915,13 @@
 /turf/open/floor/durasteel,
 /area/storage/tech)
 "SP" = (
-/obj/effect/turf_decal/tile/ship/green{
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/yellow{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/floor/durasteel,
 /area/hallway/nsv/deck1/frame1/central)
 "SQ" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -17621,6 +18024,13 @@
 	},
 /turf/open/floor/durasteel,
 /area/storage/tech)
+"Te" = (
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/green,
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck1/frame1/central)
 "Tf" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -17668,6 +18078,18 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
+"Tk" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 4
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck1/frame1/central)
 "Tl" = (
 /obj/structure/table,
 /obj/item/coin/iron,
@@ -17848,13 +18270,13 @@
 /turf/open/floor/engine,
 /area/construction)
 "TL" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
+/obj/machinery/computer/ship/viewscreen,
 /obj/effect/turf_decal/tile/ship/green{
 	dir = 1
 	},
-/obj/machinery/computer/ship/viewscreen,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 4
+	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck1/frame1/central)
 "TM" = (
@@ -18966,12 +19388,6 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port/aft)
 "Wt" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -18980,6 +19396,12 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 1
 	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck1/frame1/central)
@@ -19256,6 +19678,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 4
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/frame1/central)
 "Xd" = (
@@ -19384,13 +19812,13 @@
 /turf/open/floor/carpet/red,
 /area/security/warden)
 "Xv" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 8
-	},
+/obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/tile/ship/green{
 	dir = 1
 	},
-/obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 8
+	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck1/frame1/central)
 "Xw" = (
@@ -19615,6 +20043,20 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/carpet/green,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"XY" = (
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 1
+	},
+/obj/structure/sign/directions/plaque/munitions{
+	dir = 1;
+	pixel_y = -3;
+	pixel_x = -31
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck1/frame1/central)
 "XZ" = (
 /obj/effect/turf_decal/ship/nt_floor_logo{
 	icon_state = "0,1"
@@ -19721,6 +20163,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard/fore)
+"Yr" = (
+/obj/machinery/computer/ship/viewscreen,
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 4
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck1/frame1/central)
 "Ys" = (
 /obj/machinery/camera/autoname,
 /turf/open/floor/plating,
@@ -19915,13 +20367,13 @@
 /turf/open/openspace,
 /area/security/brig)
 "YU" = (
-/obj/effect/turf_decal/tile/ship/half/green{
-	dir = 4
-	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=deck2Down";
 	location = "down";
 	name = "deck1Down"
+	},
+/obj/effect/turf_decal/tile/ship/half/blue{
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/frame1/central)
@@ -45147,9 +45599,9 @@ Wb
 gS
 Fb
 vg
-kG
+SP
 ri
-Gy
+FY
 vg
 do
 kb
@@ -45404,9 +45856,9 @@ ub
 EZ
 dP
 vg
-va
+SP
 Br
-CZ
+FY
 vg
 Dj
 mh
@@ -46175,9 +46627,9 @@ cU
 cI
 gt
 vg
-kG
+SP
 Br
-Gy
+FY
 oH
 XV
 XV
@@ -46434,7 +46886,7 @@ wJ
 Pk
 RL
 qz
-Gi
+Ob
 Pk
 vc
 vc
@@ -46689,9 +47141,9 @@ jN
 jN
 pY
 Pk
-GK
+Jb
 Hp
-Su
+FY
 pZ
 vc
 vc
@@ -46948,7 +47400,7 @@ jN
 Pk
 yE
 Hp
-Su
+FY
 Pk
 vc
 mI
@@ -47203,9 +47655,9 @@ jN
 jN
 jN
 Pk
-MD
+SP
 Hp
-Su
+FY
 Pk
 vc
 vc
@@ -47460,9 +47912,9 @@ Ns
 wt
 jN
 qE
-MD
+SP
 Hp
-Su
+FY
 Pk
 mI
 vc
@@ -47717,9 +48169,9 @@ jN
 jN
 jN
 Pk
-yS
+va
 sQ
-DE
+cm
 Pk
 vc
 vc
@@ -47974,9 +48426,9 @@ jN
 jN
 jN
 Pk
-MD
+CZ
 Hp
-Su
+FY
 Pk
 vc
 mI
@@ -48231,9 +48683,9 @@ jN
 jN
 jN
 Pk
-MD
+SP
 Hp
-Su
+FY
 Pk
 vc
 vc
@@ -48488,9 +48940,9 @@ rF
 rF
 rF
 Pk
-MD
+wq
 Hp
-Su
+FY
 Pk
 vc
 TV
@@ -48745,9 +49197,9 @@ IF
 Ee
 uO
 dx
-GK
+fQ
 Hp
-Su
+FY
 Pk
 mI
 TV
@@ -49004,7 +49456,7 @@ Ee
 XT
 fT
 qz
-Gi
+Ob
 Pk
 vc
 TV
@@ -49261,7 +49713,7 @@ uh
 uQ
 Rm
 zu
-Su
+FY
 Pk
 TV
 TV
@@ -49516,9 +49968,9 @@ UI
 Ee
 Ee
 XT
-MD
+Jz
 EG
-Su
+FY
 Pk
 QK
 mI
@@ -49773,9 +50225,9 @@ Ee
 Ee
 Ee
 dx
-If
+pq
 Hp
-Su
+FY
 Pk
 hS
 mI
@@ -50032,7 +50484,7 @@ dx
 dx
 ej
 Hp
-Su
+FY
 Pk
 mI
 mI
@@ -50289,7 +50741,7 @@ IW
 dx
 Mu
 Hp
-DE
+cm
 Pk
 mI
 mI
@@ -50544,9 +50996,9 @@ Mi
 Mi
 tj
 dx
-MD
+Jz
 Hp
-Su
+FY
 Pk
 TV
 TV
@@ -50801,7 +51253,7 @@ Mi
 Mi
 zP
 kc
-MD
+Jz
 Hp
 xs
 Pk
@@ -51056,11 +51508,11 @@ dx
 JO
 PK
 Fd
-kY
+Fd
 jp
-MD
+Jz
 Hp
-Su
+FY
 Pk
 TV
 TV
@@ -51317,7 +51769,7 @@ MK
 nu
 nb
 Vs
-Su
+FY
 Pk
 tv
 tv
@@ -51574,7 +52026,7 @@ nK
 LB
 RP
 Wj
-Gi
+Ob
 Pk
 tv
 tv
@@ -51829,9 +52281,9 @@ Wa
 Va
 Wa
 jp
-MD
+Jz
 Hp
-Su
+Jd
 Pk
 tv
 tv
@@ -52088,7 +52540,7 @@ Tu
 dx
 TL
 Hp
-Su
+Jd
 Pk
 tv
 tv
@@ -52345,7 +52797,7 @@ FX
 dx
 nc
 Hp
-Su
+Jd
 Pk
 TV
 TV
@@ -52600,9 +53052,9 @@ gG
 dx
 BN
 dx
-dN
+xl
 Hp
-Su
+Jd
 Pk
 rc
 Pk
@@ -52863,9 +53315,9 @@ DE
 VD
 ZC
 Ix
-yS
+xc
 qF
-DE
+lf
 si
 Hu
 Hu
@@ -53114,15 +53566,15 @@ xv
 xv
 xv
 oM
-MD
+Jz
 Hp
-Su
+Te
 JB
 ZC
 tN
-MD
+Jz
 ip
-Su
+FY
 vN
 Hu
 Hu
@@ -53370,7 +53822,7 @@ ql
 ql
 ql
 ql
-vr
+ql
 HH
 ps
 HH
@@ -53379,7 +53831,7 @@ VY
 Pk
 rf
 ip
-Su
+FY
 YH
 Hu
 Hu
@@ -53620,20 +54072,20 @@ Pq
 Pq
 Pq
 iw
-FR
+Dm
 Xv
-FR
+Dm
 af
-FR
-FR
-FR
-FR
-Sz
+Dm
+Dm
+Oa
+bU
+cl
 NN
+kf
 FR
 FR
 FR
-af
 IN
 ip
 Np
@@ -54135,17 +54587,17 @@ pt
 pt
 iw
 nr
-by
-by
+nJ
+nJ
 gY
-by
-by
-by
+nJ
+nJ
+nJ
 nr
 cd
-by
+nJ
 FC
-by
+nJ
 rv
 nJ
 zY
@@ -54404,7 +54856,7 @@ pk
 pk
 pk
 pk
-zb
+pk
 HH
 VT
 za
@@ -54919,7 +55371,7 @@ Eg
 NS
 Eg
 Eg
-GK
+Tk
 Hp
 Su
 cx
@@ -55433,7 +55885,7 @@ gM
 Eu
 Vy
 Eg
-fT
+LR
 qz
 Gi
 cx
@@ -55690,7 +56142,7 @@ Ve
 JP
 ME
 Eg
-yE
+LQ
 Hp
 Su
 cx
@@ -55946,8 +56398,8 @@ MY
 sL
 JP
 QE
-hq
-MD
+Eg
+jZ
 Hp
 Su
 ZJ
@@ -56204,7 +56656,7 @@ Ve
 ia
 uT
 Eg
-MD
+xP
 Hp
 Su
 ZJ
@@ -56460,7 +56912,7 @@ MY
 Ve
 bI
 LH
-Eg
+hq
 If
 Hp
 Su
@@ -56977,7 +57429,7 @@ Kl
 tO
 MD
 Hp
-Su
+Ox
 ZJ
 lr
 TQ
@@ -57232,7 +57684,7 @@ nW
 SJ
 dH
 mX
-Mf
+pc
 Pf
 Su
 ZJ
@@ -57488,7 +57940,7 @@ iL
 ar
 ba
 uo
-vj
+Ib
 JU
 Sa
 Su
@@ -57746,7 +58198,7 @@ Xg
 pb
 Xg
 Xg
-TL
+Yr
 Hp
 Su
 ZJ
@@ -58003,7 +58455,7 @@ Rf
 qv
 fa
 pb
-fT
+gs
 qz
 Gi
 ZJ
@@ -58260,7 +58712,7 @@ lu
 Ui
 cT
 CT
-Mf
+pc
 Pf
 Su
 ZJ
@@ -59033,7 +59485,7 @@ AI
 AI
 GK
 Hp
-Su
+zb
 lm
 Pl
 nZ
@@ -59802,9 +60254,9 @@ JH
 JH
 AI
 AI
-nc
+Gy
 Hp
-Su
+zb
 Di
 hZ
 sX
@@ -60059,9 +60511,9 @@ oU
 oU
 oU
 AI
-yE
+ks
 Hp
-Su
+zb
 Di
 Da
 Bc
@@ -60316,9 +60768,9 @@ oU
 CE
 Yh
 AI
-MD
+dp
 Hp
-Su
+zb
 Di
 Wy
 Bc
@@ -60573,9 +61025,9 @@ oU
 oU
 Sb
 vO
-fT
+uX
 qz
-Gi
+td
 Di
 Yo
 iv
@@ -60832,7 +61284,7 @@ oU
 AI
 GK
 Hp
-Su
+zb
 Di
 Ov
 Ov
@@ -61087,9 +61539,9 @@ AI
 AI
 AI
 AI
-MD
+dp
 Hp
-Su
+zb
 dK
 Ux
 zl
@@ -61346,7 +61798,7 @@ Ly
 rD
 Mf
 Pf
-Su
+zb
 tT
 HG
 UY
@@ -61600,8 +62052,8 @@ kU
 kU
 dr
 aB
-RM
-MD
+Du
+wz
 jS
 xe
 gc
@@ -61857,10 +62309,10 @@ Pv
 JD
 kU
 Na
-RM
-yS
+JQ
+kG
 Hp
-wq
+Ez
 tT
 HG
 Sn
@@ -62115,7 +62567,7 @@ MC
 CL
 AI
 AI
-If
+ec
 Hp
 Ez
 tJ
@@ -62628,7 +63080,7 @@ qX
 XU
 RM
 rK
-Jz
+AI
 GK
 Hp
 Ez
@@ -62885,7 +63337,7 @@ AI
 AI
 AI
 AI
-uX
+AI
 HH
 ps
 IV
@@ -63132,31 +63584,31 @@ Bw
 Ts
 Ts
 ok
-Sz
+xS
 Jm
-FR
-FR
+be
+be
 Wt
-af
+kY
 JZ
-FR
-FR
-FR
+be
+XY
+be
 Sz
-IN
+vr
 Hp
 Ki
-af
-FR
-FR
-FR
-FR
-Sz
-FR
-FR
-FR
-FR
-af
+kY
+xE
+xE
+xE
+xE
+xS
+xE
+xE
+xE
+xE
+kY
 MB
 WF
 Ts
@@ -63648,21 +64100,21 @@ Ts
 vM
 cd
 by
-nr
+Ou
 by
 xV
-nJ
+wR
 by
 by
 by
-nr
+Ou
 cd
 dT
 ip
-Gt
-nJ
-nr
-rv
+ZC
+wR
+Ou
+jX
 by
 by
 cd
@@ -63913,10 +64365,10 @@ oH
 IC
 Ax
 oH
-ks
+oH
 hD
 aD
-Su
+wz
 oH
 oH
 oH

--- a/_maps/map_files/Galactica/Galactica2.dmm
+++ b/_maps/map_files/Galactica/Galactica2.dmm
@@ -10040,13 +10040,20 @@
 	dir = 8
 	},
 /obj/machinery/button/door{
-	id = "Skynet_launch_interior";
-	name = "Mech Bay Door Control";
-	pixel_y = -32;
-	req_access_txt = "29"
+	id = sd;
+	name = "Mech Bay Exterior Door Control";
+	pixel_y = 3;
+	req_access_txt = "29";
+	pixel_x = 28
 	},
 /obj/effect/turf_decal/tile/ship/half/purple{
 	dir = 8
+	},
+/obj/machinery/button/door{
+	id = sd;
+	name = "Mech Bay Exterior Door Control";
+	pixel_y = -32;
+	req_access_txt = "29"
 	},
 /turf/open/floor/monotile/dark,
 /area/science/robotics/mechbay)
@@ -12950,7 +12957,9 @@
 /area/engine/atmos)
 "gIX" = (
 /obj/structure/table/reinforced,
-/obj/item/flashlight/lamp,
+/obj/machinery/keycard_auth{
+	pixel_y = 3
+	},
 /turf/open/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
 "gJr" = (
@@ -14401,6 +14410,7 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced,
+/obj/item/borg/upgrade/rename,
 /turf/open/floor/monotile/dark,
 /area/science/robotics/lab)
 "hzS" = (
@@ -14884,8 +14894,10 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/chief_engineer,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
 "hNR" = (
@@ -17678,6 +17690,12 @@
 	},
 /obj/machinery/power/apc/auto_name/north,
 /obj/machinery/camera/autoname,
+/obj/machinery/button/door{
+	id = "Skynet_launch_interior";
+	name = "Mech Bay Interior Door Control";
+	req_access_txt = "29";
+	pixel_x = 28
+	},
 /turf/open/floor/monotile/dark,
 /area/science/robotics/mechbay)
 "jod" = (
@@ -18563,6 +18581,7 @@
 /area/maintenance/nsv/deck2/frame2/starboard)
 "jMx" = (
 /obj/machinery/airalarm/directional/east,
+/obj/item/paper/monitorkey,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/chief)
 "jMA" = (
@@ -18638,6 +18657,9 @@
 /mob/living/simple_animal/parrot/Poly,
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
 	},
 /turf/open/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
@@ -19116,10 +19138,10 @@
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/atmos)
 "kbF" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
 "kbJ" = (
 /obj/structure/chair/wood/normal{
@@ -21595,7 +21617,7 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/poddoor/shutters/ship{
-	id = "Skynet_launch_interior";
+	id = "Skynet_2";
 	name = "Mech Bay Shutters"
 	},
 /turf/open/floor/monotile/steel,
@@ -26121,7 +26143,9 @@
 "nRK" = (
 /obj/structure/chair/office/light,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
 "nRZ" = (
@@ -26156,6 +26180,8 @@
 	pixel_y = 5
 	},
 /obj/item/storage/belt/utility/atmostech,
+/obj/item/clothing/glasses/welding,
+/obj/item/clothing/glasses/welding,
 /turf/open/floor/monotile/dark,
 /area/science/robotics/lab)
 "nSH" = (
@@ -26245,6 +26271,13 @@
 	dir = 4
 	},
 /obj/machinery/holopad,
+/obj/machinery/button/door{
+	id = sd;
+	name = "Mech Bay Exterior Door Control";
+	pixel_y = -2;
+	req_access_txt = "29";
+	pixel_x = 32
+	},
 /turf/open/floor/monotile/steel,
 /area/science/robotics/lab)
 "nWu" = (
@@ -26608,6 +26641,10 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/secure/briefcase,
 /obj/machinery/computer/med_data/laptop,
+/obj/item/stamp/xo{
+	pixel_x = -6;
+	pixel_y = 4
+	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop{
 	name = "Executive officer's Office"
@@ -26690,6 +26727,15 @@
 	pixel_y = 4
 	},
 /obj/machinery/camera/autoname,
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
 /turf/open/floor/monotile/dark,
 /area/science/robotics/lab)
 "ofP" = (
@@ -27398,8 +27444,9 @@
 "oyo" = (
 /obj/machinery/button/door{
 	id = "Skynet_launch_interior";
-	name = "Mech Bay Door Control";
-	req_access_txt = "29"
+	name = "Mech Bay Interior Door Control";
+	req_access_txt = "29";
+	pixel_y = 7
 	},
 /turf/closed/wall/steel,
 /area/science/robotics/mechbay)
@@ -27923,12 +27970,8 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "oMB" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/chief)
 "oMI" = (
@@ -28337,18 +28380,13 @@
 /area/hallway/nsv/deck2/primary)
 "oWl" = (
 /obj/structure/table/reinforced,
-/obj/item/paper/monitorkey,
-/obj/item/clothing/glasses/meson,
-/obj/item/stamp/chief_engineer,
+/obj/item/storage/secure/briefcase,
 /obj/item/computer_hardware/hard_drive/role/engineering{
 	pixel_x = 3
 	},
+/obj/item/clothing/glasses/meson,
 /obj/item/reagent_containers/pill/patch/silver_sulf,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/clothing/mask/cigarette/cigar,
 /turf/open/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
 "oWy" = (
@@ -28657,23 +28695,11 @@
 	},
 /area/maintenance/nsv/deck2/frame4/port)
 "pdO" = (
-/obj/effect/turf_decal/tile/ship/green{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
-/obj/machinery/button/door{
-	id = "Skynet_launch_interior";
-	name = "Mech Bay Door Control";
-	pixel_y = 24;
-	req_access_txt = "29"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/durasteel,
-/area/hallway/nsv/deck2/primary)
+/turf/open/floor/carpet/orange,
+/area/crew_quarters/heads/chief)
 "pdP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -30059,10 +30085,7 @@
 /area/maintenance/nsv/deck2/frame5/starboard)
 "pSB" = (
 /obj/structure/table/reinforced,
-/obj/item/stamp/xo{
-	pixel_x = -6;
-	pixel_y = 4
-	},
+/obj/machinery/keycard_auth,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop{
 	name = "Executive officer's Office"
@@ -31808,6 +31831,14 @@
 	dir = 4
 	},
 /obj/machinery/ecto_sniffer,
+/obj/item/healthanalyzer{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/item/healthanalyzer{
+	pixel_x = 4;
+	pixel_y = -4
+	},
 /turf/open/floor/monotile/dark,
 /area/science/robotics/lab)
 "qNq" = (
@@ -32277,6 +32308,9 @@
 "rck" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
+	},
+/obj/machinery/keycard_auth{
+	pixel_y = 3
 	},
 /turf/open/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
@@ -36770,8 +36804,9 @@
 /area/engine/engineering/reactor_core)
 "tsq" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/secure/briefcase,
-/obj/item/clothing/mask/cigarette/cigar,
+/obj/item/flashlight/lamp,
+/obj/item/paper/monitorkey,
+/obj/item/stamp/chief_engineer,
 /turf/open/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
 "tsx" = (
@@ -40769,7 +40804,9 @@
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering)
 "vAJ" = (
-/obj/machinery/computer/card/minor/ce,
+/obj/machinery/computer/station_alert{
+	name = "ship alert console"
+	},
 /turf/open/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
 "vAT" = (
@@ -44189,9 +44226,6 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame2/central)
 "xvI" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
@@ -44386,12 +44420,10 @@
 /turf/open/floor/carpet/ship,
 /area/chapel/office)
 "xAO" = (
-/obj/machinery/computer/station_alert{
-	name = "ship alert console"
-	},
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
+/obj/machinery/computer/card/minor/ce,
 /turf/open/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
 "xAP" = (
@@ -66162,7 +66194,7 @@ hms
 dcQ
 iSw
 qXe
-cVs
+pdO
 oWl
 tIA
 qXe
@@ -66418,8 +66450,8 @@ vol
 hms
 neH
 iSw
+qXe
 kbF
-cVs
 vAJ
 cVs
 ijw
@@ -87247,7 +87279,7 @@ dCH
 bXy
 dCH
 wLD
-pdO
+miz
 rtl
 aJw
 htI

--- a/_maps/map_files/Galactica/Galactica2.dmm
+++ b/_maps/map_files/Galactica/Galactica2.dmm
@@ -10040,7 +10040,7 @@
 	dir = 8
 	},
 /obj/machinery/button/door{
-	id = sd;
+	id = "Skynet_2";
 	name = "Mech Bay Exterior Door Control";
 	pixel_y = 3;
 	req_access_txt = "29";
@@ -10050,7 +10050,7 @@
 	dir = 8
 	},
 /obj/machinery/button/door{
-	id = sd;
+	id = "Skynet_2";
 	name = "Mech Bay Exterior Door Control";
 	pixel_y = -32;
 	req_access_txt = "29"
@@ -26272,7 +26272,7 @@
 	},
 /obj/machinery/holopad,
 /obj/machinery/button/door{
-	id = sd;
+	id = "Skynet_2";
 	name = "Mech Bay Exterior Door Control";
 	pixel_y = -2;
 	req_access_txt = "29";

--- a/_maps/map_files/Galactica/Galactica2.dmm
+++ b/_maps/map_files/Galactica/Galactica2.dmm
@@ -15125,6 +15125,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
+/obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
 "hNR" = (
@@ -18379,7 +18380,7 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/airlock/ship{
+/obj/machinery/door/airlock/ship/public/glass{
 	name = "Museum"
 	},
 /turf/open/floor/monotile/dark,
@@ -18877,7 +18878,6 @@
 /area/maintenance/nsv/deck2/frame2/starboard)
 "jMx" = (
 /obj/machinery/airalarm/directional/east,
-/obj/item/paper/monitorkey,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/chief)
 "jMA" = (
@@ -21407,7 +21407,7 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/effect/landmark/zebra_interlock_point,
-/obj/machinery/door/airlock/ship{
+/obj/machinery/door/airlock/ship/public/glass{
 	name = "Briefing Room"
 	},
 /turf/open/floor/monotile/steel,
@@ -22983,7 +22983,6 @@
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
 "lSb" = (
-/obj/effect/landmark/nuclear_waste_spawner,
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/chief)
@@ -26576,7 +26575,6 @@
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
 "nRK" = (
-/obj/structure/chair/office/light,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -32842,9 +32840,6 @@
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
-/obj/machinery/keycard_auth{
-	pixel_y = 3
-	},
 /turf/open/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
 "rcD" = (
@@ -33999,7 +33994,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/ship{
+/obj/machinery/door/airlock/ship/public/glass{
 	name = "Briefing Room"
 	},
 /turf/open/floor/monotile/steel,
@@ -34502,7 +34497,7 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/effect/landmark/zebra_interlock_point,
-/obj/machinery/door/airlock/ship{
+/obj/machinery/door/airlock/ship/public/glass{
 	name = "Briefing Room"
 	},
 /turf/open/floor/monotile/steel,

--- a/_maps/map_files/Galactica/Galactica2.dmm
+++ b/_maps/map_files/Galactica/Galactica2.dmm
@@ -770,12 +770,15 @@
 /turf/open/floor/plating,
 /area/engine/engineering/reactor_core)
 "awh" = (
-/obj/effect/turf_decal/tile/ship/half/green,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/computer/ship/viewscreen,
+/obj/effect/turf_decal/tile/ship/brown{
+	dir = 1
 	},
-/turf/open/floor/monotile/dark,
-/area/maintenance/nsv/deck2/frame3/central)
+/obj/effect/turf_decal/tile/ship/brown{
+	dir = 4
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "awq" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -875,7 +878,6 @@
 /turf/open/floor/monotile/steel,
 /area/nsv/briefingroom)
 "azj" = (
-/obj/effect/turf_decal/tile/ship/full/blue,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
@@ -884,6 +886,12 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
@@ -915,23 +923,29 @@
 /turf/open/floor/monotile/steel,
 /area/science/lab)
 "aAz" = (
-/obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/half/brown{
 	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
 "aAQ" = (
-/obj/effect/turf_decal/tile/ship/full/blue,
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "aAX" = (
@@ -1301,6 +1315,9 @@
 	},
 /obj/item/gps{
 	gpstag = "RD0"
+	},
+/obj/effect/turf_decal/tile/ship/half/purple{
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/science)
@@ -1876,11 +1893,16 @@
 /area/engine/atmos)
 "aXh" = (
 /obj/structure/sign/directions/security{
-	dir = 1
+	dir = 1;
+	pixel_y = -3
 	},
 /obj/structure/sign/directions/command{
 	dir = 1;
-	pixel_y = -8
+	pixel_y = -9
+	},
+/obj/structure/sign/directions/supply{
+	dir = 8;
+	pixel_y = 3
 	},
 /turf/closed/wall/steel,
 /area/science/robotics/mechbay)
@@ -2092,6 +2114,14 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
+"bbf" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/blue,
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "bbk" = (
 /obj/structure/chair/fancy/bench/pew/left{
 	dir = 4
@@ -2626,10 +2656,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/ship/green{
+/obj/effect/turf_decal/tile/ship/neutral{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/ship/green{
+/obj/effect/turf_decal/tile/ship/neutral{
 	dir = 8
 	},
 /turf/open/floor/durasteel,
@@ -2716,10 +2746,10 @@
 /turf/open/floor/durasteel/padded,
 /area/maintenance/nsv/deck2/frame1/port)
 "bqv" = (
-/obj/effect/turf_decal/tile/ship/half/green{
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/light{
+/obj/effect/turf_decal/tile/ship/half/neutral{
 	dir = 1
 	},
 /turf/open/floor/monotile/dark,
@@ -2841,6 +2871,21 @@
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/monotile/light,
 /area/medical/chemistry)
+"bxM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/ship/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/red{
+	dir = 4
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "bxO" = (
 /turf/closed/wall/r_wall,
 /area/engine/engine_smes)
@@ -3365,6 +3410,26 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
+"bNb" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 1
+	},
+/obj/structure/sign/directions/plaque/munitions{
+	pixel_y = 31;
+	pixel_x = -1;
+	dir = 4
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "bNj" = (
 /turf/open/floor/plasteel/stairs{
 	dir = 1;
@@ -3464,13 +3529,13 @@
 /turf/open/floor/monotile/steel,
 /area/mine/laborcamp)
 "bOy" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
+/obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/tile/ship/neutral{
 	dir = 1
 	},
-/obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 4
+	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
 "bOC" = (
@@ -3572,11 +3637,7 @@
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
 "bQT" = (
-/obj/structure/sign/directions/science{
-	dir = 8;
-	pixel_y = 2
-	},
-/turf/closed/wall/steel,
+/turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
 "bQX" = (
 /obj/structure/lattice,
@@ -3754,11 +3815,14 @@
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
 "bVm" = (
-/obj/effect/turf_decal/tile/ship/half/green{
+/obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/tile/ship/neutral{
 	dir = 1
 	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/monotile/dark,
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 4
+	},
+/turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
 "bWd" = (
 /obj/structure/fluff/support_beam{
@@ -3897,13 +3961,13 @@
 /turf/open/floor/plating,
 /area/mine/laborcamp/security)
 "bZU" = (
-/obj/effect/turf_decal/tile/ship/green{
+/obj/machinery/camera/autoname,
+/obj/effect/turf_decal/tile/ship/neutral{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/ship/green{
+/obj/effect/turf_decal/tile/ship/neutral{
 	dir = 4
 	},
-/obj/machinery/camera/autoname,
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
 "caK" = (
@@ -4096,10 +4160,22 @@
 /turf/open/floor/monotile/dark,
 /area/medical/medbay)
 "cfO" = (
-/obj/effect/turf_decal/tile/ship/half/green{
+/obj/machinery/camera/autoname,
+/obj/effect/turf_decal/tile/ship/half/brown{
 	dir = 1
 	},
-/obj/machinery/camera/autoname,
+/obj/structure/sign/directions/command{
+	pixel_y = 24;
+	dir = 4
+	},
+/obj/structure/sign/directions/security{
+	pixel_y = 30;
+	dir = 4
+	},
+/obj/structure/sign/directions/supply{
+	dir = 1;
+	pixel_y = 36
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
 "cfS" = (
@@ -4216,6 +4292,18 @@
 "ciV" = (
 /turf/closed/wall/steel,
 /area/chapel/main)
+"cjb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/red{
+	dir = 4
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "cjn" = (
 /obj/structure/chair{
 	dir = 8
@@ -4615,13 +4703,13 @@
 /turf/open/floor/plating,
 /area/mine/laborcamp)
 "cwB" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
+/obj/machinery/camera/autoname,
+/obj/effect/turf_decal/tile/ship/brown{
 	dir = 1
 	},
-/obj/machinery/camera/autoname,
+/obj/effect/turf_decal/tile/ship/brown{
+	dir = 4
+	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
 "cwI" = (
@@ -5094,6 +5182,13 @@
 	},
 /turf/open/floor/durasteel/techfloor_grid,
 /area/engine/engineering/reactor_core)
+"cKa" = (
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/blue,
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "cKP" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light{
@@ -5838,13 +5933,13 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame2/starboard)
 "dbI" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
+/obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/light/small{
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/blue{
 	dir = 1
 	},
 /turf/open/floor/durasteel,
@@ -6337,11 +6432,11 @@
 	name = "Artillery Bay"
 	})
 "dsk" = (
-/obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1
-	},
 /obj/structure/sign/nanotrasen{
 	pixel_y = 26
+	},
+/obj/effect/turf_decal/tile/ship/half/red{
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
@@ -6599,8 +6694,8 @@
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
 "dxA" = (
-/obj/effect/turf_decal/tile/ship/half/blue,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/ship/half/blue,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
 "dxF" = (
@@ -6916,6 +7011,14 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
+"dFq" = (
+/obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/blue,
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "dFx" = (
 /obj/machinery/chem_dispenser,
 /turf/open/floor/monotile/light,
@@ -6988,6 +7091,13 @@
 /area/crew_quarters/bar{
 	name = "Night Club"
 	})
+"dJo" = (
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/neutral,
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "dJq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -7076,6 +7186,19 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame5/starboard)
+"dNL" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera/autoname,
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 1
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "dOf" = (
 /obj/machinery/atmospherics/components/binary/pump/layer2{
 	dir = 8;
@@ -7208,6 +7331,14 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/security/processing)
+"dRq" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/blue,
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "dRU" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/structure/fluff{
@@ -7390,6 +7521,18 @@
 	},
 /turf/open/floor/durasteel,
 /area/maintenance/nsv/deck2/frame5/starboard)
+"dXR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/blue,
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "dYl" = (
 /obj/machinery/door/airlock/ship/security/glass{
 	name = "Security Office";
@@ -7607,9 +7750,6 @@
 /turf/open/floor/carpet/green,
 /area/engine/engineering/reactor_control)
 "edm" = (
-/obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=8";
@@ -7630,10 +7770,13 @@
 /turf/open/floor/durasteel/techfloor_grid,
 /area/crew_quarters/kitchen)
 "eeu" = (
-/obj/effect/turf_decal/tile/ship/half/green{
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/neutral{
 	dir = 8
 	},
-/turf/open/floor/monotile/dark,
+/turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
 "eex" = (
 /obj/effect/decal/cleanable/blood/footprints{
@@ -7971,13 +8114,13 @@
 /turf/closed/wall/steel,
 /area/maintenance/nsv/deck2/frame5/starboard)
 "emZ" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
+/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/tile/ship/red{
 	dir = 1
 	},
-/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/tile/ship/red{
+	dir = 4
+	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
 "enb" = (
@@ -8009,12 +8152,6 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame3/central)
 "eoa" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -8180,16 +8317,16 @@
 /turf/open/floor/monotile/dark,
 /area/mine/laborcamp)
 "esT" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/red{
+	dir = 4
+	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
 "esV" = (
@@ -8363,6 +8500,30 @@
 /area/crew_quarters/bar{
 	name = "Night Club"
 	})
+"evQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 1
+	},
+/obj/structure/sign/directions/command{
+	pixel_y = 24;
+	dir = 8
+	},
+/obj/structure/sign/directions/security{
+	pixel_y = 30;
+	dir = 8
+	},
+/obj/structure/sign/directions/supply{
+	pixel_y = 36;
+	dir = 8
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "evU" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -8433,6 +8594,13 @@
 	},
 /turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
+"eyv" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/half/blue,
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck2/primary)
 "eyN" = (
 /obj/structure/table/wood,
 /obj/item/camera,
@@ -9664,10 +9832,10 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "fgn" = (
-/obj/effect/turf_decal/tile/ship/green{
+/obj/effect/turf_decal/tile/ship/neutral{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/ship/green{
+/obj/effect/turf_decal/tile/ship/neutral{
 	dir = 4
 	},
 /turf/open/floor/durasteel,
@@ -10178,12 +10346,25 @@
 /turf/open/floor/durasteel/techfloor_grid,
 /area/engine/engineering/reactor_core)
 "fvD" = (
-/obj/effect/turf_decal/tile/ship/green,
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/status_display/evac/east,
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/orange,
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
+"fvF" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera/autoname,
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 4
+	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
 "fwc" = (
@@ -10276,6 +10457,34 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/science/robotics/lab)
+"fxT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 1
+	},
+/obj/structure/sign/directions/evac{
+	dir = 4;
+	pixel_y = 22
+	},
+/obj/structure/sign/directions/medical{
+	dir = 8;
+	pixel_y = 28
+	},
+/obj/structure/sign/directions/science{
+	pixel_y = 34;
+	dir = 8
+	},
+/obj/structure/sign/directions/engineering{
+	dir = 8;
+	pixel_y = 40
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "fxX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -10376,11 +10585,11 @@
 /turf/open/floor/monotile/steel,
 /area/mine/laborcamp)
 "fAH" = (
-/obj/effect/turf_decal/tile/ship/green,
-/obj/effect/turf_decal/tile/ship/green{
+/obj/machinery/status_display/ai/east,
+/obj/effect/turf_decal/tile/ship/orange,
+/obj/effect/turf_decal/tile/ship/orange{
 	dir = 4
 	},
-/obj/machinery/status_display/ai/east,
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
 "fAR" = (
@@ -10919,6 +11128,12 @@
 /area/crew_quarters/bar{
 	name = "Night Club"
 	})
+"fLZ" = (
+/obj/effect/turf_decal/tile/ship/half/brown{
+	dir = 1
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck2/primary)
 "fMd" = (
 /obj/machinery/button/flasher{
 	id = "unga_armoury";
@@ -11610,13 +11825,13 @@
 /turf/open/floor/carpet/red,
 /area/bridge/showroom/corporate)
 "get" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
+/obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/tile/ship/red{
 	dir = 1
 	},
-/obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/tile/ship/red{
+	dir = 4
+	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
 "gev" = (
@@ -11706,7 +11921,6 @@
 /turf/open/floor/durasteel,
 /area/maintenance/nsv/deck2/frame5/port)
 "ggL" = (
-/obj/effect/turf_decal/tile/ship/full/blue,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
 	},
@@ -12058,9 +12272,18 @@
 	name = "Dropship Bay"
 	})
 "gqS" = (
-/obj/effect/turf_decal/tile/ship/full/blue,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/orange,
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 1
+	},
+/obj/structure/sign/ship/deck/two{
+	pixel_y = 32
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
@@ -12108,11 +12331,11 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame2/starboard)
 "grL" = (
-/obj/effect/turf_decal/tile/ship/green,
-/obj/effect/turf_decal/tile/ship/green{
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/ship/orange{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/ship/orange,
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
 "grV" = (
@@ -12133,7 +12356,6 @@
 /turf/open/floor/plasteel/techmaint,
 /area/medical/medbay)
 "gsp" = (
-/obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
@@ -12143,9 +12365,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
 "gsY" = (
@@ -12442,10 +12661,13 @@
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons)
 "gzl" = (
-/obj/effect/turf_decal/tile/ship/half/green{
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/neutral{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
 "gzr" = (
@@ -13421,6 +13643,10 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons)
+"gWr" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck2/primary)
 "gWy" = (
 /obj/effect/turf_decal/tile/ship/half/yellow{
 	dir = 1
@@ -13980,10 +14206,10 @@
 /turf/closed/wall/steel,
 /area/quartermaster/sorting)
 "hnA" = (
-/obj/effect/turf_decal/tile/ship/half/green{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/effect/turf_decal/tile/ship/half/purple{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
 "hnS" = (
@@ -14070,12 +14296,10 @@
 /turf/open/floor/monotile/dark,
 /area/security/brig)
 "hqf" = (
-/obj/effect/turf_decal/tile/ship/half/blue{
-	dir = 8
-	},
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/ship/full/orange,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
 "hqh" = (
@@ -14414,16 +14638,16 @@
 /turf/open/floor/monotile/dark,
 /area/science/robotics/lab)
 "hzS" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/computer/ship/viewscreen,
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 4
+	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
 "hzU" = (
@@ -14625,8 +14849,11 @@
 /turf/open/floor/monotile/dark,
 /area/mine/laborcamp)
 "hEF" = (
-/obj/effect/turf_decal/tile/ship/full/blue,
 /obj/machinery/light,
+/obj/effect/turf_decal/tile/ship/orange,
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 8
+	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "hFn" = (
@@ -14762,15 +14989,15 @@
 /turf/open/floor/monotile/dark,
 /area/security/brig)
 "hJZ" = (
-/obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/sign/nanotrasen{
 	pixel_y = 26
+	},
+/obj/effect/turf_decal/tile/ship/half/orange{
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
@@ -14971,6 +15198,16 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/captain)
+"hPS" = (
+/obj/effect/turf_decal/tile/ship/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/red{
+	dir = 4
+	},
+/obj/machinery/computer/ship/viewscreen,
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "hPY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -15096,6 +15333,14 @@
 	},
 /turf/open/floor/durasteel,
 /area/maintenance/nsv/deck2/frame5/port)
+"hUc" = (
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 8
+	},
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/ship/green,
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "hUe" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -15331,14 +15576,14 @@
 /turf/open/floor/durasteel/techfloor_grid,
 /area/engine/armour_pump)
 "iaB" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 8
 	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
@@ -15460,6 +15705,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame3/central)
+"icO" = (
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 1
+	},
+/obj/structure/sign/ship/deck/two{
+	dir = 4;
+	pixel_x = -37
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "icS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -15869,10 +16127,10 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "ipw" = (
-/obj/effect/turf_decal/tile/ship/green{
+/obj/effect/turf_decal/tile/ship/orange{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/ship/green,
+/obj/effect/turf_decal/tile/ship/neutral,
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
 "ipy" = (
@@ -16185,6 +16443,12 @@
 /obj/item/storage/box/donkpockets,
 /turf/open/floor/plasteel/tech/grid,
 /area/quartermaster/warehouse)
+"ixt" = (
+/obj/structure/sign/directions/evac{
+	dir = 8
+	},
+/turf/closed/wall/steel,
+/area/hallway/secondary/entry/arrivals)
 "ixU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -16267,10 +16531,14 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/quartermaster/warehouse)
 "izD" = (
-/obj/structure/sign/directions/command{
+/obj/effect/turf_decal/tile/ship/brown{
 	dir = 8
 	},
-/turf/closed/wall/steel,
+/obj/effect/turf_decal/tile/ship/brown,
+/obj/effect/turf_decal/tile/ship/brown{
+	dir = 1
+	},
+/turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
 "izU" = (
 /obj/machinery/rnd/production/protolathe/department/munitions,
@@ -16282,12 +16550,12 @@
 /turf/open/floor/monotile/dark,
 /area/science/nsv/astronomy)
 "iAq" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/ship/green,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
+	},
+/obj/effect/turf_decal/tile/ship/neutral,
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 8
 	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
@@ -16819,6 +17087,15 @@
 /obj/effect/turf_decal/tile/ship/half/red,
 /turf/open/floor/monotile/steel,
 /area/security/prison)
+"iSI" = (
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 1
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "iTn" = (
 /obj/machinery/suit_storage_unit/atmos,
 /turf/open/floor/durasteel/techfloor_grid,
@@ -17053,7 +17330,7 @@
 /turf/open/floor/monotile/steel,
 /area/nsv/briefingroom)
 "jaI" = (
-/obj/effect/turf_decal/tile/ship/full/blue,
+/obj/effect/turf_decal/tile/ship/full/neutral,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "jaQ" = (
@@ -17359,13 +17636,13 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame3/port)
 "jij" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
+/obj/machinery/computer/ship/viewscreen,
+/obj/effect/turf_decal/tile/ship/red{
 	dir = 1
 	},
-/obj/machinery/computer/ship/viewscreen,
+/obj/effect/turf_decal/tile/ship/red{
+	dir = 4
+	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
 "jik" = (
@@ -17552,9 +17829,28 @@
 /turf/open/floor/durasteel/lino,
 /area/chapel/main)
 "jlp" = (
-/obj/structure/sign/ship/deck/two,
-/turf/closed/wall/r_wall,
-/area/security/prison)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/effect/turf_decal/tile/ship/half/neutral{
+	dir = 1
+	},
+/obj/structure/sign/directions/evac{
+	dir = 8;
+	pixel_y = 22
+	},
+/obj/structure/sign/directions/medical{
+	dir = 1;
+	pixel_y = 28
+	},
+/obj/structure/sign/directions/science{
+	dir = 8;
+	pixel_y = 34
+	},
+/obj/structure/sign/directions/engineering{
+	dir = 8;
+	pixel_y = 40
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck2/primary)
 "jmg" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/structure/fluff/support_beam{
@@ -17567,13 +17863,13 @@
 /turf/open/floor/monotile/dark,
 /area/medical/medbay)
 "jmq" = (
-/obj/effect/turf_decal/tile/ship/half/green,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/ship/half/neutral,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
 "jmr" = (
@@ -17633,13 +17929,13 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame2/starboard)
 "jmK" = (
-/obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/ship/half/brown{
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
@@ -18080,12 +18376,12 @@
 /turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "jyS" = (
-/obj/machinery/door/airlock/ship/command/glass{
-	name = "Museum"
-	},
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/airlock/ship{
+	name = "Museum"
+	},
 /turf/open/floor/monotile/dark,
 /area/bridge/showroom/corporate)
 "jzh" = (
@@ -18711,13 +19007,13 @@
 /turf/open/floor/monotile/light,
 /area/security/detectives_office)
 "jPd" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/ship/brown{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/ship/brown{
+	dir = 4
+	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
 "jPh" = (
@@ -19150,7 +19446,6 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame5/starboard)
 "kbY" = (
-/obj/effect/turf_decal/tile/ship/full/blue,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
@@ -19160,6 +19455,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/orange,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "kcn" = (
@@ -19192,12 +19491,6 @@
 /turf/open/floor/monotile/dark,
 /area/security/brig)
 "kcN" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -19205,6 +19498,12 @@
 	codes_txt = "patrol;next_patrol=deck1CentralUp";
 	location = "deck2CentralUp";
 	name = "deck2CentralUp"
+	},
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 4
 	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
@@ -19389,16 +19688,16 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "kjQ" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/ship/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/brown{
+	dir = 4
 	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
@@ -19567,14 +19866,14 @@
 /turf/open/floor/durasteel/techfloor,
 /area/engine/gravity_generator)
 "kny" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
 /obj/machinery/camera/autoname,
 /obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 4
+	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
 "knD" = (
@@ -19642,11 +19941,26 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame3/port)
 "kpe" = (
-/obj/effect/turf_decal/tile/ship/half/green{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/effect/turf_decal/tile/ship/half/red{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/structure/extinguisher_cabinet/north,
+/obj/structure/sign/directions/evac{
+	dir = 4;
+	pixel_y = 22
+	},
+/obj/structure/sign/directions/medical{
+	dir = 8;
+	pixel_y = 28
+	},
+/obj/structure/sign/directions/science{
+	pixel_y = 34;
+	dir = 4
+	},
+/obj/structure/sign/directions/engineering{
+	dir = 4;
+	pixel_y = 40
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
 "kpf" = (
@@ -19846,8 +20160,8 @@
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons/gauss/battery)
 "kuD" = (
-/obj/effect/turf_decal/tile/ship/green,
-/obj/effect/turf_decal/tile/ship/green{
+/obj/effect/turf_decal/tile/ship/orange,
+/obj/effect/turf_decal/tile/ship/orange{
 	dir = 4
 	},
 /turf/open/floor/durasteel,
@@ -20082,6 +20396,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/entry/arrivals)
+"kCr" = (
+/obj/effect/turf_decal/tile/ship/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 4
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "kCB" = (
 /obj/effect/turf_decal/tile/ship/half/orange,
 /obj/machinery/airalarm/directional/north,
@@ -20158,6 +20481,9 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/green{
 	dir = 4
 	},
 /turf/open/floor/durasteel,
@@ -20341,10 +20667,10 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame2/starboard)
 "kJP" = (
-/obj/effect/turf_decal/tile/ship/green{
+/obj/effect/turf_decal/tile/ship/neutral{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/ship/green{
+/obj/effect/turf_decal/tile/ship/neutral{
 	dir = 1
 	},
 /turf/open/floor/durasteel,
@@ -20373,6 +20699,24 @@
 /area/nsv/hanger{
 	name = "Dropship Bay"
 	})
+"kKV" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/red{
+	dir = 4
+	},
+/obj/structure/sign/ship/deck/two{
+	pixel_y = 32
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "kLa" = (
 /obj/effect/turf_decal/tile/ship/half/orange,
 /obj/effect/landmark/start/pilot,
@@ -20405,11 +20749,11 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "kLt" = (
-/obj/effect/turf_decal/tile/ship/half/green{
-	dir = 8
-	},
 /obj/machinery/camera/autoname{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/half/neutral{
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
@@ -20529,14 +20873,14 @@
 /turf/open/space/basic,
 /area/ai_monitored/security/armory/lockup)
 "kOw" = (
-/obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1
-	},
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/structure/sign/nanotrasen{
 	pixel_y = 26
+	},
+/obj/effect/turf_decal/tile/ship/half/neutral{
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
@@ -20629,13 +20973,13 @@
 /turf/open/floor/fakespace,
 /area/bridge/showroom/corporate)
 "kRI" = (
-/obj/effect/turf_decal/tile/ship/half/green{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/ship/half/orange{
+	dir = 4
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
 "kRL" = (
@@ -20873,6 +21217,16 @@
 	},
 /turf/open/floor/durasteel,
 /area/maintenance/nsv/deck2/frame5/port)
+"lab" = (
+/obj/effect/turf_decal/ship/delivery/yellow,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/structure/sign/ship/deck/two{
+	pixel_y = 31
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck2/primary)
 "lac" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -20943,6 +21297,10 @@
 /obj/structure/closet/radiation,
 /turf/open/floor/durasteel/techfloor_grid,
 /area/maintenance/nsv/deck2/frame5/port)
+"laZ" = (
+/obj/effect/turf_decal/tile/ship/orange,
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck2/primary)
 "lbA" = (
 /obj/machinery/button/door{
 	id = "nacess";
@@ -20995,16 +21353,16 @@
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/chief)
 "lcT" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=deck2HallT1Up";
 	location = "deck2Down";
 	name = "deck2Down"
+	},
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 4
 	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
@@ -21040,9 +21398,6 @@
 /turf/open/floor/monotile/dark,
 /area/science/robotics/lab)
 "ldv" = (
-/obj/machinery/door/airlock/ship/command/glass{
-	name = "Briefing Room"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
@@ -21052,6 +21407,9 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/airlock/ship{
+	name = "Briefing Room"
+	},
 /turf/open/floor/monotile/steel,
 /area/nsv/briefingroom)
 "ldE" = (
@@ -21212,15 +21570,29 @@
 	},
 /turf/open/floor/durasteel/techfloor_grid,
 /area/engine/engineering/reactor_core)
-"liH" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 8
+"liB" = (
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/ship/green{
+/obj/effect/turf_decal/tile/ship/blue{
 	dir = 1
 	},
+/turf/open/floor/durasteel,
+/area/maintenance/nsv/deck2/frame3/central)
+"liH" = (
 /obj/machinery/camera/autoname{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 1
+	},
+/obj/structure/sign/directions/plaque/munitions{
+	dir = 1;
+	pixel_y = 2;
+	pixel_x = -31
 	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
@@ -21388,10 +21760,10 @@
 /turf/open/floor/carpet/red,
 /area/quartermaster/sorting)
 "lon" = (
-/obj/effect/turf_decal/tile/ship/half/green{
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/light{
+/obj/effect/turf_decal/tile/ship/half/orange{
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
@@ -21507,7 +21879,6 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame3/central)
 "lrg" = (
-/obj/effect/turf_decal/tile/ship/half/green,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 2;
 	name = "weapons bay sorting disposal pipe";
@@ -21517,6 +21888,9 @@
 	codes_txt = "patrol;next_patrol=deck2Medical";
 	location = "deck2Stairway1";
 	name = "deck2Stairway1"
+	},
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
@@ -21530,11 +21904,12 @@
 /turf/open/floor/monotile/steel,
 /area/nsv/magazine/starboard)
 "lrZ" = (
-/obj/effect/turf_decal/tile/ship/full/blue,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -26
 	},
+/obj/effect/turf_decal/tile/ship/full/neutral,
+/obj/effect/turf_decal/tile/ship/full/neutral,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
 "lse" = (
@@ -21874,12 +22249,6 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "lAk" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
@@ -22273,12 +22642,12 @@
 /turf/open/floor/monotile/dark,
 /area/security/brig)
 "lJn" = (
-/obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1
-	},
 /obj/machinery/computer/ship/viewscreen,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/half/orange{
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
@@ -22375,11 +22744,11 @@
 /turf/open/floor/monotile/dark,
 /area/medical/medbay)
 "lKQ" = (
-/obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/half/red{
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
@@ -22406,14 +22775,14 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "lNe" = (
-/obj/effect/turf_decal/tile/ship/green,
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/orange,
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
 "lNi" = (
@@ -22701,14 +23070,14 @@
 /turf/open/floor/monotile/steel,
 /area/security/detectives_office)
 "lUj" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
 /obj/machinery/computer/ship/viewscreen,
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/red{
 	dir = 4
 	},
 /turf/open/floor/durasteel,
@@ -22863,6 +23232,25 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/maintenance/nsv/deck2/frame5/starboard)
+"lXV" = (
+/obj/effect/turf_decal/tile/ship/neutral,
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 8
+	},
+/obj/structure/sign/directions/command{
+	pixel_y = -38;
+	dir = 8
+	},
+/obj/structure/sign/directions/security{
+	pixel_y = -32;
+	dir = 8
+	},
+/obj/structure/sign/directions/supply{
+	pixel_y = -26;
+	dir = 8
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "lYp" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible/layer2{
@@ -23043,11 +23431,14 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "meL" = (
-/obj/effect/turf_decal/tile/ship/green,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/airalarm/directional/east,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/ship/orange,
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 4
 	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
@@ -23114,14 +23505,14 @@
 /turf/open/floor/durasteel,
 /area/maintenance/nsv/deck2/frame4/starboard)
 "miz" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 4
 	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
@@ -23432,11 +23823,14 @@
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "mpy" = (
-/obj/effect/turf_decal/tile/ship/full/blue,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=8";
 	location = "Munitions";
 	name = "navigation beacon (Munitions Delivery)"
+	},
+/obj/effect/turf_decal/tile/ship/orange,
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 4
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
@@ -23477,14 +23871,20 @@
 /turf/open/floor/engine/co2,
 /area/engine/atmos)
 "mrO" = (
-/obj/structure/sign/directions/engineering{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/structure/sign/directions/security{
-	dir = 1;
-	pixel_y = -8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
-/turf/closed/wall/steel,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/ship/delivery/yellow,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
 "msa" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
@@ -23636,6 +24036,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/dark,
 /area/nsv/briefingroom)
+"muJ" = (
+/obj/effect/turf_decal/tile/ship/neutral,
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "muT" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/box,
@@ -23789,7 +24193,6 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame3/port)
 "mAb" = (
-/obj/effect/turf_decal/tile/ship/full/blue,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
 	},
@@ -24117,6 +24520,9 @@
 "mGp" = (
 /turf/closed/wall/steel,
 /area/security/brig)
+"mGy" = (
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/primary)
 "mGR" = (
 /obj/item/beacon,
 /turf/open/floor/noslip/dark,
@@ -24193,11 +24599,11 @@
 /turf/open/floor/monotile/dark,
 /area/security/brig)
 "mIh" = (
-/obj/effect/turf_decal/tile/ship/green,
-/obj/effect/turf_decal/tile/ship/green{
+/obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/tile/ship/neutral,
+/obj/effect/turf_decal/tile/ship/neutral{
 	dir = 8
 	},
-/obj/item/radio/intercom/directional/south,
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
 "mIr" = (
@@ -25050,6 +25456,16 @@
 	},
 /turf/open/floor/durasteel,
 /area/maintenance/nsv/deck2/frame5/port)
+"niq" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/half/red{
+	dir = 1
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck2/primary)
 "nix" = (
 /turf/closed/wall/steel,
 /area/maintenance/nsv/deck2/frame2/starboard)
@@ -25265,15 +25681,15 @@
 /turf/template_noop,
 /area/maintenance/nsv/deck2/frame3/port)
 "npP" = (
-/obj/effect/turf_decal/tile/ship/green,
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=deck2Departure";
 	location = "deck2HallT2Down";
 	name = "deck2HallT2Down"
 	},
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/neutral,
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
 "nqT" = (
@@ -25477,6 +25893,20 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
+"nyj" = (
+/obj/effect/turf_decal/tile/ship/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/red{
+	dir = 4
+	},
+/obj/structure/sign/directions/plaque/munitions{
+	pixel_y = 31;
+	pixel_x = -1;
+	dir = 4
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "nyt" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -25779,6 +26209,13 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/gravity_generator)
+"nGV" = (
+/obj/effect/turf_decal/tile/ship/half/red{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet/north,
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck2/primary)
 "nGY" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light{
@@ -25849,9 +26286,6 @@
 /turf/open/floor/engine,
 /area/engine/engineering/ftl_room)
 "nJt" = (
-/obj/effect/turf_decal/tile/ship/half/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
@@ -25861,6 +26295,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/tile/ship/full/orange,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
 "nJx" = (
@@ -26100,14 +26535,14 @@
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
 "nQr" = (
-/obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1
-	},
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/half/orange{
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
@@ -26622,6 +27057,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/ship/half/purple{
+	dir = 4
+	},
 /turf/open/floor/monotile/dark,
 /area/science/lab)
 "oeY" = (
@@ -26787,6 +27225,13 @@
 	},
 /turf/open/floor/plating/airless,
 /area/security/processing)
+"ogM" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/half/neutral,
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck2/primary)
 "ogP" = (
 /obj/structure/table,
 /obj/item/trash/waffles{
@@ -26812,6 +27257,12 @@
 /obj/item/circuitboard/computer/ammo_sorter,
 /turf/open/floor/monotile/dark,
 /area/nsv/magazine/starboard)
+"ois" = (
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 1
+	},
+/turf/open/floor/durasteel,
+/area/maintenance/nsv/deck2/frame3/central)
 "oiZ" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -27518,14 +27969,14 @@
 /turf/open/floor/durasteel/techfloor_grid,
 /area/engine/armour_pump)
 "oAw" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
 /obj/machinery/status_display/ai{
 	pixel_y = 31
+	},
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 4
 	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
@@ -27706,7 +28157,7 @@
 /turf/open/floor/plating,
 /area/engine/engineering/reactor_core)
 "oEy" = (
-/obj/effect/turf_decal/tile/ship/green{
+/obj/effect/turf_decal/tile/ship/neutral{
 	dir = 8
 	},
 /turf/open/floor/durasteel,
@@ -28057,6 +28508,13 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmospherics_engine)
+"oPu" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/effect/turf_decal/tile/ship/half/red{
+	dir = 1
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck2/primary)
 "oPG" = (
 /obj/effect/turf_decal/tile/ship/half/orange,
 /obj/effect/turf_decal/stripes/red/line{
@@ -28067,7 +28525,7 @@
 	name = "Dropship Bay"
 	})
 "oQc" = (
-/obj/effect/turf_decal/tile/ship/half/green{
+/obj/effect/turf_decal/tile/ship/half/purple{
 	dir = 1
 	},
 /turf/open/floor/monotile/dark,
@@ -28365,9 +28823,6 @@
 /turf/open/floor/monotile/light,
 /area/medical/medbay)
 "oWj" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 8
-	},
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
@@ -28375,6 +28830,9 @@
 	codes_txt = "patrol;next_patrol=deck2Arrivals";
 	location = "deck2Cross1";
 	name = "deck2Cross1"
+	},
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 8
 	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
@@ -28767,11 +29225,20 @@
 /area/engine/engineering)
 "pgY" = (
 /obj/structure/sign/directions/medical{
-	dir = 1
+	dir = 1;
+	pixel_y = -3
 	},
 /obj/structure/sign/directions/evac{
 	dir = 8;
-	pixel_y = -8
+	pixel_y = -9
+	},
+/obj/structure/sign/directions/science{
+	dir = 8;
+	pixel_y = 3
+	},
+/obj/structure/sign/directions/engineering{
+	dir = 1;
+	pixel_y = 9
 	},
 /turf/closed/wall/steel,
 /area/hallway/nsv/deck2/primary)
@@ -28978,9 +29445,7 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "ppy" = (
-/obj/effect/turf_decal/tile/ship/half/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/ship/full/orange,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
 "ppB" = (
@@ -29149,6 +29614,20 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
+"ptb" = (
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 4
+	},
+/obj/structure/sign/directions/plaque/munitions{
+	pixel_y = 30;
+	pixel_x = -1;
+	dir = 4
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "ptf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -29461,11 +29940,11 @@
 /turf/open/floor/durasteel/padded,
 /area/maintenance/nsv/deck2/frame3/central)
 "pBx" = (
-/obj/effect/turf_decal/tile/ship/green,
-/obj/effect/turf_decal/tile/ship/green{
+/obj/structure/extinguisher_cabinet/south,
+/obj/effect/turf_decal/tile/ship/neutral,
+/obj/effect/turf_decal/tile/ship/neutral{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet/south,
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
 "pBP" = (
@@ -30000,6 +30479,18 @@
 /obj/machinery/status_display/ai/east,
 /turf/open/floor/monotile/steel,
 /area/science/robotics/lab)
+"pQI" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 4
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "pQL" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -30318,14 +30809,14 @@
 /turf/open/floor/monotile/steel,
 /area/medical/medbay/lobby)
 "pYM" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
+	},
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 4
 	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
@@ -30637,15 +31128,15 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame2/central)
 "qiA" = (
-/obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/structure/sign/nanotrasen{
 	pixel_y = 26
+	},
+/obj/effect/turf_decal/tile/ship/half/neutral{
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
@@ -30940,15 +31431,15 @@
 /turf/open/floor/durasteel,
 /area/maintenance/nsv/deck2/frame5/starboard)
 "qqe" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable{
 	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 8
 	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
@@ -30968,10 +31459,10 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame5/starboard)
 "qro" = (
-/obj/effect/turf_decal/tile/ship/green{
+/obj/effect/turf_decal/tile/ship/neutral{
 	dir = 4
 	},
-/turf/open/floor/monotile/dark,
+/turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
 "qrL" = (
 /obj/structure/statue/sandstone/venus{
@@ -31102,9 +31593,6 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/briefingroom)
 "quF" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
@@ -31112,6 +31600,13 @@
 	codes_txt = "patrol;next_patrol=deck2HallT2Down";
 	location = "deck2Cross2";
 	name = "deck2Cross2"
+	},
+/obj/effect/turf_decal/tile/ship/green,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 4
 	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
@@ -31145,7 +31640,6 @@
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons/gauss/battery)
 "qvD" = (
-/obj/effect/turf_decal/tile/ship/full/blue,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
@@ -31155,6 +31649,7 @@
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/ship/full/neutral,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "qvH" = (
@@ -31209,6 +31704,14 @@
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/ai_monitored/security/armory/lockup)
+"qwR" = (
+/obj/effect/turf_decal/tile/ship/green,
+/obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/tile/ship/brown{
+	dir = 8
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "qxf" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -31422,10 +31925,10 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame2/starboard)
 "qCR" = (
-/obj/effect/turf_decal/tile/ship/half/green{
+/obj/structure/extinguisher_cabinet/north,
+/obj/effect/turf_decal/tile/ship/half/brown{
 	dir = 1
 	},
-/obj/structure/extinguisher_cabinet/north,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
 "qDv" = (
@@ -32041,13 +32544,13 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "qTH" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=deck2Squad";
 	location = "deck2HallT1Up";
 	name = "deck2HallT1Up"
+	},
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 1
 	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
@@ -32189,6 +32692,16 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame3/central)
+"qYY" = (
+/obj/machinery/camera/autoname,
+/obj/effect/turf_decal/tile/ship/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/red{
+	dir = 4
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "qZc" = (
 /obj/structure/cable/orange{
 	icon_state = "1-4"
@@ -32202,6 +32715,18 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
+"qZu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 1
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "qZC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -32239,6 +32764,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame4/starboard)
+"raR" = (
+/obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/tile/ship/neutral,
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 8
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "raY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -32315,13 +32848,13 @@
 /turf/open/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
 "rcD" = (
-/obj/effect/turf_decal/tile/ship/half/green{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
 /obj/machinery/status_display/ai/west,
+/obj/effect/turf_decal/tile/ship/half/neutral{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
 "rda" = (
@@ -32550,8 +33083,11 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "rkV" = (
-/obj/effect/turf_decal/tile/ship/full/blue,
-/turf/open/floor/monotile/dark,
+/obj/effect/turf_decal/tile/ship/orange,
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 4
+	},
+/turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "rlp" = (
 /obj/effect/spawner/lootdrop/maintenance,
@@ -32660,8 +33196,14 @@
 /turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "rpc" = (
-/obj/effect/turf_decal/tile/ship/full/blue,
 /obj/effect/landmark/nuclear_waste_spawner,
+/obj/effect/turf_decal/tile/ship/orange,
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 8
+	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "rpj" = (
@@ -32683,6 +33225,11 @@
 	},
 /turf/open/floor/carpet/red,
 /area/quartermaster/sorting)
+"rqJ" = (
+/obj/effect/turf_decal/tile/ship/full/neutral,
+/obj/effect/turf_decal/tile/ship/full/neutral,
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck2/primary)
 "rqL" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/monotile/dark,
@@ -32871,12 +33418,12 @@
 /turf/open/floor/monotile/dark,
 /area/security/prison)
 "ruh" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/ship/green,
-/obj/effect/turf_decal/tile/ship/green{
+/obj/effect/turf_decal/tile/ship/neutral{
 	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/neutral,
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 8
 	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
@@ -32987,6 +33534,19 @@
 	},
 /turf/open/floor/durasteel/techfloor_grid,
 /area/maintenance/nsv/deck2/frame2/starboard)
+"rwM" = (
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 8
+	},
+/obj/structure/sign/directions/plaque/munitions{
+	pixel_y = 2;
+	pixel_x = -31
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "rwT" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -33211,10 +33771,10 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame2/starboard)
 "rDk" = (
-/obj/effect/turf_decal/tile/ship/green{
+/obj/effect/turf_decal/tile/ship/neutral,
+/obj/effect/turf_decal/tile/ship/neutral{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/ship/green,
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
 "rDA" = (
@@ -33249,13 +33809,20 @@
 /obj/structure/lattice/catwalk/over/ship,
 /turf/open/floor/plating,
 /area/engine/engineering/reactor_core)
-"rEM" = (
+"rEe" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
 	dir = 8
 	},
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck2/primary)
+"rEM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/tile/ship/green,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 8
+	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
 "rFj" = (
@@ -33420,9 +33987,6 @@
 /turf/open/floor/monotile/dark,
 /area/science/robotics/lab)
 "rJB" = (
-/obj/machinery/door/airlock/ship/command/glass{
-	name = "Briefing Room"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
@@ -33434,6 +33998,9 @@
 /obj/effect/landmark/zebra_interlock_point,
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/ship{
+	name = "Briefing Room"
 	},
 /turf/open/floor/monotile/steel,
 /area/nsv/briefingroom)
@@ -33810,18 +34377,15 @@
 /turf/open/floor/plating,
 /area/medical/chemistry)
 "rTM" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 4
+	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
 "rTN" = (
@@ -33935,12 +34499,12 @@
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
 "sai" = (
-/obj/machinery/door/airlock/ship/command/glass{
-	name = "Briefing Room"
-	},
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/airlock/ship{
+	name = "Briefing Room"
+	},
 /turf/open/floor/monotile/steel,
 /area/nsv/briefingroom)
 "sao" = (
@@ -34002,6 +34566,20 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/durasteel/padded,
 /area/maintenance/nsv/deck2/frame5/starboard)
+"scK" = (
+/obj/effect/turf_decal/tile/ship/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/brown{
+	dir = 4
+	},
+/obj/structure/sign/directions/plaque/munitions{
+	pixel_y = 30;
+	pixel_x = -1;
+	dir = 4
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "scN" = (
 /obj/machinery/ammo_sorter{
 	dir = 4;
@@ -34034,19 +34612,13 @@
 /turf/open/floor/engine/airless,
 /area/nsv/magazine/port)
 "sdh" = (
-/obj/structure/sign/directions/science{
-	dir = 8;
-	pixel_y = -8
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 8
 	},
-/turf/closed/wall/steel,
-/area/science/robotics/mechbay)
+/obj/effect/turf_decal/tile/ship/blue,
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "sdx" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -34059,6 +34631,12 @@
 	codes_txt = "patrol;next_patrol=deck2Cross2";
 	location = "deck2Gauss";
 	name = "deck2Gauss"
+	},
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 1
 	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
@@ -34200,12 +34778,12 @@
 /turf/open/floor/monotile/steel,
 /area/science/nsv/astronomy)
 "sha" = (
-/obj/effect/turf_decal/tile/ship/green,
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/effect/turf_decal/tile/ship/neutral,
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 8
 	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
@@ -35371,6 +35949,12 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/chapel/office)
+"sJd" = (
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 1
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "sJj" = (
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/hop{
@@ -35389,13 +35973,13 @@
 /turf/open/floor/monotile/steel,
 /area/quartermaster/storage)
 "sJG" = (
-/obj/effect/turf_decal/tile/ship/half/green{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/tile/ship/half/orange{
+	dir = 4
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
 "sJI" = (
@@ -35493,6 +36077,27 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering/ftl_room)
+"sMl" = (
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 1
+	},
+/obj/structure/sign/directions/command{
+	pixel_y = 24;
+	dir = 8
+	},
+/obj/structure/sign/directions/security{
+	pixel_y = 30;
+	dir = 1
+	},
+/obj/structure/sign/directions/supply{
+	dir = 8;
+	pixel_y = 36
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "sMp" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -35683,11 +36288,14 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/port)
 "sQB" = (
-/obj/effect/turf_decal/tile/ship/green,
-/obj/effect/turf_decal/tile/ship/green{
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/ship/blue{
 	dir = 8
 	},
-/obj/machinery/light,
+/obj/effect/turf_decal/tile/ship/blue,
+/obj/structure/sign/ship/deck/two{
+	pixel_y = -27
+	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
 "sQK" = (
@@ -36003,12 +36611,17 @@
 /turf/open/floor/plating,
 /area/crew_quarters/theatre)
 "sYj" = (
-/obj/effect/turf_decal/tile/ship/full/blue,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
@@ -36244,6 +36857,16 @@
 /obj/effect/overlay/poolwater,
 /turf/open/indestructible/sound/pool/spentfuel/wall,
 /area/engine/engineering/reactor_core)
+"teu" = (
+/obj/machinery/computer/ship/viewscreen,
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 4
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "teJ" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Examination Room"
@@ -36393,16 +37016,16 @@
 /turf/open/floor/durasteel/techfloor_grid,
 /area/maintenance/disposal)
 "tis" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=deck2MessEntry";
 	location = "deck2Departure";
 	name = "deck2Departure"
+	},
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 4
 	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
@@ -36624,13 +37247,13 @@
 /turf/open/floor/monotile/dark,
 /area/hydroponics)
 "tnM" = (
-/obj/effect/turf_decal/tile/ship/green{
+/obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/tile/ship/neutral{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/ship/green{
+/obj/effect/turf_decal/tile/ship/neutral{
 	dir = 1
 	},
-/obj/item/radio/intercom/directional/west,
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
 "tnP" = (
@@ -36989,16 +37612,16 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame3/central)
 "txD" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/camera/autoname,
+/obj/effect/turf_decal/tile/ship/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/red{
+	dir = 4
+	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
 "txL" = (
@@ -37366,6 +37989,15 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/security/brig)
+"tMr" = (
+/obj/effect/turf_decal/tile/ship/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/brown{
+	dir = 4
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "tMu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -37570,13 +38202,13 @@
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
 "tQc" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
+/obj/structure/extinguisher_cabinet/north,
+/obj/effect/turf_decal/tile/ship/brown{
 	dir = 1
 	},
-/obj/structure/extinguisher_cabinet/north,
+/obj/effect/turf_decal/tile/ship/brown{
+	dir = 4
+	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
 "tQv" = (
@@ -37691,6 +38323,15 @@
 /obj/effect/spawner/room/threexfive,
 /turf/template_noop,
 /area/maintenance/nsv/deck2/frame5/port)
+"tTS" = (
+/obj/effect/turf_decal/tile/ship/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/red{
+	dir = 4
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "tTU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -37705,13 +38346,13 @@
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
 "tUg" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
+/obj/machinery/status_display/evac/north,
+/obj/effect/turf_decal/tile/ship/brown{
 	dir = 1
 	},
-/obj/machinery/status_display/evac/north,
+/obj/effect/turf_decal/tile/ship/brown{
+	dir = 4
+	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
 "tUP" = (
@@ -38155,13 +38796,13 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "ugJ" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/ship/green,
+/obj/effect/turf_decal/tile/ship/orange,
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 4
+	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
 "uhc" = (
@@ -38200,6 +38841,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame3/port)
+"uhF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/ship/neutral,
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 8
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "uhJ" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -38503,14 +39156,14 @@
 /turf/open/floor/durasteel/techfloor_grid,
 /area/maintenance/nsv/deck2/frame5/port)
 "upK" = (
-/obj/structure/sign/directions/evac{
-	dir = 8;
-	pixel_y = -8
+/obj/machinery/camera/autoname,
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 4
 	},
-/obj/structure/sign/directions/command{
+/obj/effect/turf_decal/tile/ship/neutral{
 	dir = 1
 	},
-/turf/closed/wall/steel,
+/turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
 "upV" = (
 /obj/machinery/door/airlock/ship/engineering/glass{
@@ -38619,6 +39272,16 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible/layer2,
 /turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
+"usp" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/half/neutral{
+	dir = 1
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck2/primary)
 "usq" = (
 /obj/effect/turf_decal/ship/letter{
 	icon_state = "G"
@@ -38993,11 +39656,11 @@
 /turf/open/floor/monotile/steel,
 /area/quartermaster/lobby)
 "uBa" = (
-/obj/effect/turf_decal/tile/ship/half/green{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/tile/ship/half/orange{
+	dir = 4
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
 "uBl" = (
@@ -39145,10 +39808,10 @@
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons/gauss/battery)
 "uGl" = (
-/obj/effect/turf_decal/tile/ship/half/green{
+/obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/tile/ship/half/brown{
 	dir = 1
 	},
-/obj/machinery/firealarm/directional/north,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
 "uGC" = (
@@ -39676,13 +40339,13 @@
 /turf/open/floor/carpet/ship/beige_carpet,
 /area/medical/medbay)
 "uUq" = (
-/obj/effect/turf_decal/tile/ship/green{
+/obj/machinery/status_display/evac/west,
+/obj/effect/turf_decal/tile/ship/neutral{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/ship/green{
+/obj/effect/turf_decal/tile/ship/neutral{
 	dir = 1
 	},
-/obj/machinery/status_display/evac/west,
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
 "uUy" = (
@@ -40210,11 +40873,14 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/magazine/starboard)
 "vgK" = (
-/obj/structure/sign/directions/engineering{
-	dir = 1;
-	pixel_y = -8
+/obj/structure/extinguisher_cabinet/north,
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 1
 	},
-/turf/closed/wall/steel,
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 4
+	},
+/turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
 "vgN" = (
 /obj/structure/cable{
@@ -40380,6 +41046,28 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"vmV" = (
+/obj/machinery/camera/autoname,
+/obj/effect/turf_decal/tile/ship/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/red{
+	dir = 4
+	},
+/obj/structure/sign/directions/command{
+	pixel_y = 24;
+	dir = 4
+	},
+/obj/structure/sign/directions/security{
+	pixel_y = 30;
+	dir = 4
+	},
+/obj/structure/sign/directions/supply{
+	pixel_y = 36;
+	dir = 4
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "vnu" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	req_access_txt = "12"
@@ -40495,14 +41183,16 @@
 /turf/open/floor/engine,
 /area/engine/engineering/ftl_room)
 "vqf" = (
-/obj/structure/sign/directions/supply{
-	dir = 8
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/sign/directions/medical{
-	dir = 8;
-	pixel_y = -8
+/obj/effect/turf_decal/tile/ship/brown{
+	dir = 1
 	},
-/turf/closed/wall/steel,
+/obj/effect/turf_decal/tile/ship/brown{
+	dir = 4
+	},
+/turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
 "vqg" = (
 /obj/structure/railing{
@@ -41352,9 +42042,6 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame5/starboard)
 "vNT" = (
-/obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -41714,6 +42401,14 @@
 /area/nsv/hanger{
 	name = "Dropship Bay"
 	})
+"vYb" = (
+/obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/ship/delivery/yellow,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "vYz" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/window/northleft{
@@ -41724,6 +42419,16 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/monotile/steel,
 /area/quartermaster/lobby)
+"vZL" = (
+/obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 8
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "vZX" = (
 /obj/effect/turf_decal/tile/ship/half/red{
 	dir = 8
@@ -42236,6 +42941,31 @@
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plasteel/grid/steel,
 /area/engine/atmos)
+"wpF" = (
+/obj/effect/turf_decal/tile/ship/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/brown{
+	dir = 4
+	},
+/obj/structure/sign/directions/evac{
+	dir = 4;
+	pixel_y = 22
+	},
+/obj/structure/sign/directions/medical{
+	dir = 4;
+	pixel_y = 28
+	},
+/obj/structure/sign/directions/science{
+	dir = 4;
+	pixel_y = 34
+	},
+/obj/structure/sign/directions/engineering{
+	dir = 4;
+	pixel_y = 40
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "wpZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -42262,16 +42992,16 @@
 /turf/open/floor/engine,
 /area/engine/atmos)
 "wqr" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/tile/ship/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/red{
+	dir = 4
+	},
 /turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
 "wqw" = (
@@ -42443,6 +43173,18 @@
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck2/primary)
+"wva" = (
+/obj/effect/turf_decal/tile/ship/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/brown{
+	dir = 8
+	},
+/turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
 "wvb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -42704,6 +43446,18 @@
 	dir = 1
 	},
 /turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck2/primary)
+"wDr" = (
+/obj/effect/turf_decal/tile/ship/neutral,
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 8
+	},
+/obj/structure/sign/directions/plaque/munitions{
+	pixel_y = -32;
+	pixel_x = -1;
+	dir = 4
+	},
+/turf/open/floor/durasteel,
 /area/hallway/nsv/deck2/primary)
 "wDZ" = (
 /obj/structure/showcase/perfect_employee,
@@ -43017,12 +43771,28 @@
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "wLD" = (
-/obj/structure/sign/directions/supply{
-	dir = 8;
-	pixel_y = 2
+/obj/effect/turf_decal/tile/ship/neutral,
+/obj/effect/turf_decal/tile/ship/neutral{
+	dir = 8
 	},
-/turf/closed/wall/steel,
-/area/science/robotics/mechbay)
+/obj/structure/sign/directions/evac{
+	dir = 4;
+	pixel_y = -40
+	},
+/obj/structure/sign/directions/medical{
+	dir = 8;
+	pixel_y = -34
+	},
+/obj/structure/sign/directions/science{
+	pixel_y = -28;
+	dir = 8
+	},
+/obj/structure/sign/directions/engineering{
+	dir = 8;
+	pixel_y = -22
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "wMg" = (
 /obj/effect/turf_decal/tile/ship/half/orange{
 	dir = 1
@@ -43123,6 +43893,16 @@
 /obj/item/ship_weapon/ammunition/naval_artillery/ap,
 /turf/open/floor/circuit/red/airless,
 /area/nsv/magazine/starboard)
+"wOJ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/half/orange{
+	dir = 1
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck2/primary)
 "wOO" = (
 /obj/machinery/rnd/server,
 /turf/open/floor/circuit/telecomms/server,
@@ -43371,7 +44151,6 @@
 /turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "wXW" = (
-/obj/effect/turf_decal/tile/ship/full/blue,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
@@ -43379,6 +44158,7 @@
 	dir = 8
 	},
 /obj/machinery/light,
+/obj/effect/turf_decal/tile/ship/full/neutral,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "wYp" = (
@@ -43712,11 +44492,11 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/quartermaster/warehouse)
 "xhP" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
+/obj/effect/turf_decal/tile/ship/blue{
 	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 4
 	},
 /turf/open/floor/durasteel,
 /area/maintenance/nsv/deck2/frame3/central)
@@ -44523,9 +45303,11 @@
 /turf/open/floor/monotile/steel,
 /area/storage/primary)
 "xCO" = (
-/obj/effect/turf_decal/tile/ship/full/blue,
 /obj/structure/disposalpipe/segment{
 	dir = 5
+	},
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
@@ -44731,7 +45513,6 @@
 /turf/closed/wall/steel,
 /area/medical/medbay/lobby)
 "xKs" = (
-/obj/effect/turf_decal/tile/ship/full/blue,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
@@ -44741,8 +45522,19 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/airalarm/directional/north,
 /obj/machinery/camera/autoname,
+/obj/effect/turf_decal/tile/ship/full/neutral,
+/obj/structure/sign/directions/command{
+	pixel_y = 24;
+	dir = 8
+	},
+/obj/structure/sign/directions/security{
+	pixel_y = 30;
+	dir = 1
+	},
+/obj/structure/sign/directions/supply{
+	pixel_y = 36
+	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "xLq" = (
@@ -44884,7 +45676,6 @@
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "xPC" = (
-/obj/effect/turf_decal/tile/ship/full/blue,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
@@ -44896,6 +45687,22 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/ship/full/neutral,
+/obj/structure/sign/directions/evac{
+	dir = 8;
+	pixel_y = 22
+	},
+/obj/structure/sign/directions/medical{
+	dir = 1;
+	pixel_y = 28
+	},
+/obj/structure/sign/directions/science{
+	pixel_y = 34
+	},
+/obj/structure/sign/directions/engineering{
+	pixel_y = 40;
+	dir = 1
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
@@ -44930,6 +45737,15 @@
 /obj/structure/lattice/catwalk/over/ship,
 /turf/open/floor/plating,
 /area/engine/engineering/reactor_core)
+"xQQ" = (
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 4
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "xRl" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -45232,7 +46048,7 @@
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "xZj" = (
-/obj/effect/turf_decal/tile/ship/half/green{
+/obj/effect/turf_decal/tile/ship/half/blue{
 	dir = 1
 	},
 /turf/open/floor/monotile/dark,
@@ -45714,6 +46530,16 @@
 /obj/machinery/door/window/westright,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"ylC" = (
+/obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/tile/ship/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/brown{
+	dir = 4
+	},
+/turf/open/floor/durasteel,
+/area/hallway/nsv/deck2/primary)
 "ylD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -76485,9 +77311,9 @@ wyj
 wyj
 fLa
 uoa
-lGt
+wva
 tSM
-ebc
+izD
 aFJ
 aFJ
 aFJ
@@ -76744,7 +77570,7 @@ bxU
 uoa
 tQc
 tSM
-pOH
+qwR
 aFJ
 wOl
 jwN
@@ -76999,7 +77825,7 @@ tSg
 nBs
 vJQ
 uoa
-lGt
+tMr
 tSM
 ebc
 dpL
@@ -77513,7 +78339,7 @@ dVR
 vDz
 tnr
 uoa
-lGt
+tMr
 tSM
 ebc
 dpL
@@ -77770,7 +78596,7 @@ vTt
 ulV
 yfq
 uoa
-miz
+vqf
 tSM
 ebc
 dpL
@@ -78027,7 +78853,7 @@ uoa
 erh
 uoa
 uoa
-bOy
+ylC
 tSM
 ebc
 dpL
@@ -78780,7 +79606,7 @@ jEc
 fcQ
 lxr
 xwg
-xhP
+liB
 wSk
 lGx
 iOd
@@ -78798,7 +79624,7 @@ pku
 eLD
 pku
 wjA
-lGt
+tMr
 cdy
 tYT
 wlt
@@ -79055,7 +79881,7 @@ kMp
 rqx
 xTv
 dbp
-lGt
+tMr
 cdy
 ebc
 cSh
@@ -79312,7 +80138,7 @@ lnM
 pPr
 xTv
 ndL
-lGt
+tMr
 cdy
 ebc
 cSh
@@ -79551,7 +80377,7 @@ mxV
 fcQ
 lxr
 xwg
-xhP
+liB
 wSk
 szG
 pHZ
@@ -79569,7 +80395,7 @@ aTz
 fBW
 xTv
 nJM
-lGt
+tMr
 cdy
 ebc
 cSh
@@ -80083,7 +80909,7 @@ sZz
 alR
 ujy
 pku
-miz
+vqf
 cdy
 ebc
 aFJ
@@ -80306,7 +81132,7 @@ qPA
 mGj
 lGt
 qEs
-sQB
+hUc
 rOl
 wZS
 gmO
@@ -80563,7 +81389,7 @@ oTp
 ocT
 esT
 iut
-ebc
+cKa
 tFU
 tRI
 nAN
@@ -80599,7 +81425,7 @@ agG
 pku
 tUg
 cdy
-ebc
+pOH
 jJy
 oRe
 xPJ
@@ -80820,7 +81646,7 @@ xyp
 xyp
 jij
 abe
-ebc
+sdh
 uzc
 act
 hPs
@@ -80854,7 +81680,7 @@ iwS
 oDE
 aFW
 pku
-get
+scK
 cdy
 ebc
 agB
@@ -81077,7 +81903,7 @@ xyp
 xyp
 dsk
 ulH
-gCP
+brX
 gyb
 wdv
 hPs
@@ -81332,9 +82158,9 @@ aYZ
 gmx
 fho
 rbU
-lGt
+tTS
 abe
-ebc
+sdh
 iwz
 hrv
 nPs
@@ -81368,7 +82194,7 @@ klv
 qJR
 pku
 pku
-lGt
+wpF
 cdy
 ebc
 agB
@@ -81589,9 +82415,9 @@ rot
 gMx
 xyp
 xyp
-cwB
+qYY
 abe
-ebc
+sdh
 rHy
 vQb
 hPs
@@ -81625,7 +82451,7 @@ xht
 llu
 kCV
 qCd
-lGt
+tMr
 cdy
 ebc
 jJy
@@ -81846,9 +82672,9 @@ lax
 vUy
 sYG
 kSP
-lGt
+tTS
 omP
-aJw
+dRq
 mKW
 sop
 uxT
@@ -81882,7 +82708,7 @@ mzn
 wvb
 eSa
 ddz
-lGt
+tMr
 cdy
 ebc
 jJy
@@ -82103,9 +82929,9 @@ aKw
 tDP
 tEq
 pLv
-lGt
+tTS
 abe
-ebc
+sdh
 fjt
 act
 hPs
@@ -82360,9 +83186,9 @@ gBE
 uFG
 aDT
 bBs
-hnA
+oPu
 mkb
-wCS
+eyv
 gyb
 dFx
 nAN
@@ -82874,9 +83700,9 @@ ahv
 uFG
 jqs
 kSP
-lGt
+tTS
 oVI
-aJw
+dRq
 esV
 rMy
 tYC
@@ -82910,7 +83736,7 @@ cRj
 vRc
 daT
 ofC
-jij
+awh
 cUk
 mOE
 xsD
@@ -83131,9 +83957,9 @@ pHy
 tDP
 kax
 pLv
-lGt
+tTS
 abe
-ebc
+sdh
 vPP
 xgA
 eRh
@@ -83388,9 +84214,9 @@ gTX
 uFG
 fQp
 bBs
-lGt
+tTS
 gSy
-mOE
+dXR
 ibr
 toc
 cma
@@ -83424,7 +84250,7 @@ jYx
 iDA
 iDA
 ofC
-lGt
+tMr
 pLt
 ebc
 oor
@@ -83645,9 +84471,9 @@ gTX
 uFG
 qDI
 xyp
-oQc
+nGV
 xTO
-gCP
+brX
 jRO
 pFB
 ddw
@@ -83681,7 +84507,7 @@ iBg
 iBg
 iBg
 ofQ
-oQc
+fLZ
 pLt
 gCP
 jJy
@@ -83902,9 +84728,9 @@ ejV
 uFG
 wVG
 kSP
-lGt
+tTS
 xTO
-sQB
+bbf
 xKo
 xKo
 jRO
@@ -83920,7 +84746,7 @@ ucU
 jcD
 oCX
 vlP
-xhP
+ois
 pxk
 lGx
 fjV
@@ -83938,7 +84764,7 @@ cRj
 ttP
 cRj
 mAS
-lGt
+tMr
 dvW
 ebc
 jJy
@@ -84159,9 +84985,9 @@ qPg
 tDP
 thi
 pLv
-lGt
+tTS
 xTO
-mIh
+dFq
 pHM
 qVy
 kpf
@@ -84179,7 +85005,7 @@ wte
 vlP
 vNT
 pxk
-awh
+hwO
 xwg
 vgA
 oXe
@@ -84195,7 +85021,7 @@ efp
 ifN
 oLG
 bib
-lGt
+tMr
 pLt
 ebc
 wjA
@@ -84416,9 +85242,9 @@ lOg
 eqJ
 uTA
 bBs
-lGt
+tTS
 xTO
-ebc
+sdh
 nCM
 qVy
 egD
@@ -84452,7 +85278,7 @@ rWi
 ofC
 ofC
 cAB
-lGt
+kCr
 pLt
 pOH
 wjA
@@ -84673,9 +85499,9 @@ evE
 vJq
 xyp
 xyp
-cwB
+vmV
 xTO
-ebc
+sdh
 hnV
 iMY
 yme
@@ -84709,7 +85535,7 @@ uTz
 peV
 xky
 aJP
-lGt
+sJd
 pLt
 ebc
 wjA
@@ -84932,7 +85758,7 @@ tvv
 xyp
 kpe
 mkb
-wCS
+eyv
 nCM
 iMY
 hVI
@@ -84966,7 +85792,7 @@ kwF
 fWy
 buX
 erP
-hnA
+gWr
 dDZ
 sKO
 wjA
@@ -85187,9 +86013,9 @@ abm
 iSy
 rAb
 xyp
-jij
+nyj
 xTO
-ebc
+sdh
 pHM
 psC
 iMY
@@ -85223,7 +86049,7 @@ oXo
 fWy
 buX
 erP
-lGt
+bQT
 pLt
 ukf
 wjA
@@ -85446,7 +86272,7 @@ unj
 xyp
 get
 xTO
-ebc
+sdh
 pHM
 hds
 mJb
@@ -85480,7 +86306,7 @@ rWi
 fWy
 jJI
 erP
-lGt
+bQT
 ngi
 qkL
 fiH
@@ -85700,10 +86526,10 @@ iSi
 abm
 iSy
 iSi
-jlp
-lGt
+xyp
+hPS
 xTO
-ebc
+sdh
 pHM
 dHM
 pHM
@@ -85737,7 +86563,7 @@ oXo
 fWy
 buX
 erP
-lGt
+bQT
 pLt
 ebc
 wjA
@@ -85958,7 +86784,7 @@ kHi
 lyj
 xyp
 xyp
-kPZ
+lab
 lRN
 kPZ
 aad
@@ -86217,7 +87043,7 @@ hMF
 nSM
 edm
 iGZ
-gCP
+rEe
 jyS
 eAG
 eAG
@@ -86508,7 +87334,7 @@ qNc
 hzo
 jUu
 gvp
-lGt
+xQQ
 aUd
 ebc
 lEj
@@ -86765,7 +87591,7 @@ kQt
 pHK
 pHK
 aCt
-lGt
+xQQ
 wxm
 ebc
 lEj
@@ -87022,7 +87848,7 @@ njE
 fqX
 rVL
 ojF
-lGt
+xQQ
 wxm
 ebc
 pej
@@ -87245,7 +88071,7 @@ ubm
 xUX
 lUj
 xTO
-ebc
+dJo
 aad
 keL
 eAG
@@ -87278,7 +88104,7 @@ oyo
 dCH
 bXy
 dCH
-wLD
+lUu
 miz
 rtl
 aJw
@@ -87500,9 +88326,9 @@ uWD
 kYL
 wug
 iXr
-mVo
+niq
 mkb
-wCS
+ogM
 aad
 gWa
 siZ
@@ -87759,7 +88585,7 @@ xUX
 xUX
 txD
 xTO
-ebc
+rDk
 aad
 bYw
 eAG
@@ -87793,7 +88619,7 @@ tme
 jjT
 jjT
 ltk
-lGt
+xQQ
 abe
 ebc
 wnT
@@ -88014,9 +88840,9 @@ xEu
 sHJ
 rIO
 xEu
-lWL
+kKV
 xTO
-ebc
+rDk
 jhj
 aad
 ghz
@@ -88049,8 +88875,8 @@ lUu
 jnS
 ilO
 frt
-sdh
-lGt
+lUu
+xQQ
 abe
 ebc
 ayP
@@ -88271,9 +89097,9 @@ sZq
 gTW
 tYO
 qsK
-lvy
+cjb
 xTO
-ebc
+rDk
 rmg
 wjA
 wjA
@@ -88528,9 +89354,9 @@ msI
 gTW
 tYO
 qsK
-lvy
+cjb
 xTO
-ebc
+rDk
 nDx
 nRn
 lmf
@@ -88564,7 +89390,7 @@ lju
 hKq
 tOx
 brX
-lGt
+iSI
 sph
 gus
 iDT
@@ -89042,7 +89868,7 @@ qwz
 gTW
 tYO
 qsK
-lvy
+cjb
 qZC
 sha
 nDx
@@ -89078,7 +89904,7 @@ lju
 tOx
 tOx
 brX
-lGt
+iSI
 abe
 nZN
 wnT
@@ -89299,9 +90125,9 @@ xEu
 nuu
 fhc
 xEu
-lvy
+cjb
 xTO
-ebc
+rDk
 cxd
 wjA
 wjA
@@ -89558,7 +90384,7 @@ xEu
 xEu
 wqr
 ltA
-qkL
+uhF
 eCl
 usb
 usb
@@ -89591,8 +90417,8 @@ rdS
 ipS
 ipS
 pUR
-vgK
-lGt
+wjA
+ptb
 abe
 ebc
 wnT
@@ -89813,9 +90639,9 @@ wym
 wym
 wym
 tfa
-mOY
+bxM
 sQi
-ebc
+wDr
 wjA
 jYd
 nkn
@@ -89849,7 +90675,7 @@ ipS
 ipS
 ipS
 wjA
-jij
+teu
 abe
 qEP
 pEd
@@ -90072,7 +90898,7 @@ bcP
 bcP
 hJZ
 mkb
-wCS
+ogM
 wjA
 pQL
 fZw
@@ -90327,9 +91153,9 @@ xnR
 xnR
 xnR
 xnR
-txD
+fvF
 xTO
-ebc
+rDk
 wjA
 pQL
 fZw
@@ -90841,9 +91667,9 @@ qvA
 kuc
 cEO
 xnR
-lvy
+pQI
 xTO
-ebc
+lXV
 wjA
 pQL
 fZw
@@ -91098,9 +91924,9 @@ oYx
 oxS
 vnv
 xnR
-lvy
+pQI
 xTO
-ebc
+wLD
 wjA
 pQL
 fZw
@@ -91134,7 +91960,7 @@ nvs
 fsr
 fZw
 wjA
-tQc
+vgK
 rQZ
 ebc
 aNM
@@ -91357,7 +92183,7 @@ bAC
 xnR
 nQr
 xTO
-gCP
+tOW
 wjA
 kxf
 nKl
@@ -91391,7 +92217,7 @@ gUs
 fsr
 fZw
 wjA
-oQc
+nMa
 rQZ
 gCP
 wnT
@@ -91648,7 +92474,7 @@ kmb
 dXy
 fZw
 wjA
-lGt
+fgn
 rQZ
 ebc
 wnT
@@ -91869,9 +92695,9 @@ rGM
 sGy
 fOQ
 iWf
-lvy
+qZu
 xTO
-ebc
+rDk
 wjA
 dPw
 nKl
@@ -91905,7 +92731,7 @@ kmb
 fsr
 fZw
 wjA
-lGt
+fgn
 rQZ
 ebc
 xEP
@@ -92128,7 +92954,7 @@ qIY
 lTa
 sdx
 xqs
-ebc
+rDk
 wjA
 pQL
 nKl
@@ -92383,9 +93209,9 @@ hCX
 ndj
 fOQ
 iWf
-lvy
+qZu
 xTO
-ebc
+muJ
 wjA
 pQL
 nKl
@@ -92640,9 +93466,9 @@ kVJ
 kuc
 gdi
 mna
-mVo
+wOJ
 mkb
-wCS
+ogM
 wjA
 xeo
 fZw
@@ -92676,7 +93502,7 @@ kmb
 fZw
 iVf
 wjA
-aAz
+usp
 wKA
 wCS
 wnT
@@ -92897,9 +93723,9 @@ uFW
 kuc
 cEO
 xnR
-lWL
+bNb
 xTO
-pOH
+raR
 wjA
 rdS
 xIS
@@ -92933,7 +93759,7 @@ rdS
 fZw
 fZw
 wjA
-lGt
+fgn
 rQZ
 ebc
 wnT
@@ -93154,9 +93980,9 @@ wkp
 oxS
 vnv
 xnR
-txD
+dNL
 xTO
-ebc
+rDk
 cLm
 rdS
 pQL
@@ -93190,7 +94016,7 @@ rdS
 fZw
 fZw
 wjA
-lGt
+fgn
 rQZ
 ebc
 wnT
@@ -93411,9 +94237,9 @@ jSF
 kuc
 bAC
 xnR
-lvy
+evQ
 xTO
-ebc
+rDk
 ouC
 rdS
 pQL
@@ -93447,7 +94273,7 @@ rdS
 lHZ
 rdS
 wjA
-tQc
+vgK
 rQZ
 pOH
 wnT
@@ -93668,7 +94494,7 @@ pGd
 qxT
 cEO
 xnR
-lvy
+fxT
 xTO
 pBx
 wjA
@@ -93704,7 +94530,7 @@ oAa
 ijd
 hqh
 wjA
-jij
+teu
 rQZ
 ebc
 wnT
@@ -93927,7 +94753,7 @@ bcP
 bcP
 lJn
 xTO
-gCP
+tOW
 wjA
 mpn
 fZw
@@ -93963,7 +94789,7 @@ hqh
 wjA
 kOw
 rQZ
-gCP
+tOW
 hwq
 hwq
 hwq
@@ -94182,9 +95008,9 @@ dWH
 dWH
 dWH
 lGe
-lvy
+qZu
 xTO
-ebc
+rDk
 wjA
 dPw
 fZw
@@ -94218,9 +95044,9 @@ ury
 ijd
 hqh
 jUm
-cwB
+upK
 rQZ
-ebc
+rDk
 huS
 eXb
 xdY
@@ -94441,7 +95267,7 @@ ufC
 ijf
 mOY
 nXC
-ebc
+rDk
 wjA
 pQL
 nvs
@@ -94474,10 +95300,10 @@ lPs
 rdS
 lHZ
 rdS
-vqf
-lGt
+wjA
+iSI
 rQZ
-ebc
+rDk
 huS
 iyW
 rXD
@@ -94731,10 +95557,10 @@ lPs
 rdS
 fZw
 iVf
-bQT
-bOy
-rQZ
-ebc
+wjA
+vYb
+mrO
+kPZ
 huS
 iyW
 guQ
@@ -94952,10 +95778,10 @@ fQH
 aUP
 jUY
 kqo
-srI
+ixt
 lWL
 xTO
-ebc
+rDk
 jrd
 pQL
 xuC
@@ -94970,7 +95796,7 @@ nDY
 lPs
 xKs
 jaI
-rkV
+rqJ
 jaI
 jaI
 jaI
@@ -94988,10 +95814,10 @@ lPs
 rdS
 fZw
 fZw
-mrO
-plp
+wjA
+sMl
 gsp
-plp
+rDk
 huS
 iyW
 xFz
@@ -95224,7 +96050,7 @@ wjA
 wjA
 wjA
 wjA
-iQB
+wjA
 xPC
 ksm
 fBH
@@ -95234,7 +96060,7 @@ fBH
 fBH
 oyT
 wXW
-izD
+wjA
 wjA
 wjA
 wjA
@@ -95245,10 +96071,10 @@ wjA
 wjA
 qnQ
 wjA
-upK
-hnA
+wjA
+jlp
 wKA
-wCS
+ogM
 huS
 ewM
 huS
@@ -95472,14 +96298,14 @@ xTO
 oWj
 cHi
 iaB
+fBH
 eeu
-kJP
-kJP
-kJP
+eeu
+eeu
 tjW
 rcD
-tnM
-kJP
+vZL
+rwM
 qqe
 tLI
 azj
@@ -95492,7 +96318,7 @@ udP
 tOW
 sYj
 tLI
-kJP
+icO
 kJP
 tnM
 kLt
@@ -95500,7 +96326,7 @@ pLC
 uUq
 kJP
 kJP
-eeu
+fBH
 liH
 tLI
 qTH
@@ -95765,7 +96591,7 @@ vUu
 cbf
 cbf
 tLB
-ebc
+rDk
 qif
 kCL
 kCL
@@ -96004,7 +96830,7 @@ avj
 fnr
 gga
 tOW
-rkV
+laZ
 qmr
 kuD
 kuD
@@ -96022,7 +96848,7 @@ ipw
 npP
 qro
 lzF
-ebc
+rDk
 lju
 kCL
 kCL
@@ -96277,9 +97103,9 @@ sdM
 kDu
 arc
 lju
-lGt
+fgn
 lzF
-ebc
+rDk
 lju
 kCL
 kCL
@@ -96514,10 +97340,10 @@ gqS
 mpy
 rkV
 kbY
-jaI
-jaI
+mGy
 rkV
-jaI
+rkV
+rkV
 rpc
 uFe
 ipU
@@ -96534,9 +97360,9 @@ fgw
 gIb
 arc
 gpj
-lGt
+fgn
 lzF
-ebc
+rDk
 lju
 lju
 lju
@@ -96791,7 +97617,7 @@ fgw
 gIb
 arc
 jOK
-lGt
+nMa
 moq
 bBI
 aCk
@@ -97048,7 +97874,7 @@ fgw
 gIb
 arc
 pnN
-lGt
+fgn
 lzF
 rDk
 lju
@@ -97307,7 +98133,7 @@ arc
 dwu
 bVm
 lzF
-gCP
+rDk
 bYC
 bOQ
 qif
@@ -97564,7 +98390,7 @@ arc
 lju
 bZU
 lzF
-ebc
+rDk
 lfn
 lfn
 qif
@@ -97821,7 +98647,7 @@ eKt
 lju
 tis
 lzF
-ebc
+rDk
 lfn
 lfn
 qif
@@ -98078,7 +98904,7 @@ oNh
 fLJ
 fgn
 fxX
-ebc
+rDk
 rvV
 rvV
 qif
@@ -98847,7 +99673,7 @@ fgw
 fgw
 gIb
 lju
-lGt
+fgn
 fxX
 rDk
 lju
@@ -99104,7 +99930,7 @@ fgw
 wOj
 gIb
 lju
-lGt
+fgn
 fxX
 rDk
 lju
@@ -99361,7 +100187,7 @@ fgw
 uxJ
 gIb
 lju
-lGt
+fgn
 fxX
 rDk
 lju


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This is a series of small mapping tweaks and fixes to the Galactica. No major changes to departments.

## Why It's Good For The Game

Galactica mapping bug bad. Fixman good. Signage good.

## Changelog
:cl:
add: Added Keycard Authenticators to Heads offices and bridge on the Galactica
add: Added NT territory capture beacon to the Galactica
add: Additional supplies to Galactica robotics.
add: Added Clothing vendor to Galactica Barracks
tweak: Updated Galactica signage and tiling to ease navigation of ship.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
