### PR TITLE
Tycoon Update Series- Cargo

### DIFF
--- a/_maps/map_files/Tycoon/Tycoon1.dmm
+++ b/_maps/map_files/Tycoon/Tycoon1.dmm
@@ -249,6 +249,9 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop{
 	name = "Executive officer's Office"
@@ -512,6 +515,9 @@
 /obj/structure/chair{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/heads/captain)
 "bz" = (
@@ -581,11 +587,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/heads/captain)
@@ -798,13 +804,17 @@
 /turf/open/floor/monotile,
 /area/crew_quarters/heads/captain)
 "co" = (
-/obj/structure/table/glass,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/item/megaphone/command,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/table/glass,
 /turf/open/floor/carpet/blue,
 /area/hallway/nsv/deck1/hallway)
 "cp" = (
@@ -817,7 +827,7 @@
 	id = "hopqueue";
 	name = "HoP Queue Shutters"
 	},
-/turf/open/floor/monotile,
+/turf/open/floor/plating,
 /area/hallway/nsv/deck1/hallway)
 "cr" = (
 /obj/machinery/door/airlock/ship{
@@ -1057,6 +1067,12 @@
 /obj/machinery/door/airlock/ship/command{
 	name = "Briefing Room";
 	req_one_access_txt = "19"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/hallway)
@@ -1399,11 +1415,11 @@
 /turf/closed/wall/r_wall/ship,
 /area/nsv/briefingroom)
 "dT" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/ship/preopen{
 	id = "bridge_blast";
 	name = "CIC blast doors"
 	},
+/obj/effect/spawner/structure/window/reinforced/ship,
 /turf/open/floor/plating,
 /area/nsv/briefingroom)
 "dU" = (
@@ -1447,16 +1463,12 @@
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/heads/captain)
 "dY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
@@ -1551,6 +1563,12 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
 "ej" = (
@@ -1600,11 +1618,20 @@
 /area/ai_monitored/nuke_storage)
 "er" = (
 /obj/structure/extinguisher_cabinet/south,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/carpet/blue,
 /area/hallway/nsv/deck1/hallway)
 "es" = (
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
@@ -1613,12 +1640,25 @@
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
 "eu" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
 "ev" = (
@@ -1737,16 +1777,18 @@
 /turf/open/floor/monotile/steel,
 /area/nsv/briefingroom)
 "eL" = (
-/obj/structure/window/reinforced/fulltile/ship,
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/ship/preopen{
-	dir = 4;
-	id = "bridge_blast";
-	name = "CIC blast doors"
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/nsv/briefingroom)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck1/hallway)
 "eM" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/door/airlock/turbolift/ship,
@@ -1845,9 +1887,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
 "eY" = (
@@ -1856,9 +1897,6 @@
 	name = "Executive officer's Office"
 	})
 "eZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -1964,12 +2002,6 @@
 	name = "Executive officer's Office"
 	})
 "fl" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -1977,6 +2009,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "fm" = (
@@ -1998,9 +2035,16 @@
 /area/crew_quarters/heads/captain)
 "fo" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
 "fq" = (
@@ -2015,6 +2059,9 @@
 "fr" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop{
 	name = "Executive officer's Office"
@@ -2022,6 +2069,9 @@
 "fs" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/med_data/laptop,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop{
 	name = "Executive officer's Office"
@@ -2044,6 +2094,9 @@
 "fu" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/secure_data/laptop,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop{
 	name = "Executive officer's Office"
@@ -2253,24 +2306,27 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
 "fR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
+/obj/structure/chair/fancy/shuttle{
+	dir = 4;
+	name = "briefing room chair"
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck1/hallway)
+/turf/open/floor/monotile/dark,
+/area/nsv/briefingroom)
 "fT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -2647,11 +2703,17 @@
 	name = "briefing room chair"
 	},
 /obj/effect/landmark/start/lawyer,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/monotile/dark,
 /area/nsv/briefingroom)
 "gK" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/railing/corner,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/nsv/briefingroom)
 "gL" = (
@@ -2776,16 +2838,21 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
 "gW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
@@ -3519,19 +3586,9 @@
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
 "iS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck1/hallway)
+/obj/effect/landmark/carpspawn,
+/turf/open/floor/monotile/dark/airless,
+/area/space/nearstation)
 "iT" = (
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
@@ -3559,15 +3616,14 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/central)
 "iX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
@@ -3580,9 +3636,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
@@ -3839,15 +3892,23 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
 "jw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
 "jx" = (
@@ -4008,6 +4069,9 @@
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /obj/item/pen/fountain,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop{
 	name = "Executive officer's Office"
@@ -4042,6 +4106,7 @@
 	pixel_x = -28;
 	pixel_y = -28
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "jL" = (
@@ -4197,19 +4262,25 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "kc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "kd" = (
@@ -4236,13 +4307,6 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "kh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -4253,7 +4317,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
 "kj" = (
@@ -4266,6 +4331,9 @@
 	},
 /obj/structure/railing/corner{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/briefingroom)
@@ -4350,8 +4418,11 @@
 	name = "Executive officer's Office"
 	})
 "kt" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop{
@@ -4426,9 +4497,6 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/heads/captain)
 "kA" = (
@@ -4483,12 +4551,14 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "kG" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
 "kH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -4502,7 +4572,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
 /turf/open/floor/monotile/steel,
@@ -4513,7 +4583,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "kK" = (
@@ -4521,11 +4590,6 @@
 /turf/closed/wall/ship,
 /area/hallway/nsv/deck1/hallway)
 "kL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -4543,7 +4607,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/carpet/blue,
 /area/hallway/nsv/deck1/hallway)
 "kN" = (
@@ -4554,9 +4620,7 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
 "kO" = (
@@ -4725,17 +4789,26 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "le" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
+/obj/structure/chair/fancy/shuttle{
+	dir = 4;
+	name = "briefing room chair"
 	},
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck1/hallway)
-"lf" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/effect/landmark/start/janitor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
-/area/hallway/nsv/deck1/hallway)
+/area/nsv/briefingroom)
+"lf" = (
+/obj/structure/chair/fancy/shuttle{
+	dir = 4;
+	name = "briefing room chair"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/nsv/briefingroom)
 "lg" = (
 /obj/machinery/porta_turret/ai,
 /obj/effect/turf_decal/stripes/box,
@@ -4794,6 +4867,7 @@
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "lo" = (
@@ -4834,8 +4908,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
@@ -4896,22 +4970,31 @@
 	name = "Air traffic control pod"
 	})
 "lz" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=loc3d2";
-	location = "loc2d2"
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
 "lA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=loc3d2";
+	location = "loc2d2"
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
 "lB" = (
@@ -5081,12 +5164,6 @@
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/heads/captain)
 "lT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
 /obj/machinery/newscaster{
 	pixel_x = 28
 	},
@@ -5099,13 +5176,13 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "lU" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/effect/spawner/structure/window/reinforced/ship,
 /turf/open/floor/plating,
 /area/hallway/nsv/deck1/hallway)
 "lV" = (
@@ -5203,8 +5280,8 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
 	},
 /turf/open/floor/monotile/dark,
 /area/storage/eva)
@@ -5232,6 +5309,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/storage/eva)
 "ml" = (
@@ -5240,6 +5320,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/storage/eva)
@@ -5425,6 +5508,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "mI" = (
@@ -5438,12 +5522,9 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "mJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
@@ -5545,6 +5626,25 @@
 /turf/open/floor/monotile/steel,
 /area/nsv/briefingroom)
 "mY" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/chair/fancy/shuttle{
+	dir = 4;
+	name = "briefing room chair"
+	},
+/turf/open/floor/monotile/dark,
+/area/nsv/briefingroom)
+"mZ" = (
 /obj/structure/chair/fancy/shuttle{
 	dir = 4;
 	name = "briefing room chair"
@@ -5555,23 +5655,23 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/briefingroom)
-"mZ" = (
-/obj/effect/spawner/structure/window/reinforced,
+"na" = (
+/obj/structure/chair/fancy/shuttle{
+	dir = 4;
+	name = "briefing room chair"
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/nsv/briefingroom)
-"na" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/monotile/dark,
 /area/nsv/briefingroom)
 "nb" = (
 /obj/structure/cable{
@@ -6056,17 +6156,19 @@
 	name = "Air traffic control pod"
 	})
 "ra" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/monotile/steel,
-/area/nsv/briefingroom)
+/obj/effect/spawner/structure/window/reinforced/ship,
+/turf/open/floor/plating,
+/area/nsv/hanger/deck3{
+	name = "Air traffic control pod"
+	})
 "rb" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
 /obj/machinery/door/airlock/ship/external/glass{
 	req_one_access_txt = "13"
 	},
@@ -6089,19 +6191,12 @@
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
 "rl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
 "ro" = (
@@ -6189,6 +6284,12 @@
 	},
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
+"sC" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/heads/hop{
+	name = "Executive officer's Office"
+	})
 "sP" = (
 /obj/structure/rack,
 /obj/item/fighter_component/fuel_tank,
@@ -6305,16 +6406,19 @@
 /turf/open/floor/monotile,
 /area/crew_quarters/heads/captain)
 "uy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
 "uB" = (
@@ -6322,12 +6426,26 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/miningdock)
+"uD" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/heads/hop{
+	name = "Executive officer's Office"
+	})
 "uF" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/camera/autoname{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
@@ -6378,6 +6496,14 @@
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
 	})
+"vv" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck1/hallway)
 "vC" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "hopqueue";
@@ -6395,6 +6521,7 @@
 /obj/machinery/turnstile/xo{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "vF" = (
@@ -6439,23 +6566,28 @@
 	name = "Air traffic control pod"
 	})
 "wr" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/camera/autoname{
+	dir = 4
 	},
 /turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck1/hallway)
+"wA" = (
+/obj/structure/chair/fancy/shuttle{
+	color = "#696969";
+	dir = 8;
+	name = "comfortable chair"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/carpet/blue,
 /area/hallway/nsv/deck1/hallway)
 "wG" = (
 /turf/closed/wall/r_wall/ship,
@@ -6535,6 +6667,18 @@
 	},
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
+"xs" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/heads/captain)
 "xw" = (
 /obj/machinery/door/poddoor/ship/preopen{
 	dir = 8;
@@ -6568,6 +6712,13 @@
 /obj/machinery/computer/iff_console,
 /turf/open/floor/monotile/steel,
 /area/ai_monitored/nuke_storage)
+"xS" = (
+/obj/structure/hull_plate,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark/airless,
+/area/space/nearstation)
 "yr" = (
 /obj/machinery/light{
 	dir = 4
@@ -6576,6 +6727,11 @@
 /obj/structure/closet/secure_closet/miner,
 /turf/open/floor/monotile/steel,
 /area/quartermaster/miningdock)
+"yt" = (
+/obj/structure/hull_plate,
+/obj/effect/landmark/carpspawn,
+/turf/open/floor/monotile/dark/airless,
+/area/space/nearstation)
 "yw" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -6677,6 +6833,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "AX" = (
@@ -6751,6 +6908,19 @@
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile/steel,
 /area/quartermaster/miningdock)
+"BW" = (
+/obj/structure/chair/fancy/shuttle{
+	dir = 4;
+	name = "briefing room chair"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/nsv/briefingroom)
 "CA" = (
 /obj/machinery/camera/motion{
 	c_tag = "Core SE";
@@ -6828,11 +6998,17 @@
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
 "DR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
@@ -6958,6 +7134,20 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/teleporter)
+"Gd" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck1/hallway)
 "Gg" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -7053,15 +7243,16 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "Hd" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/structure/chair/fancy/shuttle{
+	dir = 4;
+	name = "briefing room chair"
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/landmark/start/janitor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck1/hallway)
+/turf/open/floor/monotile/dark,
+/area/nsv/briefingroom)
 "He" = (
 /obj/machinery/light,
 /turf/open/floor/circuit,
@@ -7094,15 +7285,13 @@
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
 "HC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "HK" = (
@@ -7113,6 +7302,21 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/quartermaster/miningdock)
+"HX" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/carpet/blue,
+/area/hallway/nsv/deck1/hallway)
 "HZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -7121,6 +7325,17 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/quartermaster/miningdock)
+"Ia" = (
+/obj/structure/chair/fancy/shuttle{
+	dir = 4;
+	name = "briefing room chair"
+	},
+/obj/effect/landmark/start/lawyer,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/nsv/briefingroom)
 "Ie" = (
 /obj/structure/fighter_launcher{
 	dir = 4;
@@ -7139,13 +7354,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
 "Io" = (
@@ -7172,6 +7384,17 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/monotile/steel,
 /area/quartermaster/miningdock)
+"IO" = (
+/obj/effect/turf_decal/bot_white,
+/obj/effect/landmark/carpspawn,
+/turf/open/floor/monotile/dark/airless,
+/area/space/nearstation)
+"IP" = (
+/obj/item/reagent_containers/glass/bottle/clownstears,
+/obj/item/clothing/suit/space/hardsuit/clown,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck1/aft)
 "IR" = (
 /obj/machinery/status_display/evac{
 	pixel_x = -32
@@ -7266,6 +7489,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/plasteel/grid/steel,
 /area/nsv/briefingroom)
 "Ks" = (
@@ -7300,6 +7526,10 @@
 	},
 /turf/open/floor/monotile/dark/airless,
 /area/quartermaster/miningdock)
+"KL" = (
+/obj/effect/landmark/carpspawn,
+/turf/open/space/basic,
+/area/space)
 "KS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7309,21 +7539,22 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "KV" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/turf/open/floor/monotile/dark/airless,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck1/hallway)
 "Ld" = (
 /obj/effect/turf_decal/stripes/box,
 /obj/machinery/porta_turret/ai,
@@ -7435,13 +7666,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "Mj" = (
@@ -7669,6 +7896,18 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/quartermaster/miningdock)
+"Px" = (
+/obj/structure/peacekeeper_barricade/metal{
+	dir = 4
+	},
+/obj/structure/peacekeeper_barricade/metal{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/nsv/deck1/hallway)
 "PJ" = (
 /obj/machinery/door/airlock/ship/public/glass/turbolift{
 	dir = 4
@@ -7693,7 +7932,6 @@
 	id = "hopqueue";
 	name = "HoP Queue Shutters"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -7713,8 +7951,7 @@
 	id = "bridge_blast";
 	name = "CIC blast doors"
 	},
-/obj/structure/window/reinforced/fulltile/ship,
-/obj/structure/grille,
+/obj/effect/spawner/structure/window/reinforced/ship,
 /turf/open/floor/plating,
 /area/nsv/briefingroom)
 "Qg" = (
@@ -7825,10 +8062,12 @@
 	name = "Air traffic control pod"
 	})
 "QV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
 "Rc" = (
@@ -7974,12 +8213,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -7987,6 +8220,12 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /turf/open/floor/monotile/steel,
@@ -8067,19 +8306,16 @@
 /turf/open/floor/monotile/dark,
 /area/teleporter)
 "TL" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/camera/autoname{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
 "TQ" = (
 /obj/machinery/suit_storage_unit/pilot,
@@ -8142,14 +8378,20 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "Ur" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/monotile/steel,
 /area/nsv/briefingroom)
@@ -8164,16 +8406,11 @@
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
 "UT" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/ship/preopen{
-	dir = 4;
-	id = "bridge_blast";
-	name = "CIC blast doors"
-	},
-/obj/structure/window/reinforced/fulltile/ship,
-/turf/open/floor/plating,
-/area/nsv/briefingroom)
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck1/hallway)
 "UV" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
@@ -8249,6 +8486,17 @@
 /obj/effect/spawner/structure/window/reinforced/ship,
 /turf/open/floor/plating,
 /area/hallway/nsv/deck1/hallway)
+"Wq" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck1/hallway)
 "WF" = (
 /obj/structure/table,
 /obj/item/hand_tele,
@@ -8286,6 +8534,10 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/monotile/steel,
 /area/quartermaster/miningdock)
+"XB" = (
+/obj/effect/landmark/carpspawn,
+/turf/open/floor/engine/airless,
+/area/space/nearstation)
 "XE" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/squad_vendor{
@@ -8415,14 +8667,14 @@
 /turf/open/floor/monotile/steel,
 /area/ai_monitored/nuke_storage)
 "ZX" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
 	},
 /turf/open/floor/monotile/steel,
 /area/nsv/briefingroom)
@@ -31681,7 +31933,7 @@ ax
 ax
 iy
 ie
-iC
+yt
 hA
 iC
 ie
@@ -32990,7 +33242,7 @@ iC
 ie
 iC
 no
-ax
+iS
 ax
 it
 ac
@@ -34768,7 +35020,7 @@ ie
 VB
 lK
 VB
-lK
+IP
 VB
 cs
 cs
@@ -37070,7 +37322,7 @@ ax
 ax
 rQ
 ax
-ax
+iS
 ax
 rQ
 iy
@@ -37562,7 +37814,7 @@ ac
 ac
 ac
 aC
-hn
+ra
 aC
 aC
 aC
@@ -37593,7 +37845,7 @@ Xp
 iC
 aQ
 bf
-bX
+xs
 by
 ci
 wG
@@ -38086,7 +38338,7 @@ bU
 as
 Sg
 as
-hn
+ra
 ax
 Mt
 ax
@@ -38343,7 +38595,7 @@ gO
 hp
 mn
 wm
-hn
+ra
 ax
 Mt
 ax
@@ -38377,7 +38629,7 @@ iR
 gN
 bN
 kD
-jk
+HX
 er
 eG
 eW
@@ -38600,7 +38852,7 @@ pv
 bV
 pv
 pv
-hn
+ra
 ax
 Mt
 ax
@@ -38640,7 +38892,7 @@ eG
 mN
 fj
 kt
-fj
+uD
 fj
 eY
 gZ
@@ -38861,7 +39113,7 @@ aC
 hR
 Mt
 ax
-ax
+iS
 ax
 nJ
 ax
@@ -39142,7 +39394,7 @@ gw
 iT
 aL
 bO
-bO
+wA
 bO
 ak
 hP
@@ -39361,7 +39613,7 @@ ad
 ad
 ad
 aC
-hn
+ra
 aC
 aC
 aC
@@ -39399,7 +39651,7 @@ Ya
 ds
 iT
 cl
-iT
+lq
 dl
 iT
 fa
@@ -39421,7 +39673,7 @@ no
 ax
 it
 ac
-ac
+XB
 ac
 ac
 ac
@@ -39913,7 +40165,7 @@ dn
 dt
 eg
 eT
-eg
+eL
 gU
 eg
 js
@@ -39923,7 +40175,7 @@ lc
 me
 eG
 fc
-fj
+sC
 aO
 fE
 fj
@@ -40172,7 +40424,7 @@ ei
 eX
 fQ
 gV
-gV
+eX
 jv
 jw
 ki
@@ -40425,15 +40677,15 @@ aV
 cU
 dF
 dE
-es
+TL
 eZ
-fR
+ev
 gW
-gW
+ev
 iX
 kc
 kH
-lf
+ls
 mF
 jU
 jB
@@ -40713,7 +40965,7 @@ ac
 ac
 ac
 ac
-ac
+XB
 ac
 ac
 ac
@@ -40947,14 +41199,14 @@ cb
 mO
 bN
 bN
-lr
+rl
 mH
 vC
-ld
-fd
+UT
+vv
 jK
 ln
-fd
+ld
 fd
 Wi
 iC
@@ -41208,7 +41460,7 @@ lq
 mI
 cq
 fe
-fm
+Px
 jL
 fm
 fK
@@ -41462,10 +41714,10 @@ cb
 kd
 bN
 ls
-mJ
+mG
 PT
-le
 fd
+mJ
 fy
 fd
 fd
@@ -41718,7 +41970,7 @@ zM
 cb
 Hc
 bN
-rl
+lr
 Mg
 Jd
 iF
@@ -41961,7 +42213,7 @@ nO
 nO
 nR
 nJ
-ax
+iS
 ax
 iy
 iC
@@ -43256,7 +43508,7 @@ es
 bN
 ga
 gX
-iF
+bN
 dW
 ga
 bN
@@ -43513,16 +43765,16 @@ et
 fl
 wr
 HC
-iS
+kh
 dY
 kh
 kL
 lz
-Hd
+mG
 lU
 Sa
 IC
-iF
+Wi
 iC
 iC
 iC
@@ -43766,10 +44018,10 @@ iy
 iC
 yZ
 dN
-eu
+KV
 fo
 uy
-eu
+Wq
 QV
 eu
 DR
@@ -43817,7 +44069,7 @@ zW
 bQ
 aa
 aa
-aa
+KL
 aa
 aa
 aa
@@ -44024,13 +44276,13 @@ iC
 yZ
 dO
 ev
-ev
+Gd
 Uq
-TL
+jy
 iY
 jy
 Ss
-gW
+ev
 lT
 mM
 yZ
@@ -44284,7 +44536,7 @@ dS
 dS
 Kn
 iZ
-mZ
+dS
 iZ
 wK
 dS
@@ -44540,8 +44792,8 @@ dS
 ew
 mW
 Ur
-ra
-na
+eE
+eE
 eE
 ZX
 KD
@@ -44765,12 +45017,12 @@ af
 ax
 ax
 ij
-hn
-hn
-hn
-hn
-hn
-hn
+ra
+ra
+ra
+ra
+ra
+ra
 iv
 ax
 ax
@@ -44796,7 +45048,7 @@ iC
 dS
 jS
 fA
-gx
+mZ
 gx
 gx
 gx
@@ -45022,12 +45274,12 @@ af
 ax
 ax
 ij
-hn
+ra
 hB
 qX
 lj
 hH
-hn
+ra
 ij
 ax
 ax
@@ -45053,11 +45305,11 @@ iC
 dS
 eF
 fB
+BW
 gC
 gC
 gC
-gC
-gC
+fR
 kP
 LY
 dS
@@ -45279,12 +45531,12 @@ af
 ax
 ax
 ij
-hn
+ra
 mo
 ms
 cX
 hI
-hn
+ra
 ij
 ax
 ax
@@ -45304,17 +45556,17 @@ hA
 it
 Mt
 af
-hA
+IO
 iy
 iC
 dT
 eE
 gG
+na
 gC
 gC
 gC
-gC
-gC
+lf
 mQ
 eE
 dT
@@ -45541,7 +45793,7 @@ mp
 hE
 hC
 hh
-hn
+ra
 ly
 ax
 ax
@@ -45567,11 +45819,11 @@ iC
 dT
 eE
 fB
+na
 gC
 gC
 gC
-gC
-gC
+lf
 kP
 eE
 dT
@@ -45798,7 +46050,7 @@ mq
 mu
 cX
 hI
-hn
+ra
 ij
 ax
 ax
@@ -45824,11 +46076,11 @@ iy
 dT
 eE
 fB
-gI
+le
 iH
 ja
 gI
-gI
+Hd
 kP
 eE
 dT
@@ -45849,7 +46101,7 @@ Zf
 nF
 nu
 ax
-ax
+iS
 ax
 ax
 ax
@@ -46050,12 +46302,12 @@ af
 ax
 ax
 ij
-hn
+ra
 av
 qX
 lj
 hH
-hn
+ra
 ij
 ax
 ax
@@ -46081,11 +46333,11 @@ tx
 dS
 ab
 gG
-gC
+na
 gC
 jb
 gC
-gC
+lf
 mQ
 aF
 dS
@@ -46307,12 +46559,12 @@ af
 ax
 ax
 ij
-hn
-hn
-hn
-hn
-hn
-hn
+ra
+ra
+ra
+ra
+ra
+ra
 iv
 ax
 ax
@@ -46338,11 +46590,11 @@ iy
 dS
 eE
 fB
+na
 gC
 gC
 gC
-gC
-gC
+lf
 kP
 eE
 dS
@@ -46595,7 +46847,7 @@ iy
 dT
 eE
 fG
-gJ
+Ia
 Rz
 Rz
 Rz
@@ -47145,7 +47397,7 @@ ax
 ax
 ax
 ax
-ax
+iS
 ax
 ax
 ax
@@ -48135,7 +48387,7 @@ hA
 mw
 iy
 dS
-eL
+Qd
 dS
 dS
 Qd
@@ -48143,12 +48395,12 @@ Qd
 Qd
 dS
 dS
-UT
+Qd
 dS
 no
 ax
 ax
-ax
+iS
 ax
 ax
 ib
@@ -48393,13 +48645,13 @@ ax
 iy
 iC
 iC
+xS
 iC
 iC
 iC
 iC
 iC
-iC
-iC
+xS
 iC
 iC
 no
@@ -49167,7 +49419,7 @@ ax
 ax
 ax
 ax
-KV
+ax
 ax
 ax
 ax
@@ -49682,7 +49934,7 @@ ax
 ax
 UW
 UW
-ax
+iS
 ax
 ax
 ax

--- a/_maps/map_files/Tycoon/Tycoon1.dmm
+++ b/_maps/map_files/Tycoon/Tycoon1.dmm
@@ -1688,6 +1688,7 @@
 /area/nsv/briefingroom)
 "eF" = (
 /obj/machinery/computer/ship/viewscreen,
+/obj/machinery/camera/autoname,
 /turf/open/floor/monotile/steel,
 /area/nsv/briefingroom)
 "eG" = (
@@ -2745,6 +2746,9 @@
 /obj/machinery/door/window{
 	req_one_access_txt = "19"
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel/stairs/old{
 	dir = 1
 	},
@@ -2761,6 +2765,9 @@
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=loc5d2";
 	location = "loc4d2"
+	},
+/obj/machinery/camera/autoname{
+	dir = 5
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
@@ -3783,9 +3790,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/open/floor/monotile/steel,
 /area/nsv/briefingroom)
 "js" = (
@@ -4174,9 +4178,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
 /turf/open/floor/monotile/steel,
 /area/nsv/briefingroom)
 "jZ" = (
@@ -4453,6 +4454,9 @@
 /obj/machinery/door/window{
 	dir = 1;
 	req_one_access_txt = "19"
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/plasteel/stairs/old,
 /area/nsv/briefingroom)
@@ -6318,6 +6322,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/miningdock)
+"uF" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck1/hallway)
 "uT" = (
 /obj/machinery/camera/autoname{
 	dir = 1;
@@ -6339,6 +6352,7 @@
 "vf" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical,
+/obj/machinery/camera/autoname,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "vi" = (
@@ -6869,6 +6883,7 @@
 "EY" = (
 /obj/structure/table/reinforced,
 /obj/item/extinguisher/advanced/hull_repair_juice,
+/obj/machinery/camera/autoname,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "Fi" = (
@@ -7025,11 +7040,18 @@
 	req_one_access_txt = "13"
 	},
 /turf/open/floor/monotile/dark/airless,
-/area/space/nearstation)
+/area/hallway/nsv/deck1/hallway)
 "Hb" = (
 /obj/machinery/bluespace_beacon,
 /turf/open/floor/monotile/steel,
 /area/teleporter)
+"Hc" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck1/hallway)
 "Hd" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -7141,6 +7163,9 @@
 	})
 "IC" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
 /turf/open/floor/monotile/dark/airless,
 /area/hallway/nsv/deck1/hallway)
 "IJ" = (
@@ -7380,6 +7405,12 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/heads/captain)
+"LY" = (
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/monotile/steel,
+/area/nsv/briefingroom)
 "Mb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -7677,9 +7708,15 @@
 /turf/open/floor/monotile/steel,
 /area/quartermaster/miningdock)
 "Qd" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/ship/preopen{
+	dir = 4;
+	id = "bridge_blast";
+	name = "CIC blast doors"
+	},
+/obj/structure/window/reinforced/fulltile/ship,
+/obj/structure/grille,
 /turf/open/floor/plating,
-/area/space/nearstation)
+/area/nsv/briefingroom)
 "Qg" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -8126,6 +8163,17 @@
 	},
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
+"UT" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/ship/preopen{
+	dir = 4;
+	id = "bridge_blast";
+	name = "CIC blast doors"
+	},
+/obj/structure/window/reinforced/fulltile/ship,
+/turf/open/floor/plating,
+/area/nsv/briefingroom)
 "UV" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
@@ -40634,7 +40682,7 @@ aQ
 Ya
 Ya
 dG
-es
+uF
 bN
 fY
 gX
@@ -41668,7 +41716,7 @@ XE
 cb
 zM
 cb
-kf
+Hc
 bN
 rl
 Mg
@@ -42690,7 +42738,7 @@ iy
 iC
 Wi
 dJ
-es
+uF
 bN
 XE
 cb
@@ -43217,7 +43265,7 @@ ke
 lV
 yZ
 yZ
-Yf
+yZ
 Yf
 Yf
 Yf
@@ -43474,7 +43522,7 @@ Hd
 lU
 Sa
 IC
-Qd
+iF
 iC
 iC
 iC
@@ -43988,7 +44036,7 @@ mM
 yZ
 yZ
 yZ
-aI
+yZ
 jj
 jj
 jj
@@ -45011,7 +45059,7 @@ gC
 gC
 gC
 kP
-eE
+LY
 dS
 iC
 no
@@ -46030,7 +46078,7 @@ ac
 Mu
 hA
 tx
-dT
+dS
 ab
 gG
 gC
@@ -46040,7 +46088,7 @@ gC
 gC
 mQ
 aF
-dT
+dS
 no
 ax
 Xp
@@ -46287,7 +46335,7 @@ ac
 Lw
 hA
 iy
-dT
+dS
 eE
 fB
 gC
@@ -46297,7 +46345,7 @@ gC
 gC
 kP
 eE
-dT
+dS
 no
 ax
 Xp
@@ -47581,7 +47629,7 @@ jm
 jX
 kB
 lb
-eE
+LY
 dS
 no
 ax
@@ -48088,14 +48136,14 @@ mw
 iy
 dS
 eL
-eL
-eL
-eL
-eL
-eL
-eL
-eL
-eL
+dS
+dS
+Qd
+Qd
+Qd
+dS
+dS
+UT
 dS
 no
 ax

--- a/_maps/map_files/Tycoon/Tycoon1.dmm
+++ b/_maps/map_files/Tycoon/Tycoon1.dmm
@@ -1402,14 +1402,16 @@
 /turf/open/floor/plating,
 /area/nsv/briefingroom)
 "dU" = (
-/obj/machinery/door/airlock/ship/external{
-	name = "Mining Shuttle Airlock";
-	req_one_access_txt = "31;48"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
 	},
-/turf/open/floor/monotile/dark/airless,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/miningdock)
 "dV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -5876,17 +5878,9 @@
 /turf/open/floor/monotile/steel,
 /area/quartermaster/miningdock)
 "oS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/tile_full,
-/turf/open/floor/monotile/dark,
+/obj/effect/spawner/structure/window/reinforced/ship,
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/plating,
 /area/quartermaster/miningdock)
 "oW" = (
 /obj/machinery/suit_storage_unit/mining/eva,
@@ -5941,20 +5935,11 @@
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
 "pJ" = (
-/obj/structure/chair/office{
+/obj/machinery/status_display/ai/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/monotile/dark,
+/turf/open/floor/monotile/steel,
 /area/quartermaster/miningdock)
 "pU" = (
 /obj/machinery/door/airlock/ship/hatch{
@@ -5981,11 +5966,16 @@
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/aisat)
 "qe" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/quartermaster/miningdock)
@@ -6111,10 +6101,12 @@
 /turf/open/floor/monotile/steel,
 /area/quartermaster/miningdock)
 "rt" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/monotile/dark,
 /area/quartermaster/miningdock)
 "rz" = (
 /obj/machinery/camera/autoname{
@@ -6316,16 +6308,9 @@
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
 "uB" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/monotile/dark,
+/turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/miningdock)
 "uT" = (
 /obj/machinery/camera/autoname{
@@ -6515,18 +6500,14 @@
 /turf/open/floor/monotile/dark,
 /area/quartermaster/miningdock)
 "xc" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/machinery/door/airlock/ship/external{
+	name = "Mining Shuttle Airlock";
+	req_one_access_txt = "31;48"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/monotile/dark,
+/turf/open/floor/monotile/dark/airless,
 /area/quartermaster/miningdock)
 "xf" = (
 /obj/effect/turf_decal/ship/delivery{
@@ -6721,6 +6702,19 @@
 /obj/vehicle/sealed/car/realistic/fighter_tug,
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
+"BM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/tile_full,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/monotile/dark,
+/area/quartermaster/miningdock)
 "BN" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/security/telescreen/atc,
@@ -6744,16 +6738,17 @@
 /turf/open/floor/carpet/blue,
 /area/hallway/nsv/deck1/hallway)
 "CJ" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plasteel/grid/steel,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/monotile/dark,
 /area/quartermaster/miningdock)
 "Da" = (
 /obj/machinery/camera/autoname{
@@ -6790,8 +6785,15 @@
 /turf/open/floor/monotile/steel,
 /area/quartermaster/miningdock)
 "DA" = (
-/obj/machinery/status_display/ai/east,
-/turf/open/floor/monotile/steel,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/tile_full,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/monotile/dark,
 /area/quartermaster/miningdock)
 "DP" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
@@ -7124,19 +7126,8 @@
 /turf/open/floor/monotile/dark/airless,
 /area/hallway/nsv/deck1/hallway)
 "IJ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/monotile/dark,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/monotile/steel,
 /area/quartermaster/miningdock)
 "IR" = (
 /obj/machinery/status_display/evac{
@@ -7155,16 +7146,8 @@
 /turf/closed/wall/r_wall/ship,
 /area/hallway/nsv/deck1/hallway)
 "Jm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/monotile/dark,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/monotile/steel,
 /area/quartermaster/miningdock)
 "Jp" = (
 /turf/closed/wall/r_wall/ship,
@@ -7326,14 +7309,14 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/central)
 "Lt" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
@@ -7449,15 +7432,22 @@
 /turf/open/floor/monotile/dark/airless,
 /area/quartermaster/miningdock)
 "MI" = (
+/obj/effect/turf_decal/tile/neutral/tile_full,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/quartermaster/miningdock)
+"MK" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
 	},
 /turf/open/floor/monotile/dark,
 /area/quartermaster/miningdock)
@@ -7590,10 +7580,17 @@
 /turf/open/floor/monotile/dark,
 /area/maintenance/nsv/deck1/aft)
 "Pb" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/monotile/steel,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/monotile/dark,
 /area/quartermaster/miningdock)
 "Pc" = (
 /obj/structure/chair/office{
@@ -7617,19 +7614,11 @@
 /turf/open/openspace,
 /area/shuttle/turbolift/shaft)
 "Pk" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/light,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/monotile/dark,
+/turf/open/floor/monotile/steel,
 /area/quartermaster/miningdock)
 "PJ" = (
 /obj/machinery/door/airlock/ship/public/glass/turbolift{
@@ -7670,19 +7659,29 @@
 /turf/open/floor/monotile/steel,
 /area/quartermaster/miningdock)
 "Qg" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
+	dir = 10
+	},
+/turf/open/floor/monotile/dark,
+/area/quartermaster/miningdock)
+"Qn" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
-/obj/effect/turf_decal/tile/neutral/tile_full,
 /turf/open/floor/monotile/dark,
