### PR TITLE
Flares and Firelock helpers

### DIFF
--- a/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp1.dmm
@@ -112,7 +112,6 @@
 /obj/machinery/door/airlock/ship/station{
 	name = "Chapel Departures"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/ship,
 /area/chapel/main)
@@ -180,7 +179,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "aek" = (
@@ -440,7 +438,6 @@
 	req_one_access_txt = "38"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/lawoffice)
 "akT" = (
@@ -498,7 +495,6 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/airlock/ship/public/glass/turbolift,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/shuttle/turbolift/quaternary)
 "amt" = (
@@ -554,7 +550,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "ank" = (
@@ -995,7 +990,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/door/firedoor/border_only/directional/north,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/cafeteria)
 "ayV" = (
@@ -1192,7 +1186,6 @@
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Central Primary Hallway"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/hallway/primary/central/hallway)
 "aCt" = (
@@ -1206,7 +1199,6 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "aCw" = (
@@ -1338,7 +1330,6 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "aHw" = (
@@ -1466,7 +1457,6 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only/directional/south,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "aMO" = (
@@ -1679,7 +1669,6 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "12;24;46"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "aTB" = (
@@ -1702,7 +1691,6 @@
 	name = "Operating Room";
 	req_one_access_txt = "5"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/surgery)
 "aTT" = (
@@ -1723,7 +1711,6 @@
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Central Primary Hallway"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/hallway/primary/central/hallway)
 "aUl" = (
@@ -1762,7 +1749,6 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only/directional/north,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/cafeteria)
 "aVi" = (
@@ -1852,7 +1838,6 @@
 	pixel_x = -24;
 	req_access_txt = "39"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#99FF99"
 	},
@@ -2464,7 +2449,6 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/red_carpet,
 /area/ai_monitored/security/armory/security)
 "bpD" = (
@@ -2543,7 +2527,6 @@
 	name = "Maintenance Access Chapel Backroom";
 	req_one_access_txt = "22"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/maintenance/department/engine/atmos)
 "bsC" = (
@@ -2850,7 +2833,6 @@
 /obj/structure/cable/green{
 	icon_state = "6-10"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engineering/reactor_control)
 "bDK" = (
@@ -3020,7 +3002,6 @@
 	name = "Maintenance Access Bar";
 	req_one_access_txt = "12;25;28;35"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bJZ" = (
@@ -3232,7 +3213,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "5-9"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "bOM" = (
@@ -3546,7 +3526,6 @@
 	name = "Interrogation Room";
 	req_one_access_txt = "4"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/security/detectives_office)
 "bZQ" = (
@@ -3566,7 +3545,6 @@
 	name = "Detective Office";
 	req_one_access_txt = "4"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/detectives_office)
 "cas" = (
@@ -3917,7 +3895,6 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/airlock/ship/maintenance,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/maintenance/department/engine/atmos)
 "cnN" = (
@@ -3965,7 +3942,6 @@
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Central Primary Hallway"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/hallway/primary/central/hallway)
 "cpt" = (
@@ -4217,7 +4193,6 @@
 /obj/machinery/door/poddoor/ship/preopen{
 	id = "aether_atmos_lockdown"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_room)
 "cCa" = (
@@ -4410,7 +4385,6 @@
 	name = "Chief Medical Officer Office";
 	req_one_access_txt = "40"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue,
 /area/crew_quarters/heads/cmo)
 "cJk" = (
@@ -4572,7 +4546,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/tcommsat/server)
 "cRx" = (
@@ -4767,7 +4740,6 @@
 	name = "Judicial Office";
 	req_one_access_txt = "38"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/security/execution/education)
 "cWy" = (
@@ -4777,7 +4749,6 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/structure/extinguisher_cabinet/east,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "cXI" = (
@@ -5295,7 +5266,6 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "12"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "dpD" = (
@@ -5377,7 +5347,6 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "dra" = (
@@ -5405,7 +5374,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
 "drl" = (
@@ -5721,7 +5689,6 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "dCq" = (
@@ -5813,7 +5780,6 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/bar)
 "dDD" = (
@@ -5889,7 +5855,6 @@
 	name = "Maintenance Access Engineering Lounge";
 	req_one_access_txt = "10;24"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/break_room)
 "dFz" = (
@@ -5962,7 +5927,6 @@
 	name = "Shield Generator";
 	req_one_access_txt = "10"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/engine,
 /area/engine/shield_generator)
 "dHs" = (
@@ -5987,7 +5951,6 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only/directional/north,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/cafeteria)
 "dIf" = (
@@ -6011,7 +5974,6 @@
 /obj/machinery/door/airlock/ship/public{
 	name = "Bathroom Cell"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
 "dJw" = (
@@ -6112,7 +6074,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
 "dOS" = (
@@ -6176,7 +6137,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/stormdrive/monitor)
 "dQZ" = (
@@ -6225,7 +6185,6 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "12;24;46"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "dSB" = (
@@ -6288,7 +6247,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "dVF" = (
@@ -6365,7 +6323,6 @@
 	name = "Maintenance Access Morgue";
 	req_one_access_txt = "6;39;68"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "dWT" = (
@@ -6424,7 +6381,6 @@
 /obj/structure/sign/departments/minsky/medical/chemistry/chemical2{
 	pixel_x = -32
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue,
 /area/maintenance/department/medical/central)
 "dZx" = (
@@ -6586,7 +6542,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/armour_pump)
 "ech" = (
@@ -6654,7 +6609,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "egj" = (
@@ -6715,7 +6669,6 @@
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Tool Storage"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -6859,7 +6812,6 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "7"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "enb" = (
@@ -7013,7 +6965,6 @@
 /obj/machinery/door/airlock/ship/station{
 	name = "Chapel Departures"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/chapel/main)
 "eqR" = (
@@ -7037,7 +6988,6 @@
 	req_one_access_txt = "3;38"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/maintenance/department/security)
 "err" = (
@@ -7227,7 +7177,6 @@
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Tool Storage"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/storage/tools)
 "eyC" = (
@@ -7284,7 +7233,6 @@
 "eAP" = (
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/airlock/ship/engineering/glass{
 	name = "Engineering Lobby"
 	},
@@ -7412,7 +7360,6 @@
 	req_one_access_txt = "3;4;63"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/main/warroom)
 "eFQ" = (
@@ -7465,7 +7412,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "6-9"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "eHr" = (
@@ -8089,7 +8035,6 @@
 	req_one_access_txt = "4"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/security/detectives_office)
 "fdI" = (
@@ -8114,7 +8059,6 @@
 "fdV" = (
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "feG" = (
@@ -8374,7 +8318,6 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/storage)
 "fko" = (
@@ -8659,7 +8602,6 @@
 	default_raw_text = "<p>Reminder that squad equipment vendors are located in the council chamber, tool storage, and that 4-way junction at the primary hallway, Deck 1</p>"
 	},
 /obj/item/reagent_containers/spray/cleaner,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/medical/medbay/lobby)
 "fvs" = (
@@ -8793,7 +8735,6 @@
 	req_one_access_txt = "28"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "fBz" = (
@@ -8862,7 +8803,6 @@
 	name = "Maintenance Access Infirmary Lobby";
 	req_one_access_txt = "5"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "fCT" = (
@@ -8946,7 +8886,6 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "5"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue,
 /area/maintenance/department/medical/central)
 "fGD" = (
@@ -9371,7 +9310,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "fWo" = (
@@ -9413,7 +9351,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
 "fXN" = (
@@ -9495,7 +9432,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/main/warroom)
 "fZj" = (
@@ -9672,7 +9608,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/stormdrive/monitor)
 "geP" = (
@@ -9724,7 +9659,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/shield_generator)
 "giK" = (
@@ -9739,7 +9673,6 @@
 	name = "Operating Room";
 	req_one_access_txt = "5"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/surgery/aux)
 "giM" = (
@@ -9820,7 +9753,6 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "glB" = (
@@ -10087,7 +10019,6 @@
 	req_one_access_txt = "63"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/checkpoint/medical)
 "gud" = (
@@ -10268,7 +10199,6 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/genetics/cloning)
 "gDe" = (
@@ -10276,7 +10206,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/border_only/directional/north,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/cafeteria)
 "gDB" = (
@@ -10522,7 +10451,6 @@
 /obj/machinery/door/poddoor/ship{
 	id = "permacell1"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/security/prison)
 "gOx" = (
@@ -10547,7 +10475,6 @@
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_room)
 "gOQ" = (
@@ -10822,7 +10749,6 @@
 	name = "Maintenance Access Bar";
 	req_one_access_txt = "12;24;25;28;35"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "gZv" = (
@@ -10897,7 +10823,6 @@
 	req_one_access_txt = "6;39;68"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/medical/morgue)
 "hbw" = (
@@ -11649,7 +11574,6 @@
 "hHa" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/border_only/directional/south,
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/poddoor/shutters/ship/preopen{
 	id = "kitchen_shutter"
 	},
@@ -11674,7 +11598,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/checkpoint/engineering)
 "hHd" = (
@@ -11823,7 +11746,6 @@
 	name = "Judicial Office";
 	req_one_access_txt = "38"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/security/execution/education)
 "hLl" = (
@@ -12249,7 +12171,6 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "5;12;33"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
 "ibM" = (
@@ -12275,7 +12196,6 @@
 	icon_state = "2-5"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/chapel/office)
 "ick" = (
@@ -12368,7 +12288,6 @@
 	name = "Telecommunications";
 	req_one_access_txt = "61"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/tcommsat/server)
 "ifB" = (
@@ -12433,7 +12352,6 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue,
 /area/maintenance/department/medical)
 "igu" = (
@@ -12737,7 +12655,6 @@
 /obj/structure/sign/departments/minsky/medical/chemistry/chemical2{
 	pixel_x = -32
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/chemistry)
 "ion" = (
@@ -12783,7 +12700,6 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/airlock/ship/public/glass/turbolift,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/shuttle/turbolift/tertiary)
 "ipd" = (
@@ -13042,7 +12958,6 @@
 	name = "Patient Treatment Room";
 	req_one_access_txt = "5"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/patients_rooms/room_c)
 "iwi" = (
@@ -13068,7 +12983,6 @@
 	name = "Shield Generator";
 	req_one_access_txt = "10"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "ixl" = (
@@ -13171,7 +13085,6 @@
 /obj/effect/landmark/event_spawn,
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "izJ" = (
@@ -13308,7 +13221,6 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	name = "Maintenance Access Cafeteria"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/maintenance/department/engine/atmos)
 "iFb" = (
@@ -13354,7 +13266,6 @@
 	name = "Kitchen";
 	req_one_access_txt = "28"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/kitchen)
 "iFU" = (
@@ -13378,7 +13289,6 @@
 /obj/machinery/door/airlock/ship/station{
 	name = "Central Primary Hallway"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/hallway/primary/central/hallway)
 "iGX" = (
@@ -13495,7 +13405,6 @@
 	icon_state = "9-10"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
 "iKj" = (
@@ -13533,7 +13442,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "iMq" = (
@@ -13599,7 +13507,6 @@
 	name = "Maintenance Access Medbay Storage";
 	req_one_access_txt = "5;6;39;68"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue,
 /area/maintenance/department/medical)
 "iNt" = (
@@ -13685,7 +13592,6 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "iTi" = (
@@ -13753,7 +13659,6 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "iUH" = (
@@ -13874,7 +13779,6 @@
 	name = "Cloning Bay";
 	req_one_access_txt = "6;39;68"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/genetics/cloning)
 "iYk" = (
@@ -14109,7 +14013,6 @@
 	name = "Kitchen Cold Room";
 	req_one_access_txt = "28"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/kitchen/coldroom)
 "jfr" = (
@@ -14608,7 +14511,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/border_only/directional/north,
-/obj/effect/landmark/zebra_interlock_point,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/cafeteria)
@@ -14827,7 +14729,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "6-9"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/grass,
 /area/hydroponics)
 "jFF" = (
@@ -14949,7 +14850,6 @@
 	name = "Hydroponics";
 	req_one_access_txt = "35"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/hydroponics)
 "jJd" = (
@@ -15144,7 +15044,6 @@
 	req_one_access_txt = "3;12"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "jQH" = (
@@ -15176,7 +15075,6 @@
 	},
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "jQT" = (
@@ -15220,7 +15118,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/break_room)
 "jSp" = (
@@ -15270,7 +15167,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/security/prison)
 "jTY" = (
@@ -15324,7 +15220,6 @@
 	name = "Chemistry Manufacturing";
 	req_access_txt = "6;33"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/medical/apothecary)
 "jVQ" = (
@@ -15474,7 +15369,6 @@
 	name = "Interrogation Room";
 	req_one_access_txt = "4;38"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/security/detectives_office)
 "kau" = (
@@ -15958,7 +15852,6 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "5"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue,
 /area/maintenance/department/medical)
 "kvL" = (
@@ -16006,7 +15899,6 @@
 /obj/machinery/light,
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "kxw" = (
@@ -16040,7 +15932,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "kys" = (
@@ -16229,7 +16120,6 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	name = "Maintenance Access Cryostasis Storage"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "kEp" = (
@@ -16472,7 +16362,6 @@
 /obj/item/radio/intercom,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/medical/medbay/lobby)
 "kPd" = (
@@ -16628,7 +16517,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "6-9"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/medbay/lobby)
 "kUo" = (
@@ -16750,7 +16638,6 @@
 	name = "Patient Treatment Room";
 	req_one_access_txt = "5"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/patients_rooms/room_a)
 "laf" = (
@@ -16995,7 +16882,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "lhb" = (
@@ -17313,7 +17199,6 @@
 "luB" = (
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "luW" = (
@@ -17411,7 +17296,6 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "2;5;12"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "lxp" = (
@@ -18115,7 +17999,6 @@
 /obj/structure/cable{
 	icon_state = "5-10"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/engine/break_room)
 "lVn" = (
@@ -18374,7 +18257,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/storage/tech)
 "meh" = (
@@ -18406,7 +18288,6 @@
 	name = "Maintenance Access Plumbing";
 	req_one_access_txt = "5;33"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue,
 /area/maintenance/department/medical/central)
 "mfx" = (
@@ -18468,7 +18349,6 @@
 /obj/machinery/door/airlock/ship/station{
 	name = "Central Primary Hallway"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/ship,
 /area/hallway/primary/central/hallway)
@@ -18525,7 +18405,6 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/airalarm/directional/north,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "miQ" = (
@@ -18766,7 +18645,6 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "12;24"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "mpq" = (
@@ -19140,7 +19018,6 @@
 	name = "Maintenance Access Plumbing";
 	req_one_access_txt = "5;33"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue,
 /area/maintenance/department/medical/central)
 "mBv" = (
@@ -19193,7 +19070,6 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "mDr" = (
@@ -19212,7 +19088,6 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "mDK" = (
@@ -19456,7 +19331,6 @@
 	name = "Patient Treatment Room";
 	req_one_access_txt = "5"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/patients_rooms/room_c)
 "mLK" = (
@@ -19736,7 +19610,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "mUs" = (
@@ -19826,7 +19699,6 @@
 	name = "Permabrig Cell 3";
 	req_one_access_txt = "2"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/security/processing)
 "mXf" = (
@@ -20066,7 +19938,6 @@
 /obj/machinery/door/airlock/ship/engineering{
 	req_one_access_txt = "10"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/engine/armour_pump)
 "ncp" = (
@@ -20250,7 +20121,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "niT" = (
@@ -21027,7 +20897,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "nHC" = (
@@ -21055,7 +20924,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/processing)
 "nHU" = (
@@ -21233,7 +21101,6 @@
 /obj/machinery/door/airlock/ship/public{
 	name = "Permabrig Bathroom"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/security/prison)
 "nRc" = (
@@ -21419,7 +21286,6 @@
 /obj/machinery/door/airlock/ship/medical{
 	name = "Infirmary Lobby"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/medbay/lobby)
 "nVO" = (
@@ -21764,7 +21630,6 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/airlock/ship/public/glass/turbolift,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/shuttle/turbolift/secondary)
 "okE" = (
@@ -21815,7 +21680,6 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "omQ" = (
@@ -21894,7 +21758,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/break_room)
 "onM" = (
@@ -21954,7 +21817,6 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "oqm" = (
@@ -21963,7 +21825,6 @@
 /obj/machinery/door/airlock/ship/external/glass{
 	name = "External Access Deck 1 Security"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "oqz" = (
@@ -22140,7 +22001,6 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	name = "Maintenance Access Cafeteria"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/maintenance/department/engine/atmos)
 "owK" = (
@@ -22244,7 +22104,6 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/maintenance/department/engine/atmos)
 "ozH" = (
@@ -22282,7 +22141,6 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/airalarm/directional/north,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "oAG" = (
@@ -22324,7 +22182,6 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "oBw" = (
@@ -22468,7 +22325,6 @@
 	name = "Permabrig Cell 1";
 	req_one_access_txt = "2"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/security/prison)
 "oGt" = (
@@ -22519,7 +22375,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "oIn" = (
@@ -22611,7 +22466,6 @@
 	name = "Permabrig Cell 2";
 	req_one_access_txt = "2"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/security/prison)
 "oKG" = (
@@ -22692,7 +22546,6 @@
 /obj/machinery/reagentgrinder,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/item/reagent_containers/food/snacks/pie/cream,
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/poddoor/shutters/ship/preopen{
 	id = "kitchen_shutter"
 	},
@@ -22783,7 +22636,6 @@
 	name = "Maintenance Access Security War Room";
 	req_one_access_txt = "2"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/security)
 "oPt" = (
@@ -22858,7 +22710,6 @@
 	req_one_access_txt = "2;5;12"
 	},
 /obj/structure/barricade/wooden/crude,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "oRJ" = (
@@ -22924,7 +22775,6 @@
 /obj/machinery/door/poddoor/ship{
 	id = "permacell3"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/security/prison)
 "oST" = (
@@ -22960,7 +22810,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "5-10"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "oTE" = (
@@ -23268,7 +23117,6 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "pcI" = (
@@ -23391,7 +23239,6 @@
 	name = "Interrogation Room";
 	req_one_access_txt = "38"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/lawoffice)
 "pim" = (
@@ -23430,7 +23277,6 @@
 "piL" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/border_only/directional/south,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/medical/medbay/lobby)
 "pjp" = (
@@ -23499,7 +23345,6 @@
 "pjM" = (
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/airlock/ship/engineering/glass{
 	name = "Supermatter Engine";
 	req_one_access_txt = "24"
@@ -23523,7 +23368,6 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "pkZ" = (
@@ -23765,7 +23609,6 @@
 /obj/machinery/door/airlock/ship/public{
 	name = "Bathroom Cell"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/freezer,
 /area/engine/storage)
 "ptV" = (
@@ -23810,7 +23653,6 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "puW" = (
@@ -23864,7 +23706,6 @@
 	name = "Maintenance Access Plumbing";
 	req_one_access_txt = "5;12;33"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/maintenance/central/secondary)
 "pwz" = (
@@ -23952,7 +23793,6 @@
 	name = "Medbay Storage";
 	req_one_access_txt = "5;6;39;68"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/storage)
 "pzp" = (
@@ -24045,7 +23885,6 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "12;24;46"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "pEk" = (
@@ -24079,7 +23918,6 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "12;24"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "pEK" = (
@@ -24543,7 +24381,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/security/warden)
 "pTe" = (
@@ -24783,7 +24620,6 @@
 "qck" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/door/firedoor/border_only/directional/north,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/cafeteria)
 "qcC" = (
@@ -24881,7 +24717,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "qeG" = (
@@ -25020,7 +24855,6 @@
 	name = "Armory High Security";
 	req_one_access_txt = "3"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/red_carpet,
 /area/ai_monitored/security/armory/lockup)
 "qhd" = (
@@ -25029,7 +24863,6 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "qhC" = (
@@ -25102,7 +24935,6 @@
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Central Primary Hallway"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/hallway/primary/central/hallway)
 "qjc" = (
@@ -25128,7 +24960,6 @@
 /obj/machinery/atmospherics/pipe/simple/dark/visible/layer2{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "qjY" = (
@@ -25345,7 +25176,6 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/airlock/ship/medical{
 	name = "Infirmary Lobby"
 	},
@@ -25357,7 +25187,6 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "qqz" = (
@@ -25572,7 +25401,6 @@
 	name = "Maintenance Access Supermatter Engine";
 	req_one_access_txt = "24"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "qxO" = (
@@ -25986,7 +25814,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engineering/reactor_control)
 "qMX" = (
@@ -26203,7 +26030,6 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "12;24;46"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "qUs" = (
@@ -26617,7 +26443,6 @@
 /obj/machinery/door/airlock/ship/engineering/glass{
 	name = "Engineering Lobby"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/crew_quarters/cafeteria)
 "rlZ" = (
@@ -26655,7 +26480,6 @@
 	},
 /obj/item/kitchen/fork,
 /obj/machinery/door/firedoor/border_only/directional/south,
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/poddoor/shutters/ship/preopen{
 	id = "kitchen_shutter"
 	},
@@ -26769,7 +26593,6 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/machinery/door/firedoor/border_only/directional/south,
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/poddoor/shutters/ship/preopen{
 	id = "kitchen_shutter"
 	},
@@ -26857,10 +26680,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering/reactor_control)
-"rvQ" = (
-/obj/effect/landmark/zebra_interlock_point,
-/turf/closed/wall/r_wall/ship,
-/area/maintenance/department/medical/central)
 "rwr" = (
 /obj/structure/closet/crate/engineering,
 /obj/item/stack/sheet/mineral/titanium{
@@ -26894,7 +26713,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "6-8"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/medbay/lobby)
 "rwI" = (
@@ -26924,7 +26742,6 @@
 	name = "Patient Treatment Room";
 	req_one_access_txt = "5"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/patients_rooms/room_d)
 "rxN" = (
@@ -26937,7 +26754,6 @@
 	name = "Maintenance Access Chemistry and Plumbing";
 	req_one_access_txt = "33"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
 "rxP" = (
@@ -27158,7 +26974,6 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "rHn" = (
@@ -27459,7 +27274,6 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "rQq" = (
@@ -27537,7 +27351,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/maintenance/central/secondary)
 "rTN" = (
@@ -27937,7 +27750,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/storage)
 "seW" = (
@@ -27990,7 +27802,6 @@
 	id_tag = "MedbayFoyer";
 	req_one_access_txt = "5;6;33;39;68"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/medbay/lobby)
 "sgZ" = (
@@ -28059,7 +27870,6 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
-/obj/effect/landmark/zebra_interlock_point,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -28684,7 +28494,6 @@
 "sIz" = (
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "sIC" = (
@@ -28716,7 +28525,6 @@
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Cafeteria"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -29041,7 +28849,6 @@
 	name = "Patient Treatment Room";
 	req_one_access_txt = "5"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/patients_rooms/room_b)
 "sUi" = (
@@ -29335,7 +29142,6 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "teN" = (
@@ -29389,7 +29195,6 @@
 /obj/machinery/door/poddoor/ship/preopen{
 	id = "aether_atmos_lockdown"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "tgQ" = (
@@ -29538,7 +29343,6 @@
 	name = "Maintenance Access Judicial Office";
 	req_one_access_txt = "38"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "tkR" = (
@@ -29656,7 +29460,6 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "tpU" = (
@@ -29682,7 +29485,6 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/airlock/ship/public/glass/turbolift,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/shuttle/turbolift/quinary)
 "tqK" = (
@@ -29881,7 +29683,6 @@
 /area/engine/engineering/reactor_control)
 "tuR" = (
 /obj/machinery/door/firedoor/border_only/directional/north,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/cafeteria)
 "tuS" = (
@@ -30077,7 +29878,6 @@
 	name = "Maintenance Access Morgue";
 	req_one_access_txt = "6;39;68"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/maintenance/department/medical)
 "tzF" = (
@@ -30230,7 +30030,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/security/brig)
 "tGL" = (
@@ -30275,7 +30074,6 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "tHQ" = (
@@ -30608,7 +30406,6 @@
 	name = "Head of Security Office";
 	req_one_access_txt = "58"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/red_carpet,
 /area/crew_quarters/heads/hos)
 "tTs" = (
@@ -30735,7 +30532,6 @@
 	name = "Gravity Generator Room";
 	req_one_access_txt = "10"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/engine/gravity_generator)
 "tZw" = (
@@ -30752,7 +30548,6 @@
 	name = "Maintenance Access Infirmary";
 	req_one_access_txt = "5"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue,
 /area/maintenance/department/medical)
 "tZP" = (
@@ -30956,7 +30751,6 @@
 	name = "Atmospherics";
 	req_one_access_txt = "24"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "ugA" = (
@@ -31840,7 +31634,6 @@
 	name = "Patient Treatment Room";
 	req_one_access_txt = "5"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue,
 /area/medical/patients_rooms/room_a)
 "uOM" = (
@@ -32401,7 +32194,6 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/brig)
 "vlc" = (
@@ -32464,7 +32256,6 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "vnm" = (
@@ -32656,7 +32447,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "5-9"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/checkpoint/escape)
 "vso" = (
@@ -32728,7 +32518,6 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/cryopods)
 "vva" = (
@@ -32795,7 +32584,6 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "vym" = (
@@ -32906,7 +32694,6 @@
 /obj/machinery/atmospherics/pipe/multiz{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "vCC" = (
@@ -33072,7 +32859,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
 "vHO" = (
@@ -33206,7 +32992,6 @@
 /obj/machinery/door/poddoor/ship/preopen{
 	id = "aether_atmos_lockdown"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_room)
 "vNP" = (
@@ -33467,7 +33252,6 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "12;24"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "waz" = (
@@ -33658,7 +33442,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/security/brig)
 "wjH" = (
@@ -33738,7 +33521,6 @@
 /obj/machinery/door/poddoor/ship{
 	id = "permacell2"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/security/prison)
 "wlQ" = (
@@ -34099,7 +33881,6 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only/directional/north,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/cafeteria)
 "wAq" = (
@@ -34264,7 +34045,6 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/airlock/ship/public/glass/turbolift,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/shuttle/turbolift/primary)
 "wGc" = (
@@ -34533,7 +34313,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "wOb" = (
@@ -35161,7 +34940,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "6-10"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/chapel/office)
 "xoV" = (
@@ -35221,7 +34999,6 @@
 	name = "Engine Observation Room";
 	req_one_access_txt = "10;24"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/engine_smes)
 "xrv" = (
@@ -35857,7 +35634,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/brig)
 "xIy" = (
@@ -36192,7 +35968,6 @@
 "xVt" = (
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "xVu" = (
@@ -36271,7 +36046,6 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/red_carpet,
 /area/ai_monitored/security/armory/security)
 "xWX" = (
@@ -36460,7 +36234,6 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/engine/atmos)
 "ydc" = (
@@ -36532,7 +36305,6 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/checkpoint/escape)
 "yge" = (
@@ -72335,7 +72107,7 @@ vSI
 eyl
 lPZ
 enF
-rvQ
+enF
 rxN
 enF
 jqV

--- a/_maps/map_files/Aetherwhisp/Aetherwhisp2.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp2.dmm
@@ -80,7 +80,6 @@
 	name = "Bathroom Cell"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "abO" = (
@@ -216,7 +215,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "5-10"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "aiE" = (
@@ -327,7 +325,6 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "alS" = (
@@ -461,7 +458,6 @@
 	name = "Library Backroom";
 	req_one_access_txt = "37"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/wood,
 /area/library)
 "apz" = (
@@ -710,7 +706,6 @@
 	req_one_access_txt = "12;7"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
 "axW" = (
@@ -759,7 +754,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -805,7 +799,6 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/engine,
 /area/nsv/hanger/storage)
 "aAZ" = (
@@ -1218,7 +1211,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/mixing)
 "aPN" = (
@@ -1317,7 +1309,6 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "10;24"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/engine/engineering/reactor_control)
 "aSI" = (
@@ -1384,7 +1375,6 @@
 	name = "Bridge";
 	req_access_txt = "19"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -1518,7 +1508,6 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "12"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "bbg" = (
@@ -2315,7 +2304,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -2338,7 +2326,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "bxM" = (
@@ -2388,7 +2375,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms)
 "byg" = (
@@ -2681,7 +2667,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "6-10"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/research)
 "bGw" = (
@@ -2860,7 +2845,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/pool_party)
 "bTd" = (
@@ -2925,7 +2909,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/bridge)
 "bUO" = (
@@ -3722,7 +3705,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -3786,7 +3768,6 @@
 /obj/structure/cable{
 	icon_state = "5-10"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
 "cxr" = (
@@ -4129,7 +4110,6 @@
 	name = "E.X.P.E.R.I-MENTOR Access";
 	req_one_access_txt = "47"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/explab)
 "cJa" = (
@@ -4255,7 +4235,6 @@
 "cPh" = (
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/effect/landmark/event_spawn,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/blue,
 /area/bridge)
 "cPn" = (
@@ -4526,7 +4505,6 @@
 	req_one_access_txt = "55"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/xenobiology)
 "dbO" = (
@@ -4714,7 +4692,6 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "diA" = (
@@ -4870,7 +4847,6 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/airlock/ship/public/glass/turbolift,
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/shuttle/turbolift/quinary)
 "dqI" = (
@@ -4893,7 +4869,6 @@
 	dir = 4;
 	id = "aethermunitions"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/engine,
 /area/nsv/weapons/fore)
 "drW" = (
@@ -4910,7 +4885,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "dsu" = (
@@ -5067,7 +5041,6 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "10;24"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/engine/engineering/reactor_control)
 "dzp" = (
@@ -5134,7 +5107,6 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "dBX" = (
@@ -5351,7 +5323,6 @@
 	name = "Captain Quarters";
 	req_access_txt = "20"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "dKo" = (
@@ -5497,7 +5468,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "dOf" = (
@@ -5606,7 +5576,6 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/robotics/lab)
 "dQY" = (
@@ -5640,7 +5609,6 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/airlock/ship/public/glass/turbolift,
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/shuttle/turbolift/quaternary)
 "dTn" = (
@@ -6042,7 +6010,6 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "ejy" = (
@@ -6618,7 +6585,6 @@
 	req_one_access_txt = "31;50"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/quartermaster/sorting)
 "eBS" = (
@@ -6724,7 +6690,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/quartermaster/lobby)
 "eDY" = (
@@ -6928,7 +6893,6 @@
 	name = "Public EVA Storage";
 	req_access_txt = "19"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -7354,7 +7318,6 @@
 	name = "Public EVA Storage"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -7705,7 +7668,6 @@
 	name = "Server Room";
 	req_one_access_txt = "30"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/science/server)
 "fkg" = (
@@ -8117,7 +8079,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "fwr" = (
@@ -8329,7 +8290,6 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/effect/landmark/start/bridge,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/blue,
 /area/bridge)
 "fDN" = (
@@ -8574,7 +8534,6 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms)
 "fKd" = (
@@ -8739,7 +8698,6 @@
 "fRV" = (
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Dormitories"
 	},
@@ -8874,7 +8832,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "fTY" = (
@@ -9427,7 +9384,6 @@
 /obj/structure/cable/pink{
 	icon_state = "4-8"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/engine,
 /area/maintenance/fore)
 "gmR" = (
@@ -9482,7 +9438,6 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -9627,7 +9582,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/wood,
 /area/maintenance/department/crew_quarters/dorms)
 "gul" = (
@@ -9663,7 +9617,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "gvQ" = (
@@ -9689,7 +9642,6 @@
 	name = "Master At Arms Office";
 	req_access_txt = "70"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
@@ -10247,7 +10199,6 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "gQT" = (
@@ -10564,7 +10515,6 @@
 	name = "Maintenance Access Executive Officer Office";
 	req_one_access_txt = "57"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -10772,7 +10722,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "6-9"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "hkG" = (
@@ -10860,7 +10809,6 @@
 "hnK" = (
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/north,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/blue,
 /area/bridge)
 "hod" = (
@@ -11438,7 +11386,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/quartermaster/lobby)
 "hLo" = (
@@ -11518,7 +11465,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "hOJ" = (
@@ -11678,7 +11624,6 @@
 	name = "Maintenance Access Munitions Weapons Bay";
 	req_one_access_txt = "69;19"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
@@ -11807,7 +11752,6 @@
 	icon_state = "5-10"
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/crew_quarters/heads/hor)
 "hXr" = (
@@ -12510,7 +12454,6 @@
 	name = "AI Core";
 	req_one_access_txt = "16"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/ai_monitored/turret_protected/aisat_interior)
 "ixT" = (
@@ -12538,7 +12481,6 @@
 	req_one_access_txt = "12;37;55"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "iyw" = (
@@ -12681,7 +12623,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "iDL" = (
@@ -12743,7 +12684,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/quartermaster/qm)
 "iEX" = (
@@ -13018,7 +12958,6 @@
 	name = "Engine Observation Room";
 	req_one_access_txt = "10;24"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/engine/engine_smes)
 "iPS" = (
@@ -13230,7 +13169,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -13329,7 +13267,6 @@
 	name = "Chief Engineer Office";
 	req_one_access_txt = "56"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/crew_quarters/heads/chief)
 "jbh" = (
@@ -13421,7 +13358,6 @@
 /obj/machinery/door/airlock/ship/public/glass{
 	req_one_access_txt = "30"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/science/server)
 "jdq" = (
@@ -13609,7 +13545,6 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
@@ -14431,7 +14366,6 @@
 /obj/structure/cable/pink{
 	icon_state = "9-10"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -15067,7 +15001,6 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms)
 "knV" = (
@@ -15215,7 +15148,6 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "3;12;19;69;72"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/bridge)
 "kuT" = (
@@ -15474,7 +15406,6 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "kJc" = (
@@ -15583,7 +15514,6 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -15669,7 +15599,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
 "kPp" = (
@@ -15924,7 +15853,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "lav" = (
@@ -15971,7 +15899,6 @@
 	name = "Custodial Office";
 	req_one_access_txt = "26"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/janitor)
 "lbQ" = (
@@ -16090,7 +16017,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/hallway/nsv/deck2/forward)
 "lgV" = (
@@ -17058,7 +16984,6 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/airlock/ship/public/glass/turbolift,
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/shuttle/turbolift/primary)
 "lTy" = (
@@ -17092,7 +17017,6 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "3;12;19;69;72"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/maintenance/nsv/hangar)
 "lUg" = (
@@ -17104,7 +17028,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/crew_quarters/heads/chief)
 "lUj" = (
@@ -17153,7 +17076,6 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms)
 "lWu" = (
@@ -17200,7 +17122,6 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/research)
 "lYM" = (
@@ -17321,7 +17242,6 @@
 	name = "Engine Observation Room";
 	req_one_access_txt = "10;24"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/engine/engineering/reactor_control)
 "mfF" = (
@@ -17528,12 +17448,6 @@
 	},
 /area/bridge/meeting_room/council)
 "mlm" = (
-/obj/structure/table/glass,
-/obj/item/folder/yellow{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/folder/blue,
 /obj/machinery/computer/ship/viewscreen{
 	pixel_x = -32;
 	pixel_y = -6
@@ -17544,6 +17458,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/machinery/conquest_beacon/nanotrasen,
 /turf/open/floor/carpet/blue,
 /area/bridge)
 "mlt" = (
@@ -17779,7 +17694,6 @@
 	name = "Escape Pod Munitions";
 	req_one_access_txt = "3;69;72"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/bridge)
 "mqe" = (
@@ -17901,7 +17815,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/quartermaster/sorting)
 "mtJ" = (
@@ -18289,7 +18202,6 @@
 	req_one_access_txt = "69;19"
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/beige_carpet{
 	color = "#CC8899";
 	name = "nanoweave carpet (puce)"
@@ -18421,7 +18333,6 @@
 	name = "AI Core Access";
 	req_one_access_txt = "16"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "mHQ" = (
@@ -18459,7 +18370,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/robotics/lab)
 "mJw" = (
@@ -18545,7 +18455,6 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/effect/landmark/start/bridge,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/blue,
 /area/bridge)
 "mNk" = (
@@ -18988,7 +18897,6 @@
 	name = "Maintenance Access Metahuman Research";
 	req_one_access_txt = "7;9;29;47"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/medical/genetics)
 "niv" = (
@@ -19063,7 +18971,6 @@
 /obj/machinery/door/airlock/ship/public{
 	name = "Bathroom Cell"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/auxiliary)
 "njy" = (
@@ -19132,7 +19039,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/barricade/wooden/crude,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/nsv/atc)
 "nkP" = (
@@ -19152,7 +19058,6 @@
 	name = "Vault";
 	req_one_access_txt = "53"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -19252,7 +19157,6 @@
 	name = "Maintenance Access Xenobiology";
 	req_one_access_txt = "55"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "noZ" = (
@@ -19397,7 +19301,6 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/dorms)
 "nuy" = (
@@ -19632,7 +19535,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/barricade/wooden/crude,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/nsv/atc)
 "nBF" = (
@@ -20230,7 +20132,6 @@
 	name = "Council Chamber Bathroom"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -20421,7 +20322,6 @@
 	name = "Maintenance Access Cargo Security Checkpoint";
 	req_one_access_txt = "63"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/security/checkpoint/supply)
 "nYQ" = (
@@ -20557,7 +20457,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
 "obS" = (
@@ -20917,7 +20816,6 @@
 	name = "Maintenance Access Bathroom";
 	req_one_access_txt = "12"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/hangar)
 "osO" = (
@@ -21540,7 +21438,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "oNH" = (
@@ -21623,7 +21520,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/crew_quarters/heads/chief)
 "oRv" = (
@@ -21722,7 +21618,6 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
 "oVB" = (
@@ -21860,7 +21755,6 @@
 /obj/structure/cable/pink{
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/bridge)
 "oZI" = (
@@ -22145,7 +22039,6 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/hangar)
 "phk" = (
@@ -22205,7 +22098,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "pjf" = (
@@ -22307,7 +22199,6 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "12;31"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "plS" = (
@@ -23121,7 +23012,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/medical/genetics)
 "pNQ" = (
@@ -23181,7 +23071,6 @@
 /obj/structure/cable/pink{
 	icon_state = "5-6"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -23357,7 +23246,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "pTj" = (
@@ -23578,7 +23466,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/engine,
 /area/nsv/weapons/fore)
 "qek" = (
@@ -23597,7 +23484,6 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/maintenance/department/crew_quarters/dorms)
 "qeu" = (
@@ -24291,7 +24177,6 @@
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Central Primary Hallway"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/bridge/meeting_room/council)
 "qGo" = (
@@ -25142,7 +25027,6 @@
 "reK" = (
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
 "reN" = (
@@ -25420,7 +25304,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "rnm" = (
@@ -25561,7 +25444,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/quartermaster/miningoffice)
 "rrd" = (
@@ -25974,7 +25856,6 @@
 	name = "Maintenance Access Munitions Weapons Bay";
 	req_one_access_txt = "69;19"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/nsv/weapons/starboard)
 "rEj" = (
@@ -26187,7 +26068,6 @@
 	name = "Metahuman Research";
 	req_one_access_txt = "7;9;29;47"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/nsv/astronomy)
 "rJE" = (
@@ -26218,7 +26098,6 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/airlock/ship/public{
 	name = "Unnamed Airlock"
 	},
@@ -26303,7 +26182,6 @@
 	name = "Meeting Room";
 	req_access_txt = "19"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -26869,7 +26747,6 @@
 /obj/machinery/door/airlock/ship/public{
 	name = "Bathroom Cell"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "sbr" = (
@@ -27022,7 +26899,6 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	name = "Maintenance Access Science Lobby"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
 "shx" = (
@@ -27179,7 +27055,6 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
 "snp" = (
@@ -27340,7 +27215,6 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "7"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
 "ssn" = (
@@ -27366,7 +27240,6 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/airlock/ship/public/glass/turbolift,
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/shuttle/turbolift/secondary)
 "stN" = (
@@ -27483,7 +27356,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "5-6"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/wood,
 /area/maintenance/department/crew_quarters/dorms)
 "sys" = (
@@ -27527,7 +27399,6 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "7;12;29;47;55"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
 "szE" = (
@@ -27566,7 +27437,6 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "7;12;29;47;55"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
 "sAm" = (
@@ -27648,7 +27518,6 @@
 	name = "Maintenance Access Research and Development";
 	req_one_access_txt = "9;47"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/research)
 "sDg" = (
@@ -27851,7 +27720,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "6-10"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/science/server)
 "sLR" = (
@@ -28115,7 +27983,6 @@
 	req_one_access_txt = "37"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "sTF" = (
@@ -28157,7 +28024,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/orange_carpet,
 /area/crew_quarters/heads/chief)
 "sUy" = (
@@ -28209,7 +28075,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "6-9"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -28331,7 +28196,6 @@
 	name = "Metahuman Research";
 	req_one_access_txt = "7;9;29;47"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/medical/genetics)
 "tdz" = (
@@ -28356,7 +28220,6 @@
 	name = "Meeting Room";
 	req_access_txt = "19"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/blue{
 	color = "#9999DD";
 	name = "nanoweave carpet (bluer)"
@@ -28502,7 +28365,6 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "7;12;29;47;55"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
 "toW" = (
@@ -28719,7 +28581,6 @@
 	id_tag = "cabin8";
 	name = "Cabin 8"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "twL" = (
@@ -28771,7 +28632,6 @@
 	req_one_access_txt = "3;12;19;69;72"
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/bridge)
 "tyD" = (
@@ -28818,7 +28678,6 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/heads/captain/private)
 "tBl" = (
@@ -29233,7 +29092,6 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/airlock/ship/public/glass/turbolift,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/shuttle/turbolift/tertiary)
 "tTd" = (
@@ -29327,7 +29185,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "5-9"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "tWI" = (
@@ -29358,7 +29215,6 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
 "tXj" = (
@@ -29792,7 +29648,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/engine,
 /area/nsv/atc)
 "uno" = (
@@ -30072,7 +29927,6 @@
 /obj/structure/cable/white{
 	icon_state = "6-8"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/engine,
 /area/bridge)
 "uBM" = (
@@ -30268,7 +30122,6 @@
 	name = "AI Core Upload Chamber";
 	req_one_access_txt = "16"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/engine,
 /area/ai_monitored/nuke_storage)
 "uLJ" = (
@@ -30338,7 +30191,6 @@
 	req_one_access_txt = "63"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/checkpoint/science/research)
 "uPh" = (
@@ -30532,7 +30384,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
 "uVP" = (
@@ -30758,7 +30609,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/captain/private)
 "vdZ" = (
@@ -30911,7 +30761,6 @@
 	req_one_access_txt = "26"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/maintenance/nsv/hangar)
 "vlx" = (
@@ -31366,7 +31215,6 @@
 	name = "Artifact Research";
 	req_one_access_txt = "7;47"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/research)
 "vCZ" = (
@@ -31382,7 +31230,6 @@
 	id_tag = "cabin5";
 	name = "Cabin 5"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "vDm" = (
@@ -31446,7 +31293,6 @@
 	name = "AI Core Upload Chamber";
 	req_one_access_txt = "16"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/ai_monitored/turret_protected/aisat_interior)
 "vGa" = (
@@ -31818,7 +31664,6 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Dormitories"
 	},
@@ -31885,7 +31730,6 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "12"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "vWs" = (
@@ -32177,7 +32021,6 @@
 	name = "Maintenance Access Disposals";
 	req_one_access_txt = "31"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "whM" = (
@@ -32259,7 +32102,6 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/structure/cable/yellow{
 	icon_state = "6-9"
 	},
@@ -32438,7 +32280,6 @@
 /obj/structure/cable/pink{
 	icon_state = "4-8"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/engine,
 /area/nsv/weapons/starboard)
 "wqW" = (
@@ -32754,7 +32595,6 @@
 	dir = 4;
 	id = "aethermunitions"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/engine,
 /area/nsv/weapons/fore)
 "wED" = (
@@ -32769,7 +32609,6 @@
 /obj/machinery/door/airlock/ship/public{
 	name = "Shower"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/auxiliary)
 "wEG" = (
@@ -32917,7 +32756,6 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "12"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
 "wJI" = (
@@ -32946,7 +32784,6 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/science/mixing)
 "wKz" = (
@@ -33122,7 +32959,6 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/engine/engineering/reactor_control)
 "wPI" = (
@@ -33576,7 +33412,6 @@
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Central Primary Hallway"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/bridge/meeting_room/council)
 "xdA" = (
@@ -33756,7 +33591,6 @@
 	name = "Maintenance Access Pool Area";
 	req_one_access_txt = "12;46"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "xil" = (
@@ -33842,7 +33676,6 @@
 	id_tag = "cabin6";
 	name = "Cabin 6"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "xlr" = (
@@ -33898,7 +33731,6 @@
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "12"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "xnt" = (
@@ -33997,7 +33829,6 @@
 	name = "Server Room";
 	req_one_access_txt = "7;47"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship/purple_carpet,
 /area/science/server)
 "xsN" = (
@@ -34089,7 +33920,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "xvB" = (
@@ -34432,7 +34262,6 @@
 	id = "deck2_bridge";
 	next_id = "deck2_councilchamber2"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/blue,
 /area/bridge)
 "xJT" = (
@@ -34479,13 +34308,18 @@
 /area/bridge/showroom/corporate)
 "xKy" = (
 /obj/structure/table/glass,
-/obj/item/clothing/ears/earmuffs,
-/obj/item/radio/off{
-	pixel_x = -7
-	},
 /obj/machinery/computer/security/telescreen{
 	network = list("ss13");
 	pixel_x = -30
+	},
+/obj/item/folder/yellow{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/folder/blue,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/radio/off{
+	pixel_x = -7
 	},
 /turf/open/floor/carpet/blue,
 /area/bridge)
@@ -34820,7 +34654,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/engine,
 /area/nsv/hanger/storage)
 "xRR" = (
@@ -35178,7 +35011,6 @@
 "yfW" = (
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/south,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/blue,
 /area/bridge)
 "ygf" = (
@@ -35248,7 +35080,6 @@
 	name = "Battle Bridge";
 	req_access_txt = "19"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/bridge/secondary)
 "yhd" = (
@@ -35347,7 +35178,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/nsv/weapons/starboard)
 "ylv" = (

--- a/_maps/map_files/Eclipse/Eclipse1.dmm
+++ b/_maps/map_files/Eclipse/Eclipse1.dmm
@@ -8396,6 +8396,7 @@
 /turf/open/floor/monotile/steel,
 /area/bridge)
 "IN" = (
+/obj/machinery/conquest_beacon/nanotrasen,
 /turf/open/floor/plasteel,
 /area/bridge)
 "IO" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds a conquest beacon to the bridges of the Aetherwhisp and Eclipse. Also removes the depreciated firelock helpers from the Aetherwhisp.

## Why It's Good For The Game

Fix man good

## Changelog
:cl:
add: Added Conquest beacons to Aetherwhisp and Eclipse
del: Removed firelock mapping helpers from Aetherwhisp
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
