### PR TITLE
Player Missile/Torpedo durability buffs

### DIFF
--- a/nsv13/code/modules/overmap/overmap.dm
+++ b/nsv13/code/modules/overmap/overmap.dm
@@ -195,6 +195,7 @@
 	var/reserved_z = 0 //The Z level we were spawned on, and thus inhabit. This can be changed if we "swap" positions with another ship.
 	var/list/occupying_levels = list() //Refs to the z-levels we own for setting parallax and that, or for admins to debug things when EVERYTHING INEVITABLY BREAKS
 	var/torpedo_type = /obj/item/projectile/guided_munition/torpedo
+	var/missile_type = /obj/item/projectile/guided_munition/missile
 	var/next_maneuvre = 0 //When can we pull off a fancy trick like boost or kinetic turn?
 	var/flak_battery_amount = 0
 	var/broadside = FALSE //Whether the ship is allowed to have broadside cannons or not

--- a/nsv13/code/modules/overmap/types/nanotrasen.dm
+++ b/nsv13/code/modules/overmap/types/nanotrasen.dm
@@ -268,6 +268,8 @@
 	mass = MASS_MEDIUM
 	sprite_size = 48
 	ai_flags= AI_FLAG_DESTROYER
+	torpedo_type = /obj/item/projectile/guided_munition/torpedo/nerfed
+	missile_type = /obj/item/projectile/guided_munition/missile/nerfed
 	combat_dice_type = /datum/combat_dice/frigate
 
 /obj/structure/overmap/nanotrasen/patrol_cruiser/ai

--- a/nsv13/code/modules/overmap/types/nanotrasen.dm
+++ b/nsv13/code/modules/overmap/types/nanotrasen.dm
@@ -268,8 +268,8 @@
 	mass = MASS_MEDIUM
 	sprite_size = 48
 	ai_flags= AI_FLAG_DESTROYER
-	torpedo_type = /obj/item/projectile/guided_munition/torpedo/nerfed
-	missile_type = /obj/item/projectile/guided_munition/missile/nerfed
+	torpedo_type = /obj/item/projectile/guided_munition/torpedo/ai
+	missile_type = /obj/item/projectile/guided_munition/missile/ai
 	combat_dice_type = /datum/combat_dice/frigate
 
 /obj/structure/overmap/nanotrasen/patrol_cruiser/ai

--- a/nsv13/code/modules/overmap/types/solgov.dm
+++ b/nsv13/code/modules/overmap/types/solgov.dm
@@ -62,8 +62,8 @@
 	shots_left = 10000 //Issa laser.
 	torpedoes = 10
 	missiles = 10
-	torpedo_type = /obj/item/projectile/guided_munition/torpedo/nerfed
-	missile_type = /obj/item/projectile/guided_munition/missile/nerfed
+	torpedo_type = /obj/item/projectile/guided_munition/torpedo/ai
+	missile_type = /obj/item/projectile/guided_munition/missile/ai
 
 // Solgov Kadesh? Solgov Kadesh.
 /obj/structure/overmap/nanotrasen/solgov/ai/interdictor

--- a/nsv13/code/modules/overmap/types/solgov.dm
+++ b/nsv13/code/modules/overmap/types/solgov.dm
@@ -62,6 +62,8 @@
 	shots_left = 10000 //Issa laser.
 	torpedoes = 10
 	missiles = 10
+	torpedo_type = /obj/item/projectile/guided_munition/torpedo/nerfed
+	missile_type = /obj/item/projectile/guided_munition/missile/nerfed
 
 // Solgov Kadesh? Solgov Kadesh.
 /obj/structure/overmap/nanotrasen/solgov/ai/interdictor

--- a/nsv13/code/modules/overmap/types/spacepirates.dm
+++ b/nsv13/code/modules/overmap/types/spacepirates.dm
@@ -33,8 +33,8 @@
 	mass = MASS_SMALL
 	max_integrity = 400
 	armor = list("overmap_light" = 80, "overmap_medium" = 45, "overmap_heavy" = 10)