-/area/quartermaster/miningdock)
-"Qn" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/monotile/steel,
 /area/quartermaster/miningdock)
 "Qp" = (
 /obj/structure/disposalpipe/junction/flip{
@@ -7955,7 +7954,25 @@
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/aisat)
 "SF" = (
-/turf/open/floor/plasteel/grid/steel,
+/obj/effect/turf_decal/tile/neutral/tile_full,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/monotile/dark,
+/area/quartermaster/miningdock)
+"SQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
 /area/quartermaster/miningdock)
 "Tl" = (
 /obj/structure/rack,
@@ -42157,13 +42174,13 @@ ax
 ax
 ax
 ax
-Jp
-Jp
-Jp
-Jp
-Jp
 ax
 ax
+Jp
+Jp
+Jp
+Jp
+Jp
 ax
 ax
 ax
@@ -42408,6 +42425,8 @@ ax
 ax
 ax
 ax
+ax
+ax
 Jp
 Jp
 zW
@@ -42424,8 +42443,6 @@ Xp
 Xp
 Xp
 Xp
-ax
-ax
 ax
 ac
 aa
@@ -42665,6 +42682,8 @@ nC
 nD
 ax
 ax
+ax
+ax
 zW
 oW
 Ml
@@ -42682,10 +42701,8 @@ ax
 ax
 ax
 ax
-ax
-ax
 ac
-aa
+ac
 aa
 aa
 aa
@@ -42922,16 +42939,18 @@ nE
 nu
 ax
 ax
+ax
+ax
 zW
 oW
-ud
-IJ
+Ho
+Qn
 RJ
 Xy
 zr
 Ml
-Kc
-fv
+SF
+Pk
 Jp
 Jp
 zW
@@ -42940,9 +42959,7 @@ zW
 zW
 Jp
 Jp
-ax
 ac
-aa
 aa
 aa
 aa
@@ -43179,15 +43196,17 @@ kj
 nu
 ax
 ax
+ax
+ax
 zW
 oW
-xb
-Lt
+qI
+MK
 TR
 Ml
 zr
 Ml
-Kc
+MI
 ro
 Jp
 BN
@@ -43197,9 +43216,7 @@ oz
 Ft
 Bb
 zW
-ax
-ac
-aa
+bQ
 aa
 aa
 aa
@@ -43436,6 +43453,8 @@ kj
 nu
 ax
 ax
+ax
+ax
 zW
 sj
 wk
@@ -43443,20 +43462,18 @@ QC
 Qc
 VI
 Jp
-Qn
-Qg
-rt
+IJ
+MI
+Ml
 Jp
 RI
 Pc
 VF
 VF
-pJ
+Lt
 ED
 zW
-ax
-ac
-aa
+bQ
 aa
 aa
 aa
@@ -43693,6 +43710,8 @@ kj
 nu
 ax
 ax
+ax
+ax
 Jp
 Jp
 Jp
@@ -43701,19 +43720,17 @@ Jp
 Jp
 Jp
 Ml
-oS
+BM
 pj
 Du
 HZ
-uB
 qe
-qe
-xc
 rt
+rt
+Pb
+Ml
 zW
-ax
-ac
-aa
+bQ
 aa
 aa
 aa
@@ -43950,6 +43967,8 @@ kj
 nu
 ax
 ax
+ax
+ax
 zW
 Gt
 Ml
@@ -43957,8 +43976,8 @@ QC
 Ml
 YI
 Jp
-Ml
-sd
+Jm
+DA
 ND
 Jp
 OX
@@ -43968,9 +43987,7 @@ Ml
 Dz
 qk
 zW
-ax
-ac
-aa
+bQ
 aa
 aa
 aa
@@ -44207,10 +44224,12 @@ kj
 nu
 ax
 ax
+ax
+ax
 zW
 Gt
-Ho
-Pk
+ud
+CJ
 Sr
 Ml
 vc
@@ -44225,9 +44244,7 @@ Jp
 Jp
 Jp
 Jp
-ax
 ac
-aa
 aa
 aa
 aa
@@ -44464,27 +44481,27 @@ kj
 nu
 ax
 ax
+ax
+ax
 zW
 Gt
-qI
-MI
-Jm
+xb
+Qg
+SQ
 EM
 gn
 Bq
 Qp
 Nf
 pn
-CJ
-SF
-Jp
+dU
+uB
+oS
 ax
-ax
-ax
-ax
+Xp
 ax
 ac
-aa
+ac
 aa
 aa
 aa
@@ -44721,11 +44738,13 @@ kj
 nu
 ax
 ax
+ax
+ax
 zW
 yr
 wk
-Pb
-DA
+Ml
+pJ
 Fy
 Jp
 Ml
@@ -44736,9 +44755,7 @@ Qs
 GM
 Jp
 ax
-ax
-ax
-ax
+Xp
 ac
 ac
 aa
@@ -44978,6 +44995,8 @@ kj
 nu
 ax
 ax
+ax
+ax
 Jp
 Uc
 JH
@@ -44989,13 +45008,11 @@ Jp
 wX
 Jp
 Jp
-dU
+xc
 Jp
 Jp
 ax
-ac
-ax
-ac
+Xp
 ax
 ac
 aa
@@ -45236,6 +45253,8 @@ nu
 ax
 ax
 ax
+ax
+ax
 Uc
 Uy
 Uy
@@ -45250,9 +45269,7 @@ ax
 ax
 ax
 ax
-ax
-ac
-ac
+Xp
 ac
 ac
 aa
@@ -45493,6 +45510,8 @@ nu
 ax
 ax
 ax
+ax
+ax
 Uc
 Uy
 Uy
@@ -45506,12 +45525,10 @@ Jp
 ax
 ax
 ax
-Xp
+ax
+ax
+ax
 ac
-ac
-aa
-aa
-aa
 aa
 aa
 aa
@@ -45750,6 +45767,8 @@ nu
 ax
 ax
 ax
+ax
+ax
 Uc
 Uy
 Me
@@ -45762,13 +45781,11 @@ Na
 Jp
 ax
 ax
-ax
 Xp
-ax
+Xp
+Xp
 ac
-aa
-aa
-aa
+ac
 aa
 aa
 aa
@@ -46007,6 +46024,8 @@ nD
 ax
 ax
 ax
+ax
+ax
 Uc
 Uc
 Uc
@@ -46019,13 +46038,11 @@ Jp
 Jp
 ax
 ax
-ax
-Xp
 ac
+ax
 ac
-aa
-aa
-aa
+ax
+ac
 aa
 aa
 aa
@@ -46264,11 +46281,11 @@ ax
 ax
 ax
 ax
+ax
+ax
+ax
+ax
 sm
-ax
-ax
-ax
-ax
 ax
 ax
 ax
@@ -46280,9 +46297,9 @@ ax
 Xp
 ax
 ac
-aa
-aa
-aa
+ac
+ac
+ac
 aa
 aa
 aa

--- a/_maps/map_files/Tycoon/Tycoon1.dmm
+++ b/_maps/map_files/Tycoon/Tycoon1.dmm
@@ -1177,6 +1177,11 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/captain)
+"do" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/gloves/color/fyellow/old,
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck1/hallway)
 "dp" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -4207,33 +4212,21 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "kd" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
+/obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "ke" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/neck/squad,
-/obj/item/clothing/suit/ship/squad/bomber,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/light,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "kf" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/hardhat/dblue,
-/obj/item/clothing/head/hardhat/dblue,
-/obj/item/clothing/head/hardhat/dblue,
-/obj/item/clothing/head/hardhat/dblue,
-/obj/item/clothing/head/hardhat/dblue,
-/obj/item/clothing/head/hardhat/dblue,
-/obj/item/clothing/head/hardhat/dblue,
-/obj/item/clothing/head/hardhat/dblue,
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "kg" = (
@@ -5102,12 +5095,14 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "lU" = (
-/obj/machinery/door/airlock/ship/external/glass{
-	req_one_access_txt = "13"
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/monotile/steel,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plating,
 /area/hallway/nsv/deck1/hallway)
 "lV" = (
 /obj/machinery/status_display/ai,
@@ -5162,10 +5157,8 @@
 /turf/open/floor/monotile/dark,
 /area/storage/eva)
 "md" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/neck/squad,
-/obj/item/clothing/suit/ship/squad/bomber,
 /obj/machinery/light,
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "me" = (
@@ -5707,6 +5700,10 @@
 	},
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
+"nt" = (
+/obj/machinery/vending/tool,
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck1/hallway)
 "nu" = (
 /turf/open/floor/monotile/airless,
 /area/space/nearstation)
@@ -6008,6 +6005,10 @@
 /obj/machinery/ship_weapon/deck_turret/east,
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
+"qs" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck1/hallway)
 "qB" = (
 /obj/machinery/camera/autoname{
 	c_tag = "Core E";
@@ -6055,11 +6056,16 @@
 /turf/open/floor/monotile/steel,
 /area/nsv/briefingroom)
 "rb" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/ship/external/glass{
 	req_one_access_txt = "13"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "ri" = (
@@ -6557,13 +6563,11 @@
 /turf/open/floor/monotile/steel,
 /area/quartermaster/miningdock)
 "yw" = (
-/obj/machinery/door/airlock/ship/external/glass{
-	req_one_access_txt = "13"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/monotile/dark/airless,
 /area/hallway/nsv/deck1/hallway)
 "yF" = (
@@ -6629,6 +6633,15 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/ai_monitored/nuke_storage)
+"zM" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck1/hallway)
 "zW" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
 /turf/open/floor/plating,
@@ -6649,7 +6662,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "AX" = (
@@ -7003,6 +7016,16 @@
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
 	})
+"GZ" = (
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/ship/external/glass{
+	req_one_access_txt = "13"
+	},
+/turf/open/floor/monotile/dark/airless,
+/area/space/nearstation)
 "Hb" = (
 /obj/machinery/bluespace_beacon,
 /turf/open/floor/monotile/steel,
@@ -7117,12 +7140,7 @@
 	name = "Air traffic control pod"
 	})
 "IC" = (
-/obj/machinery/door/airlock/ship/external/glass{
-	req_one_access_txt = "13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/monotile/dark/airless,
 /area/hallway/nsv/deck1/hallway)
 "IJ" = (
@@ -7658,6 +7676,10 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/monotile/steel,
 /area/quartermaster/miningdock)
+"Qd" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "Qg" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -7879,11 +7901,10 @@
 	name = "Executive officer's Office"
 	})
 "Sa" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
 /obj/machinery/advanced_airlock_controller/directional/west,
-/turf/open/floor/plasteel/grid/steel,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
+/turf/open/floor/monotile/dark/airless,
 /area/hallway/nsv/deck1/hallway)
 "Sg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -7987,6 +8008,15 @@
 /obj/item/pen/fourcolor,
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/aisat)
+"TA" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = -1;
+	pixel_y = 4
+	},
+/obj/item/storage/toolbox/electrical,
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck1/hallway)
 "TJ" = (
 /obj/structure/rack,
 /obj/item/tank/internals/oxygen,
@@ -8116,11 +8146,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump,
-/turf/open/floor/plasteel/grid/steel,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/monotile/dark/airless,
 /area/hallway/nsv/deck1/hallway)
 "Vp" = (
 /obj/effect/turf_decal/bot_white,
@@ -8128,6 +8156,10 @@
 /obj/machinery/light/runway,
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
+"Vz" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck1/hallway)
 "VB" = (
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/nsv/deck1/aft)
@@ -8236,6 +8268,10 @@
 /obj/structure/grille,
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
+"XO" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck1/hallway)
 "Ya" = (
 /turf/closed/wall/r_wall/ship,
 /area/crew_quarters/heads/captain)
@@ -40857,7 +40893,7 @@ Wi
 dJ
 es
 bN
-bN
+XO
 cb
 cb
 mO
@@ -41116,7 +41152,7 @@ es
 bN
 XE
 cb
-iT
+TA
 mP
 mR
 bN
@@ -41373,7 +41409,7 @@ es
 bN
 EY
 cb
-iT
+do
 cb
 kd
 bN
@@ -41630,9 +41666,9 @@ es
 bN
 XE
 cb
-iT
+zM
 cb
-ke
+kf
 bN
 rl
 Mg
@@ -41887,7 +41923,7 @@ Im
 bN
 dm
 cb
-iT
+nt
 cb
 md
 kK
@@ -42144,7 +42180,7 @@ es
 bN
 XE
 cb
-iT
+Vz
 cb
 kf
 bN
@@ -42401,7 +42437,7 @@ es
 bN
 vf
 cb
-iT
+do
 cb
 kg
 bN
@@ -42658,7 +42694,7 @@ es
 bN
 XE
 cb
-iT
+Vz
 dZ
 mR
 bN
@@ -42913,14 +42949,14 @@ Wi
 dK
 es
 bN
-bN
+qs
 cb
 cb
 dV
 bN
 bN
 lv
-mI
+mG
 dy
 lZ
 mi
@@ -43177,7 +43213,7 @@ dW
 ga
 bN
 lv
-mG
+ke
 lV
 yZ
 yZ
@@ -43438,7 +43474,7 @@ Hd
 lU
 Sa
 IC
-iC
+Qd
 iC
 iC
 iC
@@ -43695,7 +43731,7 @@ AL
 rb
 Va
 yw
-iC
+GZ
 iC
 iC
 iC
@@ -43952,7 +43988,7 @@ mM
 yZ
 yZ
 yZ
-jj
+aI
 jj
 jj
 jj

--- a/_maps/map_files/Tycoon/Tycoon1.dmm
+++ b/_maps/map_files/Tycoon/Tycoon1.dmm
@@ -849,7 +849,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "cs" = (
@@ -1053,7 +1052,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
 "cW" = (
@@ -1063,7 +1061,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/airlock/ship/command{
 	name = "Briefing Room";
 	req_one_access_txt = "19"
@@ -1454,7 +1451,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "dX" = (
@@ -2013,7 +2009,6 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "fm" = (
@@ -2044,7 +2039,6 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
 "fq" = (
@@ -2494,7 +2488,6 @@
 	name = "Mining Equipment";
 	req_one_access_txt = "48"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/quartermaster/miningdock)
 "go" = (
@@ -2796,7 +2789,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/airlock/ship{
 	dir = 4;
 	name = "Secure Systems";
@@ -2867,7 +2859,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "gY" = (
@@ -2933,7 +2924,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/airlock/ship/command{
 	name = "Briefing Room";
 	req_one_access_txt = "19"
@@ -2978,7 +2968,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/airlock/ship/command{
 	name = "Briefing Room";
 	req_one_access_txt = "19"
@@ -3904,7 +3893,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
@@ -3926,7 +3914,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/storage/eva)
 "jy" = (
@@ -4038,7 +4025,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile,
 /area/crew_quarters/heads/hop{
 	name = "Executive officer's Office"
@@ -4262,21 +4248,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck1/hallway)
-"kc" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
@@ -5011,7 +4982,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "lC" = (
@@ -5335,7 +5305,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
@@ -6402,7 +6371,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile,
 /area/crew_quarters/heads/captain)
 "uy" = (
@@ -6514,7 +6482,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/effect/turf_decal/loading_area{
 	dir = 1
 	},
@@ -6605,7 +6572,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/airlock/ship/public/glass{
 	dir = 4;
 	name = "Briefing Room"
@@ -6972,7 +6938,6 @@
 	name = "Mining Equipment";
 	req_one_access_txt = "48"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/quartermaster/miningdock)
 "Dz" = (
@@ -7086,7 +7051,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/grid/steel,
 /area/shuttle/turbolift/tertiary)
 "Ft" = (
@@ -7122,7 +7086,6 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "FG" = (
@@ -7145,7 +7108,6 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "Gg" = (
@@ -7158,7 +7120,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/airlock/ship/public/glass{
 	dir = 4;
 	name = "Command Hallway";
@@ -7184,7 +7145,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile,
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
@@ -7368,7 +7328,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
@@ -7481,7 +7440,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/airlock/ship/public/glass{
 	dir = 4;
 	name = "Briefing Room"
@@ -7770,7 +7728,6 @@
 	name = "Mining Equipment";
 	req_one_access_txt = "48"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/quartermaster/miningdock)
 "Nx" = (
@@ -7801,7 +7758,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/airlock/ship/public/glass{
 	dir = 4;
 	name = "Command Hallway";
@@ -7918,7 +7874,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile,
 /area/shuttle/turbolift/secondary)
 "PN" = (
@@ -7936,7 +7891,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/effect/turf_decal/loading_area,
 /obj/machinery/turnstile/xo,
 /turf/open/floor/monotile/steel,
@@ -8595,7 +8549,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck3{
 	name = "Air traffic control pod"
@@ -40683,7 +40636,7 @@ ev
 gW
 ev
 iX
-kc
+Gd
 kH
 ls
 mF

--- a/_maps/map_files/Tycoon/Tycoon2.dmm
+++ b/_maps/map_files/Tycoon/Tycoon2.dmm
@@ -945,6 +945,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "acK" = (
@@ -2177,16 +2178,11 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/port)
 "afD" = (
-/obj/structure/rack,
-/obj/item/rcd_ammo/large{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/rcd_ammo/large,
 /obj/structure/window/reinforced{
 	dir = 1;
 	layer = 2.9
 	},
+/obj/machinery/space_heater,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/port)
 "afE" = (
@@ -2338,7 +2334,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/space_heater,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/port)
 "afX" = (
@@ -2705,6 +2701,11 @@
 	},
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large{
+	pixel_x = 3;
+	pixel_y = 3
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/port)
@@ -4136,7 +4137,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
+	req_access_txt = "5;12";
+	req_one_access_txt = null
+	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
@@ -15379,7 +15383,10 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
+	req_access_txt = "5;12";
+	req_one_access_txt = null
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
@@ -16993,7 +17000,10 @@
 /turf/open/floor/monotile/light,
 /area/crew_quarters/heads/cmo)
 "aUE" = (
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
+	req_access_txt = "5;12";
+	req_one_access_txt = null
+	},
 /turf/open/floor/plating,
 /area/medical/break_room)
 "aUF" = (
@@ -29710,7 +29720,10 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
+	req_access_txt = "5;12";
+	req_one_access_txt = null
+	},
 /turf/open/floor/plating,
 /area/medical/genetics)
 "bvN" = (
@@ -35256,7 +35269,9 @@
 /turf/open/floor/monotile/dark,
 /area/medical/surgery)
 "bHB" = (
-/obj/machinery/door/airlock/ship/maintenance,
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "12"
+	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -40980,7 +40995,7 @@
 	dir = 4
 	},
 /turf/open/floor/durasteel,
-/area/space/nearstation)
+/area/engine/engineering/reactor_core)
 "gaR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -42186,7 +42201,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
+	req_access_txt = "5;12";
+	req_one_access_txt = null
+	},
 /turf/open/floor/monotile/dark,
 /area/medical/morgue)
 "hxW" = (
@@ -48994,6 +49012,14 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/monotile/light,
 /area/medical/genetics)
+"qsN" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/space_heater,
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/frame1/central)
 "qtp" = (
 /obj/structure/girder/reinforced,
 /obj/structure/foamedmetal,
@@ -52256,9 +52282,6 @@
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/warehouse)
 "uKe" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
 /area/engine/storage)
@@ -53711,6 +53734,10 @@
 /obj/structure/lattice/catwalk/over/ship,
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons/fore)
+"wSt" = (
+/obj/machinery/space_heater,
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/frame1/central)
 "wSx" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -90791,7 +90818,7 @@ qRr
 bcq
 enm
 aad
-abJ
+qsN
 azD
 aSH
 aZl
@@ -91827,7 +91854,7 @@ blg
 iEz
 buY
 byA
-bGH
+wSt
 bKN
 bKW
 byA

--- a/_maps/map_files/Tycoon/Tycoon2.dmm
+++ b/_maps/map_files/Tycoon/Tycoon2.dmm
@@ -20,7 +20,6 @@
 	name = "Custodial Closet";
 	req_one_access_txt = "26"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
 /area/janitor)
@@ -49,7 +48,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "CIC Hallway"
@@ -542,7 +540,6 @@
 /obj/structure/fluff/support_beam{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/nsv/hanger/deck2)
 "abF" = (
@@ -619,7 +616,6 @@
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Medical Lounge"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/medical/break_room)
 "abR" = (
@@ -647,7 +643,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/science)
 "abT" = (
@@ -828,7 +823,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "acp" = (
@@ -1511,7 +1505,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/effect/turf_decal/ship/delivery/yellow,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
@@ -1535,7 +1528,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/medical/chemistry)
 "aee" = (
@@ -1548,7 +1540,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/medical/chemistry)
 "aef" = (
@@ -1773,7 +1764,6 @@
 /obj/structure/fluff/support_beam{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/nsv/hanger/deck2)
 "aeF" = (
@@ -2027,7 +2017,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Engineering lobby"
 	},
@@ -2380,7 +2369,6 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/nsv/hanger/deck2)
 "agc" = (
@@ -2563,7 +2551,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms/nsv/dorms_1)
 "agB" = (
@@ -3472,7 +3459,6 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/light,
 /area/medical/medbay/central)
 "aiZ" = (
@@ -4014,7 +4000,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
 "akw" = (
@@ -5924,7 +5909,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
 "aqL" = (
@@ -6151,7 +6135,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/cafeteria{
 	name = "Mess hall"
@@ -6375,7 +6358,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
@@ -6605,7 +6587,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Cryopod"
 	},
@@ -7102,7 +7083,6 @@
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Library"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/library)
 "aun" = (
@@ -9015,7 +8995,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/steel,
@@ -9827,7 +9806,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/tcommsat/computer)
 "aDY" = (
@@ -10320,7 +10298,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "aFc" = (
@@ -10334,7 +10311,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "aFd" = (
@@ -10348,7 +10324,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "aFe" = (
@@ -10645,7 +10620,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/durasteel,
 /area/security/prison)
 "aFD" = (
@@ -11042,7 +11016,6 @@
 	dir = 1
 	},
 /obj/machinery/turnstile,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/security/prison)
 "aGC" = (
@@ -11362,7 +11335,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/effect/turf_decal/ship/delivery/yellow,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
@@ -12504,7 +12476,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons/fore)
 "aKj" = (
@@ -13391,7 +13362,6 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/durasteel/eris_techfloor_alt,
 /area/science/xenobiology)
 "aMe" = (
@@ -13746,7 +13716,6 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -13860,7 +13829,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -14144,7 +14112,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -14575,7 +14542,6 @@
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Crew Lounge"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame2/port)
 "aOJ" = (
@@ -14845,7 +14811,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -15933,7 +15898,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "aRL" = (
@@ -16484,7 +16448,6 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "aST" = (
@@ -16599,7 +16562,6 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "aTm" = (
@@ -17393,7 +17355,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/tcommsat/computer)
 "aVy" = (
@@ -17508,7 +17469,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/cafeteria{
 	name = "Mess hall"
@@ -17539,7 +17499,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/cafeteria{
 	name = "Mess hall"
@@ -17846,7 +17805,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/science)
 "aWA" = (
@@ -18186,7 +18144,6 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/durasteel/eris_techfloor_alt,
 /area/science/xenobiology)
 "aXf" = (
@@ -18624,7 +18581,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/security/prison)
 "aYh" = (
@@ -19039,7 +18995,6 @@
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Library"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/library)
 "aZn" = (
@@ -19052,7 +19007,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "aZo" = (
@@ -19293,7 +19247,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Crew Lounge"
 	},
@@ -19309,7 +19262,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -19376,7 +19328,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/effect/turf_decal/ship/delivery/yellow,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
@@ -19449,7 +19400,6 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
@@ -21746,7 +21696,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/effect/turf_decal/ship/delivery/yellow,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
@@ -22840,7 +22789,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/effect/turf_decal/ship/delivery/yellow,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
@@ -23040,7 +22988,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/effect/turf_decal/ship/delivery/yellow,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
@@ -23496,7 +23443,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -24744,7 +24690,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/medical/surgery)
 "blc" = (
@@ -25245,7 +25190,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "bmo" = (
@@ -25995,7 +25939,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/effect/turf_decal/ship/delivery/yellow,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
@@ -26918,7 +26861,6 @@
 	})
 "bpR" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/nsv/weapons/gauss)
 "bpS" = (
@@ -28074,7 +28016,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/steel,
@@ -28553,7 +28494,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/ship/delivery/yellow,
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile/steel,
 /area/security/brig)
@@ -28750,7 +28690,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Aft Primary Hallway"
 	},
@@ -29309,7 +29248,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/ship/delivery/yellow,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/security/brig)
 "buJ" = (
@@ -29394,7 +29332,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/ship/delivery/yellow,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/security/brig)
 "buO" = (
@@ -29411,7 +29348,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame2/port)
 "buP" = (
@@ -29498,7 +29434,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -29573,7 +29508,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -29604,7 +29538,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/airlock/ship/public{
 	name = "Custodial Closet";
 	req_one_access_txt = "26"
@@ -29632,7 +29565,6 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "bvh" = (
@@ -29644,7 +29576,6 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "bvi" = (
@@ -29907,7 +29838,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Cryogenics";
 	req_one_access_txt = "5"
@@ -29981,7 +29911,6 @@
 	name = "Reception";
 	req_one_access_txt = "5"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -30072,7 +30001,6 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -30523,7 +30451,6 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
 /obj/structure/lattice/catwalk/over/ship,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
@@ -30888,7 +30815,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame2/port)
 "byk" = (
@@ -31325,7 +31251,6 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/ship/delivery/yellow,
 /turf/open/floor/monotile/dark,
@@ -31597,7 +31522,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/cafeteria{
 	name = "Mess hall"
@@ -31644,7 +31568,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
@@ -31664,7 +31587,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
@@ -31981,7 +31903,6 @@
 /obj/machinery/turnstile{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/security/brig)
 "bAG" = (
@@ -32043,7 +31964,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms/nsv/dorms_2)
 "bAN" = (
@@ -32099,7 +32019,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/security/brig)
 "bAR" = (
@@ -32258,7 +32177,6 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/maintenance/starboard/secondary{
 	name = "Munitions Projects"
@@ -32310,7 +32228,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
@@ -32529,7 +32446,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "CIC Hallway"
 	},
@@ -32544,7 +32460,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -32721,7 +32636,6 @@
 	name = "Cryogenics";
 	req_one_access_txt = "5"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/light,
 /area/medical/medbay/central)
 "bCi" = (
@@ -33462,7 +33376,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/effect/turf_decal/ship/delivery/yellow,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
@@ -33489,7 +33402,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/effect/turf_decal/ship/delivery/yellow,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
@@ -33951,7 +33863,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/durasteel,
 /area/security/prison)
 "bED" = (
@@ -34029,7 +33940,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/turnstile,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/security/prison)
 "bEJ" = (
@@ -34264,7 +34174,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "bFe" = (
@@ -34276,7 +34185,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/science)
 "bFf" = (
@@ -34408,7 +34316,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "bFr" = (
@@ -34755,7 +34662,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile/steel,
@@ -35274,7 +35180,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "bHu" = (
@@ -36367,7 +36272,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/science)
 "bKv" = (
@@ -36453,7 +36357,6 @@
 	name = "Munitions Control Room"
 	})
 "bKJ" = (
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/airlock/highsecurity/ship{
 	name = "Munitions Control Room";
 	req_one_access_txt = "69"
@@ -36588,7 +36491,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "CIC Hallway"
 	},
@@ -36625,7 +36527,6 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/port)
 "bLh" = (
@@ -36890,7 +36791,6 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/dark,
@@ -37004,7 +36904,6 @@
 /area/maintenance/department/cargo)
 "bLS" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/nsv/hanger/storage{
 	name = "Munitions Control Room"
@@ -37014,7 +36913,6 @@
 	name = "Weapons Bay";
 	req_one_access_txt = "69"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
@@ -37081,7 +36979,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -37208,7 +37105,6 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/bridge{
 	name = "CIC"
@@ -37868,7 +37764,6 @@
 	name = "CIC"
 	})
 "caX" = (
-/obj/effect/landmark/zebra_interlock_point,
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -37882,7 +37777,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/landmark/zebra_interlock_point,
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -37903,7 +37797,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/effect/turf_decal/ship/delivery/yellow,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame2/port)
@@ -37925,7 +37818,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/poddoor/shutters/ship{
 	id = "gaussgang";
 	name = "public gauss access shutters"
@@ -37940,7 +37832,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/poddoor/shutters/ship{
 	id = "gaussgang";
 	name = "public gauss access shutters"
@@ -37952,7 +37843,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/poddoor/shutters/ship{
 	id = "gaussgang";
 	name = "public gauss access shutters"
@@ -37980,7 +37870,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/ship/delivery/yellow,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/maintenance/starboard/secondary{
 	name = "Munitions Projects"
@@ -38180,7 +38069,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/effect/turf_decal/ship/delivery/yellow,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
@@ -38257,7 +38145,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit)
 "ckD" = (
@@ -38432,7 +38319,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "ctl" = (
@@ -38484,7 +38370,6 @@
 "cxy" = (
 /obj/structure/table/reinforced,
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
@@ -38696,7 +38581,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/bridge{
 	name = "CIC"
@@ -38728,7 +38612,6 @@
 /obj/machinery/door/airlock/ship/public{
 	name = "Crew Quarters"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms)
 "cPU" = (
@@ -38817,7 +38700,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/port)
 "cWr" = (
@@ -38890,7 +38772,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/durasteel,
 /area/security/prison)
 "cYZ" = (
@@ -39000,7 +38881,6 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/machinery/light,
-/obj/effect/landmark/zebra_interlock_point,
 /obj/structure/window/reinforced{
 	dir = 4;
 	layer = 2.9
@@ -39253,7 +39133,6 @@
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Gym"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/fitness/recreation)
 "dDX" = (
@@ -39675,7 +39554,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "ekv" = (
@@ -39851,7 +39729,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/medical/morgue)
 "eoU" = (
@@ -40109,7 +39986,6 @@
 /obj/structure/railing{
 	dir = 6
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/bridge{
 	name = "CIC"
@@ -40250,7 +40126,6 @@
 	name = "Virology";
 	req_one_access_txt = "5"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
@@ -40319,7 +40194,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "eRG" = (
@@ -40457,7 +40331,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/science/research)
 "eZK" = (
@@ -40635,7 +40508,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "fpo" = (
@@ -40675,7 +40547,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/quartermaster/storage)
 "fpP" = (
@@ -41042,7 +40913,6 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/airlock/ship/public{
 	name = "Crew Quarters"
 	},
@@ -41250,7 +41120,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "gjm" = (
@@ -41388,7 +41257,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "gsa" = (
@@ -41528,7 +41396,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/bridge{
 	name = "CIC"
@@ -42146,7 +42013,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/science/server)
 "hqs" = (
@@ -42471,7 +42337,6 @@
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Gym"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/fitness/recreation)
 "hGU" = (
@@ -42642,7 +42507,6 @@
 /area/engine/atmos)
 "hRE" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/engine/gravity_generator)
 "hRK" = (
@@ -42855,7 +42719,6 @@
 	dir = 8;
 	name = "tactical chair"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/bridge{
 	name = "CIC"
@@ -42953,7 +42816,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/bridge{
 	name = "CIC"
@@ -43142,7 +43004,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/nsv/weapons/gauss)
 "iDJ" = (
@@ -43162,7 +43023,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
@@ -43408,7 +43268,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "iQX" = (
@@ -43476,7 +43335,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
@@ -43647,7 +43505,6 @@
 	name = "Medical Equipment";
 	req_one_access_txt = "5"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
@@ -43668,7 +43525,6 @@
 	name = "Cryogenics";
 	req_one_access_txt = "5"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -43787,7 +43643,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Mess Hall"
 	},
@@ -43802,7 +43657,6 @@
 /obj/machinery/computer/ship/dradis/minor{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/structure/window/reinforced{
 	dir = 4;
 	layer = 2.9
@@ -44043,7 +43897,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/port)
 "jIC" = (
@@ -44097,7 +43950,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/nsv/weapons/gauss)
 "jLQ" = (
@@ -44259,7 +44111,6 @@
 	dir = 8;
 	name = "tactical chair"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/bridge{
 	name = "CIC"
@@ -44298,7 +44149,6 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms)
 "kbg" = (
@@ -44835,7 +44685,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Mess Hall"
 	},
@@ -44871,7 +44720,6 @@
 	},
 /obj/machinery/computer/ship/dradis/minor,
 /obj/machinery/computer/ship/viewscreen,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/bridge{
 	name = "CIC"
@@ -45150,7 +44998,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/durasteel,
 /area/engine/break_room)
 "kVE" = (
@@ -45297,7 +45144,6 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/holopad,
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/bridge{
 	name = "CIC"
@@ -45527,7 +45373,6 @@
 /obj/machinery/door/airlock/ship{
 	name = "Squad Staging Area"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/monotile/steel,
@@ -45648,7 +45493,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/bridge{
 	name = "CIC"
@@ -45824,7 +45668,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/durasteel,
 /area/engine/atmos)
 "lLK" = (
@@ -45945,7 +45788,6 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/airlock/ship/engineering/glass{
 	req_one_access_txt = "10;24"
 	},
@@ -46207,7 +46049,6 @@
 /area/quartermaster/storage)
 "moR" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
 "mpJ" = (
@@ -46298,7 +46139,6 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/bridge{
 	name = "CIC"
@@ -46338,7 +46178,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/science/research)
 "mvE" = (
@@ -46437,7 +46276,6 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -47010,7 +46848,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/durasteel,
 /area/security/prison)
 "nmN" = (
@@ -47240,7 +47077,6 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/bridge{
 	name = "CIC"
@@ -47457,7 +47293,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons/gauss)
 "nPv" = (
@@ -48005,7 +47840,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/bridge{
 	name = "CIC"
@@ -48413,7 +48247,6 @@
 	dir = 1;
 	id = "naval"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons/fore)
 "prs" = (
@@ -48576,7 +48409,6 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
 /obj/effect/turf_decal/ship/delivery/yellow,
 /turf/open/floor/monotile/dark,
 /area/security/brig)
@@ -48676,7 +48508,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/nsv/hanger/storage{
 	name = "Munitions Control Room"
@@ -48743,7 +48574,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/durasteel,
 /area/security/prison)
 "pLb" = (
@@ -48772,7 +48602,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/cafeteria{
 	name = "Mess hall"
@@ -50017,7 +49846,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "rti" = (
@@ -50231,7 +50059,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/bridge{
 	name = "CIC"
@@ -50289,7 +50116,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar)
 "rFk" = (
@@ -50312,7 +50138,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "rGm" = (
@@ -50692,7 +50517,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "ska" = (
@@ -51136,7 +50960,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/bridge{
 	name = "CIC"
@@ -51234,7 +51057,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/bridge{
 	name = "CIC"
@@ -51427,7 +51249,6 @@
 	name = "Dropship Bay";
 	req_one_access_txt = "79"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/nsv/hanger/deck2)
 "tnm" = (
@@ -51452,7 +51273,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/port)
 "tow" = (
@@ -51463,7 +51283,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/ship/delivery/yellow,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/security/brig)
 "tpo" = (
@@ -51483,7 +51302,6 @@
 /obj/structure/railing{
 	dir = 10
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/bridge{
 	name = "CIC"
@@ -51503,7 +51321,6 @@
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Medbay Lobby Access"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/light,
 /area/medical/medbay/lobby)
 "tsS" = (
@@ -51572,7 +51389,6 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
@@ -51876,7 +51692,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/quartermaster/storage)
 "tNz" = (
@@ -51960,7 +51775,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
@@ -52467,7 +52281,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "uKU" = (
@@ -52984,7 +52797,6 @@
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Medbay Lobby Access"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/light,
 /area/medical/medbay/lobby)
@@ -53113,7 +52925,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/bridge{
 	name = "CIC"
@@ -53351,7 +53162,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "weE" = (
@@ -53434,7 +53244,6 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/bridge{
 	name = "CIC"
@@ -53658,7 +53467,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/computer/ship/salvage{
 	dir = 4
 	},
@@ -53762,7 +53570,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/port)
 "wId" = (
@@ -53822,7 +53629,6 @@
 	pixel_x = 32;
 	pixel_y = -32
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/bridge{
 	name = "CIC"
@@ -54010,7 +53816,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/structure/window/reinforced{
 	dir = 4;
 	layer = 2.9
@@ -54224,7 +54029,6 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "xpP" = (
@@ -54353,7 +54157,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/bridge{
 	name = "CIC"
@@ -54367,7 +54170,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar)
 "xwC" = (

--- a/_maps/map_files/Tycoon/Tycoon2.dmm
+++ b/_maps/map_files/Tycoon/Tycoon2.dmm
@@ -276,14 +276,12 @@
 /turf/open/floor/carpet/ship,
 /area/nsv/crew_quarters/heads/maa)
 "aaN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/durasteel,
-/area/engine/engineering)
+/area/engine/break_room)
 "aaO" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -1742,6 +1740,9 @@
 	name = "Engineering RC";
 	pixel_x = 32
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
 "aeB" = (
@@ -2018,9 +2019,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "afk" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -3228,15 +3226,12 @@
 /turf/closed/wall/ship,
 /area/maintenance/department/cargo)
 "aii" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "aij" = (
@@ -4756,6 +4751,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/service)
 "amR" = (
@@ -4839,6 +4837,9 @@
 "and" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
 	},
 /turf/open/floor/durasteel/lino,
 /area/engine/engineering/reactor_control)
@@ -5089,6 +5090,12 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/chief)
 "anV" = (
@@ -5105,6 +5112,12 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/heads/chief)
 "anW" = (
@@ -5112,6 +5125,12 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/computer/ship/viewscreen,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/monotile/steel,
 /area/engine/engineering)
 "anX" = (
@@ -5122,9 +5141,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /turf/open/floor/monotile/dark,
 /area/tcommsat/computer)
@@ -5394,6 +5410,9 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "apc" = (
@@ -5403,11 +5422,7 @@
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms)
 "apd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 1
-	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
 "apf" = (
@@ -5438,17 +5453,18 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "2-5"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/monotile/steel,
 /area/engine/engineering)
 "api" = (
 /obj/structure/disposalpipe/sorting/mail/flip,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
@@ -5501,6 +5517,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/carpet/green,
 /area/engine/engineering/reactor_control)
 "apt" = (
@@ -5530,6 +5549,9 @@
 "apv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "apw" = (
@@ -5680,8 +5702,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
 	},
 /turf/open/floor/monotile/steel,
 /area/engine/engineering)
@@ -5730,15 +5755,10 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "aql" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "1-2"
 	},
 /turf/open/floor/durasteel,
 /area/engine/break_room)
@@ -5750,8 +5770,17 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/durasteel,
 /area/engine/break_room)
@@ -6471,35 +6500,36 @@
 /turf/open/floor/plating,
 /area/engine/storage)
 "aso" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
 	},
 /turf/open/floor/monotile/steel,
 /area/engine/engineering)
 "asp" = (
-/obj/machinery/door/airlock/ship/engineering/glass{
-	name = "Reactor control Room";
-	req_one_access_txt = "10; 24"
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/ship/engineering/glass{
+	name = "Reactor control Room";
+	req_one_access_txt = "10; 24"
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering/reactor_control)
@@ -6531,7 +6561,7 @@
 	pixel_y = 24
 	},
 /obj/structure/cable{
-	icon_state = "0-2"
+	icon_state = "0-4"
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/break_room)
@@ -6549,6 +6579,9 @@
 	codes_txt = "delivery;dir=4";
 	location = "Engineering";
 	name = "navigation beacon (Engineering Delivery)"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/break_room)
@@ -6583,16 +6616,13 @@
 	dir = 1;
 	name = "Pipe Control Station"
 	},
-/obj/effect/landmark/start/station_engineer,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/carpet/green,
 /area/engine/engineering/reactor_control)
 "asF" = (
@@ -7000,6 +7030,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/advanced_airlock_controller/directional/west,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/engine/atmos)
 "aug" = (
@@ -7552,13 +7585,13 @@
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
 "avQ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
 "avZ" = (
@@ -7931,11 +7964,20 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/durasteel,
 /area/engine/engine_smes)
 "ayO" = (
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
 	},
 /turf/open/floor/durasteel,
 /area/engine/engine_smes)
@@ -7959,6 +8001,9 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
 	},
 /turf/open/floor/durasteel,
 /area/engine/engineering)
@@ -7991,11 +8036,6 @@
 /turf/open/floor/durasteel/lino,
 /area/engine/engineering/reactor_control)
 "ayW" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /turf/open/floor/monotile/steel,
 /area/engine/engineering)
 "ayX" = (
@@ -8025,28 +8065,35 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/engine_smes)
 "aza" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-10"
-	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/steel,
 /area/engine/engineering)
 "azb" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/durasteel,
 /area/engine/engineering)
 "azc" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/carpet/blue,
-/area/crew_quarters/heads/chief)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/durasteel/techfloor{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "azd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -8109,12 +8156,14 @@
 /turf/open/floor/plating,
 /area/engine/storage)
 "azp" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/carpet/blue,
 /area/engine/engineering)
@@ -8152,9 +8201,14 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/engine/dcc)
 "azx" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel/ridged/steel,
-/area/engine/engineering/reactor_control)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/heads/chief)
 "azy" = (
 /obj/structure/closet/crate/bin,
 /obj/item/kitchen/knife,
@@ -8504,7 +8558,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/durasteel,
 /area/engine/engineering)
 "aAx" = (
@@ -8515,11 +8568,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
@@ -8544,6 +8600,9 @@
 "aAC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
 	},
 /turf/open/floor/durasteel,
 /area/engine/engineering)
@@ -8599,12 +8658,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
 "aAL" = (
@@ -8679,11 +8736,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
 	},
 /turf/open/floor/durasteel,
 /area/engine/storage_shared)
@@ -8698,12 +8755,6 @@
 /area/engine/engine_smes)
 "aAU" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 1
-	},
 /turf/open/floor/monotile/steel,
 /area/engine/engineering)
 "aAV" = (
@@ -8719,6 +8770,9 @@
 "aAX" = (
 /obj/structure/chair{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
 	},
 /turf/open/floor/durasteel,
 /area/engine/engine_smes)
@@ -8850,6 +8904,9 @@
 /obj/machinery/newscaster{
 	pixel_x = 30
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
 "aBo" = (
@@ -8903,9 +8960,6 @@
 /turf/open/floor/monotile/dark,
 /area/engine/storage_shared)
 "aBt" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
 "aBu" = (
@@ -8920,6 +8974,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
@@ -8943,22 +9000,16 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 1
-	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
 "aBz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/turf/open/floor/durasteel,
-/area/engine/engineering)
+/turf/open/floor/durasteel/techfloor{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "aBA" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -9039,6 +9090,9 @@
 /obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/monotile/dark,
 /area/tcommsat/computer)
@@ -9167,9 +9221,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
 	},
 /turf/open/floor/monotile/dark,
 /area/tcommsat/computer)
@@ -9349,9 +9400,6 @@
 /obj/machinery/camera/autoname{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /turf/open/floor/monotile/dark/airless{
 	initial_gas_mix = "n2=100;TEMP=80";
 	name = "telecomms server floor"
@@ -9360,16 +9408,21 @@
 "aCS" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
 	},
 /turf/open/floor/durasteel,
 /area/engine/storage_shared)
 "aCT" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/durasteel,
 /area/tcommsat/computer)
 "aCU" = (
@@ -9382,9 +9435,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/monotile/dark,
 /area/tcommsat/computer)
 "aCW" = (
@@ -9394,9 +9444,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /turf/open/floor/monotile/dark,
 /area/tcommsat/computer)
@@ -9426,9 +9473,6 @@
 	dir = 8;
 	pixel_x = 22
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/circuit/red/telecomms,
 /area/tcommsat/server)
 "aDd" = (
@@ -9439,9 +9483,6 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /turf/open/floor/monotile/dark,
 /area/engine/break_room)
 "aDe" = (
@@ -9471,15 +9512,15 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/durasteel,
 /area/tcommsat/computer)
 "aDh" = (
 /turf/open/floor/circuit/green/telecomms,
 /area/tcommsat/server)
 "aDi" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/circuit/red/telecomms,
 /area/tcommsat/server)
 "aDj" = (
@@ -9493,9 +9534,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/monotile/dark,
 /area/tcommsat/computer)
 "aDk" = (
@@ -9508,7 +9546,7 @@
 "aDm" = (
 /obj/machinery/holopad,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
 /turf/open/floor/durasteel,
 /area/tcommsat/computer)
@@ -9535,9 +9573,6 @@
 /area/tcommsat/server)
 "aDr" = (
 /obj/machinery/telecomms/server/presets/security,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/camera/autoname{
 	dir = 8
 	},
@@ -9556,9 +9591,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /turf/open/floor/monotile/dark,
 /area/engine/break_room)
 "aDt" = (
@@ -9570,12 +9602,6 @@
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
 	},
 /turf/open/floor/monotile/dark,
 /area/tcommsat/computer)
@@ -9782,9 +9808,6 @@
 /area/tcommsat/server)
 "aDW" = (
 /obj/machinery/ntnet_relay,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
 "aDX" = (
@@ -9835,9 +9858,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/monotile/dark,
 /area/tcommsat/computer)
 "aEb" = (
@@ -9854,11 +9874,14 @@
 /turf/open/floor/monotile/dark,
 /area/tcommsat/server)
 "aEc" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/durasteel,
-/area/engine/break_room)
+/area/engine/engineering)
 "aEd" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -11427,15 +11450,11 @@
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "aHw" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/turf/open/floor/durasteel,
-/area/engine/engineering)
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/heads/chief)
 "aHx" = (
 /obj/structure/table/reinforced,
 /obj/machinery/fax{
@@ -11451,11 +11470,8 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
@@ -11567,8 +11583,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
 /turf/open/floor/durasteel,
@@ -11709,14 +11730,10 @@
 /turf/open/floor/monotile/light,
 /area/security/detectives_office)
 "aIi" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/durasteel,
-/area/engine/engineering)
+/obj/effect/landmark/start/station_engineer,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/carpet/green,
+/area/engine/engineering/reactor_control)
 "aIj" = (
 /obj/machinery/computer/lore_terminal,
 /obj/effect/turf_decal/tile/red{
@@ -11864,9 +11881,11 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
@@ -12921,17 +12940,14 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "aLe" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/durasteel,
-/area/engine/engine_smes)
+/turf/open/floor/carpet/green,
+/area/engine/engineering/reactor_control)
 "aLf" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
@@ -13569,6 +13585,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/durasteel,
 /area/engine/engineering)
 "aMD" = (
@@ -13798,9 +13815,6 @@
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "aNa" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/holopad,
 /turf/open/floor/durasteel,
 /area/engine/break_room)
@@ -13847,6 +13861,9 @@
 	dir = 8
 	},
 /obj/effect/landmark/zebra_interlock_point,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/monotile/steel,
 /area/engine/break_room)
 "aNe" = (
@@ -14007,6 +14024,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
 "aNv" = (
@@ -14014,15 +14032,14 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
@@ -14265,18 +14282,14 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
 "aNV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /turf/open/floor/carpet/blue,
 /area/engine/engineering)
@@ -14390,11 +14403,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/carpet/blue,
 /area/engine/engineering)
 "aOm" = (
@@ -14435,8 +14446,8 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "aOq" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/chief)
 "aOr" = (
@@ -14729,6 +14740,10 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/dark,
 /area/engine/break_room)
 "aOY" = (
@@ -14935,20 +14950,15 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/durasteel,
 /area/engine/break_room)
 "aPr" = (
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck2/frame2/port)
+/turf/open/floor/plasteel/ridged/steel,
+/area/engine/engineering/reactor_control)
 "aPs" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -15017,37 +15027,33 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame2/port)
 "aPz" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/durasteel,
 /area/engine/break_room)
 "aPA" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/open/floor/monotile/dark,
 /area/engine/break_room)
 "aPB" = (
+/obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "0-2"
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
+/turf/open/floor/monotile/dark/airless{
+	initial_gas_mix = "n2=100;TEMP=80";
+	name = "telecomms server floor"
 	},
-/turf/open/floor/durasteel,
-/area/engine/break_room)
-"aPC" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/durasteel,
-/area/engine/break_room)
+/area/tcommsat/server)
 "aPD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -15056,10 +15062,10 @@
 	dir = 4;
 	sortType = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/durasteel,
 /area/engine/break_room)
 "aPE" = (
@@ -15071,14 +15077,9 @@
 /turf/open/floor/monotile/dark,
 /area/space/nearstation)
 "aPF" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/monotile/dark/airless{
-	initial_gas_mix = "n2=100;TEMP=80";
-	name = "telecomms server floor"
-	},
-/area/tcommsat/server)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck2/frame2/port)
 "aPH" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -15114,7 +15115,6 @@
 	dir = 4;
 	sortType = 5
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /turf/open/floor/durasteel,
 /area/engine/break_room)
 "aPM" = (
@@ -15220,7 +15220,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/monotile/dark,
 /area/engine/engineering/hangar)
 "aQs" = (
@@ -15256,6 +15255,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering/reactor_control)
@@ -15387,6 +15389,12 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/engine_smes)
 "aQF" = (
@@ -15396,6 +15404,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/monotile/steel,
 /area/engine/engineering)
 "aQG" = (
@@ -15421,33 +15430,66 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/monotile/steel,
 /area/engine/engineering)
 "aQI" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
 "aQJ" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
 	},
 /turf/open/floor/monotile/steel,
 /area/engine/engineering)
 "aQK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/chief)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/durasteel,
+/area/engine/storage_shared)
 "aQL" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
 /turf/open/floor/durasteel,
@@ -15461,6 +15503,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
 /turf/open/floor/durasteel,
 /area/engine/engineering)
 "aQP" = (
@@ -15468,17 +15516,26 @@
 	icon_state = "2-8"
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
 /turf/open/floor/monotile/steel,
 /area/engine/engineering)
 "aQQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
 	},
 /turf/open/floor/carpet/green,
 /area/engine/engineering/reactor_control)
@@ -15529,6 +15586,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
 "aQW" = (
@@ -15537,6 +15597,7 @@
 	},
 /obj/machinery/computer/lore_terminal,
 /obj/effect/landmark/nuclear_waste_spawner,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
 "aQX" = (
@@ -15589,15 +15650,11 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/steel,
 /area/engine/engineering)
 "aRc" = (
@@ -15614,9 +15671,8 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "1-2"
 	},
-/obj/machinery/power/terminal,
 /turf/open/floor/monotile/dark,
 /area/tcommsat/computer)
 "aRf" = (
@@ -15644,8 +15700,6 @@
 /area/tcommsat/server)
 "aRj" = (
 /obj/machinery/telecomms/broadcaster/preset_left,
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable,
 /turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
 "aRk" = (
@@ -15897,20 +15951,12 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "aRN" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/monotile/dark,
-/area/hallway/nsv/deck2/frame2/port)
+/turf/open/floor/durasteel,
+/area/engine/engineering)
 "aRO" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -16079,12 +16125,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/landmark/patrol_node{
 	id = "tycoon_engi";
 	next_id = "tycoon_bar"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame2/port)
@@ -16114,6 +16163,7 @@
 /obj/item/clothing/glasses/meson,
 /obj/item/paper/monitorkey,
 /obj/item/stamp/chief_engineer,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/chief)
 "aSl" = (
@@ -16362,6 +16412,12 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame2/port)
 "aSM" = (
@@ -16485,11 +16541,12 @@
 /area/nsv/weapons/fore)
 "aTe" = (
 /obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame2/port)
 "aTf" = (
@@ -16638,17 +16695,17 @@
 /turf/open/floor/carpet/red,
 /area/nsv/weapons/fore)
 "aTB" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
+	dir = 5
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame2/port)
@@ -16761,6 +16818,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/monotile/steel,
 /area/engine/engineering)
@@ -17065,9 +17126,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame2/port)
 "aUR" = (
@@ -17140,9 +17198,6 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
 /turf/open/floor/monotile/steel,
@@ -17233,9 +17288,6 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/structure/disposalpipe/junction/flip{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
@@ -17635,17 +17687,16 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/item/radio/intercom/directional/west,
+/obj/machinery/power/terminal,
+/obj/structure/cable,
 /turf/open/floor/monotile/dark,
 /area/tcommsat/computer)
 "aWi" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame2/port)
 "aWj" = (
@@ -18086,6 +18137,10 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
 "aXc" = (
@@ -18210,13 +18265,11 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /turf/open/floor/carpet/blue,
 /area/engine/engineering)
 "aXq" = (
@@ -18235,6 +18288,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame2/port)
 "aXr" = (
@@ -18250,9 +18306,6 @@
 "aXs" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /turf/open/floor/monotile/dark,
 /area/tcommsat/computer)
@@ -18270,12 +18323,11 @@
 /turf/open/floor/plasteel/techmaint,
 /area/science/research)
 "aXv" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "1-8"
 	},
+/obj/structure/table,
+/obj/item/folder/blue,
 /turf/open/floor/monotile/dark,
 /area/tcommsat/computer)
 "aXw" = (
@@ -19398,6 +19450,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
 "bae" = (
@@ -22385,6 +22438,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/break_room)
 "bfZ" = (
@@ -22895,15 +22951,17 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
 	},
 /turf/open/floor/monotile/steel,
 /area/engine/engineering)
@@ -23001,17 +23059,12 @@
 /area/engine/storage_shared)
 "bhy" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/monotile/steel,
 /area/engine/engineering)
 "bhz" = (
@@ -23953,7 +24006,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
 /turf/open/floor/monotile/steel,
@@ -24001,11 +24054,14 @@
 	pixel_y = 26
 	},
 /obj/machinery/camera/autoname,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/secondary/service)
@@ -24439,6 +24495,7 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/service)
 "bkG" = (
@@ -24645,6 +24702,7 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/service)
 "bkZ" = (
@@ -24801,6 +24859,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "blr" = (
@@ -24822,6 +24883,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/monotile/steel,
 /area/maintenance/department/engine/atmos)
@@ -24869,6 +24933,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
@@ -25581,6 +25648,9 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "bna" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/durasteel/techfloor{
 	initial_gas_mix = "TEMP=2.7"
 	},
@@ -28409,10 +28479,9 @@
 /turf/open/floor/plating,
 /area/engine/storage)
 "bta" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/durasteel,
 /area/engine/break_room)
 "btb" = (
@@ -28429,31 +28498,30 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/break_room)
 "btc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
 /turf/open/floor/durasteel,
 /area/engine/break_room)
 "btd" = (
-/obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
-	dir = 4
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame2/port)
 "bte" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -28463,19 +28531,20 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/durasteel,
 /area/engine/break_room)
 "btf" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck2/frame2/port)
