### PR TITLE
Fighter components can be alt-clicked to unload its contents

### DIFF
--- a/nsv13/code/modules/overmap/fighters/_fighters.dm
+++ b/nsv13/code/modules/overmap/fighters/_fighters.dm
@@ -945,13 +945,15 @@ due_to_damage: Was this called voluntarily (FALSE) or due to damage / external c
 	. = ..()
 	if(!Adjacent(user))
 		return
-	if(!length(contents))
-		to_chat(user, "<span class='warning'>There is nothing to unload from [name]!</span>")
+	if(!isliving(user))
 		return
-	to_chat(user, "<span class='notice'>You start to unload [name]'s stored contents...</span>")
+	if(!length(contents))
+		to_chat(user, "<span class='warning'>There is nothing to unload from [src]!</span>")
+		return
+	to_chat(user, "<span class='notice'>You start to unload [src]'s stored contents...</span>")
 	if(!do_after(user, 5 SECONDS, target=src))
 		return
-	to_chat(user, "<span class='notice>You dump [name]'s contents.</span>")
+	to_chat(user, "<span class='notice>You dump [src]'s contents.</span>")
 	dump_contents()
 
 /obj/item/fighter_component/proc/dump_contents()

--- a/nsv13/code/modules/overmap/fighters/_fighters.dm
+++ b/nsv13/code/modules/overmap/fighters/_fighters.dm
@@ -407,7 +407,7 @@ Been a mess since 2018, we'll fix it someday (probably)
 	name = "Peregrine class attack fighter"
 	desc = "A Peregrine class attack fighter, solgov's only premiere fighter, mounting minature capital grade phasers and a tiny shield generator."
 	icon = 'nsv13/icons/overmap/new/solgov/playablefighter.dmi'
-	armor = list("melee" = 60, "bullet" = 60, "laser" = 60, "energy" = 30, "bomb" = 30, "bio" = 100, "rad" = 90, "fire" = 90, "acid" = 80, "overmap_light" = 5, "overmap_medium" = 0, "overmap_heavy" = 10) 
+	armor = list("melee" = 60, "bullet" = 60, "laser" = 60, "energy" = 30, "bomb" = 30, "bio" = 100, "rad" = 90, "fire" = 90, "acid" = 80, "overmap_light" = 5, "overmap_medium" = 0, "overmap_heavy" = 10)
 	sprite_size = 32
 	damage_states = FALSE //temp
 	max_integrity = 25 //shields.
@@ -940,6 +940,19 @@ due_to_damage: Was this called voluntarily (FALSE) or due to damage / external c
 
 /obj/item/fighter_component/proc/toggle()
 	active = !active
+
+/obj/item/fighter_component/AltClick(mob/user)
+	. = ..()
+	if(!Adjacent(user))
+		return
+	if(!length(contents))
+		to_chat(user, "<span class='warning'>There is nothing to unload from [name]!</span>")
+		return
+	to_chat(user, "<span class='notice'>You start to unload [name]'s stored contents...</span>")
+	if(!do_after(user, 5 SECONDS, target=src))
+		return
+	to_chat(user, "<span class='notice>You dump [name]'s contents.</span>")
+	dump_contents()
 
 /obj/item/fighter_component/proc/dump_contents()
 	if(!length(contents))


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Alt-clicking fighter components will now unload its contents


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
There wasn't a alt-click interaction despite the examine text, so I added it.

![Altclickittounloaditscontents](https://github.com/user-attachments/assets/72b53562-989e-45db-bfe0-f3ed174ab5a1)


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![AltClicked](https://github.com/user-attachments/assets/1caadf57-ffd9-4c7c-8470-7dce6c552ef1)


</details>

## Changelog
:cl:
add: Alt-click fighter components to unload its contents
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
