### PR TITLE
[UPSTREAM] Examining atmos machinery now displays what layer it's on.

### DIFF
--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -29,6 +29,10 @@
 		component_mixture.set_volume(startingvolume)
 		airs[i] = component_mixture
 
+/obj/machinery/atmospherics/components/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>[src] is on layer [piping_layer].</span>"
+
 // Iconnery
 
 /obj/machinery/atmospherics/components/proc/update_icon_nopipes()

--- a/code/modules/atmospherics/machinery/pipes/pipes.dm
+++ b/code/modules/atmospherics/machinery/pipes/pipes.dm
@@ -23,6 +23,10 @@
 	volume = 35 * device_type
 	return ..()
 
+/obj/machinery/atmospherics/pipe/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>[src] is on layer [piping_layer].</span>"
+
 /obj/machinery/atmospherics/pipe/nullify_node(i)
 	var/obj/machinery/atmospherics/old_node = nodes[i]
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Ports https://github.com/BeeStation/BeeStation-Hornet/pull/8076 from upstream, which was ported from https://github.com/tgstation/tgstation/pull/57937. 

Atmos components and piping will now tell its layer upon examination.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
Makes identifying piping layers easier and more independent from interpreting the sprites.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![Pipe Layer Examining](https://github.com/user-attachments/assets/f9f634c6-b36c-4f30-affb-ce87a0cf437a)

</details>

## Changelog
:cl: Tsar-Salat, Ghilker, RKz
add: Examining atmos components and pipes now show their piping layer.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