+/area/engine/engineering)
 "btg" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -28515,7 +28584,6 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
 "btl" = (
@@ -28524,12 +28592,13 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/break_room)
 "btm" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/durasteel,
 /area/engine/break_room)
 "btn" = (
@@ -28561,8 +28630,6 @@
 /turf/open/floor/monotile/steel,
 /area/engine/engineering/hangar)
 "btp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/rack,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/mineral/titanium/fifty,
@@ -28581,35 +28648,31 @@
 /area/crew_quarters/heads/chief)
 "btr" = (
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
 "bts" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+/obj/effect/turf_decal/stripes/white/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/monotile/dark,
-/area/engine/engineering)
+/area/hallway/secondary/service)
 "btt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/monotile/dark,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/monotile/steel,
 /area/engine/engineering)
 "btu" = (
 /obj/structure/cable{
@@ -28627,24 +28690,13 @@
 /turf/open/floor/monotile/dark,
 /area/security/prison)
 "btv" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
 "btw" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/durasteel,
 /area/engine/engine_smes)
 "btx" = (
@@ -28654,26 +28706,17 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
 /obj/structure/table,
 /obj/item/flashlight/lamp,
 /turf/open/floor/monotile/dark,
 /area/engine/engine_smes)
 "bty" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/engine/engine_smes)
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck2/frame2/port)
 "btz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28681,28 +28724,20 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/durasteel,
 /area/engine/storage_shared)
 "btA" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
+/turf/open/floor/durasteel/techfloor{
+	initial_gas_mix = "TEMP=2.7"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 9
-	},
-/turf/open/floor/monotile/dark,
-/area/engine/engineering)
+/area/engine/atmospherics_engine)
 "btB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
 /obj/machinery/armour_plating_nanorepair_pump/aft_port{
 	apnw_id = "pleaseSendHelp"
 	},
@@ -28731,10 +28766,10 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
 /obj/machinery/airalarm/directional/south,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
 "btE" = (
@@ -28745,8 +28780,8 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame2/port)
@@ -30505,9 +30540,6 @@
 /area/hallway/nsv/deck2/frame1/central)
 "bxv" = (
 /obj/machinery/recharge_station,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /turf/open/floor/monotile/dark,
 /area/tcommsat/computer)
 "bxw" = (
@@ -30860,11 +30892,11 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame2/port)
 "byk" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
 	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/chief)
@@ -30878,10 +30910,10 @@
 /turf/open/floor/durasteel,
 /area/engine/storage_shared)
 "bym" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
 /obj/machinery/light,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
 "byn" = (
@@ -30924,24 +30956,22 @@
 /turf/open/floor/durasteel,
 /area/engine/break_room)
 "byt" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/turf/open/floor/monotile/steel,
+/area/crew_quarters/heads/chief)
+"byu" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck2/frame2/port)
-"byu" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/durasteel,
 /area/engine/break_room)
 "byv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/turf/open/floor/durasteel,
-/area/engine/break_room)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/heads/chief)
 "byx" = (
 /obj/machinery/computer/security/qm{
 	dir = 8
@@ -31762,19 +31792,17 @@
 /turf/open/space/basic,
 /area/engine/engineering/reactor_core)
 "bAm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/armour_plating_nanorepair_pump/forward_port{
 	apnw_id = "pleaseSendHelp"
 	},
 /turf/open/floor/durasteel,
 /area/engine/engineering)
 "bAn" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/durasteel,
 /area/engine/engineering)
 "bAq" = (
@@ -31782,12 +31810,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/monotile/steel,
 /area/engine/engineering)
 "bAr" = (
@@ -31841,6 +31870,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/durasteel,
 /area/tcommsat/computer)
 "bAv" = (
@@ -31853,6 +31885,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/durasteel,
 /area/engine/break_room)
 "bAw" = (
@@ -31862,19 +31897,22 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/durasteel,
 /area/engine/break_room)
 "bAy" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
+/turf/open/floor/durasteel/techfloor{
+	initial_gas_mix = "TEMP=2.7"
 	},
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck2/frame2/port)
+/area/engine/atmos)
 "bAz" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -31910,7 +31948,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame2/port)
 "bAE" = (
@@ -34626,13 +34663,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bGe" = (
-/obj/machinery/atmospherics/pipe/manifold/green/hidden,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 5
+	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering)
 "bGf" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -34640,17 +34676,17 @@
 /area/engine/engineering)
 "bGg" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/monotile/steel,
 /area/engine/engineering)
@@ -35859,26 +35895,20 @@
 /turf/closed/wall/r_wall/ship,
 /area/hallway/secondary/exit)
 "bJb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
+/obj/effect/landmark/start/station_engineer,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/durasteel,
-/area/engine/break_room)
+/area/engine/storage_shared)
 "bJc" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/durasteel,
-/area/engine/break_room)
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/monotile/dark,
+/area/engine/engineering)
 "bJd" = (
 /obj/structure/sign/ship/medical,
 /turf/closed/wall/ship,
@@ -38248,6 +38278,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/durasteel/techfloor{
 	initial_gas_mix = "TEMP=2.7"
 	},
@@ -39323,15 +39359,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/brown/hidden{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/monotile/steel,
 /area/engine/engineering)
 "dLe" = (
@@ -39447,7 +39484,6 @@
 /turf/open/floor/monotile/steel,
 /area/engine/engineering/reactor_core)
 "dXo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -39473,6 +39509,9 @@
 	},
 /obj/machinery/camera/autoname{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
@@ -39735,6 +39774,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/durasteel/techfloor{
 	initial_gas_mix = "TEMP=2.7"
 	},
@@ -39982,6 +40024,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
 "eyX" = (
@@ -40157,11 +40202,11 @@
 /turf/open/floor/carpet/blue,
 /area/hallway/secondary/exit)
 "eIN" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
 	},
 /turf/open/floor/monotile/steel,
 /area/engine/engineering)
@@ -40728,6 +40773,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/engine/atmos)
 "fAK" = (
@@ -40978,12 +41026,9 @@
 /turf/open/floor/monotile/dark,
 /area/security/prison)
 "fTk" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/durasteel,
 /area/engine/engineering)
 "fTr" = (
@@ -41209,11 +41254,12 @@
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "gjm" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/monotile/steel,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering)
 "gjw" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -41228,9 +41274,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/light{
 	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
 	},
 /turf/open/floor/monotile/dark,
 /area/tcommsat/computer)
@@ -41396,12 +41439,6 @@
 /turf/open/floor/monotile/dark,
 /area/security/brig)
 "gvQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -42270,6 +42307,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
 "hxL" = (
@@ -42700,9 +42738,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
@@ -43385,7 +43420,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "iRB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -43590,7 +43624,8 @@
 	name = "emergency shower"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
+	dir = 8;
+	on = 0
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/engine/engine_room)
@@ -44468,9 +44503,6 @@
 	},
 /area/engine/atmos)
 "kjd" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/armour_plating_nanorepair_well{
 	apnw_id = "pleaseSendHelp"
 	},
@@ -44550,6 +44582,9 @@
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
 "kmR" = (
@@ -44609,8 +44644,12 @@
 	name = "Telecomms RC";
 	pixel_y = -30
 	},
-/obj/structure/table,
-/obj/item/folder/blue,
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
 /turf/open/floor/monotile/dark,
 /area/tcommsat/computer)
 "kpf" = (
@@ -44851,19 +44890,17 @@
 	},
 /area/tcommsat/server)
 "kDD" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/turf/open/floor/monotile/steel,
-/area/engine/engineering)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/durasteel,
+/area/engine/storage_shared)
 "kES" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 1
@@ -45901,18 +45938,17 @@
 /area/maintenance/department/medical)
 "lUM" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
-	},
-/obj/machinery/door/airlock/ship/engineering/glass{
-	req_one_access_txt = "10;24"
 	},
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
 /obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/airlock/ship/engineering/glass{
+	req_one_access_txt = "10;24"
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
 "lVx" = (
@@ -46090,6 +46126,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/durasteel/techfloor{
 	initial_gas_mix = "TEMP=2.7"
 	},
@@ -47373,9 +47412,6 @@
 	},
 /area/engine/atmos)
 "nOu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -49066,6 +49102,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "qqN" = (
@@ -49086,6 +49125,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/tile/blue,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "qrD" = (
@@ -49179,6 +49221,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/service)
 "qzh" = (
@@ -49614,9 +49659,9 @@
 /turf/open/floor/durasteel/techfloor,
 /area/nsv/weapons/fore)
 "qWB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/durasteel,
-/area/engine/storage_shared)
+/obj/machinery/atmospherics/pipe/manifold4w/green/hidden,
+/turf/open/floor/plasteel/ridged/steel,
+/area/engine/engineering)
 "qXR" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/orange{
@@ -49789,6 +49834,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
 "rix" = (
@@ -49826,14 +49874,14 @@
 /turf/open/floor/monotile/steel,
 /area/science/xenobiology)
 "rjg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
-/turf/open/floor/carpet/green,
-/area/engine/engineering/reactor_control)
+/turf/open/floor/monotile/dark/airless{
+	initial_gas_mix = "n2=100;TEMP=80";
+	name = "telecomms server floor"
+	},
+/area/tcommsat/server)
 "rjt" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/machinery/atmospherics/miner/toxins,
@@ -50554,7 +50602,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
@@ -50577,6 +50624,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/monotile/steel,
 /area/engine/atmos)
@@ -51025,6 +51075,9 @@
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
 /obj/machinery/camera/autoname{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -52502,6 +52555,9 @@
 	name = "Atmospherics Airlock";
 	req_access_txt = "24"
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating/airless,
 /area/engine/atmos)
 "uUs" = (
@@ -52996,11 +53052,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
 	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_control)
@@ -53420,10 +53476,11 @@
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
 /obj/effect/decal/remains/human,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4;
+	on = 0
+	},
 /turf/open/floor/durasteel/lino,
 /area/engine/engine_room)
 "wlb" = (
@@ -53451,9 +53508,6 @@
 "woq" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 6
 	},
 /turf/open/floor/monotile/steel,
 /area/engine/engineering)