-	torpedo_type = /obj/item/projectile/guided_munition/torpedo/nerfed
-	missile_type = /obj/item/projectile/guided_munition/missile/nerfed
+	torpedo_type = /obj/item/projectile/guided_munition/torpedo/ai
+	missile_type = /obj/item/projectile/guided_munition/missile/ai
 	bound_height = 64
 	bound_width = 64
 	ai_controlled = TRUE

--- a/nsv13/code/modules/overmap/types/spacepirates.dm
+++ b/nsv13/code/modules/overmap/types/spacepirates.dm
@@ -33,6 +33,8 @@
 	mass = MASS_SMALL
 	max_integrity = 400
 	armor = list("overmap_light" = 80, "overmap_medium" = 45, "overmap_heavy" = 10)
+	torpedo_type = /obj/item/projectile/guided_munition/torpedo/nerfed
+	missile_type = /obj/item/projectile/guided_munition/missile/nerfed
 	bound_height = 64
 	bound_width = 64
 	ai_controlled = TRUE

--- a/nsv13/code/modules/overmap/types/syndicate.dm
+++ b/nsv13/code/modules/overmap/types/syndicate.dm
@@ -97,8 +97,8 @@
 	damage_states = FALSE
 	obj_integrity = 300
 	max_integrity = 300
-	torpedo_type = /obj/item/projectile/guided_munition/torpedo/nerfed
-	missile_type = /obj/item/projectile/guided_munition/missile/nerfed
+	torpedo_type = /obj/item/projectile/guided_munition/torpedo/ai
+	missile_type = /obj/item/projectile/guided_munition/missile/ai
 	area_type = /area/ruin/powered/nsv13/gunship
 	var/bounty = 1000
 	armor = list("overmap_light" = 30, "overmap_medium" = 20, "overmap_heavy" = 30)
@@ -453,7 +453,7 @@
 		torpedo_type = initial(torpedo_type)
 
 /obj/structure/overmap/syndicate/ai/submarine/elite/obj_break() //Unused for overmaps, so we just steal it to make damage phases :3c
-	torpedo_type = /obj/item/projectile/guided_munition/torpedo/viscerator/nerfed
+	torpedo_type = /obj/item/projectile/guided_munition/torpedo/viscerator/ai
 	torpedoes = CLAMP((torpedoes),2 , 3) //This is their secret weapon, they only have a few of these
 
 /obj/structure/overmap/syndicate/ai/kadesh	//I sure wonder what this one does....

--- a/nsv13/code/modules/overmap/types/syndicate.dm
+++ b/nsv13/code/modules/overmap/types/syndicate.dm
@@ -97,6 +97,8 @@
 	damage_states = FALSE
 	obj_integrity = 300
 	max_integrity = 300
+	torpedo_type = /obj/item/projectile/guided_munition/torpedo/nerfed
+	missile_type = /obj/item/projectile/guided_munition/missile/nerfed
 	area_type = /area/ruin/powered/nsv13/gunship
 	var/bounty = 1000
 	armor = list("overmap_light" = 30, "overmap_medium" = 20, "overmap_heavy" = 30)
@@ -451,7 +453,7 @@
 		torpedo_type = initial(torpedo_type)
 
 /obj/structure/overmap/syndicate/ai/submarine/elite/obj_break() //Unused for overmaps, so we just steal it to make damage phases :3c
-	torpedo_type = /obj/item/projectile/guided_munition/torpedo/viscerator
+	torpedo_type = /obj/item/projectile/guided_munition/torpedo/viscerator/nerfed
 	torpedoes = CLAMP((torpedoes),2 , 3) //This is their secret weapon, they only have a few of these
 
 /obj/structure/overmap/syndicate/ai/kadesh	//I sure wonder what this one does....

