### PR TITLE
Adds the ability for astrometrics consoles to be muted on the radio

### DIFF
--- a/nsv13/code/modules/research/astrometrics.dm
+++ b/nsv13/code/modules/research/astrometrics.dm
@@ -23,6 +23,7 @@ you build.
 	var/obj/item/radio/radio //For engineering alerts.
 	var/radio_key = /obj/item/encryptionkey/headset_sci
 	var/channel = "Science"
+	var/broadcast = TRUE
 
 /obj/machinery/computer/ship/navigation/astrometrics/Initialize(mapload)
 	. = ..()
@@ -74,6 +75,7 @@ Clean override of the navigation computer to provide scan functionality.
 	data["can_cancel"] = (scan_target) ? TRUE : FALSE
 	data["scan_progress"] = scan_progress
 	data["scan_goal"] = scan_goal
+	data["broadcast"] = broadcast
 	return data
 
 /obj/machinery/computer/ship/navigation/astrometrics/is_in_range(datum/star_system/current_system, datum/star_system/system)
@@ -90,6 +92,7 @@ Clean override of the navigation computer to provide scan functionality.
 		return
 	var/list/info = SSstar_system.ships[linked]
 	var/datum/star_system/current_system = info["current_system"]
+	var/message
 	switch(action)
 		if("scan")
 			if(!is_in_range(current_system, selected_system))
@@ -97,9 +100,8 @@ Clean override of the navigation computer to provide scan functionality.
 			scan_progress = 0 //Jus' in case.
 			scan_goal = scan_goal_system
 			scan_target = selected_system
-			say("Initiating scan of: [scan_target]")
 			playsound(src, 'nsv13/sound/voice/scan_start.wav', 100, FALSE)
-			radio.talk_into(src, "Initiating scan of: [scan_target]", channel)
+			message = "Initiating scan of: [scan_target]"
 		if("scan_anomaly")
 			var/obj/effect/overmap_anomaly/target = locate(params["anomaly_id"])
 			if(!istype(target))
@@ -107,14 +109,12 @@ Clean override of the navigation computer to provide scan functionality.
 			scan_progress = 0 //Jus' in case.
 			scan_goal = scan_goal_anomaly
 			scan_target = target
-			say("Initiating scan of: [scan_target]")
-			radio.talk_into(src, "Initiating scan of: [scan_target]", channel)
+			message = "Initiating scan of: [scan_target]"
 		if("cancel_scan")
 			if(!scan_target)
 				return
-			say("Scan of [scan_target] cancelled!")
 			playsound(src, 'nsv13/sound/voice/scanning_cancelled.wav', 100, FALSE)
-			radio.talk_into(src, "Scan of [scan_target] cancelled!", channel)
+			message = "Scan of [scan_target] cancelled!"
 			scan_progress = 0
 			scan_target = null
 		if("info")
@@ -122,6 +122,11 @@ Clean override of the navigation computer to provide scan functionality.
 			if(!istype(target))
 				return
 			to_chat(usr, "<span class='notice'>[icon2html(target)]: [target.desc]</span>")
+		if("broadcast")
+			broadcast = !broadcast
+	if(broadcast && message)
+		say(message)
+		radio.talk_into(src, message, channel)
 
 /obj/machinery/computer/ship/navigation/astrometrics/process(delta_time)
 	if(scan_target)

--- a/nsv13/code/modules/research/astrometrics.dm
+++ b/nsv13/code/modules/research/astrometrics.dm
@@ -121,7 +121,7 @@ Clean override of the navigation computer to provide scan functionality.
 			var/obj/effect/overmap_anomaly/target = locate(params["anomaly_id"])
 			if(!istype(target))
 				return
-			to_chat(usr, "<span class='notice'>[icon2html(target)]: [target.desc]</span>")
+			to_chat(usr, "<span class='notice'>[target][icon2html(target)]: [target.desc]</span>")
 		if("broadcast")
 			broadcast = !broadcast
 	if(broadcast && message)