@@ -53563,12 +53617,11 @@
 /obj/machinery/power/apc/auto_name/north{
 	pixel_y = 24
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
@@ -54287,6 +54340,9 @@
 	dir = 4
 	},
 /obj/machinery/light,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
 "xvg" = (
@@ -54574,6 +54630,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "xQR" = (
@@ -54737,9 +54799,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
 /turf/open/floor/durasteel,
 /area/engine/storage_shared)
 "yeb" = (
@@ -54809,7 +54868,8 @@
 "ykz" = (
 /obj/effect/turf_decal/delivery/red,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
+	dir = 4;
+	on = 0
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
@@ -98131,7 +98191,7 @@ hLd
 bjG
 bkF
 bkY
-bkY
+bts
 fXQ
 iuA
 ljw
@@ -98884,16 +98944,16 @@ rCt
 aRZ
 amm
 bfW
-aRN
+aOY
 bAD
-byt
-byt
-btd
-btf
-byt
-byt
+aPp
+aPp
+aPp
+bkh
+aPp
+aPp
 sdX
-bAy
+aPp
 aXr
 bkh
 nJo
@@ -99143,7 +99203,7 @@ aey
 bfP
 aSe
 aSK
-aSK
+aTe
 aTe
 aTB
 aWi
@@ -99152,14 +99212,14 @@ aWi
 aWi
 aWi
 aWi
-aWi
-aWi
-aWi
+bty
+aPF
+aPF
 aii
-qEO
-duz
-duz
-duz
+bdb
+bdb
+bdb
+bdb
 api
 qEO
 for
@@ -99401,7 +99461,7 @@ aoP
 aUQ
 btE
 aVc
-aPr
+aBJ
 aXq
 aVf
 aBJ
@@ -99409,7 +99469,7 @@ aBJ
 aBJ
 aBJ
 aBJ
-aBJ
+btd
 aBJ
 aBJ
 iuA
@@ -99424,7 +99484,7 @@ ljw
 ljw
 apV
 bjI
-bna
+btA
 hsX
 aml
 aml
@@ -99658,7 +99718,7 @@ arW
 arW
 tuz
 afk
-aPz
+aPM
 aNd
 ltR
 arW
@@ -99681,7 +99741,7 @@ any
 bAH
 aml
 rhe
-vfz
+bAy
 bxE
 aml
 npw
@@ -99938,7 +99998,7 @@ aml
 aml
 jpj
 rhe
-vfz
+bAy
 bsG
 bkf
 vse
@@ -100153,13 +100213,13 @@ aeu
 asL
 anS
 aqe
-aqe
+byv
 aSk
-aSp
+byt
 anp
 apD
 ayN
-aLe
+aAT
 aAT
 aQz
 amD
@@ -100172,7 +100232,7 @@ bfR
 aBH
 aBH
 btc
-aPB
+aBH
 bte
 bys
 bys
@@ -100194,8 +100254,8 @@ fAz
 atZ
 sIU
 uTH
-vfz
-vfz
+azc
+aBz
 wYJ
 kHI
 rbT
@@ -100426,10 +100486,10 @@ aAD
 aBp
 aey
 ast
-aEc
-aEc
-bJb
-bJc
+aBH
+aBH
+btc
+aBH
 bAv
 aBH
 aPH
@@ -100685,7 +100745,7 @@ aey
 asu
 aBH
 byu
-byv
+btc
 aNa
 bAv
 aBH
@@ -100923,14 +100983,14 @@ bJh
 vtk
 asL
 apU
-aqe
+aHw
 ayU
 aqe
 hhQ
 anp
 anQ
 aQE
-bty
+anQ
 anQ
 anQ
 amD
@@ -100941,9 +101001,9 @@ aQU
 aey
 bfY
 aBH
-aBH
+bta
 btc
-aPC
+aBH
 bAv
 aBH
 bkk
@@ -101180,15 +101240,15 @@ bJh
 iCG
 asL
 aqa
-aqe
-azc
+azx
+aOq
 aOq
 byk
-aQK
+aSi
 btp
 aph
 ayW
-iRB
+btf
 iRB
 dXo
 aIB
@@ -101198,9 +101258,9 @@ btj
 lUM
 btl
 btm
-btm
+aaN
 aPK
-bta
+aBH
 bAw
 aOc
 aPI
@@ -101446,7 +101506,7 @@ aza
 aQP
 aRb
 aTU
-aTU
+btt
 hxF
 aXb
 aXp
@@ -101455,7 +101515,7 @@ aNu
 bad
 aOX
 aPq
-aPq
+aPz
 aPD
 aql
 aqm
@@ -101699,10 +101759,10 @@ aSi
 aSi
 aSi
 aSi
-aAJ
-aQH
-bhy
 avc
+aQH
+avc
+aAJ
 aCd
 aey
 aQW
@@ -102203,7 +102263,7 @@ aQD
 amx
 vFu
 saB
-gjm
+saB
 bhn
 eIN
 saB
@@ -102212,10 +102272,10 @@ aqb
 aAU
 apd
 btr
-bts
+aBy
 aBy
 aAx
-btA
+aBy
 btD
 amC
 asr
@@ -102464,13 +102524,13 @@ wpa
 aJq
 mnp
 mnp
-kDD
+mnp
 aso
 aQJ
-btt
+hCr
 bAm
-bAn
-aBz
+aBw
+aBw
 aHN
 btB
 aQV
@@ -102726,8 +102786,8 @@ bGf
 bGg
 avQ
 aAw
-aHw
-aIi
+aAw
+aAw
 aQL
 aBw
 xuZ
@@ -102990,7 +103050,7 @@ aBw
 kmy
 amC
 aRa
-qWB
+azl
 aCS
 yea
 aQX
@@ -103235,20 +103295,20 @@ iVI
 amA
 jrd
 gVX
-bGe
-aQF
+qWB
+bhy
 bAq
-hCr
-aBw
+bJc
 fTk
-aMC
-aQO
+fTk
+aEc
+bAn
 aBw
 aQV
 amC
 bfN
 biS
-aBB
+kDD
 azl
 aOa
 amz
@@ -103497,15 +103557,15 @@ aAV
 bAr
 hCr
 aAi
-aaN
+aBw
 aMC
-aQO
+aRN
 uTq
 dXJ
 amC
 ajJ
-biS
-aBB
+bJb
+aQK
 azl
 aQY
 amz
@@ -104004,7 +104064,7 @@ ixq
 ixq
 ixq
 ixq
-ixq
+gjm
 afz
 ixq
 tXv
@@ -104023,8 +104083,8 @@ aBE
 ayJ
 ayJ
 ayJ
-azZ
-aCt
+aPB
+rjg
 aCY
 azZ
 aDp
@@ -104281,7 +104341,7 @@ aBS
 pmq
 ayJ
 aAE
-aCt
+azZ
 aCZ
 kDz
 bHg
@@ -104525,7 +104585,7 @@ aQq
 btn
 ayJ
 amB
-rjg
+aQv
 jSc
 apr
 aRc
@@ -104538,7 +104598,7 @@ aBS
 pmq
 ayJ
 azZ
-aCt
+azZ
 aDa
 azZ
 aDp
@@ -104783,19 +104843,19 @@ lZG
 ayJ
 ayV
 asy
-jSc
+aIi
 aQQ
-aRc
+aLe
 rpx
 oYN
 aBS
-azx
+aBS
 vHF
 oAa
 eni
 ayJ
 aBm
-aCt
+azZ
 aDb
 azZ
 azZ
@@ -105047,12 +105107,12 @@ pjU
 ayJ
 owl
 aBS
-aBS
+aPr
 aBF
 pmq
 ayJ
 aBD
-aCt
+azZ
 azZ
 azZ
 azZ
@@ -105314,7 +105374,7 @@ aDc
 aDi
 aDr
 aDW
-aPF
+azZ
 aRj
 amz
 amz

--- a/_maps/map_files/Tycoon/Tycoon2.dmm
+++ b/_maps/map_files/Tycoon/Tycoon2.dmm
@@ -332,12 +332,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
 "aaU" = (
@@ -681,9 +679,19 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
 "abW" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/landmark/latejoin,
-/turf/open/floor/carpet/ship,
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/box,
+/obj/machinery/camera/autoname{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "abX" = (
 /obj/structure/rack,
@@ -2529,8 +2537,15 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
 "agw" = (
@@ -3344,13 +3359,13 @@
 /turf/open/floor/durasteel/lino,
 /area/engine/engineering/reactor_control)
 "aiB" = (
-/obj/machinery/airalarm{
-	pixel_y = 26
+/obj/item/kirbyplants{
+	icon_state = "plant-21"
 	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/monotile/dark,
-/area/lawoffice)
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/monotile/steel,
+/area/crew_quarters/dorms)
 "aiE" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible,
 /obj/structure/cable{
@@ -3375,7 +3390,6 @@
 "aiJ" = (
 /obj/machinery/camera/autoname,
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/latejoin,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms)
 "aiK" = (
@@ -3409,6 +3423,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
+	req_one_access_txt = "0"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aiQ" = (
@@ -3645,6 +3664,12 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
 	},
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
@@ -4256,9 +4281,14 @@
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo)
 "alk" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/monotile/dark,
-/area/lawoffice)
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/monotile/steel,
+/area/crew_quarters/dorms)
 "all" = (
 /obj/structure/closet/secure_closet/CMO,
 /obj/machinery/computer/security/telescreen/cmo{
@@ -4637,8 +4667,16 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame2/port)
 "amq" = (
-/turf/closed/wall/ship,
-/area/lawoffice)
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/monotile/steel,
+/area/crew_quarters/dorms)
 "ams" = (
 /turf/closed/wall/ship,
 /area/crew_quarters/dorms/nsv/dorms_1)
@@ -4841,13 +4879,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
 "anm" = (
@@ -4869,26 +4905,28 @@
 /turf/closed/wall/r_wall/ship,
 /area/crew_quarters/heads/chief)
 "anr" = (
-/obj/structure/sign/nanotrasen{
-	pixel_y = 26
-	},
-/turf/open/floor/monotile/dark,
-/area/lawoffice)
-"ans" = (
+/obj/structure/closet/emcloset/anchored,
+/obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/monotile/steel,
+/area/crew_quarters/dorms)
+"ans" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
+"ant" = (
+/obj/machinery/vending/tool,
 /obj/effect/turf_decal/tile/neutral,
-/obj/structure/sign/nanotrasen{
-	pixel_y = 26
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
-"ant" = (
-/obj/structure/chair/fancy,
-/obj/machinery/computer/ship/viewscreen,
-/turf/open/floor/monotile/dark,
-/area/lawoffice)
 "anu" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess,
@@ -4902,42 +4940,30 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "anv" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching Prison Wing holding areas.";
-	name = "Prison Monitor";
-	network = list("prison");
-	pixel_y = 26
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/monotile/dark,
-/area/lawoffice)
+/turf/open/floor/monotile/steel,
+/area/crew_quarters/dorms)
 "anw" = (
-/obj/machinery/newscaster{
-	pixel_y = 28
+/obj/structure/closet/firecloset,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/camera/autoname,
-/turf/open/floor/monotile/dark,
-/area/lawoffice)
+/turf/open/floor/monotile/steel,
+/area/crew_quarters/dorms)
 "anx" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/brown/hidden,
 /turf/open/floor/monotile/steel,
 /area/engine/engineering/hangar)
 "any" = (
-/obj/machinery/photocopier,
-/obj/machinery/power/apc/auto_name/north{
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/monotile/dark,
-/area/lawoffice)
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/plating,
+/area/maintenance/department/engine/atmos)
 "anz" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -4948,8 +4974,9 @@
 /turf/open/floor/monotile/steel,
 /area/engine/engineering/reactor_core)
 "anA" = (
-/turf/open/floor/monotile/dark,
-/area/lawoffice)
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "anB" = (
 /obj/machinery/power/apc/auto_name/north{
 	pixel_y = 24
@@ -4966,8 +4993,9 @@
 /turf/open/floor/monotile/light,
 /area/crew_quarters/dorms/nsv/dorms_1)
 "anD" = (
-/turf/open/floor/carpet/blue,
-/area/lawoffice)
+/obj/structure/table,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "anG" = (
 /obj/machinery/computer/station_alert{
 	dir = 4
@@ -5806,17 +5834,24 @@
 /turf/open/floor/monotile/light,
 /area/crew_quarters/kitchen)
 "aqD" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck2/frame2/port)
+"aqE" = (
 /obj/machinery/cryopod{
 	dir = 4
 	},
-/obj/machinery/computer/cryopod{
-	pixel_y = 32
-	},
-/turf/open/floor/durasteel/eris_techfloor_alt,
-/area/crew_quarters/dorms)
-"aqE" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/box,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "aqF" = (
@@ -5833,8 +5868,9 @@
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/fitness/recreation)
 "aqH" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/effect/turf_decal/box,
+/obj/machinery/cryopod{
+	dir = 8
+	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "aqI" = (
@@ -5915,23 +5951,24 @@
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
 "aqP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/monotile/dark,
-/area/hallway/nsv/deck2/frame1/central)
+/area/crew_quarters/dorms)
 "aqQ" = (
-/obj/machinery/cryopod{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/durasteel/eris_techfloor_alt,
-/area/crew_quarters/dorms)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/lootdrop/crate_spawner,
+/turf/open/floor/plating,
+/area/maintenance/department/engine/atmos)
 "aqR" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets,
@@ -6164,17 +6201,17 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
 "arm" = (
-/obj/item/kirbyplants/random,
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/box,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/machinery/requests_console{
-	department = "Law office";
-	payment_department = "SEC";
-	pixel_y = -32
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/turf/open/floor/monotile/dark,
-/area/lawoffice)
+/turf/open/floor/monotile/steel,
+/area/crew_quarters/dorms)
 "arn" = (
 /obj/structure/table/wood,
 /obj/structure/cable{
@@ -6187,20 +6224,18 @@
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/nsv/observation)
 "aro" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/box,
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/dorms)
-"arp" = (
-/obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/computer/warrant{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/turf/open/floor/monotile/dark,
-/area/lawoffice)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/closed/wall/ship,
+/area/crew_quarters/dorms)
+"arp" = (
+/obj/structure/closet/crate,
+/turf/open/floor/plating,
+/area/maintenance/department/engine/atmos)
 "arq" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/atmospherics,
@@ -6254,8 +6289,9 @@
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/theatre)
 "arv" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/effect/turf_decal/box,
+/obj/machinery/cryopod{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "arw" = (
@@ -6310,8 +6346,16 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/dorms)
 "arB" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/box,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Crew Lounge"
+	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "arE" = (
@@ -6385,12 +6429,15 @@
 /turf/open/floor/plating,
 /area/engine/storage)
 "asc" = (
-/obj/structure/chair{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/carpet/blue,
-/area/lawoffice)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck2/frame1/central)
 "asd" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -6399,8 +6446,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "asf" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/box,
+/obj/machinery/cryopod{
+	dir = 4
+	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "asg" = (
@@ -6414,13 +6462,12 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "ash" = (
-/obj/structure/table/glass,
-/obj/machinery/fax{
-	fax_name = "Law Office";
-	name = "Law Office Fax Machine"
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/carpet/blue,
-/area/lawoffice)
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "asn" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/AI,
@@ -6524,14 +6571,14 @@
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms)
 "asx" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Public Storage"
-	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Cryopod"
+	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "asy" = (
@@ -6683,21 +6730,25 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/camera/autoname,
-/obj/structure/sign/nanotrasen{
-	pixel_y = 26
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/newscaster{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=loc6";
+	location = "loc5"
 	},
 /turf/open/floor/monotile/steel,
-/area/crew_quarters/dorms)
+/area/hallway/nsv/deck2/frame1/central)
 "ate" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/monotile/dark,
-/area/lawoffice)
+/obj/effect/landmark/latejoin,
+/turf/open/floor/monotile/steel,
+/area/crew_quarters/dorms)
 "atf" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -6886,8 +6937,12 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
 "atG" = (
+/obj/effect/turf_decal/box,
+/obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/tile/neutral,
-/obj/structure/reagent_dispensers/water_cooler,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "atH" = (
@@ -6979,9 +7034,16 @@
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms/nsv/dorms_1)
 "aui" = (
-/obj/machinery/computer/lore_terminal,
-/turf/open/floor/monotile/dark,
-/area/lawoffice)
+/obj/structure/closet/firecloset,
+/obj/machinery/newscaster{
+	pixel_y = 33
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/monotile/steel,
+/area/crew_quarters/dorms)
 "auj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -7173,22 +7235,25 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "auO" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/vending/snack/random,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/open/floor/monotile/steel,
-/area/crew_quarters/dorms)
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "auP" = (
+/obj/effect/turf_decal/box,
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
-	},
-/obj/machinery/vending/cigarette{
-	name = "Adama's Finest Cigars"
 	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
@@ -7254,10 +7319,17 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/monotile/steel,
+/turf/closed/wall/ship,
 /area/crew_quarters/dorms)
 "auX" = (
-/obj/structure/chair/stool,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/airlock/ship{
+	name = "Public Tool Storage"
+	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "auY" = (
@@ -7342,38 +7414,38 @@
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "avg" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Crew Lounge"
+/obj/item/kirbyplants{
+	icon_state = "plant-21"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/monotile/steel,
-/area/crew_quarters/dorms)
-"avh" = (
-/obj/structure/table/reinforced,
-/obj/item/folder,
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/dorms)
-"avi" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/monotile/steel,
+/area/crew_quarters/dorms)
+"avh" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 4
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/frame1/central)
+"avi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/monotile/steel,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
 "avk" = (
 /obj/structure/table,
@@ -7394,12 +7466,10 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck2)
 "avn" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/lawoffice)
+/obj/structure/table,
+/obj/item/storage/toolbox/electrical,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "avp" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -7624,6 +7694,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "axa" = (
@@ -7649,14 +7725,11 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck2)
 "axi" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=loc7";
+	location = "loc6"
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/monotile/steel,
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "axs" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/carbon_output{
@@ -8034,9 +8107,9 @@
 /turf/open/floor/carpet/red,
 /area/security/detectives_office)
 "azj" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "azk" = (
@@ -8243,6 +8316,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/durasteel/techfloor{
 	initial_gas_mix = "TEMP=2.7"
 	},
@@ -8355,9 +8429,11 @@
 	name = "Munitions Projects"
 	})
 "aAh" = (
-/obj/structure/table/reinforced,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
 	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
@@ -9766,10 +9842,16 @@
 /turf/open/floor/monotile/dark,
 /area/tcommsat/computer)
 "aDZ" = (
-/obj/structure/chair/stool,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/airlock/ship{
+	name = "Public Tool Storage"
+	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "aEa" = (
@@ -10877,10 +10959,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=loc9";
-	location = "loc8"
-	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "aGs" = (
@@ -11322,18 +11400,11 @@
 /turf/open/floor/carpet/red,
 /area/security/detectives_office)
 "aHo" = (
-/obj/structure/table/glass,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/item/pen,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/item/stamp/law,
-/turf/open/floor/carpet/blue,
-/area/lawoffice)
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/frame1/central)
 "aHp" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -12629,14 +12700,19 @@
 /turf/open/floor/durasteel/techfloor,
 /area/nsv/weapons/fore)
 "aKE" = (
-/obj/structure/chair/stool,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/monotile/dark,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "aKF" = (
 /obj/machinery/modular_fabricator/exosuit_fab,
@@ -12862,7 +12938,15 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "aLe" = (
@@ -13508,7 +13592,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/latejoin,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms)
 "aMC" = (
@@ -13609,6 +13692,12 @@
 	pixel_x = -2;
 	pixel_y = 3
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "aML" = (
@@ -13636,7 +13725,12 @@
 /area/nsv/weapons/fore)
 "aMN" = (
 /obj/item/paicard,
-/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "aMP" = (
@@ -14342,17 +14436,12 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "aOn" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/machinery/camera/autoname{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/monotile/steel,
-/area/crew_quarters/dorms)
+/obj/structure/munitions_trolley,
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
 "aOo" = (
 /obj/structure/table/reinforced,
 /obj/item/stamp/denied{
@@ -14384,6 +14473,12 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
@@ -14489,11 +14584,15 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/port)
 "aOI" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Crew Lounge"
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame2/port)
 "aOJ" = (
 /obj/structure/cable{
@@ -14678,12 +14777,15 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 4;
-	sortType = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame2/port)
 "aPa" = (
@@ -14839,10 +14941,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4;
 	sortType = 16
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame2/port)
@@ -14895,18 +14999,12 @@
 	},
 /area/engine/atmos)
 "aPv" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/turf/open/floor/monotile/dark,
-/area/hallway/nsv/deck2/frame2/port)
+/obj/structure/rack,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
 "aPw" = (
 /obj/structure/grille,
 /obj/structure/barricade/wooden/crude,
@@ -15578,16 +15676,14 @@
 /turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
 "aRk" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Ship's Attorney";
-	req_one_access_txt = "38"
+/obj/structure/chair/stool{
+	pixel_y = 8
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
-/area/lawoffice)
+/area/crew_quarters/dorms)
 "aRl" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -15802,7 +15898,7 @@
 /area/crew_quarters/fitness/recreation)
 "aRK" = (
 /obj/machinery/door/airlock/ship/public/glass{
-	name = "Public Storage"
+	name = "Cryopod"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -15872,13 +15968,13 @@
 /turf/open/floor/carpet/ship,
 /area/quartermaster/qm)
 "aRR" = (
-/obj/structure/closet/wardrobe/black,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/vending/snack/random,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "aRS" = (
@@ -15902,10 +15998,10 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "aRU" = (
-/obj/machinery/light,
-/obj/machinery/holopad,
+/obj/structure/table,
+/obj/item/storage/toolbox/emergency,
 /turf/open/floor/monotile/dark,
-/area/lawoffice)
+/area/crew_quarters/dorms)
 "aRV" = (
 /obj/machinery/vending/clothing,
 /obj/effect/turf_decal/tile/neutral{
@@ -15939,6 +16035,7 @@
 /area/crew_quarters/dorms)
 "aRY" = (
 /obj/machinery/light,
+/obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "aRZ" = (
@@ -15956,29 +16053,44 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/hos)
 "aSb" = (
-/obj/structure/rack,
-/obj/item/storage/secure/briefcase{
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/obj/item/storage/briefcase{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/clothing/glasses/sunglasses/advanced/big,
-/obj/item/clothing/glasses/sunglasses/advanced,
-/turf/open/floor/monotile/dark,
-/area/lawoffice)
-"aSc" = (
-/obj/structure/chair{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/turf/open/floor/carpet/blue,
-/area/lawoffice)
-"aSd" = (
-/obj/structure/filingcabinet/employment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	dir = 10
+	},
+/turf/open/floor/monotile/steel,
+/area/crew_quarters/dorms)
+"aSc" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical,
 /turf/open/floor/monotile/dark,
-/area/lawoffice)
+/area/crew_quarters/dorms)
+"aSd" = (
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Crew Lounge"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "aSe" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -15996,9 +16108,10 @@
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame2/port)
 "aSf" = (
-/obj/machinery/vending/wardrobe/law_wardrobe,
-/turf/open/floor/monotile/dark,
-/area/lawoffice)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/effect/landmark/latejoin,
+/turf/open/floor/monotile/steel,
+/area/crew_quarters/dorms)
 "aSh" = (
 /obj/structure/sign/directions/engineering{
 	dir = 4
@@ -18087,6 +18200,9 @@
 	dir = 4;
 	layer = 2.9
 	},
+/obj/machinery/camera/autoname{
+	dir = 6
+	},
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "aXm" = (
@@ -19020,8 +19136,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "aZx" = (
@@ -19030,104 +19148,162 @@
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "aZy" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/carpet/blue,
-/area/lawoffice)
+/obj/structure/table,
+/obj/item/clothing/gloves/color/fyellow/old,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "aZz" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
-/area/lawoffice)
+/area/hallway/nsv/deck2/frame1/central)
 "aZA" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=loc9";
+	location = "loc8"
 	},
-/turf/open/floor/plating,
-/area/lawoffice)
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "aZB" = (
+/obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
 /turf/open/floor/monotile/steel,
-/area/crew_quarters/dorms)
+/area/hallway/nsv/deck2/frame2/port)
 "aZC" = (
-/obj/structure/chair/stool,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/landmark/patrol_node{
+	id = "tycoon_dorms";
+	next_id = "tycoon_engi"
 	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "aZD" = (
-/obj/structure/table/reinforced,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/box,
+/obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/turf/open/floor/monotile/dark,
+/turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "aZE" = (
-/obj/structure/table/reinforced,
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/turf/open/floor/monotile/dark,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "aZF" = (
-/obj/structure/chair/stool,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/monotile/dark,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "aZG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/dorms)
-"aZH" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/monotile/steel,
+/area/crew_quarters/dorms)
+"aZH" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "aZI" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Crew Lounge"
 	},
-/turf/open/floor/plating,
-/area/crew_quarters/dorms)
-"aZJ" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/monotile/steel,
+/area/crew_quarters/dorms)
+"aZJ" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/junction/flip{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "aZK" = (
@@ -21682,10 +21858,14 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
@@ -22181,7 +22361,11 @@
 /turf/open/floor/monotile/dark,
 /area/engine/break_room)
 "bfS" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "bfT" = (
@@ -22207,6 +22391,9 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame2/port)
 "bfW" = (
@@ -22330,6 +22517,7 @@
 	pixel_y = 24
 	},
 /obj/machinery/camera/autoname,
+/obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "bgl" = (
@@ -22661,12 +22849,9 @@
 /turf/open/floor/monotile/dark,
 /area/security/brig)
 "bgW" = (
+/obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/light{
-	dir = 8
 	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
@@ -22881,6 +23066,9 @@
 	},
 /obj/machinery/light,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/vending/cigarette{
+	name = "Adama's Finest Cigars"
+	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "bhB" = (
@@ -23427,12 +23615,14 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "biL" = (
-/obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
-	dir = 8
+	dir = 4
 	},
-/obj/machinery/status_display/evac{
-	pixel_y = 26
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame2/port)
@@ -24044,7 +24234,12 @@
 	pixel_y = 7
 	},
 /obj/item/pen,
-/obj/effect/landmark/nuclear_waste_spawner,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "bkc" = (
@@ -25584,13 +25779,17 @@
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/warehouse)
 "bnw" = (
-/obj/machinery/camera/autoname{
-	dir = 4
+/obj/structure/chair/stool{
+	pixel_y = 8
 	},
-/turf/open/floor/durasteel/techfloor{
-	initial_gas_mix = "TEMP=2.7"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
 	},
-/area/engine/atmos)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "bnx" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-10"
@@ -25600,6 +25799,9 @@
 "bnz" = (
 /obj/effect/spawner/lootdrop,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "bnA" = (
@@ -25722,6 +25924,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
@@ -27224,6 +27429,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "bqW" = (
@@ -28574,39 +28785,29 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "btG" = (
-/obj/structure/chair/stool,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/dorms)
+/obj/effect/spawner/lootdrop/crate_spawner,
+/turf/open/floor/plating,
+/area/maintenance/department/engine/atmos)
 "btH" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/dorms)
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/frame1/central)
 "btI" = (
-/obj/structure/table/reinforced,
-/obj/item/folder,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -28614,56 +28815,34 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/monotile/dark,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "btJ" = (
-/obj/structure/chair/stool,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "btK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "btL" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "btM" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "btN" = (
@@ -28693,24 +28872,14 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "btR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "btS" = (
@@ -28759,26 +28928,11 @@
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms/nsv/dorms_2)
 "btW" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Crew Lounge"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/monotile/steel,
+/obj/effect/landmark/latejoin,
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "btX" = (
 /obj/structure/cable{
@@ -28827,18 +28981,9 @@
 /turf/open/floor/monotile/dark,
 /area/security/prison)
 "bua" = (
+/obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/disposalpipe/junction/flip{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
@@ -30771,12 +30916,8 @@
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
 "byn" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/monotile/steel,
+/turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame2/port)
 "byo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -31391,6 +31532,9 @@
 /area/science)
 "bzB" = (
 /obj/structure/closet/emcloset/anchored,
+/obj/machinery/camera/autoname{
+	dir = 6
+	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "bzC" = (
@@ -31801,13 +31945,11 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame2/port)
 "bAE" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck2/frame2/port)
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "bAF" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -31837,24 +31979,12 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "bAG" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/monotile/steel,
+/turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame2/port)
 "bAH" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/dorms)
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/maintenance/department/engine/atmos)
 "bAI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -31885,9 +32015,6 @@
 /obj/item/storage/briefcase{
 	pixel_x = 4;
 	pixel_y = -2
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
 	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
@@ -31932,18 +32059,8 @@
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms)
 "bAO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/landmark/patrol_node{
-	id = "tycoon_dorms";
-	next_id = "tycoon_engi"
+/obj/machinery/firealarm{
+	pixel_y = 24
 	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
@@ -34589,7 +34706,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/machinery/computer/ship/viewscreen,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/steel,
@@ -34673,6 +34789,12 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
@@ -38893,14 +39015,16 @@
 /turf/open/space/basic,
 /area/engine/atmos)
 "dmA" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=loc7";
-	location = "loc6"
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/box,
+/obj/machinery/camera/autoname{
+	dir = 5
 	},
-/turf/open/floor/monotile/dark,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "dmM" = (
 /obj/structure/disposalpipe/sorting/mail{
@@ -39106,6 +39230,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 26
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "dHV" = (
@@ -39260,18 +39385,9 @@
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "dTk" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Crew Lounge"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/dorms)
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating,
+/area/maintenance/department/engine/atmos)
 "dTo" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
@@ -39502,6 +39618,12 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
 	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -40926,6 +41048,12 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "gbA" = (
@@ -41328,6 +41456,11 @@
 /obj/machinery/light/small,
 /turf/open/floor/engine/n2,
 /area/engine/atmos)
+"gEl" = (
+/obj/effect/landmark/latejoin,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "gFl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -44146,14 +44279,18 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
 "keK" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/box,
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/effect/landmark/latejoin,
-/turf/open/floor/carpet/ship,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "keO" = (
 /turf/open/floor/plating,
@@ -46234,21 +46371,10 @@
 /turf/open/floor/carpet/blue,
 /area/quartermaster/qm)
 "mIL" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=loc6";
-	location = "loc5"
-	},
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck2/frame1/central)
+/obj/structure/table,
+/obj/item/clothing/ears/earmuffs,
+/turf/open/floor/plating,
+/area/maintenance/department/engine/atmos)
 "mIN" = (
 /obj/machinery/atmospherics/pipe/simple/dark/hidden{
 	dir = 4
@@ -49453,6 +49579,12 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "rhe" = (
@@ -51611,6 +51743,10 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/medical/chemistry)
+"tVL" = (
+/obj/effect/landmark/latejoin,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "tVW" = (
 /obj/machinery/light{
 	dir = 4
@@ -52111,12 +52247,9 @@
 /turf/open/floor/monotile/dark,
 /area/science/nanite)
 "uOT" = (
-/obj/structure/table/glass,
-/obj/item/computer_hardware/hard_drive/role/lawyer,
-/obj/item/taperecorder,
-/obj/item/reagent_containers/food/drinks/solgovcup,
-/turf/open/floor/carpet/blue,
-/area/lawoffice)
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "uOY" = (
 /obj/structure/closet/crate{
 	opened = 1
@@ -52544,18 +52677,11 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/hangar)
 "vwu" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck2/frame1/central)
+/area/crew_quarters/dorms)
 "vyU" = (
 /obj/effect/turf_decal/tile/orange,
 /obj/effect/turf_decal/tile/orange{
@@ -92086,9 +92212,9 @@ xSZ
 bvD
 alJ
 acg
-vwu
+bgX
 acg
-acg
+btH
 acg
 caX
 ako
@@ -92345,13 +92471,13 @@ aou
 aak
 aaT
 aak
-aak
+asc
 aak
 caY
 aak
 agu
 ank
-aFx
+aZz
 aFx
 aFx
 aFx
@@ -92605,11 +92731,11 @@ acn
 acn
 acn
 caX
-abk
+avh
 avi
-aqP
-mIL
-rXW
+abk
+abk
+atd
 acn
 amj
 aOV
@@ -92854,18 +92980,18 @@ ams
 bIg
 aRr
 aRr
-amq
-amq
-amq
-amq
-amq
-amq
 ami
 ami
-avg
+ami
+ami
+ami
+ami
+ami
+ami
+ami
 aZI
-btW
-ami
+aqz
+arB
 ami
 amm
 buO
@@ -93111,21 +93237,21 @@ ams
 bhI
 aRy
 aRz
-amq
+ami
 aiB
 alk
-alk
+aZD
 arm
-amq
+dmA
 atG
 bgW
 auW
 aZJ
-bua
-azW
+btQ
+aGr
 aOm
-amm
-biL
+bHn
+amp
 aOW
 aMH
 abd
@@ -93368,20 +93494,20 @@ ams
 aRt
 aRz
 aRz
-amq
+ami
 anr
-anD
-anD
-arp
-amq
-ans
 aqF
 aqF
-aZG
-bAO
+aqF
+aqF
 aqF
 aRO
-bHn
+aqz
+btI
+aqF
+aqF
+aRO
+amn
 bfV
 aOY
 aMH
@@ -93408,7 +93534,7 @@ apZ
 aqO
 aaY
 aAk
-bKR
+aHo
 bJI
 aad
 acj
@@ -93625,19 +93751,19 @@ ams
 aRq
 aRA
 aRq
-amq
+ami
 aui
-uOT
-asc
-ate
+aqF
+anD
+anD
 avn
-axi
-azj
+aqF
+aRO
 aDZ
 aKE
-btG
+btL
 azj
-aOn
+aRO
 aOI
 bAG
 aOZ
@@ -93678,8 +93804,8 @@ acj
 ajw
 ack
 atB
-ack
-ack
+aOn
+aPv
 ack
 ack
 ajs
@@ -93882,21 +94008,21 @@ ams
 aSv
 aYQ
 aRx
-amq
+ami
 ant
-ash
+aqF
 aSc
-anA
-aRk
-auN
-auX
-avh
-aAh
-btH
-auX
+aqF
+aqF
+aqF
 aRO
+aqz
+aZE
+ayT
+aZC
+aSb
 amn
-amp
+bAG
 aOY
 aMH
 abd
@@ -93944,8 +94070,8 @@ wvu
 aim
 bsh
 aim
-aNP
-aim
+ash
+uOT
 aim
 aim
 aim
@@ -94139,20 +94265,20 @@ ams
 aRw
 btV
 aRB
-amq
+ami
 anv
-aHo
+aqF
 aZy
-aZz
-aZA
-aZB
-aZC
-aZD
-aZE
-btI
-auX
+aqF
+aqF
+aqF
 aRO
-amn
+aqz
+aZE
+aqF
+aqF
+aRO
+aOI
 byn
 aPi
 bkj
@@ -94396,21 +94522,21 @@ ams
 auZ
 btS
 aRB
-amq
+ami
 anw
-anD
+aqF
 anD
 aRU
-amq
-atd
+anD
 aqF
+aRO
 auX
 aZF
-btJ
+aqF
 aqF
 aRO
 amn
-amp
+aZB
 aOY
 aMH
 abd
@@ -94653,15 +94779,15 @@ ams
 bhJ
 btT
 vew
-amq
-any
-aSb
-aSd
-aSf
-amq
-auO
+ami
+anr
 aqF
 aqF
+aqF
+aqF
+aqF
+aRO
+aqz
 aZG
 btK
 aqF
@@ -94910,17 +95036,17 @@ ams
 aRq
 bAM
 aRq
+ami
+avg
 amq
-amq
-amq
-amq
-amq
+keK
+abW
 amq
 auP
-avd
-avd
+bua
+aro
 aZH
-btM
+avd
 avd
 aRP
 amm
@@ -94961,7 +95087,7 @@ xGc
 adr
 acj
 aOr
-aim
+anA
 aih
 aih
 aih
@@ -95168,17 +95294,17 @@ lAs
 atz
 aoe
 ami
-aqD
-aqQ
-aqQ
-aqQ
 ami
 ami
 ami
-dTk
-aZI
+ami
+ami
+ami
+ami
+ami
+aSd
+aqz
 giC
-ami
 ami
 amm
 aPy
@@ -95218,7 +95344,7 @@ iFi
 bqB
 acj
 awT
-aim
+blz
 aih
 eLm
 eLm
@@ -95426,16 +95552,16 @@ mXe
 ahe
 eot
 aiJ
-abW
-abW
-abW
+aln
+aln
+aln
 eot
 ayG
 azW
 aGr
 aLd
 btQ
-azW
+aGr
 aOm
 amm
 bIz
@@ -95682,16 +95808,16 @@ auR
 bAN
 aLZ
 jZR
-keK
-keK
+afT
+afT
 aMB
-keK
+afT
 fTr
 aZo
 aZw
 bhF
 btF
-dmA
+ful
 ful
 bhA
 ntS
@@ -95727,10 +95853,10 @@ abr
 bpO
 bqE
 bGr
+gcf
 aiP
-aiP
-aiP
-aiP
+gcf
+gcf
 rge
 aim
 aih
@@ -95945,15 +96071,15 @@ ami
 ami
 ami
 aZp
-avf
+aRk
 avk
-avf
+bnw
 btR
-aqF
+btK
 aRR
 amn
-byn
-aPi
+amp
+aOZ
 aMH
 acR
 aks
@@ -96197,16 +96323,16 @@ bAI
 haf
 ami
 aqE
-aro
-arB
+asf
+aqE
 asf
 ami
 aZu
-aqF
+aZA
 avf
+aqP
 aqF
-btR
-aqF
+axi
 aRS
 amn
 amp
@@ -96250,7 +96376,7 @@ eLm
 boW
 aih
 ljw
-ljw
+mIL
 aih
 azN
 aim
@@ -96454,15 +96580,15 @@ tIg
 mOp
 ami
 dHB
-art
+aSf
 bfS
-aRM
+vwu
 aRK
 aZv
 aZx
 aZx
-aZx
-btL
+btJ
+aqF
 aqF
 aRT
 amn
@@ -96496,8 +96622,8 @@ aMy
 aVC
 abr
 wpd
-wpd
-bob
+aim
+auO
 aim
 aih
 eLm
@@ -96711,15 +96837,15 @@ hvH
 xYh
 ami
 bgk
-ayT
-art
+tVL
+btM
 aRY
 aqz
 bhG
 aqF
 aqF
-avf
-btR
+btU
+aqF
 aqF
 bjZ
 amn
@@ -96763,7 +96889,7 @@ eLm
 eLm
 eLm
 aih
-ljw
+btG
 ljw
 aih
 azX
@@ -96967,16 +97093,16 @@ auD
 hvH
 dyj
 ami
-aqF
-art
-aqF
-art
+gEl
+ate
+btW
+ate
 asx
 auN
 aqF
 avf
 bkb
-btU
+avf
 aqF
 aRV
 amn
@@ -97020,7 +97146,7 @@ aih
 aih
 aih
 aih
-ljw
+arp
 ljw
 aih
 aih
@@ -97230,16 +97356,16 @@ aqH
 arv
 ami
 bfU
-aqF
+bAO
 avf
 aMK
-btU
+avf
 aqF
 aRW
 amn
 amp
-aOY
-aMH
+aqD
+biL
 aeL
 ajK
 apS
@@ -97490,7 +97616,7 @@ auS
 aqF
 avf
 aMN
-btU
+avf
 aqF
 aRW
 amn
@@ -97746,13 +97872,13 @@ ami
 bfq
 aqF
 aqF
-avf
-btR
+btU
+aqF
 aqF
 aRX
 amn
-bAE
-aPv
+amp
+aOY
 bGq
 aeL
 aWg
@@ -98001,15 +98127,15 @@ btN
 aRM
 aZn
 aZv
+ans
 aZx
-aZx
-aZx
+aAh
 btL
-aqF
+azj
 bhB
 amn
-byn
-aPi
+amp
+aOZ
 aMH
 aeL
 apR
@@ -98258,10 +98384,10 @@ art
 bhz
 ami
 auT
+bAE
 aqF
 aqF
 aqF
-bAH
 aqF
 aOp
 amm
@@ -98546,7 +98672,7 @@ iuA
 iuA
 mUy
 ljw
-aiK
+aqQ
 apV
 sAj
 azV
@@ -98563,7 +98689,7 @@ apV
 apV
 aWa
 apV
-ljw
+dTk
 oyi
 oyi
 ilA
@@ -98820,7 +98946,7 @@ aWb
 aWb
 aWb
 apV
-ljw
+dTk
 oyi
 aaa
 aaa
@@ -99077,7 +99203,7 @@ apV
 apV
 apV
 apV
-ljw
+btG
 oyi
 aaa
 aaa
@@ -99316,11 +99442,11 @@ oyi
 blr
 oyi
 oyi
-ljw
-ljw
+any
+bAH
 aml
 rhe
-bnw
+vfz
 bxE
 aml
 npw

--- a/_maps/map_files/Tycoon/Tycoon2.dmm
+++ b/_maps/map_files/Tycoon/Tycoon2.dmm
@@ -4156,9 +4156,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
-	req_one_access_txt = "5"
-	},
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
@@ -5173,9 +5171,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame2/port)
 "aoo" = (
@@ -14918,12 +14914,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 4;
-	sortType = 16
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame2/port)
@@ -15410,9 +15405,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
-	req_one_access_txt = "12;5"
-	},
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
@@ -15955,6 +15948,9 @@
 	dir = 4
 	},
 /obj/structure/closet/wardrobe/grey,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "aRS" = (
@@ -16974,9 +16970,7 @@
 /turf/open/floor/monotile/light,
 /area/crew_quarters/heads/cmo)
 "aUE" = (
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
-	req_one_access_txt = "12;5"
-	},
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /turf/open/floor/plating,
 /area/medical/break_room)
 "aUF" = (
@@ -23032,8 +23026,10 @@
 	dir = 4
 	},
 /obj/machinery/light,
-/obj/structure/disposalpipe/segment,
 /obj/structure/closet/wardrobe/grey,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "bhB" = (
@@ -29748,9 +29744,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
-	req_one_access_txt = "5"
-	},
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /turf/open/floor/plating,
 /area/medical/genetics)
 "bvN" = (
@@ -34676,13 +34670,20 @@
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "bGj" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/machinery/computer/ship/viewscreen,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/monotile/steel,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 4;
+	sortType = 16
+	},
+/turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame2/port)
 "bGk" = (
 /obj/effect/landmark/patrol_node{
@@ -39599,6 +39600,12 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
+"efW" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck2/frame2/port)
 "egh" = (
 /obj/effect/turf_decal/tile/ship/orange,
 /obj/effect/turf_decal/tile/ship/orange{
@@ -42275,9 +42282,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
-	req_one_access_txt = "12;5"
-	},
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /turf/open/floor/monotile/dark,
 /area/medical/morgue)
 "hxW" = (
@@ -47043,8 +47048,9 @@
 	},
 /area/engine/atmos)
 "ntS" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
-/turf/closed/wall/ship,
+/turf/open/floor/plating,
 /area/hallway/nsv/deck2/frame2/port)
 "nuc" = (
 /obj/effect/turf_decal/delivery/red,
@@ -48472,15 +48478,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "pxy" = (
-/obj/machinery/door/airlock/ship{
-	name = "Supplies Closet"
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/machinery/door/airlock/ship/glass,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "pxF" = (
@@ -51460,6 +51464,14 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/engine/atmos)
+"ttf" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/frame2/port)
 "tup" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/barricade/wooden,
@@ -93242,9 +93254,9 @@ aqK
 aaY
 aaY
 aaY
-aad
+abq
 pxy
-aad
+abq
 aad
 aci
 evG
@@ -94245,7 +94257,7 @@ syG
 aZC
 aSb
 amm
-bAG
+efW
 aOY
 aMH
 abd
@@ -96043,8 +96055,8 @@ btF
 ful
 ful
 bhA
-ntS
-bGj
+amm
+amp
 aPo
 bkj
 acR
@@ -96300,9 +96312,9 @@ bnw
 btR
 btK
 aRR
-amn
-amp
-aOZ
+ntS
+ttf
+bGj
 aMH
 acR
 aks

--- a/_maps/map_files/Tycoon/Tycoon2.dmm
+++ b/_maps/map_files/Tycoon/Tycoon2.dmm
@@ -745,7 +745,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/light,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "acf" = (
@@ -20321,15 +20320,11 @@
 /turf/open/floor/monotile/light,
 /area/medical/storage)
 "bcc" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
+/obj/machinery/camera/autoname{
 	dir = 8
 	},
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/turf/open/floor/monotile/steel,
+/area/medical)
 "bcd" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/disposalpipe/segment,
@@ -20594,22 +20589,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
-"bcE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "bcF" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -30752,8 +30731,7 @@
 "bxT" = (
 /obj/effect/landmark/start/quartermaster,
 /obj/machinery/computer/ship/viewscreen{
-	pixel_y = -31;
-	pixel_x = -1
+	pixel_y = -31
 	},
 /turf/open/floor/carpet/blue,
 /area/quartermaster/qm)
@@ -48035,10 +48013,14 @@
 	},
 /area/engine/atmos)
 "oPR" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/template_noop,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light,
+/turf/open/floor/plating,
 /area/maintenance/department/medical)
 "oQy" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
@@ -49245,7 +49227,6 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/light/small,
 /turf/open/floor/durasteel,
 /area/maintenance/department/medical)
 "qAP" = (
@@ -53290,15 +53271,21 @@
 /turf/open/space/basic,
 /area/engine/atmos)
 "wcy" = (
-/obj/structure/sign/ship/pods/north{
-	pixel_y = 1;
-	pixel_x = -32
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/turf/open/floor/monotile/steel,
-/area/medical)
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "weE" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/machinery/firealarm{
@@ -54379,6 +54366,9 @@
 /obj/structure/sign/ship/pods/east{
 	pixel_y = -2;
 	pixel_x = 31
+	},
+/obj/machinery/camera/autoname{
+	dir = 8
 	},
 /turf/open/floor/monotile/steel,
 /area/medical)
@@ -77028,9 +77018,9 @@ pHV
 pHV
 ahS
 jqT
-agX
+hAC
 ueI
-oPR
+pHV
 pHV
 pHV
 pHV
@@ -80123,7 +80113,7 @@ aZX
 ycN
 bmS
 bYc
-wcy
+bFX
 aZX
 ahK
 dCq
@@ -80628,14 +80618,14 @@ aWq
 baz
 eLS
 aZX
-aZX
+bcc
 tVW
 aZX
 aZX
 aZX
 bvT
 xCD
-aZX
+tVW
 aZX
 rsC
 aZX
@@ -82423,7 +82413,7 @@ bsW
 bsW
 bsW
 ace
-die
+fuW
 pHV
 pHV
 pHV
@@ -82679,8 +82669,8 @@ bsX
 bBE
 bCf
 bsW
-bjk
-fuW
+oPR
+aZa
 pHV
 pHV
 pHV
@@ -93024,9 +93014,9 @@ eLm
 eLm
 eLm
 eLm
-bJu
-bLR
-aim
+aih
+wcy
+foY
 aij
 aaa
 aaa
@@ -93281,9 +93271,9 @@ eLm
 eLm
 eLm
 eLm
-aih
-bcE
-foY
+bJu
+bLR
+aim
 aij
 aaa
 aaa
@@ -94049,7 +94039,7 @@ ajs
 ajs
 ajs
 aih
-bcc
+aih
 aih
 aih
 aih
@@ -96347,8 +96337,8 @@ aim
 aih
 aih
 aih
-aih
 bcF
+aih
 aih
 aih
 bcF
@@ -97374,8 +97364,8 @@ fEj
 aih
 aih
 aih
-bcF
 aih
+bcF
 aih
 aih
 aih

--- a/_maps/map_files/Tycoon/Tycoon2.dmm
+++ b/_maps/map_files/Tycoon/Tycoon2.dmm
@@ -590,10 +590,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/steel,
 /area/hallway/secondary/exit)
 "abO" = (
@@ -846,18 +842,15 @@
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "acp" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Hydroponics";
-	req_one_access_txt = "35"
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/monotile/steel,
-/area/hydroponics)
+/area/hallway/secondary/exit)
 "acr" = (
 /turf/closed/wall/ship,
 /area/science/nanite)
@@ -1004,14 +997,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/chapel/office)
-"acO" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/monotile/steel,
-/area/hallway/secondary/exit)
 "acP" = (
 /obj/machinery/power/apc/auto_name/north{
 	pixel_y = 24
@@ -1207,7 +1192,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/corner,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -1230,7 +1214,6 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/steel,
 /area/hallway/secondary/exit)
 "adu" = (
@@ -1239,7 +1222,6 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/steel,
 /area/hallway/secondary/exit)
 "adw" = (
@@ -1258,27 +1240,32 @@
 /turf/open/floor/monotile/dark,
 /area/chapel/office)
 "adx" = (
-/obj/structure/closet/crate,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/tech/grid,
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/techmaint,
 /area/quartermaster/warehouse)
 "ady" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel/tech/grid,
 /area/quartermaster/warehouse)
 "adz" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/grid/steel,
-/area/quartermaster/storage)
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/monotile/steel,
+/area/hallway/secondary/exit)
 "adA" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -1404,6 +1391,10 @@
 "adQ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
@@ -1958,6 +1949,9 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
 "afa" = (
@@ -1973,7 +1967,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar)
 "afc" = (
@@ -2104,10 +2098,7 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "1-2"
 	},
 /turf/open/floor/carpet/blue,
 /area/hallway/secondary/exit)
@@ -2899,6 +2890,9 @@
 	pixel_y = 26
 	},
 /obj/machinery/camera/autoname,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
 "ahu" = (
@@ -3242,7 +3236,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/engine/atmos)
 "aij" = (
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/department/cargo)
@@ -3256,11 +3250,20 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "ail" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/chair/fancy{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/blue,
+/area/hallway/secondary/exit/departure_lounge)
 "aim" = (
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
@@ -3271,17 +3274,9 @@
 /turf/open/floor/plating,
 /area/nsv/crew_quarters/heads/maa)
 "aio" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/auto_name/north{
-	pixel_y = 24
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/obj/structure/filingcabinet,
+/turf/open/floor/carpet/ship,
+/area/quartermaster/storage)
 "aip" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -3305,13 +3300,12 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/chief)
 "ais" = (
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/engine/atmos)
 "aiu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -3358,30 +3352,14 @@
 /turf/open/floor/monotile/dark,
 /area/lawoffice)
 "aiE" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 8
-	},
-/obj/machinery/door/airlock/ship/maintenance{
-	name = "Incinerator";
-	req_access_txt = "24"
-	},
+/obj/machinery/atmospherics/pipe/simple/dark/visible,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/turf/open/floor/durasteel/techfloor{
+	initial_gas_mix = "TEMP=2.7"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/engine/atmospherics_engine)
 "aiG" = (
 /turf/open/floor/plasteel/chapel{
 	dir = 1
@@ -3401,9 +3379,14 @@
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms)
 "aiK" = (
-/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/engine/atmos)
 "aiM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -3411,17 +3394,23 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "aiO" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck2/frame1/central)
+"aiP" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"aiP" = (
-/obj/structure/table,
-/obj/item/poster/random_contraband,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "aiQ" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/stripes/line{
@@ -3456,15 +3445,11 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/chief)
 "aiW" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/engine/atmos)
 "aiX" = (
 /obj/structure/chair/fancy{
 	dir = 8
@@ -3486,9 +3471,11 @@
 /turf/open/floor/monotile/light,
 /area/medical/medbay/central)
 "aiZ" = (
-/obj/item/cigbutt,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/carpet/ship,
+/area/quartermaster/qm)
 "aja" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/effect/turf_decal/stripes/white/line{
@@ -3528,10 +3515,26 @@
 /turf/open/floor/monotile/dark,
 /area/medical/morgue)
 "ajg" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance/three,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/tech/grid,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/station/mining{
+	name = "Warehouse";
+	req_one_access_txt = "31;48"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/monotile/dark,
 /area/quartermaster/warehouse)
 "ajh" = (
 /obj/machinery/light,
@@ -3539,20 +3542,34 @@
 /turf/open/floor/monotile/light,
 /area/medical/medbay/lobby)
 "aji" = (
-/obj/structure/closet/crate/freezer,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/tech/grid,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/station/mining{
+	name = "Warehouse";
+	req_one_access_txt = "31;48"
+	},
+/turf/open/floor/monotile/dark,
 /area/quartermaster/warehouse)
 "ajj" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/monotile/dark,
 /area/quartermaster/storage)
 "ajk" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit)
@@ -3561,8 +3578,13 @@
 /turf/open/floor/monotile/dark,
 /area/quartermaster/storage)
 "ajm" = (
-/obj/effect/decal/cleanable/oil/streak,
-/turf/open/floor/plasteel/tech/grid,
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plasteel/techmaint,
 /area/quartermaster/warehouse)
 "ajn" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
