### PR TITLE
alert level change fixes

### DIFF
--- a/code/modules/security_levels/security_levels.dm
+++ b/code/modules/security_levels/security_levels.dm
@@ -73,7 +73,7 @@ GLOBAL_VAR_INIT(security_level, SEC_LEVEL_GREEN)
 			else
 				gq_announce(CONFIG_GET(string/alert_zebra_downto), sound='nsv13/sound/effects/ship/condition_zebra.ogg') //Nsv13 - Condition Z
 			toggle_gq_lights(TRUE)
-			addtimer(CALLBACK(GLOBAL_PROC, PROC_REF(toggle_gq_lights), FALSE), 30 SECONDS)
+			addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(toggle_gq_lights), FALSE), 30 SECONDS)
 			for(var/obj/machinery/firealarm/FA in GLOB.machines)
 				if(is_station_level(FA.z))
 					FA.update_icon()

--- a/code/modules/security_levels/security_levels.dm
+++ b/code/modules/security_levels/security_levels.dm
@@ -55,7 +55,7 @@ GLOBAL_VAR_INIT(security_level, SEC_LEVEL_GREEN)
 			else
 				minor_announce(CONFIG_GET(string/alert_red_downto), "Attention! General Quarters!")
 			toggle_gq_lights(TRUE)
-			addtimer(CALLBACK(GLOBAL_PROC, PROC_REF(toggle_gq_lights), FALSE), 45 SECONDS)
+			addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(toggle_gq_lights), FALSE), 45 SECONDS)
 			for(var/obj/machinery/firealarm/FA in GLOB.machines)
 				if(is_station_level(FA.z))
 					FA.update_icon()

--- a/nsv13/code/game/turfs/custom_turfs.dm
+++ b/nsv13/code/game/turfs/custom_turfs.dm
@@ -127,7 +127,7 @@
 /obj/effect/spawner/structure/window/reinforced
 	name = "reinforced window spawner"
 	icon_state = "rwindow_spawner"
-	spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/fulltile/ship/interior, /obj/machinery/door/firedoor/window, /obj/effect/landmark/zebra_interlock_point) //All windows should "batten down" on zebra.
+	spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/fulltile/ship/interior, /obj/machinery/door/firedoor/window) //All windows should "batten down" on zebra.
 
 /obj/structure/window/reinforced/ship
 	icon = 'nsv13/goonstation/icons/obj/window_pane.dmi'

--- a/nsv13/code/modules/security_levels/security_levels.dm
+++ b/nsv13/code/modules/security_levels/security_levels.dm
@@ -1,13 +1,13 @@
 /obj/effect/landmark/zebra_interlock_point
-	name = "Condition zebra interlock helper"
+	name = "(DEPRECATED - DO NOT USE) Condition zebra interlock helper"
+	desc = "This landmark is DEPRECATED. Do not use it. Firelocks register the signal automatically. This type is pending deletion."
 	icon = 'nsv13/icons/effects/mapping_helpers.dmi'
 	icon_state = "zebra_interlock"
 
 
 /obj/effect/landmark/zebra_interlock_point/Initialize(mapload)
-	. = ..()
-	for(var/obj/machinery/door/firedoor/FD in get_turf(src))
-		FD.RegisterSignal(SSdcs, COMSIG_GLOB_SECURITY_ALERT_CHANGE, /obj/machinery/door/firedoor/proc/on_alert_level_change, override=TRUE) //In case you have a zebra spawner on a window, this instance of alert level change will override the old one.
+	..()
+	return INITIALIZE_HINT_QDEL
 
 /obj/machinery/door/firedoor/Initialize(mapload)
 	. = ..()

--- a/nsv13/code/modules/security_levels/security_levels.dm
+++ b/nsv13/code/modules/security_levels/security_levels.dm
@@ -17,6 +17,8 @@
 	. = ..()
 	var/level = GLOB.security_level
 	if(level == SEC_LEVEL_ZEBRA) //Zebra is a special case. Nothing else triggers this behaviour.
+		if(welded || (machine_stat & NOPOWER))
+			return
 		addtimer(CALLBACK(src, PROC_REF(close)), 3 SECONDS) //Snap shut again if zebra's still active.
 
 /obj/machinery/door/firedoor/proc/on_alert_level_change(level)
@@ -26,11 +28,15 @@
 		return
 
 	if(level == SEC_LEVEL_ZEBRA) //Zebra is a special case. Nothing else triggers this behaviour.
+		if(welded || (machine_stat & NOPOWER))
+			return
 		spawn()
 			close()
 	else
 		var/area/A = get_area(src)
 		if((A.fire) || is_holding_pressure())
+			return
+		if(welded || (machine_stat & NOPOWER))
 			return
 		spawn()
 			open()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Firstly, GQ lights are supposed to switch off of being very red after 30 seconds but this has been runtiming instead because of a wrong `PROC_REF` macro. This fixes that.

Secondly, zebra level currenty ignores checks on firelocks, sometimes letting them operate when unable to (namely, welded shut, other cases should generally already get caught but better safe). They no longer do that.

Additionally, marks the `zebra_interlock_helper` type deprecated because it doesn't actually do anything, and removes its pseudofunctionality. Removal from maps / code pending but I don't feel like turning this PR into a mass map change.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Changelog
:cl:
fix: GQ (red) lights auto-disabling after some time isn't broken anymore.
fix: Zebra alert doesn't allow non-operational firelocks to operate.
tweak: the zebra interlock mapping helper is now deprecated (as it didn't actually do anything).
del: Window spawners no longer contain a zebra interlock mapping helper.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
