### PR TITLE
[UPSTREAM] Fixes the overlapping buttons on nuclear bomb interfaces.

### DIFF
--- a/tgui/packages/tgui/interfaces/NuclearBomb.js
+++ b/tgui/packages/tgui/interfaces/NuclearBomb.js
@@ -29,7 +29,7 @@ const NukeKeypad = (props, context) => {
                 textAlign="center"
                 fontSize="40px"
                 lineHeight="50px"
-                width="55px"
+                width="40px"
                 className={classes([
                   'NuclearBomb__Button',
                   'NuclearBomb__Button--keypad',


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Ports this PR from upstream:

- https://github.com/BeeStation/BeeStation-Hornet/pull/12070

Turns out the overlapping buttons were an issue on Bee as well and all it took to fix it was reducing the width of the keypad by 15 pixels.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
Fix man good.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Before Fix:
![Nuclear_Bomb_Interface_Before](https://github.com/user-attachments/assets/dbdb3f79-36e3-4ba5-a14b-46e7819c95a7)

After Fix:
![Nuclear_Bomb_Interface_After](https://github.com/user-attachments/assets/aabd104d-be8f-464a-8307-b111b48ad738)

</details>

## Changelog
:cl: HowToLoLu
fix: Buttons on nuclear bomb interfaces no longer overlap.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