@@ -3618,22 +3640,21 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "ajw" = (
-/obj/structure/sign/poster/official/fruit_bowl{
-	pixel_y = -6
+/obj/structure/disposalpipe/segment{
+	dir = 8
 	},
-/turf/closed/wall/ship,
-/area/quartermaster/qm)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
 "ajx" = (
 /turf/closed/wall/ship,
 /area/science/research)
 "ajy" = (
-/obj/structure/closet/secure_closet/quartermaster,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/machinery/camera/autoname,
-/turf/open/floor/carpet/ship,
-/area/quartermaster/qm)
+/obj/effect/landmark/start/shaft_miner,
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
 "ajz" = (
 /turf/open/floor/carpet/blue,
 /area/hallway/secondary/exit/departure_lounge)
@@ -3681,9 +3702,6 @@
 /area/medical/medbay/central)
 "ajF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
@@ -3804,11 +3822,9 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "akd" = (
-/obj/machinery/computer/cargo{
-	dir = 4
-	},
-/turf/open/floor/carpet/ship,
-/area/quartermaster/qm)
+/obj/machinery/light,
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
 "ake" = (
 /obj/machinery/mineral/ore_redemption{
 	input_dir = 4;
@@ -3823,13 +3839,20 @@
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "akf" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/curtain/obscuring/grey,
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/quartermaster/qm)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/frame1/central)
 "akg" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -3945,10 +3968,14 @@
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/nsv/observation)
 "akt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/nsv/observation)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "akv" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/green{
@@ -4704,6 +4731,9 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/service)
 "amR" = (
@@ -4815,7 +4845,9 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
 "anm" = (
@@ -5389,9 +5421,12 @@
 /turf/open/floor/monotile/steel,
 /area/engine/engineering)
 "api" = (
-/obj/structure/closet/firecloset,
+/obj/structure/disposalpipe/sorting/mail/flip,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/engine/atmos)
 "apj" = (
 /turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
@@ -5407,7 +5442,7 @@
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "apm" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/stripes/line{
@@ -5430,14 +5465,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/storage)
-"apo" = (
-/obj/structure/rack,
-/obj/item/storage/box/lights/mixed,
-/obj/item/stack/sheet/mineral/copper{
-	amount = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "app" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -5482,6 +5509,9 @@
 /area/engine/atmos)
 "apw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 8
 	},
 /turf/open/floor/monotile/steel,
@@ -6067,6 +6097,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/kitchen)
 "arh" = (
@@ -6127,6 +6158,9 @@
 	name = "CondiMaster Neo";
 	pixel_x = -4
 	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 1
+	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
 "arm" = (
@@ -6145,6 +6179,10 @@
 /obj/structure/table/wood,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/nsv/observation)
@@ -6187,12 +6225,6 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
 	},
 /turf/open/floor/monotile/steel,
@@ -6336,10 +6368,19 @@
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos)
 "asa" = (
-/obj/effect/landmark/xeno_spawn,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "asb" = (
 /turf/open/floor/plating,
 /area/engine/storage)
@@ -6567,20 +6608,8 @@
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "asN" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/turf/open/floor/carpet/ship,
+/area/quartermaster/storage)
 "asV" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6694,6 +6723,9 @@
 "ati" = (
 /obj/structure/table/wood,
 /obj/item/clothing/mask/cigarette/cigar,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/nsv/observation)
 "atj" = (
@@ -6753,6 +6785,9 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar)
 "att" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/bar)
 "atu" = (
@@ -6762,6 +6797,7 @@
 /mob/living/simple_animal/hostile/retaliate/goat{
 	name = "Technical debt"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
 "atv" = (
@@ -6792,6 +6828,9 @@
 /area/hallway/nsv/deck2/frame1/central)
 "aty" = (
 /obj/effect/landmark/start/bartender,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/bar)
 "atz" = (
@@ -6812,22 +6851,9 @@
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
 "atB" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	name = "Hydroponics Backroom";
-	req_one_access_txt = "35"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/wood,
-/area/hydroponics)
+/obj/machinery/computer/ship/munitions_computer/west,
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
 "atC" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -6854,7 +6880,9 @@
 /turf/open/floor/monotile/dark,
 /area/hydroponics)
 "atF" = (
-/obj/machinery/atmospherics/pipe/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/manifold/dark/visible{
+	dir = 4
+	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
 "atG" = (
@@ -7373,10 +7401,12 @@
 /turf/open/floor/plating,
 /area/lawoffice)
 "avp" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/effect/landmark/start/cargo_technician,
+/turf/open/floor/carpet/ship,
+/area/quartermaster/storage)
 "avq" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -7386,11 +7416,11 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "avr" = (
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/structure/barricade/wooden/crude,
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
+	req_one_access_txt = "0"
+	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "avs" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrous_output{
 	dir = 8
@@ -7487,13 +7517,20 @@
 /turf/open/floor/durasteel/lino,
 /area/engine/engineering/reactor_control)
 "awc" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/enzyme{
-	layer = 5
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
-/obj/item/reagent_containers/food/condiment/flour,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/monotile/steel,
+/area/hydroponics)
 "awe" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2o{
 	dir = 1
@@ -7578,14 +7615,17 @@
 /turf/open/floor/monotile/dark,
 /area/engine/engine_room)
 "awT" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	name = "Abandoned cargo storage"
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "axa" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxin_input{
 	dir = 8
@@ -8065,7 +8105,7 @@
 	name = "ST13 source code"
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "azA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 6
@@ -8133,39 +8173,63 @@
 /obj/item/stack/sheet/mineral/copper{
 	amount = 5
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "azN" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "azO" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmospherics_engine)
 "azP" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/structure/closet/radiation,
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/structure/chair/fancy{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/monotile/dark,
-/area/engine/atmospherics_engine)
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/nsv/observation)
 "azQ" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/nsv/hangar)
 "azR" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/item/storage/toolbox/emergency,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/durasteel/techfloor{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmospherics_engine)
+"azS" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/durasteel/techfloor{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmospherics_engine)
+"azT" = (
 /obj/machinery/power/smes{
 	capacity = 9e+006;
 	charge = 10000
@@ -8173,69 +8237,35 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/monotile/dark,
-/area/engine/atmospherics_engine)
-"azS" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/reagent_dispensers/fueltank,
-/obj/item/storage/toolbox/emergency,
 /obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/turf/open/floor/monotile/dark,
-/area/engine/atmospherics_engine)
-"azT" = (
-/obj/structure/cable{
-	icon_state = "2-8"
+/turf/open/floor/durasteel/techfloor{
+	initial_gas_mix = "TEMP=2.7"
 	},
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/monotile/dark,
 /area/engine/atmospherics_engine)
 "azU" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/machinery/light{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/item/storage/box/lights/mixed,
+/obj/structure/rack,
+/obj/machinery/light,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"azV" = (
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
+/turf/open/floor/durasteel/techfloor{
+	initial_gas_mix = "TEMP=2.7"
 	},
-/turf/open/floor/monotile/dark,
-/area/engine/atmospherics_engine)
-"azV" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/monotile/dark,
 /area/engine/atmospherics_engine)
 "azW" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -8252,7 +8282,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "azY" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	req_one_access_txt = "24"
@@ -8268,15 +8298,17 @@
 "aAa" = (
 /obj/item/clothing/under/rank/engineering/engineer/hazard,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "aAb" = (
 /obj/structure/table,
-/obj/item/kitchen/rollingpin,
-/obj/item/reagent_containers/glass/beaker,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/enzyme{
+	layer = 5
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "aAc" = (
 /obj/effect/landmark/start/paramedic,
 /obj/structure/disposalpipe/segment{
@@ -8646,8 +8678,10 @@
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
 "aAZ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/monotile/dark,
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/durasteel/techfloor{
+	initial_gas_mix = "TEMP=2.7"
+	},
 /area/engine/atmospherics_engine)
 "aBa" = (
 /obj/structure/cable{
@@ -8673,86 +8707,74 @@
 /turf/open/floor/carpet/green,
 /area/engine/engineering/reactor_control)
 "aBc" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/durasteel/techfloor{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmospherics_engine)
+"aBd" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/durasteel/techfloor{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmospherics_engine)
+"aBe" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/monotile/dark,
-/area/engine/atmospherics_engine)
-"aBd" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/turf/open/floor/monotile/dark,
-/area/engine/atmospherics_engine)
-"aBe" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 8
-	},
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/turf/open/floor/durasteel/techfloor{
+	initial_gas_mix = "TEMP=2.7"
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/monotile/dark,
 /area/engine/atmospherics_engine)
 "aBf" = (
 /turf/closed/wall/r_wall/ship,
 /area/security/detectives_office)
 "aBh" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/maintenance/starboard/fore)
-"aBi" = (
-/obj/machinery/button/door/incinerator_vent_atmos_aux{
-	pixel_x = -8;
-	pixel_y = -24
-	},
-/obj/machinery/button/door/incinerator_vent_atmos_main{
-	pixel_x = -8;
-	pixel_y = -36
-	},
-/obj/machinery/button/ignition/incinerator/atmos{
-	pixel_x = 8;
-	pixel_y = -36
-	},
-/obj/machinery/atmospherics/components/trinary/filter/flipped,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/landmark/start/cargo_technician,
+/obj/structure/chair/office{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
+"aBi" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/ship/station/mining{
+	name = "Quartermaster's Office";
+	req_one_access_txt = "41"
 	},
-/turf/open/floor/monotile/dark,
-/area/engine/atmospherics_engine)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/qm)
 "aBj" = (
 /turf/open/floor/monotile/steel,
 /area/nsv/engine/dcc)
@@ -8850,25 +8872,16 @@
 /turf/open/floor/durasteel,
 /area/engine/engineering)
 "aBx" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
-/obj/machinery/computer/turbine_computer{
-	dir = 1;
-	id = "incineratorturbine"
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/durasteel/techfloor{
+	initial_gas_mix = "TEMP=2.7"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/monotile/dark,
 /area/engine/atmospherics_engine)
 "aBy" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -8892,8 +8905,6 @@
 /turf/open/floor/durasteel,
 /area/engine/engineering)
 "aBA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -9090,11 +9101,11 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "aCi" = (
 /obj/machinery/atmospherics/components/trinary/filter,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "aCk" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -9116,22 +9127,11 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "aCm" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/atmospherics_engine)
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall/ship,
+/area/maintenance/department/engine/atmos)
 "aCn" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/engine,
+/turf/open/floor/engine/vacuum,
 /area/engine/atmospherics_engine)
 "aCo" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
@@ -9831,8 +9831,11 @@
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/security/armory)
 "aEf" = (
-/turf/closed/wall/r_wall/ship,
-/area/quartermaster/qm)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/cafeteria{
+	name = "Mess hall"
+	})
 "aEg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -12322,13 +12325,16 @@
 /turf/open/floor/monotile/dark,
 /area/science/robotics)
 "aJX" = (
-/obj/structure/table/glass,
-/obj/item/folder/white{
-	pixel_x = 4;
-	pixel_y = -3
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/carpet/blue,
-/area/hallway/secondary/exit/departure_lounge)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/monotile/dark,
+/area/hallway/secondary/exit)
 "aJY" = (
 /obj/machinery/atmospherics/pipe/manifold,
 /obj/structure/cable{
@@ -13441,19 +13447,14 @@
 /turf/open/floor/monotile/light,
 /area/medical/medbay/central)
 "aMt" = (
-/obj/structure/chair/fancy{
-	dir = 8
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/landmark/start/quartermaster,
-/turf/open/floor/carpet/ship,
-/area/quartermaster/qm)
+/turf/open/floor/plating,
+/area/quartermaster/storage)
 "aMu" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -13478,10 +13479,6 @@
 /turf/closed/wall/ship,
 /area/maintenance/department/security)
 "aMy" = (
-/obj/machinery/atmospherics/pipe/manifold/dark/visible{
-	dir = 4
-	},
-/obj/machinery/icecream_vat,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
@@ -13498,6 +13495,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/service)
 "aMB" = (
@@ -13674,23 +13672,15 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "aMS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
 "aMT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/grid/steel,
-/area/quartermaster/storage)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/monotile/dark,
+/area/hydroponics)
 "aMU" = (
 /obj/machinery/power/apc/auto_name/north{
 	pixel_y = 24
@@ -13705,6 +13695,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/nsv/observation)
 "aMX" = (
@@ -13836,14 +13828,14 @@
 /turf/open/floor/monotile/dark,
 /area/chapel/main)
 "aNi" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
+/obj/structure/rack,
+/obj/item/paper_bin,
+/obj/item/pen{
+	pixel_x = 4;
+	pixel_y = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/monotile/dark,
-/area/hallway/secondary/exit)
+/turf/open/floor/carpet/ship,
+/area/quartermaster/storage)
 "aNj" = (
 /obj/machinery/door/poddoor{
 	id = "chapelgun";
@@ -13901,17 +13893,19 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/secondary/exit)
 "aNp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit)
 "aNq" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/food/drinks/solgovcup,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/carpet/blue,
 /area/hallway/secondary/exit/departure_lounge)
 "aNr" = (
@@ -13924,9 +13918,14 @@
 /turf/open/floor/plasteel/grid/steel,
 /area/hallway/secondary/exit)
 "aNt" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit)
@@ -14216,35 +14215,25 @@
 /turf/open/floor/carpet/blue,
 /area/engine/engineering)
 "aNW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/obj/structure/disposalpipe/junction{
+	dir = 8
 	},
-/obj/item/kirbyplants{
-	icon_state = "plant-10"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/monotile/steel,
-/area/hallway/secondary/exit)
+/turf/open/floor/plating,
+/area/maintenance/department/engine/atmos)
 "aNX" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
+	dir = 4
 	},
-/turf/open/floor/monotile/steel,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit)
 "aNY" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/item/kirbyplants{
-	icon_state = "plant-10"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /turf/open/floor/monotile/steel,
@@ -14390,28 +14379,32 @@
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/chief)
 "aOr" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/stamp/quartermaster,
-/turf/open/floor/carpet/ship,
-/area/quartermaster/qm)
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "aOs" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/computer/cargo/request{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
+/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only{
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen,
+/obj/machinery/door/window/eastright{
+	name = "Cargo Desk";
+	req_access_txt = "31"
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel/grid/steel,
@@ -14444,9 +14437,6 @@
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "aOz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -14481,22 +14471,20 @@
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/warehouse)
 "aOE" = (
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/camera/autoname,
-/obj/item/radio/intercom{
-	pixel_x = -26
+/obj/machinery/camera/autoname{
+	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "aOF" = (
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
 	},
 /turf/open/floor/plating,
-/area/quartermaster/storage)
+/area/maintenance/department/cargo)
 "aOH" = (
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/port)
@@ -14511,14 +14499,18 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
 	},
 /obj/structure/disposalpipe/junction/flip{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
 "aOK" = (
@@ -14726,31 +14718,26 @@
 	name = "Mess hall"
 	})
 "aPd" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
 	},
-/obj/structure/closet/secure_closet/hydroponics,
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
 	},
-/obj/item/watertank,
-/turf/open/floor/monotile/steel,
-/area/hydroponics)
+/turf/open/floor/plasteel/tech/grid,
+/area/quartermaster/warehouse)
 "aPe" = (
 /obj/structure/chair/office{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "aPf" = (
@@ -14776,17 +14763,10 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "aPh" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck2/frame1/central)
+/mob/living/simple_animal/sloth/paperwork,
+/obj/structure/bed/dogbed/runtime,
+/turf/open/floor/carpet/ship,
+/area/quartermaster/qm)
 "aPi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -14850,7 +14830,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/recharge_station,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "aPo" = (
@@ -14937,7 +14916,7 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "aPx" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -15882,16 +15861,16 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "aRQ" = (
-/obj/effect/turf_decal/ship/delivery/yellow,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
+/obj/machinery/holopad,
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
 	},
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck2/frame1/central)
+/turf/open/floor/carpet/ship,
+/area/quartermaster/qm)
 "aRR" = (
 /obj/structure/closet/wardrobe/black,
 /obj/effect/turf_decal/tile/neutral{
@@ -16868,8 +16847,6 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "aUy" = (
@@ -17037,8 +17014,6 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "aVa" = (
@@ -17131,6 +17106,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/bar)
 "aVj" = (
@@ -17207,13 +17185,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/engine/storage)
-"aVr" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/cafeteria{
-	name = "Mess hall"
-	})
 "aVs" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -17237,6 +17208,9 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/theatre)
 "aVu" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/theatre)
 "aVv" = (
@@ -17290,28 +17264,26 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/theatre)
 "aVA" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4
-	},
 /obj/machinery/airalarm/kitchen_cold_room{
 	dir = 1;
 	pixel_y = -24
 	},
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/kitchen/coldroom)
-"aVB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
+/obj/machinery/icecream_vat,
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/kitchen/coldroom)
+"aVB" = (
 /obj/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on/coldroom{
 	dir = 1
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
 "aVC" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on/coldroom{
-	dir = 1
-	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
 "aVD" = (
@@ -17348,7 +17320,7 @@
 "aVK" = (
 /obj/item/disk/holodisk/enterprise_log/two,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "aVL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -17369,14 +17341,17 @@
 /turf/open/floor/monotile/light,
 /area/medical/genetics)
 "aVN" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/structure/rack,
+/obj/item/paper_bin,
+/obj/item/pen{
+	pixel_x = 4;
+	pixel_y = 4
 	},
-/turf/open/floor/monotile/steel,
-/area/hydroponics)
+/turf/open/floor/carpet/ship,
+/area/quartermaster/storage)
 "aVO" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/snacks/pie/cream,
@@ -17440,6 +17415,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "aVT" = (
@@ -17457,13 +17435,16 @@
 	name = "Mess hall"
 	})
 "aVU" = (
+/obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
-	dir = 1
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/closet/secure_closet/hydroponics,
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/landmark/start/botanist,
+/obj/item/watertank,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
 "aVV" = (
@@ -17770,9 +17751,20 @@
 /turf/open/floor/monotile/dark,
 /area/science/robotics)
 "aWG" = (
-/obj/machinery/holopad,
-/turf/open/floor/plasteel/tech/grid,
-/area/quartermaster/warehouse)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/monotile/steel,
+/area/hallway/secondary/exit)
 "aWH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -18322,9 +18314,8 @@
 /turf/open/floor/monotile/dark,
 /area/medical/morgue)
 "aXO" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/nsv/deck2/frame1/central)
 "aXP" = (
@@ -18614,41 +18605,50 @@
 /turf/open/floor/monotile/steel,
 /area/ai_monitored/security/armory)
 "aYx" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_x = -3;
-	pixel_y = 6
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "aYy" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "aYz" = (
 /obj/item/reagent_containers/food/drinks/solgovcup,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "aYA" = (
 /obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/four,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "aYB" = (
 /obj/item/crowbar,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "aYD" = (
 /obj/structure/closet/secure_closet/freezer/kitchen/maintenance,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "aYE" = (
 /obj/structure/kitchenspike_frame,
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "aYF" = (
 /obj/structure/rack,
 /obj/item/stack/rods{
@@ -18657,11 +18657,18 @@
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "aYH" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/machinery/meter,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/durasteel/techfloor{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmospherics_engine)
 "aYI" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
 /turf/open/floor/plating,
@@ -19294,11 +19301,10 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 10
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
 "bak" = (
@@ -19521,9 +19527,10 @@
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 1;
+	sortType = 19
+	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "baI" = (
@@ -19809,10 +19816,12 @@
 /turf/template_noop,
 /area/maintenance/department/science)
 "bbw" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/theatre)
 "bbx" = (
 /obj/machinery/computer/scan_consolenew,
 /obj/machinery/light{
@@ -19832,6 +19841,9 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/cafeteria{
 	name = "Mess hall"
@@ -19877,6 +19889,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/cafeteria{
 	name = "Mess hall"
@@ -19887,6 +19901,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/cafeteria{
 	name = "Mess hall"
@@ -19907,17 +19923,9 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "bbG" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck2/frame1/central)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel/tech/grid,
+/area/quartermaster/warehouse)
 "bbH" = (
 /obj/machinery/camera/autoname,
 /obj/machinery/computer/scan_consolenew,
@@ -19927,10 +19935,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/cafeteria{
 	name = "Mess hall"
@@ -19948,6 +19959,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 8
 	},
 /turf/open/floor/monotile/steel,
@@ -19983,7 +19997,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/theatre)
 "bbN" = (
@@ -20019,7 +20033,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/theatre)
 "bbQ" = (
@@ -20054,7 +20070,8 @@
 	name = "Mess hall"
 	})
 "bbT" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/theatre)
 "bbU" = (
@@ -20073,13 +20090,13 @@
 	name = "Mess hall"
 	})
 "bbV" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
 /obj/machinery/gibber,
 /obj/machinery/computer/ship/viewscreen,
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
@@ -20145,16 +20162,15 @@
 /turf/open/floor/monotile/light,
 /area/medical/storage)
 "bcc" = (
-/obj/machinery/smartfridge/drying_rack,
-/obj/machinery/power/apc/auto_name/north{
-	pixel_y = 24
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
-/obj/machinery/camera/autoname,
-/turf/open/floor/wood,
-/area/hydroponics)
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "bcd" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/disposalpipe/segment,
@@ -20232,8 +20248,8 @@
 /turf/open/floor/carpet/blue,
 /area/hallway/secondary/exit/departure_lounge)
 "bcj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit/departure_lounge)
@@ -20260,10 +20276,20 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/theatre)
 "bcn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Diplomatic Reception Area"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/space/basic,
+/area/hallway/secondary/exit/departure_lounge)
 "bco" = (
 /obj/structure/chair{
 	dir = 4
@@ -20284,32 +20310,25 @@
 /area/hallway/nsv/deck2/frame1/central)
 "bcr" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
+	dir = 4
 	},
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "bcs" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/plasticflaps/opaque,
+/obj/machinery/door/window/eastright{
+	dir = 8;
+	name = "Kitchen Delivery";
+	req_access_txt = "28"
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=1";
+	location = "Kitchen";
+	name = "navigation beacon (Kitchen Delivery)"
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plasteel/grid/steel,
-/area/quartermaster/storage)
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/techmaint,
+/area/crew_quarters/kitchen/coldroom)
 "bct" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
@@ -20319,14 +20338,14 @@
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
 "bcu" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/grid/steel,
-/area/quartermaster/storage)
+/obj/machinery/door/airlock/ship/public/glass/turbolift,
+/turf/open/floor/plating,
+/area/shuttle/turbolift/tertiary)
 "bcv" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/table/reinforced,
+/obj/machinery/fax{
+	fax_name = "Cargo";
+	name = "Cargo Fax Machine"
 	},
 /turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
@@ -20417,43 +20436,44 @@
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
 "bcE" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/camera/autoname{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck2/frame1/central)
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "bcF" = (
-/obj/structure/table/glass,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
 	},
-/turf/open/floor/carpet/blue,
-/area/hallway/secondary/exit)
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
+	req_one_access_txt = "0"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "bcG" = (
-/obj/structure/chair/fancy{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/carpet/blue,
-/area/hallway/secondary/exit)
+/area/crew_quarters/theatre)
 "bcH" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/machinery/camera/autoname{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/monotile/steel,
-/area/hallway/secondary/exit)
+/obj/effect/landmark/start/shaft_miner,
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
 "bcI" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -20462,35 +20482,35 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/steel,
 /area/hallway/secondary/exit)
 "bcJ" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit)
 "bcK" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/chair/fancy{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/turf/open/floor/monotile/steel,
-/area/hallway/secondary/exit)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/carpet/blue,
+/area/hallway/secondary/exit/departure_lounge)
 "bcL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20582,16 +20602,11 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bcW" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/grid/steel,
-/area/quartermaster/storage)
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/monotile/dark,
+/area/hydroponics)
 "bcX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment,
@@ -20601,9 +20616,6 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bcY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -20612,9 +20624,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "bcZ" = (
@@ -20653,14 +20662,9 @@
 /turf/open/floor/carpet/green,
 /area/chapel/main)
 "bdb" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/monotile/steel,
-/area/hallway/secondary/exit)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/department/engine/atmos)
 "bdd" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -20696,17 +20700,16 @@
 	name = "Mess hall"
 	})
 "bdg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "bdh" = (
@@ -20737,10 +20740,12 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
 /obj/machinery/chem_dispenser/mutagensaltpetersmall,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
 "bdk" = (
@@ -20976,12 +20981,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/cafeteria{
 	name = "Mess hall"
@@ -21213,15 +21214,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=loc11";
 	location = "loc10"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
@@ -21597,21 +21598,20 @@
 /turf/open/floor/monotile/steel,
 /area/security/warden)
 "beL" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/durasteel/techfloor{
+	initial_gas_mix = "TEMP=2.7"
 	},
-/turf/open/floor/plasteel/tech/grid,
-/area/quartermaster/warehouse)
+/area/engine/atmos)
 "beM" = (
-/obj/machinery/computer/security/qm,
-/obj/machinery/power/apc/auto_name/north{
-	pixel_y = 24
-	},
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
-/turf/open/floor/carpet/ship,
-/area/quartermaster/qm)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
 "beO" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -21633,11 +21633,12 @@
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "beQ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
 	},
 /turf/open/floor/plasteel/grid/steel,
-/area/hallway/secondary/exit)
+/area/quartermaster/storage)
 "beR" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -21663,45 +21664,57 @@
 /turf/open/floor/carpet/ship,
 /area/quartermaster/qm)
 "beT" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/turf/open/floor/carpet/ship,
-/area/quartermaster/qm)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/recharge_station,
+/turf/open/floor/monotile/steel,
+/area/crew_quarters/cafeteria{
+	name = "Mess hall"
+	})
 "beV" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
+"beW" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
+"beX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/exit/departure_lounge)
-"beW" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/monotile/dark,
-/area/hallway/secondary/exit/departure_lounge)
-"beX" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit)
 "beY" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit)
 "beZ" = (
@@ -22096,11 +22109,9 @@
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "bfK" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/status_display/supply{
-	pixel_y = -32
+/obj/item/clothing/ears/earmuffs,
+/obj/machinery/computer/ship/dradis/minor/cargo{
+	dradis_id = "nt_cargo_torpedo_launcher"
 	},
 /turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
@@ -22670,27 +22681,16 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "bha" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 9
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/engine/atmos)
 "bhb" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -22823,19 +22823,15 @@
 /area/engine/engineering/hangar)
 "bhv" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/ship/delivery/yellow,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "bhw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -23330,12 +23326,13 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
 "biB" = (
@@ -23582,13 +23579,14 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/gauss)
 "bjb" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/landmark/start/shaft_miner,
-/turf/open/floor/plasteel/grid/steel,
-/area/quartermaster/storage)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/secondary/exit/departure_lounge)
 "bjd" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -23601,14 +23599,14 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bje" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "bjf" = (
@@ -23711,12 +23709,10 @@
 	})
 "bjo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/kitchen)
 "bjp" = (
@@ -23792,14 +23788,12 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "bjy" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck2/frame1/central)
+/turf/open/floor/carpet/ship,
+/area/quartermaster/qm)
 "bjz" = (
 /obj/machinery/computer/ship/viewscreen,
 /obj/structure/disposalpipe/segment{
@@ -23830,9 +23824,6 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-10"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
 /turf/open/floor/monotile/steel,
 /area/hallway/secondary/exit)
 "bjD" = (
@@ -23859,30 +23850,23 @@
 	pixel_y = 26
 	},
 /obj/machinery/camera/autoname,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/secondary/service)
 "bjH" = (
-/obj/structure/closet,
-/obj/item/clothing/gloves/color/fyellow,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/tech/grid,
+/area/quartermaster/warehouse)
 "bjI" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/engine/atmospherics_engine)
 "bjJ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -24104,34 +24088,27 @@
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
 "bkf" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/door/airlock/ship/engineering/glass{
+	name = "Atmospherics Storage";
+	req_one_access_txt = "10; 24"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/dark/visible,
+/turf/open/floor/durasteel/techfloor{
+	initial_gas_mix = "TEMP=2.7"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/hydroponics)
+/area/engine/atmos)
 "bkg" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
 /obj/structure/chair/fancy/sofa/old/right{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/theatre)
@@ -24306,16 +24283,14 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 6
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/service)
 "bkG" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/machinery/ship_weapon/torpedo_launcher/cargo/east{
+	launcher_id = "nt_cargo_torpedo_launcher"
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
 "bkH" = (
 /obj/structure/table,
 /obj/item/clothing/head/welding{
@@ -24498,7 +24473,9 @@
 	pixel_y = 24
 	},
 /obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
 "bkX" = (
@@ -24512,13 +24489,14 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/service)
 "bkZ" = (
-/obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/engine/atmos)
 "bla" = (
 /obj/structure/closet{
 	name = "'Evidence Closet'"
@@ -24606,9 +24584,15 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "blh" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/monotile/dark,
-/area/hydroponics)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/monotile/steel,
+/area/hallway/secondary/exit)
 "bli" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -24619,14 +24603,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "blk" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/lazylift/master{
+	pixel_y = -31
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/open/floor/monotile/dark,
+/area/shuttle/turbolift/tertiary)
 "bll" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/steel,
@@ -24634,32 +24615,38 @@
 "bln" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
-	dir = 4
+	dir = 2
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/service)
 "blo" = (
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Hydroponics";
+	req_one_access_txt = "35"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plating,
+/area/hydroponics)
+"blp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/closed/wall/ship,
-/area/maintenance/starboard/fore)
-"blp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/engine/atmos)
 "blq" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/sorting/mail/flip,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/engine/atmos)
 "blr" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	name = "Atmospherics maintenance";
@@ -24677,8 +24664,11 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
 /turf/open/floor/monotile/steel,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/engine/atmos)
 "bls" = (
 /obj/effect/spawner/lootdrop/maintenance/three,
 /obj/structure/closet/crate{
@@ -24721,6 +24711,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "blx" = (
@@ -24739,16 +24732,17 @@
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "blz" = (
-/obj/structure/disposalpipe/segment,
-/turf/closed/wall/ship,
-/area/maintenance/starboard/fore)
-"blA" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/junction,
+/obj/structure/closet/crate,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
+"blA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/loading_area,
+/turf/open/floor/monotile/dark,
+/area/hallway/secondary/exit)
 "blB" = (
 /obj/structure/rack,
 /obj/item/circuitboard/machine/cell_charger,
@@ -24813,29 +24807,18 @@
 /turf/open/floor/monotile/light,
 /area/crew_quarters/kitchen)
 "blL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/engine/atmos)
 "blM" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/disposalpipe/sorting/mail{
-	sortType = 18
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "blO" = (
 /obj/machinery/mass_driver{
 	id = "chapelgun"
@@ -24893,18 +24876,16 @@
 	name = "Mess hall"
 	})
 "blV" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/monotile/steel,
-/area/crew_quarters/cafeteria{
-	name = "Mess hall"
-	})
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/secondary/exit)
 "blW" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/ship,
@@ -24915,9 +24896,6 @@
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
 "bmb" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
@@ -25146,33 +25124,24 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "bmw" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
 "bmx" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
 "bmy" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -25189,6 +25158,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
 "bmC" = (
@@ -25221,8 +25192,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "bmG" = (
@@ -25233,7 +25202,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
@@ -25242,13 +25210,22 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
 "bmJ" = (
-/obj/machinery/light{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/obj/effect/landmark/start/botanist,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/monotile/steel,
 /area/hydroponics)
 "bmK" = (
 /obj/effect/turf_decal/tile/red{
@@ -25427,6 +25404,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "bmZ" = (
@@ -25440,15 +25422,10 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "bna" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/turf/open/floor/durasteel/techfloor{
+	initial_gas_mix = "TEMP=2.7"
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/engine/atmospherics_engine)
 "bnc" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/steel,
@@ -25485,15 +25462,6 @@
 /obj/machinery/recharge_station,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
-"bng" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "bni" = (
 /obj/machinery/vending/cola/random,
 /obj/item/radio/intercom{
@@ -25597,6 +25565,11 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "bnv" = (
@@ -25611,50 +25584,40 @@
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/warehouse)
 "bnw" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"bnx" = (
-/obj/machinery/power/apc/auto_name/north{
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/camera/autoname{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/open/floor/durasteel/techfloor{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
+"bnx" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-10"
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/secondary/exit)
 "bnz" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
+/obj/effect/spawner/lootdrop,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "bnA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
+/obj/structure/table,
+/obj/item/poster/random_contraband,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "bnB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/grid/steel,
+/area/hallway/secondary/exit)
 "bnD" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
@@ -25670,42 +25633,6 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "bnG" = (
-/obj/structure/table,
-/obj/item/stack/wrapping_paper,
-/obj/item/stack/wrapping_paper,
-/obj/item/stack/package_wrap{
-	pixel_x = 2;
-	pixel_y = -3
-	},
-/obj/item/stack/package_wrap{
-	pixel_x = 2;
-	pixel_y = -3
-	},
-/obj/item/stack/package_wrap{
-	pixel_x = 2;
-	pixel_y = -3
-	},
-/obj/item/stack/package_wrap{
-	pixel_x = 2;
-	pixel_y = -3
-	},
-/obj/item/stack/package_wrap{
-	pixel_x = 2;
-	pixel_y = -3
-	},
-/obj/item/stack/package_wrap{
-	pixel_x = 2;
-	pixel_y = -3
-	},
-/obj/item/stack/package_wrap{
-	pixel_x = 2;
-	pixel_y = -3
-	},
-/obj/item/stack/package_wrap{
-	pixel_x = 2;
-	pixel_y = -3
-	},
-/obj/item/storage/box/lights/mixed,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
@@ -25730,16 +25657,11 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
 "bnK" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door/airlock/ship{
+	name = "Escape Pod"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/grid/steel,
-/area/quartermaster/storage)
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "bnL" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -25788,24 +25710,21 @@
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "bnS" = (
-/obj/structure/table,
-/obj/item/folder/yellow,
-/obj/item/pen{
-	pixel_x = 4;
-	pixel_y = 4
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "bnT" = (
-/obj/machinery/camera/autoname{
-	dir = 8
+/obj/effect/landmark/xeno_spawn,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/item/radio/intercom{
-	pixel_x = 26
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/structure/filingcabinet/filingcabinet,
-/turf/open/floor/plasteel/grid/steel,
-/area/quartermaster/storage)
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "bnW" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -25843,14 +25762,17 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/steel,
 /area/hallway/secondary/exit)
 "bob" = (
-/obj/effect/spawner/lootdrop/grille_or_trash,
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "bod" = (
 /obj/effect/turf_decal/delivery/white,
 /obj/structure/cable{
@@ -25998,25 +25920,19 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bor" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/structure/disposalpipe/segment{
 	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "bos" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "bot" = (
@@ -26107,48 +26023,33 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "boC" = (
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/cafeteria{
+	name = "Mess hall"
+	})
+"boD" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"boE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
-"boD" = (
-/obj/machinery/door/airlock/ship/station/mining{
-	name = "Warehouse";
-	req_one_access_txt = "31;48"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/monotile/dark,
-/area/quartermaster/warehouse)
-"boE" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plasteel/techmaint,
-/area/quartermaster/warehouse)
 "boF" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
@@ -26190,26 +26091,20 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/port)
 "boL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
+/turf/open/floor/carpet/blue,
+/area/hallway/secondary/exit/departure_lounge)
+"boM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/monotile/dark,
+/area/hallway/secondary/exit/departure_lounge)
+"boN" = (
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
-"boM" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/techmaint,
-/area/quartermaster/warehouse)
-"boN" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "boO" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/disposal/bin,
@@ -26274,23 +26169,23 @@
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/port)
 "boV" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/status_display/supply{
-	pixel_x = 32
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/grid/steel,
-/area/quartermaster/storage)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/monotile/steel,
+/area/crew_quarters/cafeteria{
+	name = "Mess hall"
+	})
 "boW" = (
-/obj/structure/grille,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/effect/spawner/room/threexfive,
+/turf/template_noop,
+/area/maintenance/department/cargo)
 "boX" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -26751,20 +26646,16 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "bpO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/structure/table,
+/obj/item/stock_parts/manipulator,
+/obj/item/disk/holodisk/enterprise_log,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"bpQ" = (
+/obj/structure/chair/stool,
 /obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel/grid/steel,
-/area/quartermaster/storage)
-"bpP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -26772,30 +26663,16 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/turf/open/floor/plasteel/grid/steel,
-/area/quartermaster/storage)
-"bpQ" = (
-/obj/machinery/door/airlock/ship/station/mining{
-	name = "Quartermaster's Office";
-	req_one_access_txt = "41"
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/durasteel,
-/area/quartermaster/qm)
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/cafeteria{
+	name = "Mess hall"
+	})
 "bpR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/effect/landmark/zebra_interlock_point,
@@ -26874,37 +26751,27 @@
 /area/chapel/main)
 "bpX" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
 "bpY" = (
-/obj/effect/turf_decal/tile/brown{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/structure/disposalpipe/junction/flip{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/secondary/exit)
 "bpZ" = (
-/obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen,
 /obj/machinery/door/window/eastright{
 	name = "Cargo Desk";
 	req_access_txt = "31"
@@ -26915,22 +26782,30 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/structure/table/reinforced,
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "bqa" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "bqb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/landmark/start/shaft_miner,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "bqc" = (
@@ -26959,46 +26834,34 @@
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "bqf" = (
-/obj/structure/table/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/carpet/ship,
-/area/quartermaster/storage)
+/area/quartermaster/qm)
 "bqg" = (
-/obj/machinery/computer/bounty,
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 1;
-	sortType = 2
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/carpet/ship,
+/turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "bqh" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/curtain/obscuring/grey,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/quartermaster/qm)
+/obj/structure/chair/stool,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/cafeteria{
+	name = "Mess hall"
+	})
 "bqi" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
-/turf/open/floor/carpet/ship,
-/area/quartermaster/qm)
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
 "bqj" = (
 /obj/machinery/door/airlock/ship{
 	name = "Experimental munitions";
@@ -27185,12 +27048,17 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/secondary/exit)
 "bqA" = (
-/obj/structure/chair/office{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/landmark/start/cargo_technician,
-/mob/living/simple_animal/sloth/paperwork,
-/turf/open/floor/carpet/ship,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "bqB" = (
 /obj/machinery/modular_fabricator/autolathe,
@@ -27204,61 +27072,50 @@
 /turf/open/floor/carpet/ship,
 /area/quartermaster/qm)
 "bqD" = (
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 1;
+	height = 4;
+	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
+	width = 3
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"bqE" = (
+/obj/structure/closet,
+/obj/item/clothing/gloves/color/fyellow,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"bqF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
+	dir = 9
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"bqE" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 8;
-	sortType = 21
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"bqF" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
+/area/maintenance/department/cargo)
+"bqG" = (
+/obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"bqG" = (
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 8;
-	sortType = 20
+/obj/structure/table/reinforced,
+/obj/item/stamp,
+/obj/item/stamp/denied{
+	pixel_y = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/open/floor/carpet/ship,
+/area/quartermaster/qm)
 "bqH" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/engine/atmos)
 "bqI" = (
 /obj/machinery/computer/card/minor/rd{
 	dir = 4
@@ -27316,76 +27173,58 @@
 /turf/open/floor/monotile/dark,
 /area/science/nanite)
 "bqP" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "bqQ" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "bqR" = (
-/obj/machinery/computer/cargo,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/carpet/ship,
-/area/quartermaster/storage)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/cafeteria{
+	name = "Mess hall"
+	})
 "bqS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/table/reinforced,
 /turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "bqT" = (
-/obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/ship_weapon/torpedo_launcher/cargo/east{
-	launcher_id = "nt_cargo_torpedo_launcher"
+/obj/structure/window/reinforced,
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "packageExternal"
 	},
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "bqU" = (
-/obj/machinery/camera/autoname{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "bqV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 8;
+	sortType = 2
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/computer/ship/dradis/minor/cargo{
-	dradis_id = "nt_cargo_torpedo_launcher"
-	},
-/obj/item/clothing/ears/earmuffs,
-/turf/open/floor/carpet/ship,
+/turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "bqW" = (
 /obj/machinery/modular_computer/console/preset/research{
@@ -27425,18 +27264,12 @@
 /turf/open/floor/monotile/dark,
 /area/security/prison)
 "brb" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/sign/poster/official/fruit_bowl{
+	pixel_y = -2;
+	pixel_x = 33
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plasteel/grid/steel,
-/area/quartermaster/storage)
+/turf/open/floor/carpet/ship,
+/area/quartermaster/qm)
 "brc" = (
 /obj/machinery/computer/robotics{
 	dir = 4
@@ -27558,23 +27391,31 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bro" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/machinery/status_display/supply{
+	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/carpet/ship,
+/area/quartermaster/storage)
+"brp" = (
+/obj/structure/disposalpipe/junction/flip{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/monotile/steel,
-/area/hallway/secondary/exit)
-"brp" = (
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 1;
-	sortType = 2
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/carpet/ship,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "brq" = (
 /obj/machinery/disposal/bin,
@@ -27685,15 +27526,9 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "brC" = (
-/obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/effect/spawner/room/fivexfour,
+/turf/template_noop,
+/area/maintenance/department/cargo)
 "brD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -27868,14 +27703,18 @@
 /turf/open/floor/monotile/dark,
 /area/security/prison)
 "brT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck2/frame1/central)
 "brU" = (
 /obj/structure/disposaloutlet{
 	dir = 1
@@ -27911,14 +27750,13 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bsa" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 1
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/computer/bounty,
 /turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "bsb" = (
@@ -27947,8 +27785,10 @@
 /area/hallway/secondary/exit)
 "bse" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit)
 "bsf" = (
@@ -27958,32 +27798,37 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/disposalpipe/junction/flip{
-	dir = 1
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/secondary/exit)
 "bsg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/table/glass,
+/obj/item/folder/white{
+	pixel_x = 4;
+	pixel_y = -3
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/carpet/blue,
 /area/hallway/secondary/exit/departure_lounge)
 "bsh" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/landmark/nuclear_waste_spawner,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"bsi" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/turf/open/floor/wood,
-/area/hydroponics)
-"bsi" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/effect/landmark/zebra_interlock_point,
+/obj/effect/turf_decal/ship/delivery/yellow,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/frame1/central)
 "bsj" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -28014,16 +27859,26 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/monotile/steel,
 /area/hallway/secondary/exit)
 "bso" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit/departure_lounge)
@@ -28140,11 +27995,15 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "bsw" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "bsx" = (
@@ -28221,16 +28080,17 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "bsG" = (
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 10
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/durasteel/techfloor{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "bsH" = (
 /obj/machinery/conveyor{
 	id = "garbage_space"
@@ -28285,17 +28145,10 @@
 /turf/open/floor/plasteel/grid/steel,
 /area/hallway/secondary/exit)
 "bsM" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/monotile/steel,
-/area/hallway/secondary/exit)
+/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/quartermaster/qm)
 "bsN" = (
 /obj/machinery/mass_driver{
 	id = "trash"
@@ -28948,12 +28801,8 @@
 	},
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 1;
-	sortType = 19
+	sortType = 21
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "btZ" = (
@@ -29008,10 +28857,10 @@
 	name = "Mess hall"
 	})
 "buc" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/kitchen)
 "bud" = (
@@ -29046,20 +28895,23 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/theatre)
 "buf" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/monotile/dark,
-/area/hydroponics)
+/area/hallway/secondary/exit)
 "buh" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/crew_quarters/cafeteria{
-	name = "Mess hall"
-	})
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet/crate/freezer,
+/turf/open/floor/plasteel/tech/grid,
+/area/quartermaster/warehouse)
 "bui" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -29083,25 +28935,20 @@
 /turf/open/floor/monotile/dark,
 /area/hydroponics)
 "bul" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/monotile/dark,
 /area/hydroponics)
 "bum" = (
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
 /turf/open/floor/monotile/steel,
-/area/hydroponics)
+/area/hallway/secondary/exit)
 "bun" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -29118,25 +28965,26 @@
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
 "bup" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/bar)
 "buq" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/monotile/steel,
-/area/hydroponics)
+/obj/item/reagent_containers/food/drinks/solgovcup,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/obj/structure/table/reinforced,
+/turf/open/floor/carpet/ship,
+/area/quartermaster/storage)
 "bur" = (
 /obj/structure/chair/fancy{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/nsv/observation)
 "bus" = (
@@ -29146,21 +28994,14 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
 "but" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/dark,
 /area/hydroponics)
 "buu" = (
@@ -29171,43 +29012,43 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
+	icon_state = "1-8"
 	},
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
 "buv" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
-/obj/effect/landmark/start/botanist,
-/turf/open/floor/monotile/dark,
-/area/hydroponics)
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
 "buw" = (
-/obj/machinery/smartfridge/drying_rack,
-/turf/open/floor/wood,
-/area/hydroponics)
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
 "bux" = (
+/obj/structure/table/wood,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
-/area/hydroponics)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/nsv/observation)
 "buy" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/theatre)
 "buz" = (
@@ -29222,11 +29063,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/monotile/light,
 /area/crew_quarters/kitchen)
@@ -29254,9 +29095,6 @@
 	name = "old sink";
 	pixel_y = 28
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -29270,7 +29108,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
 "buF" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/monotile/light,
@@ -29465,16 +29303,9 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "buS" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck2/frame1/central)
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/carpet/blue,
+/area/quartermaster/qm)
 "buT" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -29491,11 +29322,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4;
+	on = 0
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
@@ -30037,7 +29866,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/machinery/camera/autoname,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
@@ -30569,70 +30397,82 @@
 /turf/open/floor/monotile/dark,
 /area/tcommsat/computer)
 "bxw" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "bxx" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
+"bxy" = (
+/obj/structure/disposalpipe/sorting/mail/flip{
+	sortType = 2
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/quartermaster/warehouse)
-"bxy" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/carpet/ship,
-/area/quartermaster/qm)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
 "bxz" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/machinery/computer/cargo/request{
+	dir = 8
 	},
-/obj/machinery/camera/autoname{
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "bxA" = (
-/obj/machinery/door/airlock/ship/station/mining{
-	name = "Mining Equipment";
-	req_one_access_txt = "48"
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "bxB" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/turf/open/floor/plasteel/grid/steel,
-/area/quartermaster/storage)
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/monotile/steel,
+/area/hallway/secondary/exit)
 "bxC" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel/grid/steel,
-/area/quartermaster/storage)
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/monotile/steel,
+/area/engine/atmos)
 "bxD" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -30641,28 +30481,27 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/monotile/steel,
 /area/hallway/secondary/exit)
 "bxE" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 4
 	},
-/obj/effect/landmark/start/cargo_technician,
-/turf/open/floor/carpet/ship,
-/area/quartermaster/storage)
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/durasteel/techfloor{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "bxF" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/secondary/exit)
@@ -30685,9 +30524,6 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -30696,32 +30532,16 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/secondary/exit)
-"bxJ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
+"bxK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/grid/steel,
-/area/quartermaster/storage)
-"bxK" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/engine/atmos)
 "bxN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -30753,66 +30573,48 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/secondary/exit)
 "bxP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/grid/steel,
+/turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit)
 "bxQ" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/grid/steel,
