### PR TITLE
some more z robotics controls are shipwide

### DIFF
--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -70,10 +70,11 @@
 		data["can_hack"] = TRUE
 
 	data["cyborgs"] = list()
+	var/linked_overmap = get_overmap() //nsv13 - used for shipwide robotics control.
 	for(var/mob/living/silicon/robot/R in GLOB.silicon_mobs)
 		if(!can_control(user, R))
 			continue
-		if(get_virtual_z_level() != (get_turf(R)).get_virtual_z_level())
+		if(!(linked_overmap && R.last_overmap == linked_overmap) && get_virtual_z_level() != (get_turf(R)).get_virtual_z_level()) //nsv13 - shipwide robotics control.
 			continue
 		var/list/cyborg_data = list(
 			name = R.name,
@@ -91,7 +92,7 @@
 	for(var/mob/living/simple_animal/drone/D in GLOB.drones_list)
 		if(D.hacked)
 			continue
-		if(get_virtual_z_level() != (get_turf(D)).get_virtual_z_level())
+		if(!(linked_overmap && D.last_overmap == linked_overmap) && get_virtual_z_level() != (get_turf(D)).get_virtual_z_level()) //nsv13 - shipwide robotics control.
 			continue
 		var/list/drone_data = list(
 			name = D.name,

--- a/code/modules/modular_computers/file_system/programs/borg_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/borg_monitor.dm
@@ -28,8 +28,9 @@
 	data["card"] = !!get_id_name()
 
 	data["cyborgs"] = list()
+	var/linked_overmap = computer.get_overmap() //nsv13 - shipwide monitoring
 	for(var/mob/living/silicon/robot/R in GLOB.silicon_mobs)
-		if(!evaluate_borg(R))
+		if(!evaluate_borg(R, linked_overmap)) //nsv13 - shipwide monitoring
 			continue
 
 		var/list/upgrade
@@ -88,10 +89,10 @@
 			return TRUE
 
 ///This proc is used to determin if a borg should be shown in the list (based on the borg's scrambledcodes var). Syndicate version overrides this to show only syndicate borgs.
-/datum/computer_file/program/borg_monitor/proc/evaluate_borg(mob/living/silicon/robot/R)
+/datum/computer_file/program/borg_monitor/proc/evaluate_borg(mob/living/silicon/robot/R, linked_overmap) //nsv13 - call adjusted for shipwide monitoring
 	var/turf/computer_turf = get_turf(computer)
 	var/turf/robot_turf = get_turf(R)
-	if(computer_turf.get_virtual_z_level() != robot_turf.get_virtual_z_level())
+	if(!(linked_overmap && R.last_overmap == linked_overmap) && computer_turf.get_virtual_z_level() != robot_turf.get_virtual_z_level()) //nsv13 - shipwide monitoring.
 		return FALSE
 	if(R.scrambledcodes)
 		return FALSE
@@ -117,8 +118,8 @@
 /datum/computer_file/program/borg_monitor/syndicate/run_emag()
 	return FALSE
 
-/datum/computer_file/program/borg_monitor/syndicate/evaluate_borg(mob/living/silicon/robot/R)
-	if((get_turf(computer)).get_virtual_z_level() != (get_turf(R)).get_virtual_z_level())
+/datum/computer_file/program/borg_monitor/syndicate/evaluate_borg(mob/living/silicon/robot/R, linked_overmap) //nsv13 - call adjusted for shipwide monitoring
+	if(!(linked_overmap && R.last_overmap == linked_overmap) && (get_turf(computer)).get_virtual_z_level() != (get_turf(R)).get_virtual_z_level()) //nsv13 - shipwide monitoring.
 		return FALSE
 	if(!R.scrambledcodes)
 		return FALSE

--- a/code/modules/modular_computers/file_system/programs/robocontrol.dm
+++ b/code/modules/modular_computers/file_system/programs/robocontrol.dm
@@ -33,9 +33,10 @@
 	botcount = 0
 	current_user = user
 
+	var/linked_overmap = computer.get_overmap() //nsv13 - shipwide tracking.
 	for(var/B in GLOB.bots_list)
 		var/mob/living/simple_animal/bot/Bot = B
-		if(!Bot.on || Bot.get_virtual_z_level() != zlevel || Bot.remote_disabled) //Only non-emagged bots on the same Z-level are detected!
+		if(!Bot.on || (!(linked_overmap && Bot.last_overmap == linked_overmap) && Bot.get_virtual_z_level() != zlevel) || Bot.remote_disabled) //NSV13 - Only non-emagged bots on the same Z-level OR SHIP are detected!
 			continue
 		else if(computer) //Also, the inserted ID must have access to the bot type
 			var/obj/item/card/id/id_card = card_slot ? card_slot.stored_card : null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
We still have a split between tracking things, where some are shipwide (e.g. AI remote control, crew monitoring), and some only access a single z (see: these).

As most things that monitor stuff for one z of a ship should be able to track things on any of them, the robotics control console, cyborg monitoring program, and robot control program, now work shipwide, provided their hosts ARE on a ship.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less ladder-hopping to figure out whether your medbots are slag yet.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
Not actively tested, but should work in theory.

## Changelog
:cl:
balance: The robotics control console, cyborg monitoring program and robot control program now work ship-wide as opposed to single-z.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
