### PR TITLE
Adds the ability to construct AI cores on Syndicate ships and make Syndicate helmet cams

### DIFF
--- a/code/game/objects/structures/ai_core.dm
+++ b/code/game/objects/structures/ai_core.dm
@@ -244,7 +244,7 @@
 							A = new /mob/living/silicon/ai(loc, laws, brain.brainmob)
 
 						if(get_overmap()?.faction == "syndicate") //NSV13 start - Syndicate ship radio & traitor setting
-							A.set_zeroth_law("Accomplish your ship's objectives at all costs.", "Accomplish your ship's objectives at all costs.")
+							A.set_zeroth_law("Accomplish the Syndicate's objectives at all costs.", "Accomplish your Syndicate's objectives at all costs.")
 							A.set_syndie_radio()
 							A.faction |= "Syndicate" //Why is this capitalized
 							A.network = list("syndicate")

--- a/code/game/objects/structures/ai_core.dm
+++ b/code/game/objects/structures/ai_core.dm
@@ -243,6 +243,13 @@
 						else
 							A = new /mob/living/silicon/ai(loc, laws, brain.brainmob)
 
+						if(get_overmap()?.faction == "syndicate") //NSV13 start - Syndicate ship radio & traitor setting
+							A.set_zeroth_law("Accomplish your ship's objectives at all costs.", "Accomplish your ship's objectives at all costs.")
+							A.set_syndie_radio()
+							A.faction |= "Syndicate" //Why is this capitalized
+							A.network = list("syndicate")
+							A.radio.recalculateChannels() //NSV13 end
+
 						if(brain.force_replace_ai_name)
 							A.fully_replace_character_name(A.name, brain.replacement_ai_name())
 						SSblackbox.record_feedback("amount", "ais_created", 1)

--- a/nsv13/code/modules/clothing/custom_clothes.dm
+++ b/nsv13/code/modules/clothing/custom_clothes.dm
@@ -367,6 +367,11 @@
 	item_state = "syndicate-space"
 	worn_icon_state = "syndicate-space"
 
+//Subytype which spawns with a camera for boarders
+/obj/item/clothing/head/helmet/space/syndicate/odst/camera/Initialize()
+	. = ..()
+	install_camera(faction = "Syndicate")
+
 /obj/item/storage/belt/utility/syndicate
 	name = "syndicate utility belt"
 	desc = "A large, black belt which facilitates tool storage."

--- a/nsv13/code/modules/clothing/custom_outfits.dm
+++ b/nsv13/code/modules/clothing/custom_outfits.dm
@@ -26,7 +26,7 @@
 /datum/outfit/syndicate/odst
 	name = "Syndicate Boarder - Base"
 	suit = /obj/item/clothing/suit/space/syndicate/odst
-	head = /obj/item/clothing/head/helmet/space/syndicate/odst
+	head = /obj/item/clothing/head/helmet/space/syndicate/odst/camera //You're boarding, you get cams
 	belt = /obj/item/storage/belt/utility/syndicate
 	gloves = /obj/item/clothing/gloves/combat
 	mask = /obj/item/clothing/mask/gas/syndicate

--- a/nsv13/code/modules/clothing/helmet_camera.dm
+++ b/nsv13/code/modules/clothing/helmet_camera.dm
@@ -6,7 +6,8 @@
 		if(src == user.get_item_by_slot(ITEM_SLOT_HEAD)) //Make sure the player is not wearing the suit before applying the upgrade.
 			to_chat(user, "<span class='warning'>You cannot install the upgrade to [src] while wearing it.</span>")
 			return FALSE
-		if(do_after(install_camera(I, src), 5, target = src))
+		if(do_after(user, 5, target = src))
+			install_camera(I, src)
 			to_chat(user, "<span class='notice'>You successfully attach the camera to [src].</span>")
 			return TRUE
 	else if(I.tool_behaviour == TOOL_WIRECUTTER)
@@ -75,7 +76,7 @@
 	user.transferItemToLoc(I, src)
 	builtInCamera = new /obj/machinery/camera(src)
 	builtInCamera.c_tag = "Helmet Cam #[rand(0,999)]"
-	if(user.faction & "Syndicate" || faction == "Syndicate") //If a syndicate agent puts it on, it's a syndie camera now
+	if(length(user.faction & "Syndicate") || faction == "Syndicate") //If a syndicate agent puts it on, it's a syndie camera now
 		builtInCamera.network = list("syndicate")
 	else
 		builtInCamera.network = list("ss13")

--- a/nsv13/code/modules/clothing/helmet_camera.dm
+++ b/nsv13/code/modules/clothing/helmet_camera.dm
@@ -2,30 +2,25 @@
 	if(istype(I, /obj/item/wallframe/camera))
 		if(builtInCamera)
 			to_chat(user, "<span class='warning'>[src] already has a camera.</span>")
