### PR TITLE
S'More Dipity Touchups

### DIFF
--- a/_maps/map_files/Serendipity/Serendipity1.dmm
+++ b/_maps/map_files/Serendipity/Serendipity1.dmm
@@ -5814,7 +5814,7 @@
 /mob/living/simple_animal/pet/fox/Renault,
 /obj/structure/bed/dogbed/renault,
 /turf/open/floor/carpet,
-/area/ai_monitored/nuke_storage)
+/area/crew_quarters/heads/captain/private)
 "tu" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
@@ -39732,7 +39732,7 @@ jN
 jN
 jN
 jN
-Hr
+jN
 Oc
 Fb
 tc
@@ -39989,7 +39989,7 @@ jN
 jN
 OD
 UA
-Hr
+jN
 TP
 vt
 QG
@@ -40246,7 +40246,7 @@ jN
 FF
 YU
 xj
-Hr
+jN
 oC
 pK
 xT
@@ -41017,7 +41017,7 @@ jN
 HP
 dv
 ua
-Hr
+jN
 Jv
 st
 ci
@@ -41274,7 +41274,7 @@ jN
 bt
 xd
 Lu
-Hr
+jN
 Iz
 me
 am

--- a/_maps/map_files/Serendipity/Serendipity2.dmm
+++ b/_maps/map_files/Serendipity/Serendipity2.dmm
@@ -66,6 +66,9 @@
 "ao" = (
 /obj/structure/extinguisher_cabinet/north,
 /obj/machinery/light/floor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/monotile/light,
 /area/quartermaster)
 "ap" = (
@@ -1061,8 +1064,8 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/green/hidden/layer4{
-	dir = 9
+/obj/machinery/atmospherics/pipe/manifold/green/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/atmos)
@@ -1253,8 +1256,9 @@
 /turf/open/floor/carpet/ship/beige_carpet,
 /area/hallway/nsv/deck1/hallway)
 "fQ" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden/layer2{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/green/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/green/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/atmos)
@@ -1598,6 +1602,10 @@
 /area/nsv/weapons/starboard)
 "ha" = (
 /obj/machinery/status_display/supply/north,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
+	dir = 4;
+	name = "scrubbers injection port"
+	},
 /turf/open/floor/monotile/light,
 /area/quartermaster)
 "hb" = (
@@ -3413,6 +3421,10 @@
 "pR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2{
+	dir = 4;
+	name = "o2 tank port"
 	},
 /turf/open/floor/engine,
 /area/engine/atmos)
@@ -7770,6 +7782,13 @@
 /turf/open/floor/plasteel/white,
 /area/engine/break_room)
 "Kz" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
+	dir = 1;
+	name = "n2 tank port"
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden/layer2{
+	dir = 9
+	},
 /turf/open/floor/engine,
 /area/engine/atmos)
 "KA" = (
@@ -7797,6 +7816,9 @@
 	input_tag = "o2_in_alt";
 	output_tag = "o2_out_alt";
 	sensors = list("o2_sensor_alt"="Oxygen Tank")
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/engine/atmos)
@@ -10634,13 +10656,15 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "WR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/monotile/light,
 /area/quartermaster)


### PR DESCRIPTION


## About The Pull Request

Contains changes to add atmos injection ports in engineering and cargo as well as area designation for Captain's office to prevent pet from tripping motion sensor

## Why It's Good For The Game

Fix lady good

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>
<img width="597" height="486" alt="Atmos injections" src="https://github.com/user-attachments/assets/be82abb4-5f70-4a8e-ad37-46f3aeb6e761" />
<img width="414" height="354" alt="Atmos Injections 2" src="https://github.com/user-attachments/assets/90c7eabb-5f27-4d7d-a53b-2b1a3b8ab4bb" />
<img width="918" height="581" alt="Area Fixed" src="https://github.com/user-attachments/assets/9715b5e9-bb15-4d11-a48c-2d36672cd9d9" />



</details>

## Changelog
:cl:
add: Added atmos connector port for the N2 Tank
add: Added atmos connector port for the O2 Tank
add: Added atmos connector port for cargo
fix: Fixed Area designation in Captain's office
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
