### PR TITLE
Gives syndicate boarding crew flashlights

### DIFF
--- a/nsv13/code/modules/overmap/boarding/ghost_role_spawners.dm
+++ b/nsv13/code/modules/overmap/boarding/ghost_role_spawners.dm
@@ -29,7 +29,6 @@
 	suit = /obj/item/clothing/suit/space/officer
 	l_pocket = /obj/item/ammo_box/magazine/pistolm9mm
 	r_pocket = /obj/item/gun/ballistic/automatic/pistol/APS
-	implants = list()
 
 /datum/outfit/syndicate_empty/boarding
 	name = "Syndicate Crewman (Boarding)"
@@ -38,6 +37,7 @@
 	l_pocket = /obj/item/ammo_box/magazine/m10mm
 	r_pocket = /obj/item/gun/ballistic/automatic/pistol
 	back = /obj/item/storage/backpack/duffelbag/syndie
+	glasses = /obj/item/clothing/glasses/night
 	backpack_contents = list(/obj/item/storage/box/syndie=1,\
 	/obj/item/kitchen/knife/combat/survival=1)
 

--- a/nsv13/code/modules/overmap/boarding/ghost_role_spawners.dm
+++ b/nsv13/code/modules/overmap/boarding/ghost_role_spawners.dm
@@ -37,9 +37,9 @@
 	l_pocket = /obj/item/ammo_box/magazine/m10mm
 	r_pocket = /obj/item/gun/ballistic/automatic/pistol
 	back = /obj/item/storage/backpack/duffelbag/syndie
-	glasses = /obj/item/clothing/glasses/night
 	backpack_contents = list(/obj/item/storage/box/syndie=1,\
-	/obj/item/kitchen/knife/combat/survival=1)
+	/obj/item/kitchen/knife/combat/survival=1,\
+	/obj/item/flashlight/seclite)
 
 /obj/effect/mob_spawn/human/syndicate/boarding
 	name = "Syndicate Crewman"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds one seclite to the bags of syndicate crews on board able ships. Also lets syndicate captains use guns with syndicate firing pins.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Syndicate crew should be able to see inside their own ship, especially if lights break.


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Something like this happened on a boarding round. 
![WhyItIsGoodForTheGame](https://github.com/user-attachments/assets/9a3e42c9-0791-4453-a723-943e0affa37d)


They have seclites now.
![SyndiLight](https://github.com/user-attachments/assets/42fbca4a-ba5d-499b-a47e-36ab4fbfbf81)

</details>

## Changelog
:cl:
add: Syndicate boarding crew now have flashlights
add: Syndicate boarding captains now have weapon auth implants
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