-/area/hallway/secondary/exit)
-"bxR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/grid/steel,
-/area/hallway/secondary/exit)
-"bxS" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plasteel/grid/steel,
-/area/hallway/secondary/exit)
-"bxT" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
 /turf/open/floor/monotile/steel,
-/area/hallway/secondary/exit)
+/area/hydroponics)
+"bxR" = (
+/obj/structure/closet/secure_closet/quartermaster,
+/turf/open/floor/carpet/ship,
+/area/quartermaster/qm)
+"bxS" = (
+/obj/structure/closet/crate,
+/obj/effect/turf_decal/delivery,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/quartermaster/warehouse)
+"bxT" = (
+/obj/effect/landmark/start/quartermaster,
+/turf/open/floor/carpet/blue,
+/area/quartermaster/qm)
 "bxU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -31031,9 +30833,14 @@
 /turf/open/floor/durasteel,
 /area/engine/break_room)
 "byx" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/obj/machinery/computer/security/qm{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/carpet/blue,
+/area/quartermaster/qm)
 "byz" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -31583,15 +31390,9 @@
 /turf/open/floor/monotile/dark,
 /area/science)
 "bzB" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/theatre)
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/frame1/central)
 "bzC" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/machinery/light{
@@ -31613,12 +31414,18 @@
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
 "bzF" = (
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
 "bzG" = (
 /obj/structure/closet/crate{
 	opened = 1
@@ -31785,10 +31592,14 @@
 /turf/open/floor/monotile/steel,
 /area/medical/storage)
 "bzY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
 /turf/open/floor/plating,
-/area/hallway/secondary/exit)
+/area/maintenance/department/cargo)
 "bzZ" = (
 /obj/structure/sign/ship/nosmoking{
 	dir = 8
@@ -32137,15 +31948,10 @@
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "bAP" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck2/frame1/central)
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/monotile/dark,
+/area/hydroponics)
 "bAQ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -32262,16 +32068,18 @@
 	name = "Munitions Control Room"
 	})
 "bBf" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck2/frame1/central)
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/secondary/exit)
 "bBg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -32349,15 +32157,15 @@
 /turf/open/floor/monotile/steel,
 /area/nsv/hanger/deck2)
 "bBp" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/item/radio/intercom{
+	pixel_x = 26
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+/obj/machinery/camera/autoname{
 	dir = 8
 	},
-/turf/open/floor/monotile/dark,
-/area/hallway/nsv/deck2/frame1/central)
+/obj/structure/table,
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
 "bBq" = (
 /obj/machinery/deck_turret/powder_gate,
 /obj/effect/turf_decal/tile/orange{
@@ -32406,7 +32214,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
@@ -32615,6 +32424,8 @@
 	},
 /obj/effect/landmark/zebra_interlock_point,
 /obj/effect/turf_decal/ship/delivery/yellow,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
 "bBM" = (
@@ -32707,17 +32518,15 @@
 "bBX" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck2/frame1/central)
+/area/hydroponics)
 "bBY" = (
 /obj/structure/lattice/catwalk/over/ship,
 /obj/structure/cable/yellow{
@@ -33276,6 +33085,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit)
 "bDg" = (
@@ -33298,25 +33111,27 @@
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/port)
 "bDh" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 4
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Hydroponics";
+	req_one_access_txt = "35"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/techmaint,
-/area/quartermaster/warehouse)
+/turf/open/floor/plating,
+/area/hydroponics)
 "bDi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/machinery/computer/ship/viewscreen{
+	pixel_y = -4;
+	pixel_x = -32
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/carpet/ship,
+/turf/open/floor/carpet/blue,
 /area/quartermaster/qm)
 "bDj" = (
 /obj/structure/disposalpipe/segment{
@@ -33331,44 +33146,29 @@
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "bDk" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/effect/landmark/start/shaft_miner,
-/turf/open/floor/plasteel/grid/steel,
-/area/quartermaster/storage)
-"bDl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/secondary/exit/departure_lounge)
+"bDl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/machinery/door/airlock/ship/station/mining{
-	name = "Warehouse";
-	req_one_access_txt = "31;48"
-	},
-/obj/machinery/door/firedoor/border_only{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/monotile/dark,
-/area/quartermaster/warehouse)
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
 "bDm" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -33392,17 +33192,17 @@
 /turf/open/floor/monotile/dark,
 /area/medical/break_room)
 "bDo" = (
-/obj/effect/turf_decal/tile/brown{
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/brown{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/monotile/steel,
-/area/hallway/secondary/exit)
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck2/frame1/central)
 "bDp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -33419,21 +33219,27 @@
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/port)
 "bDq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit)
 "bDr" = (
-/obj/structure/chair/fancy{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/carpet/blue,
-/area/hallway/secondary/exit/departure_lounge)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/monotile/dark,
+/area/hallway/secondary/exit)
 "bDs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -33443,10 +33249,6 @@
 /area/hallway/secondary/exit)
 "bDt" = (
 /obj/effect/turf_decal/stripes/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/grid/steel,
 /area/hallway/secondary/exit)
 "bDu" = (
@@ -33593,32 +33395,25 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck2)
 "bDN" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet/blue,
-/area/hallway/secondary/exit/departure_lounge)
-"bDO" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -27
+	},
+/turf/open/floor/carpet/ship,
+/area/quartermaster/storage)
+"bDP" = (
+/obj/structure/table/glass,
+/obj/item/reagent_containers/food/drinks/solgovcup,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/monotile/dark,
-/area/hallway/secondary/exit/departure_lounge)
-"bDP" = (
-/obj/machinery/light,
-/turf/open/floor/monotile/dark,
+/turf/open/floor/carpet/blue,
 /area/hallway/secondary/exit/departure_lounge)
 "bDR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -33798,28 +33593,11 @@
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
 "bEj" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/ship/delivery/yellow,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/monotile/dark,
-/area/hallway/nsv/deck2/frame1/central)
+/turf/open/floor/plasteel/tech/grid,
+/area/quartermaster/warehouse)
 "bEk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
@@ -34029,11 +33807,11 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
@@ -34402,15 +34180,11 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=loc4";
-	location = "loc3-1"
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
@@ -34719,14 +34493,23 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "bFZ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/monotile/steel,
+/area/hydroponics)
 "bGa" = (
 /obj/machinery/vending/hydroseeds{
 	slogan_delay = 700
@@ -34737,6 +34520,9 @@
 	},
 /obj/machinery/airalarm{
 	pixel_y = 23
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
@@ -34784,15 +34570,20 @@
 /turf/open/floor/monotile/steel,
 /area/engine/engineering)
 "bGh" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/turf/open/floor/monotile/dark,
-/area/hallway/nsv/deck2/frame1/central)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
 "bGj" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -34876,25 +34667,17 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame2/port)
 "bGr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/structure/closet/firecloset,
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/turf/open/floor/plasteel/grid/steel,
-/area/quartermaster/storage)
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "bGs" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
+/obj/machinery/computer/cargo,
 /turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "bGt" = (
@@ -34997,11 +34780,8 @@
 	name = "Prototype munitions bay"
 	})
 "bGD" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/machinery/holopad,
-/turf/open/floor/carpet/ship,
+/obj/machinery/computer/cargo,
+/turf/open/floor/carpet/blue,
 /area/quartermaster/qm)
 "bGE" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -35016,15 +34796,8 @@
 /turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "bGG" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/plasteel/grid/steel,
 /area/hallway/secondary/exit)
 "bGH" = (
 /obj/machinery/portable_atmospherics/scrubber,
@@ -35034,9 +34807,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
@@ -35044,10 +34819,6 @@
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
 	},
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -35059,9 +34830,10 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
 /turf/open/floor/monotile/steel,
@@ -35421,13 +35193,13 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/engine/atmos)
 "bHx" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/engine/atmos)
 "bHy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable{
@@ -35480,12 +35252,13 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/junction/flip,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
 "bHJ" = (
@@ -35496,7 +35269,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/cafeteria{
 	name = "Mess hall"
@@ -35518,11 +35293,23 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "bHN" = (
-/obj/machinery/computer/bounty{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
-/turf/open/floor/carpet/ship,
-/area/quartermaster/qm)
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
 "bHO" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -35682,16 +35469,16 @@
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/nsv/observation)
 "bIi" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Hydroponics";
-	req_one_access_txt = "35"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/monotile/steel,
-/area/hydroponics)
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/department/cargo)
 "bIj" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/green/visible,
@@ -35746,11 +35533,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
@@ -35812,8 +35599,9 @@
 	name = "Prototype munitions bay"
 	})
 "bIC" = (
-/turf/closed/wall/r_wall/ship,
-/area/quartermaster/storage)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/quartermaster/qm)
 "bID" = (
 /obj/machinery/lazylift_button,
 /turf/closed/wall/r_wall/ship,
@@ -35960,6 +35748,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
 "bJa" = (
@@ -36036,19 +35830,15 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bJi" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
+/obj/effect/landmark/start/quartermaster,
+/obj/structure/chair/office{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/monotile/dark,
-/area/engine/atmospherics_engine)
+/turf/open/floor/carpet/blue,
+/area/quartermaster/qm)
 "bJj" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -36092,68 +35882,33 @@
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/port)
 "bJp" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_x = -3;
+	pixel_y = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"bJq" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"bJt" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/quartermaster/storage)
-"bJu" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/quartermaster/storage)
-"bJv" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/landmark/nuclear_waste_spawner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"bJw" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
+"bJq" = (
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"bJx" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plating,
-/area/quartermaster/storage)
-"bJz" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	name = "Mining dock";
-	req_one_access_txt = "31; 48"
+/area/maintenance/department/cargo)
+"bJt" = (
+/obj/machinery/door/airlock/ship/station/mining{
+	name = "Administrative Supplies";
+	req_one_access_txt = "48"
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -36165,63 +35920,97 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
-"bJA" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/junction/flip{
+"bJu" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"bJv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"bJB" = (
+"bJw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
+/turf/open/floor/monotile/dark,
+/area/hallway/secondary/exit)
+"bJx" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/carpet/ship,
+/area/quartermaster/storage)
+"bJz" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/carpet/ship,
+/area/quartermaster/storage)
+"bJA" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
+"bJB" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/ship/maintenance{
+	name = "Mining dock";
+	req_one_access_txt = "31; 48"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "bJC" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/cafeteria{
+	name = "Mess hall"
+	})
 "bJD" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "0-2"
 	},
-/obj/structure/disposalpipe/junction/flip{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
@@ -36240,58 +36029,33 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"bJG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"bJG" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "bJH" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "bJI" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/obj/structure/closet/firecloset,
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/frame1/central)
 "bJJ" = (
 /obj/machinery/door/poddoor/incinerator_atmos_aux,
 /turf/open/floor/engine/vacuum,
@@ -36715,6 +36479,7 @@
 	id = "tycoon_central_primary";
 	next_id = "tycoon_brig"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
 "bLc" = (
@@ -36891,11 +36656,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit)
@@ -36912,6 +36677,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit)
 "bLw" = (
@@ -36920,6 +36688,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit)
 "bLx" = (
@@ -36930,6 +36699,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit)
 "bLy" = (
@@ -36946,33 +36716,30 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit)
 "bLA" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit)
 "bLB" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit)
 "bLC" = (
@@ -36983,16 +36750,8 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/monotile/dark,
-/area/hallway/secondary/exit)
-"bLD" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit)
 "bLE" = (
@@ -37008,6 +36767,8 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/landmark/zebra_interlock_point,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit)
 "bLF" = (
@@ -37109,16 +36870,14 @@
 /turf/open/floor/monotile/steel,
 /area/medical/surgery)
 "bLR" = (
-/obj/docking_port/stationary{
-	dir = 2;
-	dwidth = 1;
-	height = 4;
-	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
-	width = 3
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
-/obj/structure/fans/tiny/invisible,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "bLS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/effect/landmark/zebra_interlock_point,
@@ -37200,6 +36959,8 @@
 	},
 /obj/effect/landmark/zebra_interlock_point,
 /obj/effect/turf_decal/ship/delivery/yellow,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
 "bMe" = (
@@ -37266,6 +37027,9 @@
 "bNC" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/gambling,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/nsv/observation)
 "bOr" = (
@@ -37343,10 +37107,20 @@
 	name = "CIC"
 	})
 "bUn" = (
-/obj/effect/spawner/lootdrop/maintenance/two,
-/obj/structure/rack,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/secondary/exit/departure_lounge)
 "bUM" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /turf/open/floor/durasteel/techfloor{
@@ -37602,20 +37376,11 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
 "bYJ" = (
-/obj/structure/table/reinforced,
-/obj/item/computer_hardware/hard_drive/role/quartermaster{
-	pixel_x = -4;
-	pixel_y = 7
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
-/obj/item/computer_hardware/hard_drive/role/quartermaster,
-/obj/item/computer_hardware/hard_drive/role/quartermaster{
-	pixel_x = 6;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/food/drinks/solgovcup,
-/obj/item/clothing/ears/earmuffs,
-/turf/open/floor/carpet/ship,
-/area/quartermaster/qm)
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
 "bYK" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "naval";
@@ -37739,6 +37504,7 @@
 /area/security/brig)
 "bZn" = (
 /obj/effect/landmark/start/clown,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/theatre)
 "bZo" = (
@@ -38327,18 +38093,10 @@
 	},
 /area/engine/atmos)
 "ciL" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space)
 "ciY" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -38385,14 +38143,14 @@
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "clm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/durasteel/techfloor{
+	initial_gas_mix = "TEMP=2.7"
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/engine/atmospherics_engine)
 "cmf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -38454,7 +38212,7 @@
 "cob" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 4
+	dir = 5
 	},
 /turf/open/space/basic,
 /area/engine/atmos)
@@ -38483,15 +38241,19 @@
 /area/medical/medbay/central)
 "cpD" = (
 /obj/structure/table,
+/obj/item/kitchen/rollingpin,
+/obj/item/reagent_containers/glass/beaker{
+	pixel_y = 10;
+	pixel_x = -3
+	},
 /obj/item/reagent_containers/food/condiment/saltshaker{
 	pixel_x = -3
 	},
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = 3
 	},
-/obj/item/trash/popcorn,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "cri" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -38617,15 +38379,12 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/hangar)
 "cAw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/machinery/computer/bounty,
+/obj/machinery/camera/autoname{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/open/floor/carpet/blue,
+/area/quartermaster/qm)
 "cBD" = (
 /obj/structure/sign/ship/shock{
 	dir = 1
@@ -38661,7 +38420,13 @@
 /turf/open/floor/monotile/dark,
 /area/medical/virology)
 "cDF" = (
-/turf/open/floor/plating,
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/camera/autoname,
+/obj/item/radio/intercom{
+	pixel_x = -26
+	},
+/obj/structure/filingcabinet,
+/turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "cED" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer2{
@@ -38720,7 +38485,7 @@
 	},
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/engine/atmos)
 "cIR" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/electrical{
@@ -39138,9 +38903,12 @@
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "dmM" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 2;
+	sortType = 20
+	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/engine/atmos)
 "dmS" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -39165,12 +38933,14 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "dnZ" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/glowstick,
-/obj/effect/spawner/lootdrop/maintenance/four,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/monotile/steel,
+/area/hallway/secondary/exit)
 "drl" = (
 /obj/machinery/meter,
 /obj/structure/grille,
@@ -39203,11 +38973,12 @@
 	name = "Mess hall"
 	})
 "duz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/closed/wall/r_wall/ship,
-/area/engine/atmospherics_engine)
+/turf/open/floor/plating,
+/area/maintenance/department/engine/atmos)
 "dwf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -39316,7 +39087,7 @@
 "dFv" = (
 /obj/structure/sign/poster/contraband/donut_corp,
 /turf/closed/wall/ship,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/engine/atmos)
 "dFO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -39583,9 +39354,9 @@
 	},
 /area/engine/atmos)
 "dXL" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/structure/filingcabinet/filingcabinet,
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
 "eba" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/orange,
@@ -39726,26 +39497,15 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "ekv" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "elG" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
@@ -39820,9 +39580,16 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "eno" = (
-/obj/machinery/lazylift/master,
-/turf/open/floor/monotile/dark,
-/area/shuttle/turbolift/tertiary)
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/durasteel/techfloor{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmospherics_engine)
 "enx" = (
 /obj/item/reagent_containers/food/drinks/sillycup{
 	pixel_x = -5;
@@ -39915,16 +39682,15 @@
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
 "epQ" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 4
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
 	},
-/obj/effect/spawner/lootdrop/maintenance/four,
-/obj/structure/closet,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/open/floor/monotile/steel,
+/area/hallway/secondary/exit)
 "eqv" = (
 /turf/template_noop,
 /area/maintenance/central)
@@ -40007,10 +39773,44 @@
 /turf/open/floor/plasteel/freezer/airless,
 /area/medical/virology)
 "evG" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/structure/table,
+/obj/item/stack/wrapping_paper,
+/obj/item/stack/wrapping_paper,
+/obj/item/stack/package_wrap{
+	pixel_x = 2;
+	pixel_y = -3
+	},
+/obj/item/stack/package_wrap{
+	pixel_x = 2;
+	pixel_y = -3
+	},
+/obj/item/stack/package_wrap{
+	pixel_x = 2;
+	pixel_y = -3
+	},
+/obj/item/stack/package_wrap{
+	pixel_x = 2;
+	pixel_y = -3
+	},
+/obj/item/stack/package_wrap{
+	pixel_x = 2;
+	pixel_y = -3
+	},
+/obj/item/stack/package_wrap{
+	pixel_x = 2;
+	pixel_y = -3
+	},
+/obj/item/stack/package_wrap{
+	pixel_x = 2;
+	pixel_y = -3
+	},
+/obj/item/stack/package_wrap{
+	pixel_x = 2;
+	pixel_y = -3
+	},
+/obj/item/storage/box/lights/mixed,
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
 "exT" = (
 /obj/structure/bookcase/random/fiction,
 /turf/open/floor/wood,
@@ -40182,7 +39982,7 @@
 "eFj" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/engine/atmos)
 "eFK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -40231,11 +40031,10 @@
 /turf/open/floor/monotile/steel,
 /area/engine/engineering/reactor_core)
 "eJW" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -27
-	},
-/turf/open/floor/carpet/ship,
-/area/quartermaster/qm)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "eKw" = (
 /obj/machinery/atmospherics/pipe/simple/brown/hidden,
 /turf/open/floor/monotile/steel,
@@ -40274,13 +40073,11 @@
 /turf/open/floor/monotile/light,
 /area/medical/virology)
 "eNG" = (
-/obj/structure/closet/cardboard,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/spawner/lootdrop/maintenance/four,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "eNN" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 8
@@ -40474,7 +40271,7 @@
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "faG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -40597,11 +40394,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/computer/ship/viewscreen,
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=loc3";
 	location = "loc2"
 	},
-/obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "fnR" = (
@@ -40623,14 +40420,15 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/fitness/recreation)
 "for" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/engine/atmos)
 "foY" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -40652,18 +40450,19 @@
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
 "fpJ" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/three,
+/obj/structure/disposalpipe/sorting/mail{
+	sortType = 18;
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/engine/atmos)
 "fpL" = (
 /obj/machinery/door/airlock/ship/station/mining{
 	name = "Cargo Bay";
 	req_one_access_txt = "31; 48"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -40738,7 +40537,7 @@
 /obj/structure/table,
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "fxX" = (
 /obj/structure/lattice,
 /turf/open/space,
@@ -40747,7 +40546,7 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "fyJ" = (
 /obj/structure/lattice/catwalk/over/ship,
 /obj/machinery/status_display/evac{
@@ -40851,9 +40650,23 @@
 /turf/open/space/basic,
 /area/engine/engineering/reactor_core)
 "fEj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/closed/wall/r_wall/ship,
-/area/engine/atmospherics_engine)
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
+	req_one_access_txt = "0"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "fEH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -40895,12 +40708,21 @@
 /area/engine/atmos)
 "fJP" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "0-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/monotile/dark,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/durasteel/techfloor{
+	initial_gas_mix = "TEMP=2.7"
+	},
 /area/engine/atmospherics_engine)
 "fJR" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -41059,7 +40881,6 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/newscaster{
 	pixel_y = -32
 	},
@@ -41092,21 +40913,21 @@
 /turf/open/floor/durasteel,
 /area/space/nearstation)
 "gaR" = (
-/obj/structure/table/reinforced,
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/item/reagent_containers/food/drinks/solgovcup,
-/obj/item/clothing/ears/earmuffs,
-/obj/item/clothing/ears/earmuffs,
-/turf/open/floor/carpet/ship,
-/area/quartermaster/storage)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "gbA" = (
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /obj/machinery/door/firedoor/border_only{
@@ -41151,11 +40972,12 @@
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
 "gcf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/item/storage/box/lights/mixed,
-/obj/structure/rack,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "gdZ" = (
@@ -41261,17 +41083,14 @@
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
 "glh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/monotile/dark,
+/area/hallway/secondary/exit)
 "glX" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -41442,8 +41261,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
-/area/maintenance/starboard/fore)
+/area/hallway/secondary/service)
 "gAS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -41535,9 +41355,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -41644,17 +41461,11 @@
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
 "gKB" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/dark/visible,
+/turf/open/floor/durasteel/techfloor{
+	initial_gas_mix = "TEMP=2.7"
 	},
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/engine/atmospherics_engine)
 "gMB" = (
 /obj/machinery/photocopier{
 	pixel_y = 3
@@ -41701,12 +41512,9 @@
 /turf/open/floor/monotile/steel,
 /area/nsv/engine/dcc)
 "gRe" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/decal/cleanable/oil/streak,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/engine/atmos)
 "gRE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -41824,17 +41632,21 @@
 /turf/open/floor/engine/o2,
 /area/engine/atmos)
 "gYf" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1
+	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/hallway/secondary/exit/departure_lounge)
 "gZm" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -42018,7 +41830,7 @@
 "hjm" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "hjP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/ship/preopen{
@@ -42155,14 +41967,17 @@
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/chief)
 "hsX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/durasteel/techfloor{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmospherics_engine)
 "hti" = (
 /obj/structure/cable,
 /obj/structure/grille,
@@ -42213,13 +42028,8 @@
 	},
 /area/engine/atmos)
 "hwO" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/closed/wall/r_wall/ship,
+/area/quartermaster/warehouse)
 "hwT" = (
 /obj/machinery/power/turbine{
 	dir = 4
@@ -42240,20 +42050,17 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "hxd" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=1";
-	location = "Kitchen";
-	name = "navigation beacon (Kitchen Delivery)"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
 	},
-/obj/machinery/door/window/eastright{
-	dir = 1;
-	name = "Kitchen Delivery";
-	req_access_txt = "28"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
-/obj/structure/plasticflaps/opaque,
-/turf/open/floor/plasteel/techmaint,
-/area/crew_quarters/kitchen/coldroom)
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/quartermaster/warehouse)
 "hxi" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -42390,18 +42197,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "hBe" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Hydroponics";
-	req_one_access_txt = "35"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/monotile/steel,
-/area/hydroponics)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/department/engine/atmos)
 "hCf" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -42417,17 +42218,15 @@
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
 "hCE" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
+	req_one_access_txt = "0"
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "hER" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -42467,15 +42266,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "hHa" = (
 /obj/effect/turf_decal/pool/corner{
 	dir = 1
@@ -42828,7 +42623,7 @@
 "ilA" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/engine/atmos)
 "ilH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -42925,15 +42720,12 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "isx" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/monotile/steel,
-/area/hallway/secondary/exit)
+/obj/effect/landmark/start/botanist,
+/turf/open/floor/monotile/dark,
+/area/hydroponics)
 "itk" = (
 /obj/machinery/computer/ship/navigation/console/end{
 	dir = 4
@@ -42959,7 +42751,7 @@
 /area/engine/engineering/reactor_core)
 "iuA" = (
 /turf/closed/wall/ship,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/engine/atmos)
 "iwo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -43035,12 +42827,15 @@
 /area/maintenance/department/security)
 "izj" = (
 /obj/structure/disposalpipe/segment{
-	dir = 9
+	dir = 4
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 2
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/disposal/bin,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "iBy" = (
@@ -43071,9 +42866,20 @@
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo)
 "iCC" = (
-/obj/effect/decal/cleanable/oil,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/item/stack/sheet/cardboard,
+/obj/item/stack/sheet/cardboard,
+/obj/item/stack/sheet/cardboard,
+/obj/item/stack/sheet/cardboard,
+/obj/item/storage/box/lights/mixed,
+/turf/open/floor/carpet/ship,
+/area/quartermaster/storage)
 "iCD" = (
 /obj/structure/closet/lasertag/blue,
 /obj/machinery/light,
@@ -43567,18 +43373,15 @@
 /turf/open/floor/plasteel/techmaint,
 /area/engine/engine_room)
 "jbq" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/stamp/quartermaster,
+/turf/open/floor/carpet/ship,
+/area/quartermaster/qm)
 "jbD" = (
 /obj/effect/turf_decal/ship/outline,
 /obj/machinery/shower{
@@ -43674,11 +43477,16 @@
 /turf/open/floor/plasteel/freezer,
 /area/medical/virology)
 "jku" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
+/obj/structure/disposalpipe/junction{
+	dir = 1
 	},
-/turf/closed/wall/r_wall/ship,
-/area/engine/atmospherics_engine)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/carpet/ship,
+/area/quartermaster/storage)
 "jkO" = (
 /obj/machinery/light{
 	dir = 4
@@ -43746,6 +43554,9 @@
 /obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Mess Hall"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
 	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/cafeteria{
@@ -43868,10 +43679,9 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
 "jvE" = (
-/obj/effect/spawner/lootdrop,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel/grid/steel,
+/area/hallway/secondary/exit)
 "jvI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -44585,11 +44395,15 @@
 /turf/open/space/basic,
 /area/engine/atmos)
 "kpT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/monotile/steel,
+/area/hallway/secondary/exit)
 "kqi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -44614,8 +44428,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/status_display/ai{
 	pixel_x = -32
 	},
@@ -45281,11 +45093,8 @@
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/fitness/recreation)
 "ljw" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/engine/atmos)
 "ljD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -45294,6 +45103,8 @@
 	id = "tycoon_bar";
 	next_id = "tycoon_deck2_ladder"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
 "ljS" = (
@@ -45560,15 +45371,11 @@
 	name = "CIC"
 	})
 "lzn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -27
-	},
-/obj/machinery/computer/ship/munitions_computer/west,
-/turf/open/floor/plasteel/grid/steel,
-/area/quartermaster/storage)
+/turf/open/floor/monotile/steel,
+/area/hallway/secondary/exit)
 "lAf" = (
 /obj/machinery/atmospherics/components/binary/pump/rbmk_input{
 	dir = 1;
@@ -45591,16 +45398,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/engine)
-"lAV" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "lCE" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/closed/wall/r_wall/ship,
@@ -45716,10 +45513,20 @@
 /turf/open/floor/wood,
 /area/library)
 "lLc" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/structure/chair/stool,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/cafeteria{
+	name = "Mess hall"
+	})
 "lLt" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -46033,21 +45840,14 @@
 /turf/open/floor/plating,
 /area/medical/medbay/lobby)
 "mlC" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 10
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/durasteel/techfloor{
+	initial_gas_mix = "TEMP=2.7"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/engine/atmospherics_engine)
 "mlM" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -46418,11 +46218,21 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "mIw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
+/obj/structure/table/reinforced,
+/obj/item/computer_hardware/hard_drive/role/quartermaster{
+	pixel_x = -4;
+	pixel_y = 7
 	},
-/turf/closed/wall/r_wall/ship,
-/area/engine/atmospherics_engine)
+/obj/item/computer_hardware/hard_drive/role/quartermaster,
+/obj/item/computer_hardware/hard_drive/role/quartermaster{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/drinks/solgovcup,
+/obj/item/clothing/ears/earmuffs,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/carpet/blue,
+/area/quartermaster/qm)
 "mIL" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -46456,11 +46266,12 @@
 /turf/open/floor/monotile/steel,
 /area/engine/gravity_generator)
 "mJh" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 4
+/obj/machinery/newscaster{
+	pixel_y = -28
 	},
-/turf/closed/wall/r_wall/ship,
-/area/engine/atmos)
+/obj/effect/landmark/start/quartermaster,
+/turf/open/floor/carpet/blue,
+/area/quartermaster/qm)
 "mKh" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 8
@@ -46541,7 +46352,6 @@
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
 "mOC" = (
-/obj/structure/window/reinforced,
 /obj/machinery/door/window/eastleft{
 	base_state = "right";
 	dir = 8;
@@ -46553,6 +46363,7 @@
 	dir = 8;
 	id = "packageExternal"
 	},
+/obj/structure/window/reinforced,
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "mON" = (
@@ -46677,12 +46488,11 @@
 	},
 /area/engine/atmos)
 "mUy" = (
-/obj/structure/table,
-/obj/item/stock_parts/manipulator,
-/obj/item/disk/holodisk/enterprise_log,
-/obj/effect/decal/cleanable/cobweb,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/engine/atmos)
 "mUL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -46798,7 +46608,7 @@
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "ndL" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
@@ -46829,15 +46639,10 @@
 /turf/open/floor/plating,
 /area/engine/engineering/hangar)
 "nfz" = (
-/obj/machinery/atmospherics/components/binary/pump/on,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1
 	},
-/obj/machinery/airlock_sensor/incinerator_atmos{
-	pixel_x = -8;
-	pixel_y = 24
-	},
-/turf/open/floor/engine,
+/turf/open/floor/engine/vacuum,
 /area/engine/atmospherics_engine)
 "ngo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -46908,6 +46713,9 @@
 	codes_txt = "patrol;next_patrol=loc3-1";
 	location = "loc3"
 	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit)
 "nnZ" = (
@@ -47253,20 +47061,21 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/fitness/recreation)
 "nMg" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/turf/open/floor/engine,
