### PR TITLE
Pilots dying turns docking mode on

### DIFF
--- a/nsv13/code/modules/overmap/fighters/_fighters.dm
+++ b/nsv13/code/modules/overmap/fighters/_fighters.dm
@@ -79,6 +79,7 @@ Been a mess since 2018, we'll fix it someday (probably)
 	. = ..()
 	if(.)
 		RegisterSignal(src, COMSIG_MOB_OVERMAP_CHANGE, PROC_REF(pilot_overmap_change))
+		RegisterSignal(user, COMSIG_MOB_DEATH, PROC_REF(pilot_death))
 
 /obj/structure/overmap/small_craft/key_down(key, client/user)
 	if(disruption && prob(min(95, disruption)))
@@ -600,6 +601,7 @@ Been a mess since 2018, we'll fix it someday (probably)
 	if(eject_mob && !eject(M, force))
 		return FALSE
 	UnregisterSignal(src, COMSIG_MOB_OVERMAP_CHANGE)
+	UnregisterSignal(M, COMSIG_MOB_DEATH)
 	M.stop_sound_channel(CHANNEL_SHIP_ALERT)
 	M.remove_verb(overmap_verbs)
 	return ..()
@@ -627,6 +629,13 @@ Been a mess since 2018, we'll fix it someday (probably)
 	SIGNAL_HANDLER
 	if(newOM != src)
 		INVOKE_ASYNC(src, PROC_REF(stop_piloting), M, FALSE, TRUE)
+
+/obj/structure/overmap/small_craft/proc/pilot_death(mob/living/M)
+	SIGNAL_HANDLER
+	var/obj/item/fighter_component/docking_computer/DC = loadout.get_slot(HARDPOINT_SLOT_DOCKING)
+	if(!DC)
+		return
+	DC.docking_mode = TRUE
 
 /obj/structure/overmap/small_craft/escapepod/eject(mob/living/M, force=FALSE)
 	. = ..()

--- a/nsv13/code/modules/overmap/fighters/fighters_launcher.dm
+++ b/nsv13/code/modules/overmap/fighters/fighters_launcher.dm
@@ -389,6 +389,8 @@ d) the ships[] list of ssstarsystem is acting up again.
 	weapon_safety = TRUE
 	if(pilot)
 		to_chat(pilot, "<span class='notice'>Docking complete. <b>Gun safeties have been engaged automatically.</b></span>")
+	if(pilot.incapacitated())
+		brakes = TRUE
 	SEND_SIGNAL(src, COMSIG_FTL_STATE_CHANGE)
 	if(reserved_z)
 		free_treadmills += reserved_z

--- a/nsv13/code/modules/overmap/fighters/fighters_launcher.dm
+++ b/nsv13/code/modules/overmap/fighters/fighters_launcher.dm
@@ -389,8 +389,8 @@ d) the ships[] list of ssstarsystem is acting up again.
 	weapon_safety = TRUE
 	if(pilot)
 		to_chat(pilot, "<span class='notice'>Docking complete. <b>Gun safeties have been engaged automatically.</b></span>")
-	if(pilot.incapacitated())
-		brakes = TRUE
+		if(pilot.incapacitated())
+			brakes = TRUE
 	SEND_SIGNAL(src, COMSIG_FTL_STATE_CHANGE)
 	if(reserved_z)
 		free_treadmills += reserved_z

--- a/nsv13/code/modules/overmap/fighters/fighters_launcher.dm
+++ b/nsv13/code/modules/overmap/fighters/fighters_launcher.dm
@@ -389,8 +389,8 @@ d) the ships[] list of ssstarsystem is acting up again.
 	weapon_safety = TRUE
 	if(pilot)
 		to_chat(pilot, "<span class='notice'>Docking complete. <b>Gun safeties have been engaged automatically.</b></span>")
-		if(pilot.incapacitated())
-			brakes = TRUE
+	if(!pilot || pilot.incapacitated())
+		brakes = TRUE
 	SEND_SIGNAL(src, COMSIG_FTL_STATE_CHANGE)
 	if(reserved_z)
 		free_treadmills += reserved_z


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a way for fighters with a dead pilot to be recovered. If a pilot dies in their fighter, docking mode turns on. Docking with a dead or incapacitated pilot will also toggle brakes to stop the fighter from flying back into space.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes recovering fighters with dead pilots easier

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![LooksLikeItsWorking](https://github.com/user-attachments/assets/ab320f39-f533-4183-9ce7-b6fef25899cb)



</details>

## Changelog
:cl:
add: pilots dying in fighters turns on docking mode
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
