### PR TITLE
Hammerheads pumps rotated to match ship orientation

### DIFF
--- a/_maps/map_files/Hammerhead/Hammerhead.dmm
+++ b/_maps/map_files/Hammerhead/Hammerhead.dmm
@@ -24839,6 +24839,12 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"eEb" = (
+/obj/item/toy/plush/hfighter{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space)
 "eEd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -47313,6 +47319,15 @@
 	},
 /turf/open/floor/durasteel,
 /area/security/warden)
+"sXt" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/item/toy/plush/hfighter{
+	dir = 4
+	},
+/turf/open/floor/durasteel/padded,
+/area/construction)
 "sXM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -74520,11 +74535,11 @@ anv
 anv
 mZN
 sIx
-sdq
+pIf
 qCz
 phS
 qCz
-pIf
+sdq
 sIx
 aAn
 bkE
@@ -74779,7 +74794,7 @@ akX
 rAY
 mMR
 qCz
-phS
+sXt
 qCz
 ldW
 sIx
@@ -75291,11 +75306,11 @@ mCn
 rPC
 pVJ
 ifm
-iYr
+bVh
 qCz
 twi
 qCz
-bVh
+iYr
 sIx
 aun
 aeX
@@ -80700,7 +80715,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+eEb
 aaa
 aaa
 aaa

--- a/_maps/map_files/Hammerhead/Hammerhead.dmm
+++ b/_maps/map_files/Hammerhead/Hammerhead.dmm
@@ -24839,12 +24839,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"eEb" = (
-/obj/item/toy/plush/hfighter{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space)
 "eEd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -80706,7 +80700,7 @@ aaa
 aaa
 aaa
 aaa
-eEb
+aaa
 aaa
 aaa
 aaa

--- a/_maps/map_files/Hammerhead/Hammerhead.dmm
+++ b/_maps/map_files/Hammerhead/Hammerhead.dmm
@@ -47319,15 +47319,6 @@
 	},
 /turf/open/floor/durasteel,
 /area/security/warden)
-"sXt" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/item/toy/plush/hfighter{
-	dir = 4
-	},
-/turf/open/floor/durasteel/padded,
-/area/construction)
 "sXM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -74794,7 +74785,7 @@ akX
 rAY
 mMR
 qCz
-sXt
+phS
 qCz
 ldW
 sIx


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Mirrors the pumps horizontally as to make them match the ship map's orientation
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
Less headache when changing the pumps around

</details>

## Changelog
:cl:
tweak: Hammerhead pumps rotated to match ship orientation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