--- a/nsv13/code/modules/overmap/weapons/projectiles_fx.dm
+++ b/nsv13/code/modules/overmap/weapons/projectiles_fx.dm
@@ -413,8 +413,8 @@ Misc projectile types, effects, think of this as the special FX file.
 	valid_angle = 150
 	homing_turn_speed = 35
 	damage = 250
-	obj_integrity = 200
-	max_integrity = 200
+	obj_integrity = 120
+	max_integrity = 120
 	range = 250
 	armor = list("overmap_light" = 20, "overmap_medium" = 10, "overmap_heavy" = 0)
 	flag = "overmap_heavy"
@@ -432,8 +432,8 @@ Misc projectile types, effects, think of this as the special FX file.
 	relay_projectile_type = /obj/item/projectile/bullet/delayed_prime/relayed_viscerator_torpedo
 	damage = 75	//Simply kinetic damagewise..
 	flag = "overmap_medium"
-	obj_integrity = 400
-	max_integrity = 400
+	obj_integrity = 240
+	max_integrity = 240
 
 /obj/item/projectile/guided_munition/torpedo/viscerator/nerfed //AI Ship usage
 	obj_integrity = 80
@@ -457,8 +457,8 @@ Misc projectile types, effects, think of this as the special FX file.
 
 /obj/item/projectile/guided_munition/torpedo/decoy/nerfed //AI Ship usage
 	icon_state = "torpedo"
-	obj_integrity = 200
-	max_integrity = 200
+	obj_integrity = 120
+	max_integrity = 120
 
 /obj/item/projectile/guided_munition/torpedo/hellfire
 	icon_state = "torpedo_hellfire"
@@ -472,8 +472,8 @@ Misc projectile types, effects, think of this as the special FX file.
 
 /obj/item/projectile/guided_munition/torpedo/hellfire/player_version
 	damage = 300	//A bit less initial damage to compensate for the /guaranteed/ hellburn effect dealing hefty damage.
-	obj_integrity = 125
-	max_integrity = 125
+	obj_integrity = 75
+	max_integrity = 75
 
 
 /obj/item/projectile/guided_munition/torpedo/hellfire/spec_overmap_hit(obj/structure/overmap/target)
@@ -509,8 +509,8 @@ Misc projectile types, effects, think of this as the special FX file.
 	name = "prototype disruption torpedo"
 	ai_disruption = 15 //Do you like stuncombat? Well the AI doesn't.
 	ai_disruption_cap = 30 //Very effective if applied spaced out over time against damage-resistant ships.
-	obj_integrity = 200
-	max_integrity = 200
+	obj_integrity = 120
+	max_integrity = 120
 
 /obj/item/projectile/guided_munition/torpedo/disruptor/spec_overmap_hit(obj/structure/overmap/target)
 	if(length(target.occupying_levels))
@@ -546,8 +546,8 @@ Misc projectile types, effects, think of this as the special FX file.
 	damage = 175
 	valid_angle = 120
 	homing_turn_speed = 25
-	obj_integrity = 200
-	max_integrity = 200
+	obj_integrity = 120
+	max_integrity = 120
 	range = 250
 	flag = "overmap_medium"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/torpedo

--- a/nsv13/code/modules/overmap/weapons/projectiles_fx.dm
+++ b/nsv13/code/modules/overmap/weapons/projectiles_fx.dm
@@ -501,6 +501,8 @@ Misc projectile types, effects, think of this as the special FX file.
 	icon_state = "torpedo_disruptor"
 	name = "disruption torpedo"
 	damage = 140	//Lower damage, does some special stuff when it hits a target.
+	obj_integrity = 40
+	max_integrity = 40
 	var/ai_disruption = 30
 	var/ai_disruption_cap = 120
 

--- a/nsv13/code/modules/overmap/weapons/projectiles_fx.dm
+++ b/nsv13/code/modules/overmap/weapons/projectiles_fx.dm
@@ -413,13 +413,18 @@ Misc projectile types, effects, think of this as the special FX file.
 	valid_angle = 150
 	homing_turn_speed = 35
 	damage = 250
