### PR TITLE
Some projectile relaying & impact tweaks

### DIFF
--- a/nsv13/code/modules/overmap/armour/armour_quadrant.dm
+++ b/nsv13/code/modules/overmap/armour/armour_quadrant.dm
@@ -33,6 +33,23 @@
 		if(270 to 360) //Then this represents the last quadrant of the circle, the northwest one
 			return ARMOUR_FORWARD_STARBOARD
 
+/**
+ * Special armor quadrant proc for projectiles in particular
+ * Determines effective quadrant by projectile facing rather than relative location.
+ * Should on average feel more accurate than relative angles due to physics shenanegans.
+ */
+/obj/structure/overmap/proc/projectile_quadrant_impact(obj/item/projectile/P)
+	var/hit_angle = (720 + P.Angle - angle) % 360
+	switch(hit_angle)
+		if(0 to 89)
+			return ARMOUR_AFT_PORT
+		if(90 to 179)
+			return ARMOUR_FORWARD_PORT
+		if(180 to 269)
+			return ARMOUR_FORWARD_STARBOARD
+		else
+			return ARMOUR_AFT_STARBOARD
+
 /* UNUSED
 /obj/screen/alert/overmap_integrity
 	name = "Ship integrity"

--- a/nsv13/code/modules/overmap/weapons/damage.dm
+++ b/nsv13/code/modules/overmap/weapons/damage.dm
@@ -55,7 +55,7 @@ Bullet reactions
 		visible_message("<span class='danger'>[src] is hit by \a [P]!</span>", null, null, COMBAT_MESSAGE_RANGE)
 		if(!QDELETED(src)) //Bullet on_hit effect might have already destroyed this object
 			//var/datum/vector2d/point_of_collision = src.physics2d?.collider2d.get_collision_point(P.physics2d?.collider2d)//Get the collision point, see if the armour quadrants need to absorb this hit.
-			take_quadrant_hit(run_obj_armor(P.damage, P.damage_type, P.flag, null, P.armour_penetration), quadrant_impact(P)) //This looks horrible, but trust me, it isn't! Probably!. Armour_quadrant.dm for more info
+			take_quadrant_hit(run_obj_armor(P.damage, P.damage_type, P.flag, null, P.armour_penetration), projectile_quadrant_impact(P)) //This looks horrible, but trust me, it isn't! Probably!. Armour_quadrant.dm for more info
 
 /**
  * Used to relay a projectile impacting an overmap onto an overmap's interior zlevels.

--- a/nsv13/code/modules/overmap/weapons/damage.dm
+++ b/nsv13/code/modules/overmap/weapons/damage.dm
@@ -74,8 +74,9 @@ Bullet reactions
 	proj.firer = null
 	proj.def_zone = "chest"
 	proj.original = pickedgoal
+	var/targeting_angle = get_angle(pickedstart,pickedgoal) + ((rand() - 0.5) * 40) //Target center +- 20°
 	spawn()
-		proj.fire(get_angle(pickedstart,pickedgoal))
+		proj.fire(targeting_angle)
 		proj.set_pixel_speed(4)
 
 /obj/structure/overmap/small_craft/relay_damage(proj_type)

--- a/nsv13/code/modules/overmap/weapons/damage.dm
+++ b/nsv13/code/modules/overmap/weapons/damage.dm
@@ -80,8 +80,7 @@ Bullet reactions
 		else
 			effective_side = WEST //Aft impact
 
-	var/startside = pick(effective_side)
-	var/turf/pickedstart = spaceDebrisStartLoc(startside, theZ)
+	var/turf/pickedstart = spaceDebrisStartLoc(effective_side, theZ)
 	var/turf/pickedgoal = locate(round(world.maxx * 0.5, 1), round(world.maxy * 0.5, 1), theZ)
 	var/obj/item/projectile/proj = new proj_type(pickedstart)
 	proj.starting = pickedstart


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Have you ever wondered why that one chair on the Atlas bridge seems to get punctured by railguns far more often than other places?
Well, relayed projectiles aren't actually fully random but tend to always target the exact z center.
This makes certain locations in the exact center quite hazardous vs. piercing projectiles.

This PR changes that, by adding a degree of randomness (+- 20° angle) to relayed projectiles, making them not target the exact center tile, only center-ish.

In addition because I wanted to do it since a while, relayed projectiles now determine the side of the ship they hit from depending on their angle when hitting the ship. I've thought a while about how to best determine the side and this feels like the most consistent, with our somewhat wacky physics.

Also moves the projectile quadrant impact calculations to use that same logic because it should feel more consistent.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less getting porcupined because your chair was in the wrong place, more being able to yell at bridge if the side you really don't want hit keeps being exposed.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
Fairly tested; Though probably something to gauge the feels of.

## Changelog
:cl:
tweak: Relayed projectiles now have a higher degree of targeting randomness.
tweak: Relayed projectile starting sides are now determined by the angle of the original projectile.
tweak: Projectile impact quadrants are now determined by projectile facing rather than relative position to ship (hopefully feels more accurate).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