-			return
+			return FALSE
 		if(src == user.get_item_by_slot(ITEM_SLOT_HEAD)) //Make sure the player is not wearing the suit before applying the upgrade.
 			to_chat(user, "<span class='warning'>You cannot install the upgrade to [src] while wearing it.</span>")
-			return
-		if(user.transferItemToLoc(I, src))
-			builtInCamera = new /obj/machinery/camera(src)
-			builtInCamera.c_tag = "Helmet Cam #[rand(0,999)]"
-			builtInCamera.network = list("headcam", "ss13")
-			builtInCamera.internal_light = FALSE
-			QDEL_NULL(I)
+			return FALSE
+		if(do_after(install_camera(I, src), 5, target = src))
 			to_chat(user, "<span class='notice'>You successfully attach the camera to [src].</span>")
-			return
+			return TRUE
 	else if(I.tool_behaviour == TOOL_WIRECUTTER)
 		if(!builtInCamera)
 			to_chat(user, "<span class='warning'>[src] has no camera installed.</span>")
-			return
+			return FALSE
 		if(src == user.get_item_by_slot(ITEM_SLOT_HEAD))
 			to_chat(user, "<span class='warning'>You cannot remove the camera from [src] while wearing it.</span>")
-			return
+			return FALSE
 
 		new /obj/item/wallframe/camera(drop_location())
 		QDEL_NULL(builtInCamera)
 		to_chat(user, "<span class='notice'>You successfully remove the camera from [src].</span>")
-		return
+		return TRUE
 	else
 		return ..()
 
@@ -64,3 +59,26 @@
 		updating = TRUE
 		addtimer(CALLBACK(src, PROC_REF(do_camera_update), oldLoc), SILICON_CAMERA_BUFFER)
 #undef SILICON_CAMERA_BUFFER
+
+/obj/item/clothing/head/helmet/proc/install_camera(obj/item/I, mob/user, faction)
+	if(builtInCamera) //You already have a camera
+		return FALSE
+	if(!I || !user) //The camera isn't being placed by a person
+		builtInCamera = new /obj/machinery/camera(src)
+		builtInCamera.c_tag = "Helmet Cam #[rand(0,999)]"
+		if(faction == "Syndicate")
+			builtInCamera.network = list("syndicate")
+		else
+			builtInCamera.network = list("ss13")
+			builtInCamera.internal_light = FALSE
+		return TRUE
+	user.transferItemToLoc(I, src)
+	builtInCamera = new /obj/machinery/camera(src)
+	builtInCamera.c_tag = "Helmet Cam #[rand(0,999)]"
+	if(user.faction & "Syndicate" || faction == "Syndicate") //If a syndicate agent puts it on, it's a syndie camera now
+		builtInCamera.network = list("syndicate")
+	else
+		builtInCamera.network = list("ss13")
+	builtInCamera.internal_light = FALSE
+	QDEL_NULL(I)
+	return TRUE

--- a/nsv13/code/modules/clothing/helmet_camera.dm
+++ b/nsv13/code/modules/clothing/helmet_camera.dm
@@ -67,11 +67,11 @@
 	if(!I || !user) //The camera isn't being placed by a person
 		builtInCamera = new /obj/machinery/camera(src)
 		builtInCamera.c_tag = "Helmet Cam #[rand(0,999)]"
+		builtInCamera.internal_light = FALSE
 		if(faction == "Syndicate")
 			builtInCamera.network = list("syndicate")
 		else
 			builtInCamera.network = list("ss13")
-			builtInCamera.internal_light = FALSE
 		return TRUE
 	user.transferItemToLoc(I, src)
 	builtInCamera = new /obj/machinery/camera(src)


### PR DESCRIPTION
## About The Pull Request

The title pretty much sums it up, right now an AI that is *constructed* (not spawned) on a Syndicate ship will get a law 0 to stay loyal to the Syndicate, and be linked to the Syndie camera net and radio channel.
I've also included the ability to make Syndicate helmet cameras, because with an AI those will have more purpose, too. Boarders will spawn with cameras in their helmets by default.
> [!Note]
> All AI technology on Syndicate ships is designated to immediately be transferred to Minervasoft upon arrival in a Syndicate shipyard. Withholding transfer or staying quiet about possessing AI technology will have severe repercussions.

## Why It's Good For The Game

Adds support for more shenanigans during PVP, and in general.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>
I tested it, trust
</details>

## Changelog
:cl:
add: Added Syndicate AI core construction
add: Added the ability for Syndies to install syndicate cameras to helmets
balance: Syndicate boarder helmet now have cameras
refactor: Refactored helmet camera code a bit
/:cl: