### PR TITLE
Fixes fighter launchers on Serendipity and Hammerhead

### DIFF
--- a/_maps/map_files/Hammerhead/Hammerhead.dmm
+++ b/_maps/map_files/Hammerhead/Hammerhead.dmm
@@ -252,9 +252,7 @@
 /area/janitor)
 "aaW" = (
 /turf/closed/wall/r_wall/ship,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/left)
 "aaX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -283,9 +281,7 @@
 /obj/item/clothing/suit/hazardvest,
 /obj/item/clothing/head/hardhat,
 /turf/open/floor/durasteel,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/left)
 "abg" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -298,9 +294,7 @@
 	pixel_y = 26
 	},
 /turf/open/floor/durasteel,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/left)
 "abh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -357,9 +351,7 @@
 /area/science/mixing)
 "abm" = (
 /turf/open/floor/durasteel,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/left)
 "abn" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
@@ -451,9 +443,7 @@
 	},
 /obj/effect/landmark/start/pilot,
 /turf/open/floor/durasteel,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/left)
 "abB" = (
 /turf/open/floor/durasteel/eris_techfloor_alt,
 /area/hallway/primary/aft)
@@ -509,9 +499,7 @@
 	},
 /obj/effect/landmark/start/pilot,
 /turf/open/floor/durasteel,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/left)
 "abS" = (
 /turf/template_noop,
 /area/maintenance/starboard/central)
@@ -604,9 +592,7 @@
 /obj/item/clothing/suit/hazardvest,
 /obj/item/clothing/head/hardhat,
 /turf/open/floor/durasteel,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/right)
 "acm" = (
 /obj/machinery/washing_machine,
 /turf/open/floor/durasteel/padded,
@@ -673,9 +659,7 @@
 "acF" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/durasteel,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/left)
 "acG" = (
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
@@ -689,9 +673,7 @@
 	dir = 1
 	},
 /turf/open/floor/durasteel,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/left)
 "acJ" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/sunnybush,
@@ -920,9 +902,7 @@
 /area/science/robotics/lab)
 "adq" = (
 /turf/closed/wall/r_wall/ship,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/right)
 "adr" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -28
@@ -988,16 +968,12 @@
 	dir = 4
 	},
 /turf/open/floor/durasteel,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/left)
 "adE" = (
 /obj/machinery/computer/ship/dradis/minor,
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/durasteel,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/left)
 "adF" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/durasteel,
@@ -1009,9 +985,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/durasteel,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/right)
 "adH" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -1024,9 +998,7 @@
 	pixel_y = 26
 	},
 /turf/open/floor/durasteel,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/right)
 "adK" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -1089,18 +1061,14 @@
 	},
 /obj/effect/landmark/start/pilot,
 /turf/open/floor/durasteel,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/right)
 "adZ" = (
 /obj/structure/chair/office{
 	dir = 4
 	},
 /obj/effect/landmark/start/pilot,
 /turf/open/floor/durasteel,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/right)
 "aeb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -1169,39 +1137,29 @@
 /obj/machinery/computer/ship/dradis/minor,
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/durasteel,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/right)
 "aej" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/durasteel,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/left)
 "ael" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/durasteel,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/left)
 "aem" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/durasteel,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/right)
 "aeo" = (
 /obj/machinery/computer/ship/fighter_launcher{
 	dir = 1
 	},
 /turf/open/floor/durasteel,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/right)
 "aep" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -1223,9 +1181,7 @@
 "aer" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/durasteel,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/right)
 "aet" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/airlock/ship/external/glass{
@@ -2410,9 +2366,7 @@
 	},
 /obj/effect/landmark/start/air_traffic_controller,
 /turf/open/floor/durasteel/padded,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/left)
 "ahW" = (
 /obj/structure/chair/office,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -2423,9 +2377,7 @@
 	},
 /obj/effect/landmark/start/air_traffic_controller,
 /turf/open/floor/durasteel/padded,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/right)
 "ahX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -2435,9 +2387,7 @@
 	},
 /obj/effect/landmark/start/pilot,
 /turf/open/floor/durasteel,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/left)
 "aid" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -10098,9 +10048,7 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/open/floor/durasteel,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/right)
 "aGq" = (
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/security/prison)
@@ -16217,9 +16165,7 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/durasteel,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/left)
 "bad" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -16302,9 +16248,7 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/durasteel,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/right)
 "bam" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -18333,9 +18277,7 @@
 	dir = 8
 	},
 /turf/open/floor/durasteel/riveted,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/left)
 "bgy" = (
 /obj/effect/turf_decal/stripes/full,
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
@@ -22126,9 +22068,7 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/durasteel/padded,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/left)
 "cNU" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