+/turf/open/floor/engine/vacuum,
 /area/engine/atmospherics_engine)
 "nMj" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel/grid/steel,
 /area/hallway/secondary/exit)
 "nNn" = (
@@ -47421,11 +47230,17 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "nUJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/item/reagent_containers/glass/beaker,
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/department/cargo)
 "nVs" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -47619,10 +47434,12 @@
 /turf/open/floor/plating/airless,
 /area/medical/virology)
 "ooh" = (
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
 "ope" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -47652,12 +47469,8 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
 "opK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit)
 "oqq" = (
@@ -47700,7 +47513,7 @@
 "oum" = (
 /obj/item/clothing/glasses/sunglasses/advanced,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "oun" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	req_one_access_txt = "8;13"
@@ -47744,7 +47557,7 @@
 /area/medical/morgue)
 "oyi" = (
 /turf/closed/wall/r_wall/ship,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/engine/atmos)
 "oyj" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 9
@@ -47884,19 +47697,11 @@
 	name = "CIC"
 	})
 "oII" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/ship/maintenance{
-	req_access_txt = "35"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/maintenance/starboard/fore)
+/turf/open/floor/monotile/dark,
+/area/hallway/secondary/exit/departure_lounge)
 "oJa" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/turf_decal/tile/orange{
@@ -47920,10 +47725,12 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "oMQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump/on,
+/obj/machinery/airlock_sensor/incinerator_atmos{
+	pixel_x = -8;
+	pixel_y = 24
 	},
-/turf/closed/wall/r_wall/ship,
+/turf/open/floor/engine/vacuum,
 /area/engine/atmospherics_engine)
 "oOl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible/layer2{
@@ -48130,11 +47937,12 @@
 /turf/open/floor/wood,
 /area/library)
 "phM" = (
-/obj/item/radio/intercom{
-	pixel_y = -26
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/turf/open/floor/carpet/ship,
-/area/quartermaster/qm)
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
 "pjr" = (
 /obj/structure/chair,
 /obj/machinery/computer/ship/viewscreen,
@@ -48155,9 +47963,9 @@
 /turf/open/floor/durasteel/lino,
 /area/engine/engineering/reactor_control)
 "pkh" = (
-/obj/machinery/computer/ship/viewscreen,
-/turf/open/floor/carpet/ship,
-/area/quartermaster/qm)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel/grid/steel,
+/area/hallway/secondary/exit)
 "pkk" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/structure/cable{
@@ -48253,7 +48061,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /obj/item/radio/intercom{
 	pixel_x = 26
 	},
@@ -48329,11 +48136,9 @@
 /turf/open/floor/monotile/light,
 /area/medical/medbay/central)
 "pvj" = (
-/obj/machinery/door/airlock/ship/public/glass/turbolift{
-	dir = 4
-	},
+/obj/item/cigbutt,
 /turf/open/floor/plating,
-/area/shuttle/turbolift/tertiary)
+/area/maintenance/department/cargo)
 "pwx" = (
 /obj/machinery/light{
 	dir = 4
@@ -48382,9 +48187,17 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "pxy" = (
-/obj/machinery/newscaster,
-/turf/closed/wall/ship,
-/area/quartermaster/qm)
+/obj/machinery/door/airlock/ship{
+	name = "Supplies Closet"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/frame1/central)
 "pxF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -48444,10 +48257,13 @@
 /area/security/brig)
 "pBU" = (
 /obj/effect/landmark/xeno_spawn,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "pBW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -48510,16 +48326,12 @@
 /turf/open/floor/durasteel/techfloor,
 /area/nsv/hanger/deck2)
 "pFX" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/monotile/dark,
+/area/hydroponics)
 "pHr" = (
 /obj/effect/spawner/room/tenxfive,
 /turf/template_noop,
@@ -48610,18 +48422,12 @@
 /turf/open/floor/durasteel,
 /area/security/prison)
 "pLb" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/open/floor/monotile/dark,
+/area/hallway/secondary/exit/departure_lounge)
 "pNz" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 1
@@ -48898,12 +48704,22 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "qjd" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/turbine_computer{
+	dir = 1;
+	id = "incineratorturbine"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/durasteel/techfloor{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmospherics_engine)
 "qlR" = (
 /obj/structure/closet/crate{
 	opened = 1
@@ -48924,14 +48740,20 @@
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "qnS" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/monotile/dark,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/durasteel/techfloor{
+	initial_gas_mix = "TEMP=2.7"
+	},
 /area/engine/atmospherics_engine)
 "qoc" = (
 /obj/structure/disposalpipe/junction/yjunction{
@@ -48958,10 +48780,13 @@
 /turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "qqN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "qqT" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -49051,6 +48876,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/service)
 "qzh" = (
@@ -49178,11 +49004,19 @@
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "qEi" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/engine,
-/area/engine/atmospherics_engine)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/monotile/steel,
+/area/crew_quarters/cafeteria{
+	name = "Mess hall"
+	})
 "qEj" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank - Mix";
@@ -49191,8 +49025,12 @@
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos)
 "qEO" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/engine/atmos)
 "qFC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow{
@@ -49380,6 +49218,9 @@
 	},
 /obj/machinery/newscaster{
 	pixel_x = 30
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/secondary/exit)
@@ -49569,19 +49410,13 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/fitness/recreation)
 "rew" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
 	},
-/obj/structure/window/reinforced,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/turf/open/floor/monotile/steel,
+/area/hallway/secondary/exit)
 "rfC" = (
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -49612,20 +49447,14 @@
 /turf/open/floor/monotile/steel,
 /area/medical/medbay/central)
 "rge" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/monotile/steel,
-/area/hallway/secondary/exit)
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "rhe" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -49797,14 +49626,11 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
 "rso" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
+/obj/machinery/camera/autoname{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/open/floor/engine/vacuum,
+/area/engine/atmospherics_engine)
 "rsC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -49863,10 +49689,14 @@
 /area/nsv/engine/dcc)
 "ruX" = (
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
 "rvU" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -50667,19 +50497,26 @@
 	name = "Munitions Projects"
 	})
 "stk" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/machinery/meter,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/button/door/incinerator_vent_atmos_aux{
+	pixel_x = -8;
+	pixel_y = -24
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/button/door/incinerator_vent_atmos_main{
+	pixel_x = -8;
+	pixel_y = -36
+	},
+/obj/machinery/button/ignition/incinerator/atmos{
+	pixel_x = 8;
+	pixel_y = -36
+	},
+/obj/machinery/atmospherics/components/trinary/filter/flipped,
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/durasteel/techfloor{
+	initial_gas_mix = "TEMP=2.7"
 	},
-/turf/open/floor/monotile/dark,
 /area/engine/atmospherics_engine)
 "stP" = (
 /obj/machinery/portable_atmospherics/canister/air,
@@ -50796,11 +50633,10 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "sAj" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/structure/lattice/catwalk,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/space/basic,
+/area/engine/atmospherics_engine)
 "sBR" = (
 /obj/machinery/camera/autoname,
 /obj/machinery/vending/games,
@@ -51083,6 +50919,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile/steel,
 /area/hallway/secondary/exit)
 "tfG" = (
@@ -51097,24 +50936,20 @@
 /turf/open/floor/monotile/steel,
 /area/engine/engineering/reactor_core)
 "tfI" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/plasteel/grid/steel,
 /area/hallway/secondary/exit)
 "tgd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 5
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/cafeteria{
+	name = "Mess hall"
+	})
 "tgV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/turf_decal/tile/orange,
@@ -51354,6 +51189,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/central)
 "txH" = (
@@ -51616,10 +51452,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "tLT" = (
-/obj/structure/girder/reinforced,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/recharge_station,
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/frame1/central)
 "tMg" = (
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /obj/structure/cable{
@@ -51866,6 +51701,10 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "udH" = (
@@ -52097,6 +51936,9 @@
 	id = "tycoon_escapes";
 	next_id = "tycoon_central_primary"
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit)
 "utB" = (
@@ -52173,18 +52015,14 @@
 /turf/open/floor/plating,
 /area/medical/virology)
 "uIA" = (
-/obj/machinery/power/apc/auto_name/north{
-	pixel_y = 24
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister,
-/turf/open/floor/durasteel/techfloor,
-/area/engine/atmospherics_engine)
+/turf/open/floor/plating,
+/area/maintenance/department/engine/atmos)
 "uKa" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -52285,7 +52123,7 @@
 	},
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "uPh" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -52384,22 +52222,12 @@
 /turf/open/floor/monotile/steel,
 /area/engine/engineering/reactor_core)
 "vbj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
+/obj/machinery/light,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/table/reinforced,
-/obj/machinery/fax{
-	fax_name = "Cargo";
-	name = "Cargo Fax Machine"
-	},
-/turf/open/floor/plasteel/grid/steel,
-/area/quartermaster/storage)
+/turf/open/floor/monotile/dark,
+/area/hallway/secondary/exit/departure_lounge)
 "vbz" = (
 /obj/machinery/door/poddoor/ship{
 	dir = 4;
@@ -52537,14 +52365,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "vjc" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/rack,
+/obj/item/storage/box/lights/mixed,
+/obj/item/stack/sheet/mineral/copper{
+	amount = 5
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "vjL" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -52643,28 +52470,24 @@
 /turf/open/floor/monotile/steel,
 /area/engine/engineering/reactor_core)
 "vpr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/structure/rack,
+/obj/item/stamp/denied{
+	pixel_y = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/item/stamp,
+/turf/open/floor/carpet/ship,
+/area/quartermaster/storage)
 "vri" = (
 /obj/structure/table_frame,
 /obj/item/shard,
 /turf/open/floor/monotile/light,
 /area/medical/virology)
 "vse" = (
-/obj/effect/spawner/lootdrop/minor/beret_or_rabbitears,
-/obj/structure/table/wood,
-/obj/structure/curtain/obscuring/grey,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/atmospherics/pipe/simple/dark/visible,
+/turf/open/floor/durasteel/techfloor{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmos)
 "vsn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -53101,11 +52924,14 @@
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering)
 "vZc" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/grid/steel,
+/area/hallway/secondary/exit)
 "wat" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 4
@@ -53357,27 +53183,14 @@
 	name = "Prototype munitions bay"
 	})
 "wsH" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
+	dir = 5
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/turf/open/floor/monotile/dark,
+/area/hallway/secondary/exit)
 "wvu" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -53544,9 +53357,14 @@
 /turf/open/floor/monotile/steel,
 /area/engine/engineering/hangar)
 "wGp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit)
@@ -53749,7 +53567,7 @@
 "wXi" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/engine/atmos)
 "wYf" = (
 /obj/structure/table/reinforced,
 /obj/item/grenade/chem_grenade,
@@ -53772,12 +53590,17 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "wYw" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/durasteel/techfloor{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/engine/atmospherics_engine)
 "wYE" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/east,
@@ -53960,7 +53783,7 @@
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/maintenance/starboard/fore)
+/area/maintenance/department/cargo)
 "xmt" = (
 /obj/machinery/newscaster{
 	pixel_x = -28
@@ -54098,7 +53921,7 @@
 	},
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/crew_quarters/kitchen/coldroom)
 "xuS" = (
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/nsv/weapons)
@@ -54293,13 +54116,14 @@
 /turf/open/floor/monotile/steel,
 /area/medical/medbay/lobby)
 "xIH" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/engine/atmos)
 "xJX" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -54339,11 +54163,17 @@
 	name = "Prototype munitions bay"
 	})
 "xOX" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/area/maintenance/starboard/fore)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/monotile/dark,
