### PR TITLE
Fixes a xenobio server freeze vector

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_structures.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_structures.dm
@@ -394,16 +394,23 @@ GLOBAL_LIST_EMPTY(bluespace_slime_crystals)
 	uses_process = FALSE
 	var/crystals = 0
 
+//NSV13 - cerulean crystal logic modified to not stall the server.
+
 /obj/structure/slime_crystal/cerulean/Initialize(mapload)
 	. = ..()
-	while(crystals < 3)
+	for(var/iter = 0; iter < 3; iter++)
 		spawn_crystal()
 
 /obj/structure/slime_crystal/cerulean/proc/spawn_crystal()
 	if(crystals >= 3)
 		return
-	for(var/turf/T as() in RANGE_TURFS(2,src))
-		if(is_blocked_turf(T) || isspaceturf(T)  || T == get_turf(src) || prob(50))
+	var/list/crystal_candidate_turfs = RANGE_TURFS(2,src) - get_turf(src)
+	var/list/crystal_fallback_turfs = list()
+	for(var/turf/T as() in crystal_candidate_turfs)
+		if(is_blocked_turf(T) || isspaceturf(T))
+			continue
+		if(prob(50))
+			crystal_fallback_turfs += T
 			continue
 		var/obj/structure/cerulean_slime_crystal/CSC = locate() in range(1,T)
 		if(CSC)
@@ -411,6 +418,17 @@ GLOBAL_LIST_EMPTY(bluespace_slime_crystals)
 		new /obj/structure/cerulean_slime_crystal(T, src)
 		crystals++
 		return
+
+	//We had valid turfs, but skipped them due to rng and didn't find one later = we use one as fallback.
+	for(var/turf/T as() in crystal_fallback_turfs)
+		var/obj/structure/cerulean_slime_crystal/CSC = locate() in range(1,T)
+		if(CSC)
+			continue
+		new /obj/structure/cerulean_slime_crystal(T, src)
+		crystals++
+		return
+
+//NSV13 end.
 
 /obj/structure/slime_crystal/pyrite
 	colour = "pyrite"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title.
Improves that logic to not do that while also keeping its intended functionality of creating three crystals whenever possible.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Players don't like having to wait for me to dig through to an object to stop it from eating the server alive.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
This is tested.

## Changelog
:cl:
fix: A certain xenobio pylon doesn't occasionally grind the server to a halt anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