@@ -22552,9 +22492,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/left)
 "dcV" = (
 /obj/structure/girder,
 /obj/structure/grille,
@@ -23361,9 +23299,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/effect/landmark/start/pilot,
 /turf/open/floor/durasteel,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/left)
 "dzQ" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -23390,9 +23326,7 @@
 /obj/structure/fighter_launcher,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plating,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/left)
 "dCA" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet/black,
@@ -24075,9 +24009,7 @@
 	dir = 8
 	},
 /turf/open/floor/durasteel,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/right)
 "eci" = (
 /obj/effect/turf_decal/tile/orange{
 	dir = 4
@@ -24789,9 +24721,7 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/durasteel/padded,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/right)
 "eAW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -26350,9 +26280,7 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/durasteel/padded,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/right)
 "fBx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/tile/yellow{
@@ -27345,9 +27273,7 @@
 	dir = 1
 	},
 /turf/open/floor/durasteel,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/left)
 "gjQ" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -27474,9 +27400,7 @@
 	dir = 1
 	},
 /turf/open/floor/durasteel,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/right)
 "goU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 5
@@ -28054,9 +27978,7 @@
 	dir = 9
 	},
 /turf/open/floor/durasteel,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/left)
 "gNq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -28381,9 +28303,7 @@
 	dir = 4
 	},
 /turf/open/floor/durasteel,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/right)
 "haO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -29329,9 +29249,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/durasteel,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/left)
 "hzo" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -30060,9 +29978,7 @@
 	pixel_y = 22
 	},
 /turf/open/floor/durasteel,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/right)
 "hYv" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -30894,9 +30810,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/right)
 "izF" = (
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/plating,
@@ -31156,9 +31070,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/right)
 "iIR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -32169,9 +32081,7 @@
 	pixel_y = -4
 	},
 /turf/closed/wall/ship,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/right)
 "jsQ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -34529,9 +34439,7 @@
 	name = "safety shutters"
 	},
 /turf/open/floor/plating,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/right)
 "kWb" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
@@ -36010,9 +35918,7 @@
 	dir = 8
 	},
 /turf/open/floor/durasteel/riveted,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/left)
 "lSH" = (
 /obj/structure/closet/radiation,
 /obj/item/clothing/mask/gas,
@@ -38706,9 +38612,7 @@
 	dir = 8
 	},
 /turf/open/floor/durasteel/riveted,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/right)
 "nAq" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 10
@@ -39537,9 +39441,7 @@
 	pixel_y = -24
 	},
 /turf/open/floor/durasteel,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/right)
 "nXk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -42134,9 +42036,7 @@
 	dir = 8
 	},
 /turf/open/floor/durasteel/riveted,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/right)
 "pFO" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -42348,9 +42248,7 @@
 /obj/structure/fighter_launcher,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plating,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/right)
 "pOK" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -42921,9 +42819,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/durasteel,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/left)
 "qfz" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Workshop"
@@ -43169,9 +43065,7 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/durasteel,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/right)
 "qot" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -43951,9 +43845,7 @@
 	name = "safety shutters"
 	},
 /turf/open/floor/plating,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/left)
 "qNU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45322,9 +45214,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/left)
 "rFh" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westright{
@@ -46604,9 +46494,7 @@
 	pixel_y = 22
 	},
 /turf/open/floor/durasteel,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/left)
 "svW" = (
 /obj/structure/rack,
 /obj/item/gun/ballistic/automatic/wt550,
@@ -46920,9 +46808,7 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/durasteel/padded,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/left)
 "sDX" = (
 /obj/machinery/door/airlock/ship/hatch{
 	name = "Telecomms Server Floor Access";
@@ -50366,9 +50252,7 @@
 	pixel_y = -24
 	},
 /turf/open/floor/durasteel,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/left)
 "uJE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -51152,9 +51036,7 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/durasteel,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/left)
 "vlA" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -51873,9 +51755,7 @@
 	dir = 8
 	},
 /turf/open/floor/durasteel/riveted,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/left)
 "vMJ" = (
 /obj/machinery/light{
 	dir = 4
@@ -52109,9 +51989,7 @@
 	pixel_y = -4
 	},
 /turf/closed/wall/ship,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/left)
 "vRm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -52764,9 +52642,7 @@
 "wnV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/durasteel,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/right)
 "woi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -53990,9 +53866,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
-/area/nsv/hanger/deck2/starboard{
-	name = "Launch tubes 1 and 2"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/left)
 "xeo" = (
 /turf/closed/wall/r_wall/ship,
 /area/chapel/office)
@@ -54789,9 +54663,7 @@
 	},
 /obj/effect/landmark/start/pilot,
 /turf/open/floor/durasteel,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/right)
 "xCk" = (
 /obj/structure/extinguisher_cabinet/north,
 /obj/machinery/atmospherics/pipe/simple/dark/visible/layer2{
@@ -55497,9 +55369,7 @@
 	dir = 8
 	},
 /turf/open/floor/durasteel/riveted,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/right)
 "xYl" = (
 /obj/machinery/computer/ship/viewscreen{
 	pixel_x = -32;
@@ -55791,9 +55661,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/durasteel,
-/area/nsv/hanger/deck2/port{
-	name = "Launch tubes 3 and 4"
-	})
+/area/nsv/hanger/notkmcstupidhanger/launchtube/right)
 "ygv" = (
 /obj/machinery/camera/autoname{
 	dir = 4

--- a/_maps/map_files/Hammerhead/Hammerhead.dmm
+++ b/_maps/map_files/Hammerhead/Hammerhead.dmm
@@ -22552,7 +22552,9 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/nsv/hanger)
+/area/nsv/hanger/deck2/starboard{
+	name = "Launch tubes 1 and 2"
+	})
 "dcV" = (
 /obj/structure/girder,
 /obj/structure/grille,
@@ -23388,7 +23390,9 @@
 /obj/structure/fighter_launcher,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plating,
-/area/nsv/hanger)
+/area/nsv/hanger/deck2/starboard{
+	name = "Launch tubes 1 and 2"
+	})
 "dCA" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet/black,
@@ -42337,6 +42341,16 @@
 	},
 /turf/open/floor/plating/airless,
 /area/maintenance/department/cargo)
+"pOE" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/fighter_launcher,
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/plating,
+/area/nsv/hanger/deck2/port{
+	name = "Launch tubes 3 and 4"
+	})
 "pOK" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -102648,7 +102662,7 @@ afv
 kjC
 adQ
 adQ
-dAS
+pOE
 kjC
 afv
 abh
@@ -104704,7 +104718,7 @@ afv
 kjC
 adQ
 adQ
-dAS
+pOE
 afv
 afv
 abh

--- a/_maps/map_files/Serendipity/Serendipity2.dmm
+++ b/_maps/map_files/Serendipity/Serendipity2.dmm
@@ -7610,7 +7610,7 @@
 /obj/structure/fighter_launcher,
 /obj/machinery/light/floor,
 /turf/open/floor/engine/vacuum,
-/area/nsv/hanger)
+/area/bridge/cic)
 "JZ" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable{


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the area tile mag-cats are on to match the control consoles area so they can link up properly.


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Things not working should work

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Serendipity

![DipityMagcatFix](https://github.com/user-attachments/assets/caf1843f-70d8-460d-9f72-2a41d818fccd)

Hammerhead
 (The area the control consoles are "launch tube 1 and 2" and "launch tube 3 and 4" so I'm assuming they're meant to be separate)
![HammerheadMagcat1234](https://github.com/user-attachments/assets/84e69381-32d7-499d-839b-213976d1a735)


</details>

## Changelog
:cl:
fix: fixed mag-cats on Serendipity and Hammerhead

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