--- a/tgui/packages/tgui/interfaces/Astrometrics.js
+++ b/tgui/packages/tgui/interfaces/Astrometrics.js
@@ -13,6 +13,7 @@ export const Astrometrics = (props, context) => {
   const { act, data } = useBackend(context);
   const screen = data.screen;
   let scan_target = data.scan_target;
+  let broadcast = data.broadcast;
 
   const handleSystemAction = (system) => act('select_system', { star_id: system.star_id });
 
@@ -36,6 +37,12 @@ export const Astrometrics = (props, context) => {
                 icon="map"
                 onClick={() =>
                   act('map')} />
+              <Button
+                content="Broadcast Scanning"
+                color={broadcast? 'default':"red"}
+                icon="bell"
+                onClick={() =>
+                  act('broadcast')} />
               <Section title={`Current scan: ${scan_target}`}
                 buttons={(
                   <Button
@@ -55,7 +62,32 @@ export const Astrometrics = (props, context) => {
               </Section>
             </Fragment>
           )}
-          {screen === 1 && drawStarmap(props, context, handleSystemAction)}
+          {screen === 1 && (
+            <>
+              <Button
+                content="Ship Information"
+                icon="info-circle"
+                onClick={() =>
+                  act('shipinf')} />
+              <Button
+                content="Show Map"
+                icon="map"
+                ilstyle="position:absolute;left:10px"
+                onClick={() =>
+                  act('map')} />
+              <Button
+                content="Change Sector"
+                icon="bullseye"
+                onClick={() =>
+                  act('sector')} />
+              <Button
+                content="Broadcast Scanning"
+                icon="bell"
+                color={broadcast? 'default':"red"}
+                onClick={() =>
+                  act('broadcast')} />
+            </>
+          )}{screen === 1 && drawStarmap(props, context, handleSystemAction)}
           {screen === 2 && (
             <Fragment>
               <Button
@@ -68,6 +100,12 @@ export const Astrometrics = (props, context) => {
                 icon="map"
                 onClick={() =>
                   act('map')} />
+              <Button
+                content="Broadcast Scanning"
+                icon="bell"
+                color={broadcast? 'default':"red"}
+                onClick={() =>
+                  act('broadcast')} />
               <br />
               <Section title={`Current scan: ${scan_target}`}
                 buttons={(

--- a/tgui/packages/tgui/interfaces/Starmap.js
+++ b/tgui/packages/tgui/interfaces/Starmap.js
@@ -91,37 +91,19 @@ export const drawStarmap = (props, context, starCallback) => {
   let Connections = (data.lines).map(drawLines);
 
   return (
-    <>
-      <Button
-        content="Ship Information"
-        icon="info-circle"
-        onClick={() =>
-          act('shipinf')} />
-      <Button
-        content="Show Map"
-        icon="map"
-        ilstyle="position:absolute;left:10px"
-        onClick={() =>
-          act('map')} />
-      <Button
-        content="Change Sector"
-        icon="bullseye"
-        onClick={() =>
-          act('sector')} />
-      <Map initial_focus_x={data.focus_x}
-        initial_focus_y={data.focus_y}
-        initial_scale_factor={scale_factor}>
-        <>
-          {data.star_systems && SystemNodes}
-          {data.lines && Connections}
-          {!!travelling && (
-            <span unselectable="on" style={arrowStyle}>
-              <i class="fa fa-arrow-right" />
-            </span>
-          )}
-        </>
-      </Map>
-    </>
+    <Map initial_focus_x={data.focus_x}
+      initial_focus_y={data.focus_y}
+      initial_scale_factor={scale_factor}>
+      <>
+        {data.star_systems && SystemNodes}
+        {data.lines && Connections}
+        {!!travelling && (
+          <span unselectable="on" style={arrowStyle}>
+            <i class="fa fa-arrow-right" />
+          </span>
+        )}
+      </>
+    </Map>
   );
 };
 
@@ -191,7 +173,26 @@ export const Starmap = (props, context) => {
               )}
             </>
           )}
-          {screen === 1 && drawStarmap(props, context, handleSystemAction)}
+          {screen === 1 && (
+            <>
+              <Button
+                content="Ship Information"
+                icon="info-circle"
+                onClick={() =>
+                  act('shipinf')} />
+              <Button
+                content="Show Map"
+                icon="map"
+                ilstyle="position:absolute;left:10px"
+                onClick={() =>
+                  act('map')} />
+              <Button
+                content="Change Sector"
+                icon="bullseye"
+                onClick={() =>
+                  act('sector')} />
+            </>
+          )}{screen === 1 && drawStarmap(props, context, handleSystemAction)}
           {screen === 2 && (
             <>
               <Button


### PR DESCRIPTION
## About The Pull Request

Adds a simple ui button to turn off broadcasting on the astrometrics console.

## Why It's Good For The Game

A helpful way to avoid spamming the chat when there's more than one console.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>
I tested this, all works
</details>

## Changelog
:cl:
add: Added a mute button to the Astrometrics console
/:cl: