### PR TITLE
Culls a broken shield hook

### DIFF
--- a/nsv13/code/modules/overmap/FTL/ftl_jump_mishaps/jump_mishap_helpers.dm
+++ b/nsv13/code/modules/overmap/FTL/ftl_jump_mishaps/jump_mishap_helpers.dm
@@ -18,10 +18,10 @@
 ///Called on jump start if the jump is a misjump.
 /obj/structure/overmap/proc/on_misjump_start(datum/star_system/target_system, jump_length)
 	if(!occupying_levels || !linked_areas)
-		take_damage(0.4 * max_integrity, BRUTE, bypasses_shields = TRUE, sound_effect = FALSE)
+		take_damage(0.4 * max_integrity, BRUTE, sound_effect = FALSE)
 		return
 	else
-		take_damage((rand(5, 10) / 100) * max_integrity, BRUTE, bypasses_shields = TRUE, sound_effect = FALSE)
+		take_damage((rand(5, 10) / 100) * max_integrity, BRUTE, sound_effect = FALSE)
 	handle_concerning_noises(jump_length)
 	addtimer(CALLBACK(src, PROC_REF(fry_phasestate)), rand(35, 180) SECONDS)
 	disjoint_phasestate()
@@ -29,12 +29,12 @@
 ///Called on jump end if the jump is a misjump.
 /obj/structure/overmap/proc/on_misjump_end(datum/star_system/target_system)
 	if(!occupying_levels || !linked_areas)
-		take_damage(0.5 * max_integrity, BRUTE, bypasses_shields = TRUE, sound_effect = FALSE, nsv_damagesound = FALSE)
+		take_damage(0.5 * max_integrity, BRUTE, sound_effect = FALSE, nsv_damagesound = FALSE)
 		return
 	else
 		var/structure_stress = prob(25) ? 10 : rand(15,75)
 		var/structure_damage = (structure_stress / 100) * max_integrity
-		take_damage(structure_damage, BRUTE, bypasses_shields = TRUE, sound_effect = FALSE, nsv_damagesound = FALSE)
+		take_damage(structure_damage, BRUTE, sound_effect = FALSE, nsv_damagesound = FALSE)
 
 	var/fun_meteors = pick(0,0,0,0,1,2,2,3,4)
 	var/oops_asteroid_collision = 25
@@ -169,7 +169,7 @@
 /obj/structure/overmap/ref_0x000000/handle_cloak(state)
 	return
 
-/obj/structure/overmap/ref_0x000000/take_damage(damage_amount, damage_type, damage_flag, sound_effect, bypasses_shields, nsv_damagesound)
+/obj/structure/overmap/ref_0x000000/take_damage(damage_amount, damage_type, damage_flag, sound_effect, nsv_damagesound)
 	return
 
 /obj/structure/overmap/ref_0x000000/bullet_act(obj/item/projectile/P)

--- a/nsv13/code/modules/overmap/fighters/_fighters.dm
+++ b/nsv13/code/modules/overmap/fighters/_fighters.dm
@@ -770,7 +770,7 @@ Been a mess since 2018, we'll fix it someday (probably)
 	return ..()
 
 
-/obj/structure/overmap/small_craft/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, bypasses_shields = FALSE, nsv_damagesound = TRUE)
+/obj/structure/overmap/small_craft/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, nsv_damagesound = TRUE)
 	var/obj/item/fighter_component/armour_plating/A = loadout.get_slot(HARDPOINT_SLOT_ARMOUR)
 	if(A && istype(A))
 		A.take_damage(damage_amount, damage_type, damage_flag, sound_effect)

--- a/nsv13/code/modules/overmap/physics.dm
+++ b/nsv13/code/modules/overmap/physics.dm
@@ -129,7 +129,7 @@ This proc is to be used when someone gets stuck in an overmap ship, gauss, WHATE
 	disruption = max(0, disruption - 1)
 	if(hullburn > 0)
 		hullburn = max(0, hullburn - 1)
-		take_damage(hullburn_power, BURN, "fire", FALSE, TRUE) //If you want a ship to be resistant to hullburn, just give it fire armor.
+		take_damage(hullburn_power, BURN, "fire", FALSE) //If you want a ship to be resistant to hullburn, just give it fire armor.
 		if(hullburn == 0)
 			hullburn_power = 0
 	ai_process()

--- a/nsv13/code/modules/overmap/weapons/damage.dm
+++ b/nsv13/code/modules/overmap/weapons/damage.dm
@@ -81,22 +81,14 @@ Bullet reactions
 /obj/structure/overmap/small_craft/relay_damage(proj_type)
 	return
 
-/obj/structure/overmap/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, bypasses_shields = FALSE, nsv_damagesound = TRUE)
-	var/blocked = FALSE
+/obj/structure/overmap/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, nsv_damagesound = TRUE)
 	var/damage_sound = pick(GLOB.overmap_impact_sounds)
-	if(!bypasses_shields && shields && shields.absorb_hit(damage_amount))
-		blocked = TRUE
-		damage_sound = pick('nsv13/sound/effects/ship/damage/shield_hit.ogg', 'nsv13/sound/effects/ship/damage/shield_hit2.ogg')
-		if(!impact_sound_cooldown)
-			add_overlay(new /obj/effect/temp_visual/overmap_shield_hit(get_turf(src), src))
 	if(nsv_damagesound && !impact_sound_cooldown && damage_sound)
 		relay(damage_sound)
 		if(damage_amount >= 15) //Flak begone
 			shake_everyone(5)
 		impact_sound_cooldown = TRUE
 		addtimer(VARSET_CALLBACK(src, impact_sound_cooldown, FALSE), 1 SECONDS)
-	if(blocked)
-		return FALSE
 	if(CHECK_BITFIELD(overmap_deletion_traits, DAMAGE_STARTS_COUNTDOWN) && !(CHECK_BITFIELD(overmap_deletion_traits, DAMAGE_DELETES_UNOCCUPIED) && !has_occupants())) //Code for handling "superstructure crit" countdown
 		if(obj_integrity <= damage_amount || structure_crit) //Superstructure crit! They would explode otherwise, unable to withstand the hit.
 			SEND_SIGNAL(src, COMSIG_ATOM_DAMAGE_ACT, damage_amount) //Sending the comsig here because we do not call parent in this case.

--- a/nsv13/code/modules/overmap/weapons/mines.dm
+++ b/nsv13/code/modules/overmap/weapons/mines.dm
@@ -90,7 +90,7 @@
 		if(OM.use_armour_quadrants)
 			OM.take_quadrant_hit(OM.run_obj_armor(damage, damage_type, damage_flag, null, armour_penetration), OM.quadrant_impact(src))
 		else
-			OM.take_damage(damage, damage_type, damage_flag, FALSE, TRUE)
+			OM.take_damage(damage, damage_type, damage_flag, FALSE)
 		if(OM.linked_areas) //Hope nothing precious was in that room.
 			var/area/A = pick(OM.linked_areas)
 			var/turf/T = pick(get_area_turfs(A))
@@ -101,7 +101,7 @@
 			if(OM.use_armour_quadrants)
 				OM.take_quadrant_hit(OM.run_obj_armor(damage, damage_type, damage_flag, null, armour_penetration), OM.quadrant_impact(src))
 			else
-				OM.take_damage(damage, damage_type, damage_flag, FALSE, TRUE)
+				OM.take_damage(damage, damage_type, damage_flag, FALSE)
 	new /obj/effect/temp_visual/fading_overmap(get_turf(src), name, icon, icon_state, alpha)
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Shields had a hook in the general damage code, however that has not worked because shields expect a projectile, and not a damage number. Since we generally don't want random things that are not projectiles affected by shields by default, this culls that hook as opposed to rendering it functional.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Broken "free runtime" dispenser bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
No.

## Changelog
:cl:
del: Removed a broken shield hook that hasn't been working for I don't even know how long.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