-	obj_integrity = 40
-	max_integrity = 40
+	obj_integrity = 200
+	max_integrity = 200
 	range = 250
 	armor = list("overmap_light" = 20, "overmap_medium" = 10, "overmap_heavy" = 0)
 	flag = "overmap_heavy"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/torpedo
 	spread = 5 //Helps them not get insta-bonked when launching
+
+/obj/item/projectile/guided_munition/torpedo/nerfed //AI Ship usage
+	icon_state = "torpedo"
+	obj_integrity = 40
+	max_integrity = 40
 
 /obj/item/projectile/guided_munition/torpedo/viscerator
 	//icon_state = "???"	- alt sprite would be nice
@@ -427,6 +432,10 @@ Misc projectile types, effects, think of this as the special FX file.
 	relay_projectile_type = /obj/item/projectile/bullet/delayed_prime/relayed_viscerator_torpedo
 	damage = 75	//Simply kinetic damagewise..
 	flag = "overmap_medium"
+	obj_integrity = 400
+	max_integrity = 400
+
+/obj/item/projectile/guided_munition/torpedo/viscerator/nerfed //AI Ship usage
 	obj_integrity = 80
 	max_integrity = 80
 
@@ -436,9 +445,18 @@ Misc projectile types, effects, think of this as the special FX file.
 	damage = 200
 	armour_penetration = 40
 
+/obj/item/projectile/guided_munition/torpedo/shredder/nerfed //AI Ship usage
+	obj_integrity = 40
+	max_integrity = 40
+
 /obj/item/projectile/guided_munition/torpedo/decoy
 	icon_state = "torpedo"
 	damage = 0
+	obj_integrity = 500
+	max_integrity = 500
+
+/obj/item/projectile/guided_munition/torpedo/decoy/nerfed //AI Ship usage
+	icon_state = "torpedo"
 	obj_integrity = 200
 	max_integrity = 200
 
@@ -454,6 +472,9 @@ Misc projectile types, effects, think of this as the special FX file.
 
 /obj/item/projectile/guided_munition/torpedo/hellfire/player_version
 	damage = 300	//A bit less initial damage to compensate for the /guaranteed/ hellburn effect dealing hefty damage.
+	obj_integrity = 125
+	max_integrity = 125
+
 
 /obj/item/projectile/guided_munition/torpedo/hellfire/spec_overmap_hit(obj/structure/overmap/target)
 	if(length(target.occupying_levels))
@@ -483,11 +504,13 @@ Misc projectile types, effects, think of this as the special FX file.
 	var/ai_disruption = 30
 	var/ai_disruption_cap = 120
 
-///Player-accessible version of parent. Weaker because reverse engineered ~~and balance~~
+///Player-accessible version of parent. Weaker effect because reverse engineered, buffed durability because player ship
 /obj/item/projectile/guided_munition/torpedo/disruptor/prototype
 	name = "prototype disruption torpedo"
 	ai_disruption = 15 //Do you like stuncombat? Well the AI doesn't.
 	ai_disruption_cap = 30 //Very effective if applied spaced out over time against damage-resistant ships.
+	obj_integrity = 200
+	max_integrity = 200
 
 /obj/item/projectile/guided_munition/torpedo/disruptor/spec_overmap_hit(obj/structure/overmap/target)
 	if(length(target.occupying_levels))
@@ -523,10 +546,16 @@ Misc projectile types, effects, think of this as the special FX file.
 	damage = 175
 	valid_angle = 120
 	homing_turn_speed = 25
+	obj_integrity = 200
+	max_integrity = 200
 	range = 250
 	flag = "overmap_medium"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/torpedo
 	spread = 5 //!Helps them not get insta-bonked when launching
+
+/obj/item/projectile/guided_munition/missile/nerfed //AI ship usage
+	obj_integrity = 40
+	max_integrity = 40
 
 /* Sleep for now, we'll see you again
 /obj/item/projectile/guided_munition/torpedo/nuclear/detonate(atom/target)
@@ -538,7 +567,6 @@ Misc projectile types, effects, think of this as the special FX file.
 
 	return BULLET_ACT_HIT
 */
-
 
 /obj/item/projectile/bullet/pdc_round
 	icon_state = "pdc"

--- a/nsv13/code/modules/overmap/weapons/projectiles_fx.dm
+++ b/nsv13/code/modules/overmap/weapons/projectiles_fx.dm
@@ -421,7 +421,7 @@ Misc projectile types, effects, think of this as the special FX file.
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/torpedo
 	spread = 5 //Helps them not get insta-bonked when launching
 
-/obj/item/projectile/guided_munition/torpedo/nerfed //AI Ship usage
+/obj/item/projectile/guided_munition/torpedo/ai //AI Ship usage
 	icon_state = "torpedo"
 	obj_integrity = 40
 	max_integrity = 40
@@ -435,7 +435,7 @@ Misc projectile types, effects, think of this as the special FX file.
 	obj_integrity = 240
 	max_integrity = 240
 
-/obj/item/projectile/guided_munition/torpedo/viscerator/nerfed //AI Ship usage
+/obj/item/projectile/guided_munition/torpedo/viscerator/ai //AI Ship usage
 	obj_integrity = 80
 	max_integrity = 80
 
@@ -445,7 +445,7 @@ Misc projectile types, effects, think of this as the special FX file.
 	damage = 200
 	armour_penetration = 40
 
-/obj/item/projectile/guided_munition/torpedo/shredder/nerfed //AI Ship usage
+/obj/item/projectile/guided_munition/torpedo/shredder/ai //AI Ship usage
 	obj_integrity = 40
 	max_integrity = 40
 
@@ -455,7 +455,7 @@ Misc projectile types, effects, think of this as the special FX file.
 	obj_integrity = 500
 	max_integrity = 500
 
-/obj/item/projectile/guided_munition/torpedo/decoy/nerfed //AI Ship usage
+/obj/item/projectile/guided_munition/torpedo/decoy/ai //AI Ship usage
 	icon_state = "torpedo"
 	obj_integrity = 120
 	max_integrity = 120
@@ -555,7 +555,7 @@ Misc projectile types, effects, think of this as the special FX file.
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/torpedo
 	spread = 5 //!Helps them not get insta-bonked when launching
 
-/obj/item/projectile/guided_munition/missile/nerfed //AI ship usage
+/obj/item/projectile/guided_munition/missile/ai //AI ship usage
 	obj_integrity = 40
 	max_integrity = 40
 

--- a/nsv13/code/modules/overmap/weapons/weapons.dm
+++ b/nsv13/code/modules/overmap/weapons/weapons.dm
@@ -124,7 +124,7 @@
 		var/obj/structure/overmap/OM = target
 		if(istype(OM))
 			ai_aim = FALSE // This is a homing projectile
-		fire_projectile(/obj/item/projectile/guided_munition/missile, target, lateral = FALSE, ai_aim = ai_aim)
+		fire_projectile(missile_type, target, lateral = FALSE, ai_aim = ai_aim)
 		var/datum/ship_weapon/SW = weapon_types[FIRE_MODE_MISSILE]
 		relay_to_nearby(pick(SW.overmap_firing_sounds))
 		return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This pull request creates a subtype of all missiles and torpedoes for AI usage and then buffs the durability player-only variants by 200%

## Why It's Good For The Game

Missiles and torpedoes should be effective. Here, we have a single player ship sometimes fighting huge fleets. This should help those weapons actually be effective when facing more than 2 or 3 enemies. 

## Changelog
:cl:
add: Added variants of torpedos and missiles for AI usage
balance: Buffed the durability of player ship missiles and torps
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
