### PR TITLE
Hand teleporter manual portal deactivation has a delay

### DIFF
--- a/nsv13.dme
+++ b/nsv13.dme
@@ -3843,6 +3843,7 @@
 #include "nsv13\code\game\objects\items\religion.dm"
 #include "nsv13\code\game\objects\items\space_pirate_items.dm"
 #include "nsv13\code\game\objects\items\storage_items.dm"
+#include "nsv13\code\game\objects\items\teleportation.dm"
 #include "nsv13\code\game\objects\items\colorizers\fighters.dm"
 #include "nsv13\code\game\objects\items\devices\radio\gulagpack.dm"
 #include "nsv13\code\game\objects\items\robot\hypo.dm"

--- a/nsv13/code/game/objects/items/teleportation.dm
+++ b/nsv13/code/game/objects/items/teleportation.dm
@@ -1,0 +1,14 @@
+//modular OVERRIDE
+/obj/item/hand_tele/try_dispel_portal(atom/target, mob/user, delay = 30)
+	var/datum/beam/B = user.Beam(target, icon_state = "rped_upgrade", maxdistance = 50)
+	if(is_parent_of_portal(target))
+		. = TRUE
+		if((delay && !do_after(user, delay, target = target)))
+			qdel(B)
+			return
+		qdel(target)
+		to_chat(user, "<span class='notice'>You dispel [target] with \the [src]!</span>")
+		qdel(B)
+		return
+	qdel(B)
+	return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Effectively a port of https://github.com/Citadel-Station-13/Citadel-Station-13/pull/11051 , albeit with some small changes that make you not slip through the portal if you abort the channel.

Hand teleporters are all fine and dandy, however them being able to instantly close portals makes them a little bit too effective at countering pursuit, especially across z levels (e.g. used fairly commonly during boarding). This adds a delay to manual closure (requiring a doafter channel), making it easier to follow the user.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This should make hand teleporters more interesting when used in unsafe situations, as it makes it less feasible to prevent others from following, opening up the door to either tomfoolery (unauthorized access), or evil deeds (counter-boarders chasing a retreat, goose chase across the ship, etc)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
Yeah this is tested.

## Changelog
:cl:
balance: Hand teleporters take some time (3 seconds) to manually disengage their portals (as opposed to it being instantaneous). This is a channeled, stationary, action.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
