### PR TITLE
Fixes tesla coil manual zap not respecting power net load

### DIFF
--- a/code/modules/power/tesla/coil.dm
+++ b/code/modules/power/tesla/coil.dm
@@ -103,10 +103,12 @@
 /obj/machinery/power/tesla_coil/proc/zap()
 	if((last_zap + zap_cooldown) > world.time || !powernet)
 		return FALSE
+	var/power = (surplus()/2)
+	if(!power)
+		return FALSE
 	last_zap = world.time
 	var/coeff = (20 - ((input_power_multiplier - 1) * 3))
 	coeff = max(coeff, 10)
-	var/power = (powernet.avail/2)
 	add_load(power)
 	playsound(src.loc, 'sound/magic/lightningshock.ogg', 100, 1, extrarange = 5)
 	tesla_zap(src, 10, power/(coeff/2), tesla_flags)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Currently, tesla coils when being used to zap manually (via their wire) can use more power than actually available in the powernet they are linked to, as it only checks for available power without checking the already present load. This uses `surplus()` for that variable instead, which does respect it.

Mirrored upstream at <https://github.com/BeeStation/BeeStation-Hornet/pull/12493>, thus no `//nsvchange` present.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![coilzap](https://github.com/user-attachments/assets/b4b470ab-acc3-48a3-9255-f2d32f17bb30)
(Recorded on beecode)
(Without the second SMES, the power grid is too taxed by the station to cause a zap, with the SMES enabled, after the next power recalculation tick, there is enough power surplus and a zap is created)

</details>

## Changelog
:cl:
fix: Manually triggering a lightning discharge via tesla coils now respects current grid load when deciding zap power.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