+/area/hydroponics)
 "xPq" = (
 /obj/effect/landmark/start/munitions_tech,
 /obj/effect/turf_decal/tile/orange{
@@ -54380,6 +54210,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
 /turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "xQR" = (
@@ -84356,7 +84189,7 @@ adh
 adh
 adh
 bIJ
-aaa
+aOe
 aaa
 aaa
 aaa
@@ -84612,8 +84445,8 @@ bjh
 acc
 acc
 acc
+acc
 aOe
-aaa
 aaa
 aaa
 aaa
@@ -84867,12 +84700,12 @@ aNy
 aNy
 aNy
 aNr
-aNW
-acc
+aNr
+lzn
+bnx
 aOg
 aOg
 aOg
-aaa
 aaa
 aaa
 aaa
@@ -85116,7 +84949,7 @@ uYD
 gWy
 wGp
 tfx
-dIP
+bnB
 nMj
 dIP
 dIP
@@ -85124,12 +84957,12 @@ dIP
 dIP
 dIP
 dIP
-aNX
-aNZ
+dIP
+acp
+blA
 aOd
 ezQ
 esn
-aaa
 aaa
 aaa
 aaa
@@ -85371,22 +85204,22 @@ aOg
 aOe
 aer
 afp
-acc
+beX
 aNo
 aNs
-bxP
+aNs
 aNI
 aNO
 aNO
 aNR
 aNs
 aNs
-isx
+aNs
+bxB
 ltH
 aOe
 aOe
 aOe
-aaa
 aaa
 aaa
 aaa
@@ -85629,21 +85462,21 @@ aOe
 aet
 afr
 ajk
-bdb
-beQ
-bxQ
+bDs
+bDv
+bDx
 aNI
 aNO
 aNO
 aNR
 aNs
-aNs
+jvE
 tfI
-aNZ
+rew
+blA
 aOd
 svU
 esn
-aaa
 aaa
 aaa
 aaa
@@ -85884,23 +85717,23 @@ aaa
 aaa
 aOg
 aez
-bcF
-aNi
+aez
+beX
 aNo
 aNs
-bxR
 aNs
 aNs
 aNs
 aNs
 aNs
 aNs
-isx
+aNs
+aNs
+kpT
 acc
 aOg
 aOg
 aOg
-aaa
 aaa
 aaa
 aaa
@@ -86141,23 +85974,23 @@ aaa
 aaa
 aOg
 bjj
-bcF
+aez
 beX
-bxT
+aNo
 bDt
-bxS
+bjf
 aNz
 aNz
 bGM
 aNz
 bjf
 aNT
-isx
+aNs
+bxB
 acc
 aOg
-aaa
-wIM
-aaa
+aaJ
+ciL
 aaa
 aaa
 aaa
@@ -86398,7 +86231,7 @@ aaa
 aaa
 aOe
 bfL
-bcG
+aeC
 uti
 fOa
 bsK
@@ -86410,11 +86243,11 @@ bAS
 abM
 bsU
 bGG
+bxB
 acc
 aOg
-aaa
-wIM
-aaa
+aaJ
+ciL
 aaa
 aaa
 aaa
@@ -86655,8 +86488,8 @@ aOe
 aOg
 bJa
 aep
-bcH
-aNp
+afp
+aNt
 aNo
 bsb
 bjg
@@ -86666,12 +86499,12 @@ bGN
 aNG
 bjg
 bsL
-isx
+aNs
+bxB
 acc
 aOg
-aaa
-wIM
-aaa
+aaJ
+ciL
 aaa
 aaa
 aaa
@@ -86914,21 +86747,21 @@ wqk
 hSP
 gFM
 beY
-bDs
-bDu
-bDv
-bDv
-bDx
+aNo
+bsc
+aNs
+aNs
+aNs
 aNs
 aNs
 aNs
 bsc
-isx
+aNs
+bxB
 acc
 aOg
 aOg
 aOg
-aaa
 aaa
 aaa
 aaa
@@ -87169,8 +87002,8 @@ aOe
 aOe
 aOe
 aeF
-bcH
-aNp
+afp
+aNt
 aNo
 bsc
 aNs
@@ -87180,13 +87013,13 @@ aNO
 aNR
 aNs
 bsc
-tfI
-aNZ
+aNs
+blh
+blA
 aOd
 ezQ
 esn
 aOi
-aaa
 aaa
 aaa
 aaa
@@ -87426,23 +87259,23 @@ aaa
 aaa
 aOe
 pjr
-bcH
+afp
 aNp
-aNo
-bsc
+dnZ
+vZc
 aNs
 aNI
 aNO
 aNO
 aNR
-aNs
-bsc
-isx
+pkh
+bDu
+bDv
+adz
 ltH
 aOe
 aOe
 aOe
-aaa
 aaa
 aaa
 aaa
@@ -87683,8 +87516,8 @@ aOg
 aOg
 aOe
 aeG
-bcH
-aNp
+afp
+bxP
 aNo
 bsc
 aNs
@@ -87694,12 +87527,12 @@ aNs
 aNs
 aNs
 bsc
-tfI
+aNs
+epQ
 aNZ
 aOd
 svU
 esn
-aaa
 aaa
 aaa
 aaa
@@ -87930,18 +87763,18 @@ adu
 bxD
 bGJ
 bxF
-adu
-adu
-adu
-adu
+bxF
+bxF
+bxF
+bxF
 bGK
 abN
-acO
-acO
+bxF
+bxF
 bpX
 boa
 bcI
-aNt
+beX
 bjC
 bsd
 aNH
@@ -87952,11 +87785,11 @@ aNH
 aNH
 bsd
 aNY
-acc
+bpY
+bnx
+aOe
+aOe
 aOg
-aOg
-aOg
-aaa
 aaa
 aaa
 aaa
@@ -88184,35 +88017,35 @@ twU
 bLv
 bLw
 bLx
-bDf
+buf
 bLz
 bLA
 bLB
 bLC
+bLz
+glh
 bDf
-bDf
-bDf
-bLD
-bDf
-bDf
+bLz
+aJX
+glh
 bLE
-bDf
+glh
 bcJ
 bDq
-acc
-bse
-acc
-acc
-acc
-acc
-acc
+bJw
+blV
+bBf
+bDr
+bDr
+bDr
+bDr
 nmN
 bse
 opK
-acc
+aNX
+opK
+wsH
 aOe
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -88444,32 +88277,32 @@ bqz
 qOP
 acd
 bxH
-bDo
+acd
 bcz
 acd
 acd
 acd
-bpY
-bnr
-bnr
-bzY
-bro
-bro
-bcK
-bro
+acd
+bqz
+acd
+bpX
+afe
+afe
+afe
+afe
 bsf
 bsn
-bro
-bro
-pqr
-bro
-bsn
-bsM
-rge
 afe
+afe
+pqr
+afe
+bsf
+afe
+afe
+afe
+bum
+aWG
 aOe
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -88692,8 +88525,8 @@ caT
 gBn
 aoL
 bmr
-bFI
-bmU
+bDo
+akf
 aci
 aci
 bnM
@@ -88708,15 +88541,18 @@ aci
 ake
 bpZ
 aOs
+bxz
+aci
 aci
 aci
 aem
 eQZ
-beV
 ajB
-eQZ
+bcn
+ajB
 bIE
 bIE
+aOe
 aOe
 aOe
 aOe
@@ -88724,9 +88560,6 @@ aOe
 aOe
 bIe
 aOe
-aOe
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -88956,24 +88789,27 @@ adD
 pSE
 ads
 aOz
-aOz
+bzF
 bDm
 bcY
 bdg
-bje
+beW
 bje
 bqa
 aPe
+aBh
 aOt
+aOy
 aOy
 aci
 aff
 afj
-beW
-afj
 bcj
 bso
+afj
+pLb
 aNM
+aaa
 aaa
 aaa
 aaa
@@ -88981,9 +88817,6 @@ aaa
 aOg
 aOb
 aOe
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -89205,32 +89038,35 @@ bYZ
 caW
 bmE
 cee
-buS
-bGh
+bmr
+bFI
 bmV
 aci
 adS
 bfa
-adz
-aes
-aes
-aes
-aes
-aes
-aes
-aes
-aMT
-bxJ
-bjb
-bxz
+bqe
+ack
+ack
+ack
+ack
+bJA
+ack
+ack
+ack
+ack
+bqb
+ack
+ajy
+bcH
 aci
 afg
-ajz
-bDr
+bxX
 ajC
-bsg
-afj
+ail
+ajz
+oII
 aNM
+aaa
 aaa
 aaa
 aaa
@@ -89238,9 +89074,6 @@ aaa
 aOe
 bIf
 aOe
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -89468,28 +89301,28 @@ bmU
 aci
 adV
 bnO
-adz
-aes
-aes
-aes
-aes
-aes
-aes
-aes
+bqe
+boN
 bcr
-bDj
+bcr
+bcr
+bcr
+bcr
+bcr
+bcr
+bnP
 bqb
-bDk
+ack
+ajy
+ajy
 aci
 bgb
-bxX
-aJX
 aNq
 bsg
 bDP
+boL
+vbj
 bIE
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -89725,30 +89558,30 @@ bmU
 aci
 afh
 bnP
-adz
-aes
-aes
-ajl
-aes
-aes
-aes
-aes
-bcr
 bqe
+bos
+aes
+aes
+aes
+aes
+aes
+aes
+aes
+bnQ
+bqb
 ack
-bcu
+ack
+akd
 aci
 aMU
 aOk
 bci
-bci
-bDN
+bcK
+aOk
+bDk
 bIE
 bIE
 bIE
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -89981,32 +89814,32 @@ bHd
 bmU
 aci
 aMY
-bqd
-bcW
+bnQ
+bqe
+bos
 aes
 aes
 aes
 aes
-ajl
 aes
 aes
-bcr
-vbj
-aOo
+aes
+bnQ
+bGh
 bcv
+aOo
+asN
 aci
 afo
 sax
 bjD
-afj
-bDO
+bjb
+boM
+bUn
 aNN
 bjE
 aNQ
 bJg
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -90238,31 +90071,31 @@ bFI
 bmU
 aci
 agM
-aOB
-bnK
-aes
+bnQ
+bDj
+buv
 aes
 aes
 ajl
-ajr
 aes
 aes
-bcr
-bqV
+aes
+aes
+bqd
 bqA
 bfK
+avp
+bro
 aci
 aci
 aci
 aci
-aci
-bha
+bIE
+bIE
+gYf
 bIE
 bIE
 bIE
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -90496,30 +90329,30 @@ bmU
 aci
 aMZ
 bnQ
-adz
-aes
-ajj
-aes
+bqe
+bos
 aes
 aes
 aes
 aes
-bpO
-bqR
-bGF
+ajl
+aes
+aes
+bnQ
+bGh
 bGs
-aci
+bGF
 aOE
-aOF
-cDF
 aci
-bJH
+cDF
+iCC
+aNi
+aih
 aNP
+hGU
 mVt
 aij
-aaa
-aaa
-aaa
+aij
 aaa
 aaa
 aaa
@@ -90753,26 +90586,28 @@ bmU
 aci
 bns
 bnR
-adz
+bqe
+bos
 aes
 aes
 aes
+ajl
+ajr
 aes
 aes
-aes
-aes
-bpP
-bqg
+bnQ
 brp
 bsa
 bxA
-bJx
+jku
 bJt
 bJx
 bJz
-bJA
+bJx
 bJB
 gcf
+asa
+azU
 aij
 aij
 aij
@@ -90781,8 +90616,6 @@ aYI
 aYI
 aYI
 aij
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -91011,36 +90844,36 @@ aci
 aXl
 bnG
 bor
-afl
+bos
 aes
-ajl
+ajj
 aes
 aes
-ajl
 aes
-bcr
-bqf
-bxE
+aes
+aes
+bnQ
+bqb
 bqS
+avp
+bDN
 aci
-cDF
-bJu
-cDF
-bIC
+vpr
+aVN
 aio
-bJC
+aij
 bJD
 bJF
-bJF
+boD
 bJG
+bJG
+bzY
 aim
 aim
 hPI
 fLt
 aYI
 jLQ
-oUI
-aaa
 aaa
 aaa
 aaa
@@ -91266,8 +91099,9 @@ bFI
 bmU
 aci
 bnt
-bnS
+ack
 bqP
+bos
 aes
 aes
 aes
@@ -91275,13 +91109,14 @@ aes
 aes
 aes
 aes
-bcr
-gaR
-bqS
+bnQ
+bqb
+buq
+asN
 iYd
 vUD
-bID
-pvj
+vUD
+vUD
 vUD
 vUD
 aij
@@ -91289,14 +91124,12 @@ aij
 soJ
 aij
 aij
-bJH
+bLR
 aim
 qNT
 vmJ
 roq
 aYI
-aaa
-oUI
 aaa
 aaa
 aaa
@@ -91525,20 +91358,22 @@ adq
 aOu
 qir
 bqP
+bos
+afl
+aes
+ajl
 aes
 aes
+ajl
 aes
-aes
-aes
-aes
-aes
-bcr
-bqe
+bnQ
+bqb
+ack
+ack
 bqc
-lzn
-vUD
-avD
+bID
 uir
+avD
 uir
 vUD
 lEE
@@ -91546,15 +91381,13 @@ aNP
 rAy
 dzX
 aij
-wsH
+aYx
 aih
 aij
 aij
 gbA
 aij
 aij
-jLQ
-aaa
 aaa
 aaa
 aaa
@@ -91760,7 +91593,7 @@ eSX
 qzh
 agm
 mzE
-bcq
+bcw
 wjq
 aad
 acI
@@ -91778,40 +91611,40 @@ byA
 bmv
 bHI
 bmY
-adg
+aMt
 bnu
 bxw
 bqQ
+beQ
 aes
 aes
 aes
 aes
 aes
-ajj
 aes
-bcr
-bqe
+aes
+bnQ
+bqb
+ack
+ack
 bqc
-bqT
-vUD
-eno
+bcu
 uir
 uir
+blk
 vUD
 ffp
 aim
 jrs
 aim
 aij
-bJH
+bLR
 atf
 aij
 eLm
 eLm
 hzH
 aYI
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -92003,7 +91836,7 @@ aam
 aam
 amk
 bgX
-bAP
+acg
 aKC
 bIk
 bKe
@@ -92032,13 +91865,14 @@ byA
 byA
 byA
 bLc
-aRQ
-bEj
+bKR
+bEe
 bhv
 aci
 mOC
-bxC
+ack
 bsw
+bos
 aes
 aes
 aes
@@ -92046,10 +91880,11 @@ aes
 aes
 aes
 aes
-bcr
-bqe
-bqc
-bqU
+bnQ
+bqb
+ack
+ack
+phM
 vUD
 uir
 jkO
@@ -92060,16 +91895,14 @@ vQm
 ihA
 bdC
 aij
-bJH
+bLR
 aim
 rou
 eLm
 eLm
 eLm
 aYI
-aaa
 oUI
-aaa
 aaa
 aaa
 aaa
@@ -92275,38 +92108,40 @@ baH
 aBA
 btY
 bdY
-aPh
+ceu
 buU
-bbG
-bcE
+bgX
+aKC
 kqZ
-bjy
-bjy
-bbG
-bjy
-bBf
-bBX
-bjy
-bbG
+acg
+acg
+bgX
+acg
+acg
+aKC
+acg
+bgX
 bhw
 bmF
 bIu
-bmZ
-moE
-aXk
-bnT
-bxB
+aPk
+aci
+bqT
+ack
+bsw
 bos
-boC
-boL
-bGr
-boV
-boL
-boL
-bcs
-brb
+aes
+aes
+aes
+aes
+aes
+ajj
+aes
+aOB
 izj
-bnO
+ack
+ajs
+bIC
 vUD
 vUD
 vUD
@@ -92317,16 +92152,14 @@ aij
 aij
 aij
 aij
-bJH
+bLR
 bjF
 aij
 eLm
 eLm
 eLm
 aYI
-jLQ
 oUI
-aaa
 aaa
 aaa
 aaa
@@ -92523,16 +92356,16 @@ aFx
 aFx
 aFx
 aOJ
+aak
+aak
 adQ
-adQ
-adQ
-adQ
-adQ
-adQ
+aak
+aak
+aiO
 bMd
 bai
-adQ
-adQ
+brT
+bmI
 biA
 ljD
 bmB
@@ -92541,49 +92374,49 @@ bmI
 bmI
 bmI
 bmI
-bBp
+bmI
 bBt
 bmI
 bmI
 bBL
 bmI
 bIZ
-aPk
-aad
-acj
-acj
+bmZ
+moE
+aXk
+ack
 bDl
-acj
-boD
-acj
-acj
-ajs
-ajs
-akf
-bpQ
-bqh
-pxy
-aEf
+bos
+aes
+aes
+aes
+aes
+aes
+aes
+aes
+bnQ
+bqb
+ack
 bIC
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aij
-bJH
+aPh
+bjy
+cAw
+bDi
+mJh
+ajs
+eLm
+eLm
+eLm
+brC
+aih
+bLR
 aim
 aij
 aij
 aij
 aij
 aij
-aaa
 oUI
-aaa
 aaa
 aaa
 aaa
@@ -92782,12 +92615,12 @@ amj
 aOV
 ars
 acn
+wfy
 acn
 acn
-acn
-acn
-cfx
 bcg
+bsi
+bcC
 bcC
 bdd
 aVS
@@ -92799,43 +92632,43 @@ rXW
 acn
 acn
 acn
-acn
+wfy
 acn
 acn
 cfx
 acn
 lPA
 aPn
-aad
-adi
-adp
-bDh
-aOD
+aci
+aci
+dXL
+bDl
+buw
 boE
-boM
-boR
-ajs
-ajy
-beS
-bDi
+boE
+bqU
+boE
+boE
+boE
+boE
 bqi
-bqC
-aEf
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aij
-bJH
+bqb
+ack
+bIC
+aka
+beS
+bGD
+bJi
+bxT
+ajs
+eLm
+eLm
+eLm
+eLm
+bJu
+bLR
 aim
 aij
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -93060,38 +92893,38 @@ aqK
 aaY
 aaY
 aaY
-aaY
-aaY
-aaY
-aaY
-adj
-ajA
+aad
+pxy
+aad
+aad
+aci
+evG
 bxx
-ajA
-beL
-adr
-adp
-ajs
+bqa
+bqa
+bqa
+ruX
+beV
 beM
-beT
+beM
 bxy
-aka
+beM
 bHN
-aEf
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aij
-ekv
+bxw
+aBi
+bqf
+aRQ
+mIw
+byx
+buS
+ajs
+eLm
+eLm
+eLm
+eLm
+aih
+bcE
 foY
-aij
-aij
 aij
 aaa
 aaa
@@ -93317,39 +93150,39 @@ alW
 daH
 aqO
 aaY
-bbZ
-aPd
-bke
-aaY
-bnv
-adr
-adx
-adr
-ajg
-ajm
-ajo
+bzB
+bKR
+tLT
+aad
+aci
+bBp
+bDl
+bqg
+bnS
+bnG
+ooh
+bqV
+ack
+ack
+bqc
+ack
+ack
+ack
+bIC
+aka
+aiZ
+aka
+aka
+aka
 ajs
-pkh
-aka
-bGD
-aka
-eJW
-aEf
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aij
-bJH
+eLm
+eLm
+eLm
+eLm
+aih
+bLR
 aim
-anb
-aaJ
-aaJ
+aij
 aaJ
 aaa
 aaa
@@ -93562,51 +93395,51 @@ dud
 atH
 aVd
 bbJ
-blU
-blU
-blU
-blV
-acp
+atH
+atH
+atH
+aVw
+aeM
 bmw
-buf
-buk
+alW
+apZ
 bul
-buk
-bum
-hBe
-buq
-buv
-ccW
+apZ
+aqO
 aaY
-adl
-adr
+aAk
+bKR
+bJI
+aad
+acj
+acj
 ajg
-aWG
+acj
 aji
-adr
-ajp
-ajs
-aka
-akd
+acj
+acj
+ajw
+bkG
+ack
 bYJ
-aOr
-phM
-aEf
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aij
-bJH
-byx
+bnG
+bnG
+bnG
+bsM
+bqC
+brb
+bqG
+jbq
+bxR
+ajs
+eLm
+eLm
+eLm
+eLm
+aih
 bLR
-aaJ
-aaJ
+aim
+aij
 aaJ
 aaa
 aaa
@@ -93818,52 +93651,52 @@ abd
 ata
 bbC
 bdk
-bbL
-aOR
-aOR
-aOR
-atD
-aeM
+bpQ
+bqh
+bqh
+bqh
+qEi
+blo
 bdj
 but
-apZ
-alW
-apZ
-bun
-aeM
-atw
-alW
-aVN
+buk
+pFX
+bcW
+awc
 aaY
-adm
-adr
+aaY
+aaY
+aaY
+aaY
+adi
+adp
 adx
-adr
-adx
-adr
-ajq
+aOD
+ajm
+boR
+acj
 ajw
-aka
-aka
-aMt
-aka
-aka
-aEf
-aaa
-aaa
-aaa
-aaa
-aaa
-aij
-aij
-aij
-aij
-aij
-bJH
+ack
+atB
+ack
+ack
+ack
+ack
+ajs
+ajs
+ajs
+ajs
+ajs
+ajs
+ajs
+aih
+bcc
+aih
+aih
+aih
+bLR
 bCd
-anb
-aaJ
-aaJ
+aij
 aaJ
 aaa
 aaa
@@ -94079,47 +93912,47 @@ bbS
 aVg
 aPb
 aVg
-aVw
-bIi
+atD
+aeM
 aeZ
 alW
 apZ
 aOv
 apZ
-bun
-aeM
-aHj
-aVU
-ccV
+sqF
 aaY
-adn
-ady
-ubq
-xrq
-xGc
+bbZ
+aVU
+bke
+aaY
+adj
+ajA
+hxd
 adr
-adp
-iuA
-iuA
-iuA
-iuA
-iuA
-iuA
-aij
-aij
-aij
-aij
-aij
-aij
-aij
-bbw
-atf
-bbw
+adr
+adr
+acj
+ajw
+ack
 aih
-bJH
+aih
+aih
+aih
+aih
+aih
+wvu
 aim
-aij
-aij
+bsh
+aim
+aNP
+aim
+aim
+aim
+aim
+wpd
+aih
+bLR
+aim
 aij
 aaa
 aaa
@@ -94343,41 +94176,41 @@ alW
 apZ
 alW
 apZ
-sqF
+bun
+aeM
+atw
+isx
+ccW
 aaY
-atA
-aMw
-aVV
-aaY
-adp
-dJP
-tLt
-uKa
-iFi
-bqB
-adp
-iuA
-xOX
-qEO
-vZc
-qEO
-qEO
+bnv
+adr
+bxS
+adr
+adr
+ajo
+acj
+gaR
+aih
+aih
+aim
+aim
+aim
+aim
 aih
 wvu
-wvu
-aNP
-aim
-aim
-aim
-aim
-aim
-aim
-aim
+akt
+eJW
+eJW
+eJW
+aOF
 bJH
+bJH
+bJH
+bJH
+bJH
+bqF
 bjF
 aij
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -94590,51 +94423,51 @@ bui
 blU
 blU
 bkc
+bqR
+bqR
 buz
-atH
-atH
 aVw
 aaY
 ahs
 alW
 apZ
-alW
-apZ
-bun
+aMT
+bAP
+bFZ
+bDh
+bBX
+xOX
+bxQ
 aaY
-aaY
-aaY
-aaY
-iuA
-iuA
-iuA
-oyi
-oyi
-oyi
-iuA
-iuA
-iuA
-fyq
-qEO
+adl
+bbG
+aPd
+bjH
+bEj
+ajp
+acj
+aOr
+aim
+bnK
 bqD
-bcn
-bsG
-asN
-bFZ
-bFZ
+aim
+aim
+aim
+aih
+aim
 bJv
-bFZ
-bFZ
-bFZ
-jbq
-bFZ
-bFZ
-bFZ
-bJI
-wpd
+aim
+aim
+aim
+bJv
+aim
+aim
+aim
+aim
+aim
+aim
+aim
 aij
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -94853,33 +94686,33 @@ aOR
 aVw
 aaY
 bkW
-blh
-blh
-blh
-blh
+alW
+alW
+alW
+alW
 bus
-aaY
-bcc
+aeM
+aHj
 bmJ
-buw
-iuA
-wXi
-dXL
-iuA
-mUy
-bjH
-api
-apo
-iuA
-qEO
-eFj
-brC
-eFj
-vjc
+ccV
+aaY
+adm
+adr
+buh
+adr
+adr
+ajq
+acj
+aOr
+aim
+aih
+aim
+aim
+aim
+aim
 aih
 aih
-aih
-aih
+bJq
 aih
 aih
 aij
@@ -94890,8 +94723,8 @@ aij
 aij
 aij
 aij
-aaa
-aaa
+aij
+aij
 aaa
 aaa
 aaa
@@ -95115,31 +94948,31 @@ bIr
 bIs
 atv
 buu
-atB
-bkf
-bsh
-bux
-oII
-bnw
-qEO
-iuA
-aiO
-aiZ
-apl
-qEO
-iuA
-qEO
-qEO
-brT
-uOY
-vjc
-iuA
-awc
+aaY
+atA
+aMw
+aVV
+aaY
+adn
+ady
+ubq
+xrq
+xGc
+adr
+acj
+aOr
+aim
+aih
+aih
+aih
+aih
+aih
+aih
 aAb
-aYx
-aYA
+bJv
+blz
 uOY
-oyi
+aij
 ndL
 aij
 bMp
@@ -95360,11 +95193,11 @@ abZ
 aNc
 aOR
 aOR
-bbU
+lLc
 aOR
 aOR
 aOR
-aVw
+beT
 aaY
 akv
 amf
@@ -95377,26 +95210,26 @@ abr
 abr
 abr
 abr
-bnx
-qEO
-iuA
-jvE
-qEO
-asa
-avp
+adp
+dJP
+tLt
+uKa
+iFi
+bqB
+acj
 awT
-bcn
-bcn
-bsi
-bcn
-bxK
-bzF
+aim
+aih
+eLm
+eLm
+hzH
+aih
 bJp
-bJq
-bJw
-qEO
+aim
+bJv
+aim
 aYA
-oyi
+aij
 tjC
 aij
 arT
@@ -95612,13 +95445,13 @@ acR
 bGn
 akm
 bur
-akt
-buh
-bui
-blU
-blU
-bkc
-buz
+acS
+aVk
+asZ
+atH
+aEf
+bJC
+atH
 atH
 atH
 aVw
@@ -95634,26 +95467,26 @@ byW
 atn
 aMz
 abr
-vjc
-qEO
-iuA
-qEO
-qEO
-qEO
-qEO
-iuA
-qEO
-aiK
-brT
-eFj
-vjc
-iuA
+acj
+acj
+hwO
+hwO
+hwO
+acj
+acj
+aOr
+aim
+aih
+eLm
+eLm
+eLm
+aih
 cpD
 apl
-apl
+bIi
 apl
 eZK
-oyi
+aij
 arT
 arT
 arT
@@ -95890,27 +95723,27 @@ bkd
 buE
 atp
 aMS
-hxd
-vjc
-qEO
-iuA
+abr
+bpO
+bqE
+bGr
 aiP
 aiP
-dXL
-wXi
-iuA
-qEO
-iCC
-brT
-qqN
-vjc
-iuA
+aiP
+aiP
+rge
+aim
+aih
+eLm
+eLm
+eLm
+aih
 azy
-aBh
+bCd
 pBU
 fyq
 aYD
-oyi
+aij
 aaa
 aaa
 aaa
@@ -96124,11 +95957,11 @@ aPi
 aMH
 acR
 aks
-arn
+bux
 arn
 aMV
 bbz
-bbB
+boV
 bbD
 bbE
 bdE
@@ -96149,25 +95982,25 @@ atu
 aVA
 abr
 vjc
-qEO
-iuA
-iuA
-iuA
-iuA
-iuA
-iuA
-qEO
-qEO
-cAw
-qEO
-vjc
-iuA
+pvj
+ekv
+aim
+aih
+aih
+aih
+aih
+bcF
+aih
+aih
+bcF
+aih
+aih
 azM
-apl
+nUJ
 qqN
-aBh
+bCd
 aYE
-oyi
+aij
 aaa
 aaa
 aaa
@@ -96387,11 +96220,11 @@ acS
 abZ
 asY
 aOR
-aVr
+aOR
 bHJ
-aOR
-aOR
-aOR
+boC
+boC
+tgd
 aVw
 aVR
 asV
@@ -96406,25 +96239,25 @@ atF
 aVB
 abr
 bnz
-bkZ
-bob
-blz
-sAj
-fpJ
-evG
+aim
+bnT
+aim
+aih
+eLm
+eLm
+eLm
+eLm
 boW
-bkZ
-boW
-lAV
-bob
-bqE
-iuA
+aih
+ljw
+ljw
+aih
 azN
-qEO
-qEO
+aim
+blM
 xmr
 aYF
-oyi
+aij
 aaa
 aaa
 aaa
@@ -96638,7 +96471,7 @@ aOY
 aMH
 acR
 bIh
-atI
+azP
 atI
 acS
 abZ
@@ -96662,26 +96495,26 @@ bmy
 aMy
 aVC
 abr
-ruX
-ail
-ail
-gKB
-ail
-ail
-ail
-ail
-ail
-ail
+wpd
+wpd
+bob
+aim
+aih
+eLm
+eLm
+eLm
+eLm
+eLm
 hCE
-ail
-bqF
+ljw
+ljw
 avr
 eNG
 aCh
-aBh
+bCd
 aYB
 ncH
-oyi
+aij
 aaa
 aaa
 aaa
@@ -96917,28 +96750,28 @@ abr
 abr
 xuu
 abr
-abr
+bcs
 abr
 bnA
-bkZ
+bnA
 bob
-blz
-lLc
-boN
-dnZ
-boW
-ooh
-bkZ
-ciL
+wvu
+aih
+eLm
+eLm
+eLm
+eLm
+eLm
+aih
 ljw
-bqG
-iuA
+ljw
+aih
 azX
 aCi
 aYy
 hjm
-aYH
-oyi
+mVt
+aij
 aaa
 aaa
 aaa
@@ -97171,31 +97004,31 @@ bzC
 aqT
 arc
 iuA
-dmM
+ljw
 blp
 bkZ
-bkZ
-bng
-bnB
-mIw
+ljw
+aih
+aih
+aih
 fEj
-fEj
-jku
-apV
-apV
-apV
-apV
-apV
-apV
-apV
-hGU
-iuA
-iuA
+aih
+aih
+aih
+bcF
+aih
+aih
+aih
+aih
+ljw
+ljw
+aih
+aih
 aPw
-iuA
-oyi
-oyi
-oyi
+aih
+aij
+aij
+aij
 aaa
 aaa
 aaa
@@ -97428,29 +97261,29 @@ hLd
 iuA
 iuA
 iuA
-qEO
-apV
-apV
-apV
-apV
-apV
+xIH
+dmM
+duz
+duz
+duz
+duz
 duz
 uIA
-apV
-qEi
-apV
-bJJ
-aWb
-aWb
-aWb
-aWb
-apV
-glh
-iuA
-qEO
+ljw
+ljw
+aiW
+ljw
+ljw
+ljw
+ljw
+aiW
+ljw
+ljw
+aih
+aim
 aVK
 oum
-oyi
+aij
 aaa
 aaa
 aaa
@@ -97667,7 +97500,7 @@ aMH
 aeL
 aWf
 bZn
-aqV
+bcG
 bbT
 bbM
 bbN
@@ -97687,27 +97520,27 @@ cIi
 iuA
 aiK
 apV
-bFj
-azC
-azP
-bJi
-azU
-aBi
-aCe
-aCm
-aCe
-lgc
 apV
 apV
 apV
-aWa
 apV
-glh
-iuA
+apV
+apV
+apV
+apV
+apV
+apV
+apV
+apV
+apV
+apV
+apV
+ljw
+aih
 aAa
 fwJ
 aYz
-oyi
+aij
 aaa
 aaa
 aaa
@@ -97929,8 +97762,8 @@ aqV
 bbi
 bcl
 bcR
+bbw
 bdp
-bzB
 hmf
 bgo
 hLd
@@ -97939,32 +97772,32 @@ bkF
 bkY
 bkY
 fXQ
-blz
-nUJ
 iuA
-qEO
+ljw
+iuA
+bxK
 apV
-aWb
+xXX
 azO
 azR
 azV
 fJP
 qnS
-aCg
+apV
 aCn
-aCs
-bJE
-aDU
-aVY
-aVZ
+apV
+bJJ
+aWb
+aWb
+aWb
 aWb
 apV
 bqH
-iuA
-iuA
-iuA
-iuA
-oyi
+aih
+aih
+aih
+aih
+aij
 aaa
 aaa
 aaa
@@ -98199,10 +98032,10 @@ aMA
 gAp
 blL
 ais
-qEO
+fpJ
 apV
-aWb
-azO
+bFj
+azC
 azS
 aAZ
 aBd
@@ -98210,15 +98043,15 @@ stk
 aCe
 nfz
 aCe
-wqR
+lgc
 apV
 apV
 apV
 aWa
 apV
-glh
+ljw
 bHw
-qEO
+ljw
 bHx
 bHx
 ilA
@@ -98453,31 +98286,31 @@ aVD
 aVG
 igg
 bln
-iuA
-for
-iuA
-iuA
+aCm
+hBe
+bdb
+aNW
 apV
-xXX
-azO
+apV
+apV
 azT
 aBc
 aBe
 aBx
-apV
+aCg
 nMg
+aCs
+bJE
+aDU
+aVY
+aVZ
+aWb
 apV
-bJJ
-aWb
-aWb
-aWb
-aWb
-apV
-glh
+ljw
 iuA
 wXi
-qEO
-qEO
+ljw
+ljw
 ilA
 aaa
 aaa
@@ -98709,28 +98542,28 @@ iuA
 iuA
 iuA
 iuA
-blo
 iuA
-for
-pLb
-rew
+iuA
+mUy
+ljw
+aiK
 apV
-apV
-apV
-apV
-apV
+sAj
+azV
+eno
+gKB
 aiE
-apV
-apV
+aYH
+aCe
 oMQ
+aCe
+wqR
 apV
 apV
 apV
+aWa
 apV
-apV
-apV
-apV
-glh
+ljw
 oyi
 oyi
 ilA
@@ -98962,32 +98795,32 @@ aWi
 aWi
 aWi
 aii
-bjI
-bkG
-bkZ
-nUJ
-blp
-nUJ
+qEO
+duz
+duz
+duz
+api
+qEO
 for
 qEO
-qEO
-hwO
-qEO
-qEO
+bha
+apV
+bjI
+bna
 clm
 wYw
 mlC
 qjd
-xIH
+apV
 rso
-qjd
-qjd
-tgd
-kpT
+apV
+bJJ
+aWb
+aWb
+aWb
+aWb
+apV
 ljw
-pFX
-ljw
-vpr
 oyi
 aaa
 aaa
@@ -99222,13 +99055,13 @@ iuA
 eFj
 aiW
 gRe
-blk
+ljw
 blq
-blA
-blM
-bjI
-bjI
-gYf
+ljw
+aiW
+ljw
+ljw
+apV
 bjI
 bna
 hsX
@@ -99239,12 +99072,12 @@ aml
 aml
 aml
 aml
-epQ
-qEO
-bUn
-oyi
-tLT
-vse
+apV
+apV
+apV
+apV
+apV
+ljw
 oyi
 aaa
 aaa
@@ -99483,12 +99316,12 @@ oyi
 blr
 oyi
 oyi
-qEO
-qEO
+ljw
+ljw
 aml
-aml
-aml
-aml
+rhe
+bnw
+bxE
 aml
 npw
 tsS
@@ -99496,7 +99329,7 @@ kgr
 stP
 nqT
 aml
-mJh
+aml
 aml
 aml
 oyi
@@ -99744,15 +99577,15 @@ aml
 aml
 jpj
 rhe
-rhe
-rhe
-hbD
 vfz
-vfz
-vfz
-vfz
-vfz
-hbD
+bsG
+bkf
+vse
+vse
+vse
+vse
+vse
+bkf
 cob
 nyJ
 aml
@@ -100000,7 +99833,7 @@ fAz
 atZ
 sIU
 uTH
-rhe
+vfz
 vfz
 wYJ
 kHI
@@ -100508,7 +100341,7 @@ bIt
 beF
 bAB
 biV
-axY
+bxC
 ucr
 asG
 rhe
@@ -101027,7 +100860,7 @@ eEX
 aml
 qHG
 vfz
-vfz
+beL
 vfz
 vfz
 vfz

--- a/_maps/map_files/Tycoon/Tycoon2.dmm
+++ b/_maps/map_files/Tycoon/Tycoon2.dmm
@@ -581,15 +581,11 @@
 /turf/closed/wall/ship,
 /area/hallway/secondary/exit)
 "abN" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/monotile/steel,
-/area/hallway/secondary/exit)
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "abO" = (
 /obj/structure/sign/nanotrasen{
 	pixel_y = 26
@@ -679,19 +675,8 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
 "abW" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/box,
-/obj/machinery/camera/autoname{
-	dir = 9
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/monotile/steel,
+/obj/structure/filingcabinet/employment,
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "abX" = (
 /obj/structure/rack,
@@ -1209,6 +1194,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
 	},
+/obj/structure/closet/emcloset/anchored,
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "adt" = (
@@ -1428,7 +1414,6 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/camera/autoname,
 /obj/machinery/door/window/eastleft{
 	dir = 2;
 	name = "Mail";
@@ -3141,6 +3126,9 @@
 	pixel_x = 3;
 	pixel_y = -2
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/engine,
 /area/medical/medbay/central)
 "ahU" = (
@@ -3359,12 +3347,12 @@
 /turf/open/floor/durasteel/lino,
 /area/engine/engineering/reactor_control)
 "aiB" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
+/obj/machinery/airalarm{
+	pixel_y = 26
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/monotile/steel,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "aiE" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible,
@@ -3388,9 +3376,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "aiJ" = (
-/obj/machinery/camera/autoname,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet/ship,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "aiK" = (
 /obj/structure/disposalpipe/segment{
@@ -4281,13 +4273,15 @@
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo)
 "alk" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/box,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/monotile/steel,
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "all" = (
 /obj/structure/closet/secure_closet/CMO,
@@ -4667,14 +4661,7 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame2/port)
 "amq" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/box,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "ams" = (
@@ -4905,12 +4892,10 @@
 /turf/closed/wall/r_wall/ship,
 /area/crew_quarters/heads/chief)
 "anr" = (
-/obj/structure/closet/emcloset/anchored,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/structure/sign/nanotrasen{
+	pixel_y = 26
 	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "ans" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -4920,12 +4905,12 @@
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "ant" = (
-/obj/machinery/vending/tool,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/structure/chair/fancy,
+/obj/machinery/computer/ship/viewscreen,
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "anu" = (
 /obj/structure/disposalpipe/segment,
@@ -4940,20 +4925,26 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "anv" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching Prison Wing holding areas.";
+	name = "Prison Monitor";
+	network = list("prison");
+	pixel_y = 26
 	},
-/turf/open/floor/monotile/steel,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "anw" = (
-/obj/structure/closet/firecloset,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/machinery/newscaster{
+	pixel_y = 28
 	},
-/turf/open/floor/monotile/steel,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/camera/autoname,
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "anx" = (
 /obj/effect/turf_decal/delivery,
@@ -4993,8 +4984,13 @@
 /turf/open/floor/monotile/light,
 /area/crew_quarters/dorms/nsv/dorms_1)
 "anD" = (
-/obj/structure/table,
-/turf/open/floor/monotile/dark,
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/carpet/blue,
 /area/crew_quarters/dorms)
 "anG" = (
 /obj/machinery/computer/station_alert{
@@ -5405,6 +5401,12 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/engine/atmos)
+"apc" = (
+/obj/machinery/camera/autoname{
+	dir = 5
+	},
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "apd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow,
@@ -6201,16 +6203,16 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
 "arm" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/box,
-/obj/machinery/light{
-	dir = 8
+/obj/item/kirbyplants/random,
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/machinery/requests_console{
+	department = "Law office";
+	payment_department = "SEC";
+	pixel_y = -32
 	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "arn" = (
 /obj/structure/table/wood,
@@ -6743,6 +6745,9 @@
 	codes_txt = "patrol;next_patrol=loc6";
 	location = "loc5"
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "ate" = (
@@ -6937,11 +6942,9 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
 "atG" = (
-/obj/effect/turf_decal/box,
-/obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/machinery/vending/cigarette{
+	name = "Adama's Finest Cigars"
 	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
@@ -7034,15 +7037,8 @@
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms/nsv/dorms_1)
 "aui" = (
-/obj/structure/closet/firecloset,
-/obj/machinery/newscaster{
-	pixel_y = 33
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/monotile/steel,
+/obj/machinery/computer/lore_terminal,
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "auj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -7247,14 +7243,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "auP" = (
-/obj/effect/turf_decal/box,
-/obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/vending/snack/random,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "auQ" = (
@@ -7315,22 +7307,17 @@
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/fitness/recreation)
 "auW" = (
+/obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/closed/wall/ship,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "auX" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
-/obj/machinery/door/airlock/ship{
-	name = "Public Tool Storage"
-	},
-/turf/open/floor/monotile/dark,
+/turf/open/floor/carpet/blue,
 /area/crew_quarters/dorms)
 "auY" = (
 /obj/structure/sign/nanotrasen{
@@ -7396,13 +7383,12 @@
 /turf/open/floor/monotile/steel,
 /area/engine/engineering)
 "avd" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "ave" = (
 /turf/open/floor/plasteel/ridged,
@@ -7414,13 +7400,10 @@
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "avg" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/carpet/blue,
 /area/crew_quarters/dorms)
 "avh" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -7466,10 +7449,17 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/deck2)
 "avn" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/electrical,
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/dorms)
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/monotile/steel,
+/area/hallway/secondary/exit)
 "avp" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -7640,9 +7630,6 @@
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
-	},
-/obj/structure/sink{
-	pixel_y = 32
 	},
 /obj/structure/sink{
 	dir = 4;
@@ -7863,6 +7850,9 @@
 	},
 /obj/machinery/camera/autoname,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "ayH" = (
@@ -8342,13 +8332,7 @@
 	},
 /area/engine/atmospherics_engine)
 "azW" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
@@ -9842,16 +9826,7 @@
 /turf/open/floor/monotile/dark,
 /area/tcommsat/computer)
 "aDZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/obj/machinery/door/airlock/ship{
-	name = "Public Tool Storage"
-	},
+/obj/structure/table/reinforced,
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "aEa" = (
@@ -12703,16 +12678,17 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/monotile/steel,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "aKF" = (
 /obj/machinery/modular_fabricator/exosuit_fab,
@@ -13813,6 +13789,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "aMZ" = (
@@ -14539,6 +14516,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/closet/firecloset,
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "aOA" = (
@@ -15003,6 +14981,9 @@
 /obj/item/clothing/ears/earmuffs,
 /obj/item/clothing/ears/earmuffs,
 /obj/item/clothing/ears/earmuffs,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "aPw" = (
@@ -15974,7 +15955,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/vending/snack/random,
+/obj/structure/closet/wardrobe/grey,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "aRS" = (
@@ -15998,8 +15979,8 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "aRU" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/emergency,
+/obj/machinery/light,
+/obj/machinery/holopad,
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "aRV" = (
@@ -16065,21 +16046,19 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "aSc" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical,
-/turf/open/floor/monotile/dark,
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/carpet/blue,
 /area/crew_quarters/dorms)
 "aSd" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Crew Lounge"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -16089,7 +16068,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/monotile/dark,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "aSe" = (
 /obj/structure/cable{
@@ -16769,6 +16755,7 @@
 /area/hallway/nsv/deck2/frame1/central)
 "aTP" = (
 /obj/structure/table/glass,
+/obj/machinery/light,
 /turf/open/floor/monotile/light,
 /area/medical/medbay/central)
 "aTU" = (
@@ -18192,16 +18179,10 @@
 /obj/machinery/disposal/deliveryChute{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4;
 	layer = 2.9
-	},
-/obj/machinery/camera/autoname{
-	dir = 6
 	},
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
@@ -19148,9 +19129,10 @@
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "aZy" = (
-/obj/structure/table,
-/obj/item/clothing/gloves/color/fyellow/old,
-/turf/open/floor/monotile/dark,
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/carpet/blue,
 /area/crew_quarters/dorms)
 "aZz" = (
 /obj/structure/cable{
@@ -19183,36 +19165,32 @@
 	id = "tycoon_dorms";
 	next_id = "tycoon_engi"
 	},
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "aZD" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/box,
-/obj/machinery/firealarm/directional/west,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/machinery/camera/autoname{
+	dir = 5
 	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "aZE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/monotile/steel,
+/obj/structure/table/reinforced,
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "aZF" = (
 /obj/structure/cable{
@@ -19224,14 +19202,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/monotile/steel,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "aZG" = (
 /obj/structure/cable{
@@ -19243,19 +19215,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "aZH" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -19270,6 +19241,16 @@
 	},
 /obj/machinery/firealarm{
 	pixel_y = 24
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Crew Lounge"
 	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
@@ -19303,7 +19284,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "aZK" = (
@@ -20464,7 +20447,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/space/basic,
+/turf/open/floor/monotile/steel,
 /area/hallway/secondary/exit/departure_lounge)
 "bco" = (
 /obj/structure/chair{
@@ -20759,6 +20742,9 @@
 "bcT" = (
 /obj/machinery/computer/ship/viewscreen,
 /obj/item/kirbyplants/random,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/monotile/light,
 /area/medical/medbay/lobby)
 "bcU" = (
@@ -20792,16 +20778,15 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bcY" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/grid/steel,
-/area/quartermaster/storage)
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/monotile/steel,
+/area/crew_quarters/dorms)
 "bcZ" = (
 /obj/machinery/light{
 	dir = 4
@@ -21774,11 +21759,12 @@
 /turf/open/floor/monotile/steel,
 /area/security/warden)
 "beL" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/durasteel/techfloor{
-	initial_gas_mix = "TEMP=2.7"
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/area/engine/atmos)
+/turf/open/floor/monotile/steel,
+/area/crew_quarters/dorms)
 "beM" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -22383,6 +22369,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/camera/autoname,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "bfV" = (
@@ -22849,7 +22836,8 @@
 /turf/open/floor/monotile/dark,
 /area/security/brig)
 "bgW" = (
-/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -22877,14 +22865,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "bhb" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/light,
-/turf/open/floor/monotile/dark,
-/area/medical)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/monotile/steel,
+/area/crew_quarters/dorms)
 "bhd" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/beaker/cryoxadone{
@@ -23066,9 +23054,7 @@
 	},
 /obj/machinery/light,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/vending/cigarette{
-	name = "Adama's Finest Cigars"
-	},
+/obj/structure/closet/wardrobe/grey,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "bhB" = (
@@ -25255,6 +25241,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/frame1/central)
 "bmr" = (
@@ -25736,6 +25725,9 @@
 /obj/structure/window/reinforced,
 /obj/structure/plasticflaps/opaque,
 /obj/machinery/computer/ship/viewscreen,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "bnt" = (
@@ -26308,6 +26300,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "boN" = (
 /obj/effect/turf_decal/stripes/corner,
+/obj/machinery/light/floor,
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "boO" = (
@@ -27065,6 +27058,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/obj/machinery/light/floor,
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "bqj" = (
@@ -27391,7 +27385,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "bqR" = (
@@ -28817,11 +28811,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/structure/chair/stool{
+	pixel_y = 8
 	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/monotile/steel,
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "btJ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
@@ -28871,10 +28864,11 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
@@ -28981,9 +28975,9 @@
 /turf/open/floor/monotile/dark,
 /area/security/prison)
 "bua" = (
-/obj/structure/reagent_dispensers/watertank,
+/obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
@@ -29172,6 +29166,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/obj/machinery/light/floor,
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "bux" = (
@@ -29449,6 +29444,7 @@
 /area/hallway/nsv/deck2/frame1/central)
 "buS" = (
 /obj/machinery/firealarm/directional/south,
+/obj/machinery/light,
 /turf/open/floor/carpet/blue,
 /area/quartermaster/qm)
 "buT" = (
@@ -30623,9 +30619,6 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -30758,6 +30751,10 @@
 /area/quartermaster/warehouse)
 "bxT" = (
 /obj/effect/landmark/start/quartermaster,
+/obj/machinery/computer/ship/viewscreen{
+	pixel_y = -31;
+	pixel_x = -1
+	},
 /turf/open/floor/carpet/blue,
 /area/quartermaster/qm)
 "bxU" = (
@@ -32059,11 +32056,10 @@
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms)
 "bAO" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/open/floor/monotile/dark,
-/area/crew_quarters/dorms)
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
 "bAP" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -33244,9 +33240,9 @@
 /turf/open/floor/plating,
 /area/hydroponics)
 "bDi" = (
-/obj/machinery/computer/ship/viewscreen{
-	pixel_y = -4;
-	pixel_x = -32
+/obj/structure/sign/poster/official/bless_this_spess{
+	pixel_y = -1;
+	pixel_x = -30
 	},
 /turf/open/floor/carpet/blue,
 /area/quartermaster/qm)
@@ -34950,9 +34946,6 @@
 "bGK" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/machinery/camera/autoname{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -37595,6 +37588,13 @@
 /area/bridge{
 	name = "CIC"
 	})
+"bZj" = (
+/obj/structure/disposalpipe/segment,
+/obj/item/kirbyplants{
+	icon_state = "plant-21"
+	},
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "bZl" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -38621,6 +38621,15 @@
 /obj/item/storage/toolbox/electrical,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/frame1/port)
+"cJn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "cJz" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 8
@@ -38696,6 +38705,17 @@
 "cOK" = (
 /turf/closed/wall/ship,
 /area/maintenance/nsv/hangar)
+"cPI" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/ship/public{
+	name = "Crew Quarters"
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/carpet/ship,
+/area/crew_quarters/dorms)
 "cPU" = (
 /obj/item/radio/intercom{
 	pixel_y = -26
@@ -39015,16 +39035,10 @@
 /turf/open/space/basic,
 /area/engine/atmos)
 "dmA" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/box,
 /obj/machinery/camera/autoname{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/monotile/steel,
+/turf/closed/wall/ship,
 /area/crew_quarters/dorms)
 "dmM" = (
 /obj/structure/disposalpipe/sorting/mail{
@@ -39086,6 +39100,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/nsv/weapons/gauss)
+"dtV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
 "dud" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -39119,6 +39140,20 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/engine/gravity_generator)
+"dwq" = (
+/obj/structure/rack,
+/obj/item/storage/secure/briefcase{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/storage/briefcase{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/clothing/glasses/sunglasses/advanced/big,
+/obj/item/clothing/glasses/sunglasses/advanced,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "dwM" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -39168,6 +39203,13 @@
 	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/engineering/reactor_core)
+"dCq" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/monotile/steel,
+/area/medical)
 "dCz" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -39758,7 +39800,6 @@
 "eot" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/crew_quarters/dorms)
 "eoI" = (
@@ -40394,6 +40435,12 @@
 /obj/effect/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"fam" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/dorms)
 "faG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -40960,15 +41007,15 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/airlock/ship/public{
-	name = "Crew Quarters"
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/airlock/ship/public{
+	name = "Crew Quarters"
+	},
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms)
 "fUk" = (
@@ -41047,7 +41094,9 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
+	req_one_access_txt = "31; 48"
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -41108,6 +41157,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"gcq" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/monotile/steel,
+/area/crew_quarters/dorms)
 "gdZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -41323,9 +41382,9 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/hangar)
 "gub" = (
-/obj/machinery/light,
-/turf/open/floor/monotile/light,
-/area/medical/medbay/central)
+/obj/machinery/vending/wardrobe/law_wardrobe,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "guw" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	req_one_access_txt = "24"
@@ -41461,6 +41520,18 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
+"gET" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/turf/open/floor/monotile/steel,
+/area/hallway/secondary/exit)
 "gFl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -42195,16 +42266,9 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/quartermaster/warehouse)
 "hxi" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/monotile/light,
-/area/medical/medbay/central)
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
 "hxF" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -42548,6 +42612,10 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
 	name = "Mix Tank Outlet"
+	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics Tank - Mix";
+	dir = 8
 	},
 /turf/open/space/basic,
 /area/engine/atmos)
@@ -42998,6 +43066,13 @@
 /obj/item/clothing/glasses/hud/health,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo)
+"iCl" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
 "iCC" = (
 /obj/machinery/light{
 	dir = 8
@@ -43421,6 +43496,16 @@
 	},
 /turf/open/floor/durasteel,
 /area/engine/engineering)
+"iWj" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/sign/nanotrasen{
+	pixel_y = 26
+	},
+/turf/open/floor/monotile/steel,
+/area/crew_quarters/dorms)
 "iWF" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -44089,6 +44174,24 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons/fore)
+"jUM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "jUR" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2,
@@ -44232,6 +44335,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/weapons)
+"kcQ" = (
+/obj/structure/table/glass,
+/obj/machinery/fax{
+	fax_name = "Law Office";
+	name = "Law Office Fax Machine"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/dorms)
 "kdb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -44279,18 +44396,9 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
 "keK" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/box,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/monotile/steel,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/table/reinforced,
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "keO" = (
 /turf/open/floor/plating,
@@ -44552,6 +44660,12 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"kqo" = (
+/obj/machinery/camera/autoname{
+	dir = 9
+	},
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
 "kqI" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -45274,6 +45388,18 @@
 /obj/structure/closet/radiation,
 /turf/open/floor/monotile/dark,
 /area/engine/gravity_generator)
+"lkG" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/monotile/steel,
+/area/crew_quarters/dorms)
 "lkS" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -46155,6 +46281,16 @@
 /area/bridge{
 	name = "CIC"
 	})
+"mvf" = (
+/obj/machinery/photocopier,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "mvj" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/southright{
@@ -46457,6 +46593,10 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard)
+"mNI" = (
+/obj/structure/extinguisher_cabinet/south,
+/turf/open/floor/carpet/ship,
+/area/quartermaster/qm)
 "mOp" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -46490,6 +46630,9 @@
 	id = "packageExternal"
 	},
 /obj/structure/window/reinforced,
+/obj/machinery/camera/autoname{
+	dir = 6
+	},
 /turf/open/floor/plasteel/grid/steel,
 /area/quartermaster/storage)
 "mON" = (
@@ -46707,6 +46850,13 @@
 /obj/item/ship_weapon/ammunition/naval_artillery,
 /turf/open/floor/durasteel/techfloor,
 /area/nsv/weapons/fore)
+"nbG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
 "nbH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/crate,
@@ -46756,6 +46906,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"neG" = (
+/obj/structure/table/glass,
+/obj/item/computer_hardware/hard_drive/role/lawyer,
+/obj/item/taperecorder,
+/obj/item/reagent_containers/food/drinks/solgovcup,
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/dorms)
 "nfm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/monotile/dark,
@@ -47142,6 +47299,10 @@
 /obj/structure/bookcase/random/adult,
 /turf/open/floor/wood,
 /area/library)
+"nJw" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
 "nJZ" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
@@ -47753,6 +47914,13 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/science/mixing/chamber)
+"oEQ" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
 "oES" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -48271,6 +48439,15 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms)
+"pwB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
 "pwJ" = (
 /obj/effect/turf_decal/tile/orange{
 	dir = 1
@@ -48965,6 +49142,19 @@
 /obj/structure/foamedmetal,
 /turf/open/floor/plating,
 /area/medical/virology)
+"quG" = (
+/obj/structure/table/glass,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen,
+/obj/item/stamp/law,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/dorms)
 "qvd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -49347,6 +49537,9 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/secondary/exit)
@@ -50072,6 +50265,23 @@
 /area/bridge{
 	name = "CIC"
 	})
+"rFC" = (
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Ship's Attorney";
+	req_one_access_txt = "38"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "rGm" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/multiz/layer2{
@@ -50739,14 +50949,10 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
 "syG" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/light,
-/turf/open/floor/monotile/light,
-/area/medical/medbay/lobby)
+/obj/effect/landmark/event_spawn,
+/obj/structure/table/reinforced,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "szH" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
 /obj/machinery/atmospherics/pipe/layer_manifold/visible{
@@ -52864,9 +53070,6 @@
 	name = "CIC"
 	})
 "vMi" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
@@ -53723,6 +53926,10 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/machinery/camera{
+	c_tag = "Atmospherics Tank - Mix";
+	dir = 8
+	},
 /turf/open/floor/durasteel/techfloor{
 	initial_gas_mix = "TEMP=2.7"
 	},
@@ -53897,6 +54104,28 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/carpet,
 /area/library)
+"xjH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/monotile/steel,
+/area/crew_quarters/dorms)
+"xkb" = (
+/obj/machinery/light,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/computer/warrant{
+	dir = 1
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "xlf" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
@@ -54091,6 +54320,10 @@
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"xwF" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "xwM" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -79893,7 +80126,7 @@ bYc
 wcy
 aZX
 ahK
-baY
+dCq
 baY
 bCh
 bbp
@@ -80151,9 +80384,9 @@ bnl
 bCo
 qoc
 beA
-bhb
+beA
 akI
-hxi
+nKJ
 eZb
 bcU
 aUy
@@ -80932,7 +81165,7 @@ bvS
 aUh
 bhU
 aUe
-gub
+aUe
 aKh
 vMi
 xHl
@@ -81195,7 +81428,7 @@ gks
 mmh
 bGk
 bpi
-syG
+gks
 faG
 afC
 kKB
@@ -87629,6 +87862,7 @@ aad
 cjB
 bnJ
 aOe
+aOe
 aOg
 aOg
 aOg
@@ -87638,8 +87872,7 @@ aOg
 aOg
 aOg
 aOg
-aOg
-aOg
+aOe
 aOe
 aeG
 afp
@@ -87887,16 +88120,16 @@ bLu
 adt
 adu
 bxD
-bGJ
+bxF
 bxF
 bxF
 bxF
 bxF
 bxF
 bGK
-abN
 bxF
 bxF
+bGJ
 bpX
 boa
 bcI
@@ -88401,12 +88634,12 @@ bnr
 bnL
 bqz
 qOP
-acd
+gET
 bxH
 acd
 bcz
 acd
-acd
+avn
 acd
 acd
 bqz
@@ -88917,7 +89150,7 @@ ads
 aOz
 bzF
 bDm
-bcY
+beW
 bdg
 beW
 bje
@@ -89432,11 +89665,11 @@ boN
 bcr
 bcr
 bcr
+iCl
 bcr
 bcr
 bcr
-bcr
-bnP
+oEQ
 bqb
 ack
 ajy
@@ -90456,7 +90689,7 @@ aci
 aMZ
 bnQ
 bqe
-bos
+bAO
 aes
 aes
 aes
@@ -90464,7 +90697,7 @@ aes
 ajl
 aes
 aes
-bnQ
+dtV
 bGh
 bGs
 bGF
@@ -91483,8 +91716,8 @@ bmU
 adq
 aOu
 qir
-bqP
-bos
+pwB
+beQ
 afl
 aes
 ajl
@@ -91741,7 +91974,7 @@ aMt
 bnu
 bxw
 bqQ
-beQ
+bAO
 aes
 aes
 aes
@@ -91749,7 +91982,7 @@ aes
 aes
 aes
 aes
-bnQ
+dtV
 bqb
 ack
 ack
@@ -92009,7 +92242,7 @@ aes
 bnQ
 bqb
 ack
-ack
+kqo
 phM
 vUD
 uir
@@ -92265,7 +92498,7 @@ ajj
 aes
 aOB
 izj
-ack
+akd
 ajs
 bIC
 vUD
@@ -92773,7 +93006,7 @@ buw
 boE
 boE
 bqU
-boE
+nbG
 boE
 boE
 boE
@@ -93239,7 +93472,7 @@ aRy
 aRz
 ami
 aiB
-alk
+ful
 aZD
 arm
 dmA
@@ -93247,7 +93480,7 @@ atG
 bgW
 auW
 aZJ
-btQ
+aGr
 aGr
 aOm
 bHn
@@ -93299,7 +93532,7 @@ aka
 aiZ
 aka
 aka
-aka
+mNI
 ajs
 eLm
 eLm
@@ -93496,15 +93729,15 @@ aRz
 aRz
 ami
 anr
+auX
+fam
+xkb
+ami
+iWj
 aqF
-aqF
-aqF
-aqF
-aqF
-aRO
-aqz
+avf
 btI
-aqF
+avf
 aqF
 aRO
 amn
@@ -93753,16 +93986,16 @@ aRA
 aRq
 ami
 aui
-aqF
+neG
 anD
-anD
-avn
-aqF
-aRO
+abN
+aqz
+bua
+avf
 aDZ
 aKE
-btL
-azj
+keK
+aiJ
 aRO
 aOI
 bAG
@@ -93806,8 +94039,8 @@ ack
 atB
 aOn
 aPv
-ack
-ack
+hxi
+nJw
 ajs
 ajs
 ajs
@@ -94010,18 +94243,18 @@ aYQ
 aRx
 ami
 ant
-aqF
+kcQ
 aSc
-aqF
-aqF
-aqF
-aRO
-aqz
+avd
+rFC
+xjH
+alk
+cJn
 aZE
-ayT
+syG
 aZC
 aSb
-amn
+amm
 bAG
 aOY
 aMH
@@ -94267,15 +94500,15 @@ btV
 aRB
 ami
 anv
-aqF
+quG
 aZy
 aqF
-aqF
-aqF
-aRO
 aqz
-aZE
-aqF
+bua
+ayT
+avf
+jUM
+avf
 aqF
 aRO
 aOI
@@ -94524,17 +94757,17 @@ btS
 aRB
 ami
 anw
-aqF
-anD
-aRU
-anD
-aqF
-aRO
+avg
 auX
+aRU
+ami
+iWj
+xwF
+btR
 aZF
 aqF
 aqF
-aRO
+baF
 amn
 aZB
 aOY
@@ -94780,18 +95013,18 @@ bhJ
 btT
 vew
 ami
-anr
-aqF
-aqF
-aqF
-aqF
-aqF
-aRO
-aqz
+mvf
+dwq
+abW
+gub
+ami
+auP
+bhb
+lkG
 aZG
-btK
-aqF
-baF
+bhb
+bhb
+aRP
 amm
 aol
 aOY
@@ -95037,18 +95270,18 @@ aRq
 bAM
 aRq
 ami
-avg
-amq
-keK
-abW
-amq
-auP
-bua
+ami
+ami
+ami
+ami
+ami
+ami
+ami
 aro
 aZH
-avd
-avd
-aRP
+aqz
+giC
+ami
 amm
 bfX
 aOY
@@ -95293,19 +95526,19 @@ fXp
 lAs
 atz
 aoe
-ami
-ami
-ami
-ami
-ami
-ami
-ami
-ami
-ami
+cPI
+aqy
+apc
+aqy
+aqy
+cPI
+amq
+bcY
+beL
 aSd
-aqz
-giC
-ami
+beL
+beL
+gcq
 amm
 aPy
 aPj
@@ -95551,18 +95784,18 @@ aqy
 mXe
 ahe
 eot
-aiJ
 aln
 aln
 aln
+bZj
 eot
 ayG
 azW
 aGr
 aLd
-btQ
 aGr
-aOm
+aGr
+btQ
 amm
 bIz
 aOY
@@ -97356,7 +97589,7 @@ aqH
 arv
 ami
 bfU
-bAO
+aqF
 avf
 aMK
 avf
@@ -100986,7 +101219,7 @@ eEX
 aml
 qHG
 vfz
-beL
+vfz
 vfz
 vfz
 vfz


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR updates cargo/service department, and adds a public tool storage to the former lawyers office, as well as joining the ships main Turbine Generator to the rest of vaccuum atmos. It also reroutes a hilarious amount of piping of all types in those areas for de-cluttering and gameplay reasons.

## Why It's Good For The Game

Cargo techs may like more than one tile around the shuttle to work with. Maintenance rooms are good. Less vulnerable atmos and delivery network. Reworked piping means that its possible to control atmos in those areas much better.

## Screenshots of Changes
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![Tycoon Cargo Update Before Jpeg](https://github.com/user-attachments/assets/65745386-47df-4b8b-98ee-c8b7d73605d6)
![Tycoon Cargo Update After Jpeg](https://github.com/user-attachments/assets/58138191-92f5-4636-80d3-074de576715e)

</details>

## Changelog
:cl:
add: Added public tool storage to the upper deck squad vendor area of Tycoon
tweak: Reworked Tycoon supply and service department
tweak: Cleaned up various atmospheric piping and wiring on the Tycoon
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->


