### PR TITLE
The ruined stormdrive (from a ruin) isn't invisible anymore

### DIFF
--- a/_maps/map_files/Mining/nsv13/ruins/mining11.dmm
+++ b/_maps/map_files/Mining/nsv13/ruins/mining11.dmm
@@ -79,11 +79,7 @@
 /turf/open/floor/engine/airless,
 /area/ruin/powered)
 "t" = (
-/obj/machinery/smartfridge/drinks{
-	desc = "Abandoned for ages. Could probably be used to store your beer.";
-	icon = 'nsv13/goonstation/icons/reactor.dmi';
-	icon_state = "broken";
-	name = "Ruined stormdrive";
+/obj/machinery/smartfridge/drinks/pretender_stormdrive{
 	pixel_x = -16
 	},
 /turf/open/floor/engine/airless,

--- a/nsv13.dme
+++ b/nsv13.dme
@@ -3822,6 +3822,7 @@
 #include "nsv13\code\game\machinery\computer\tactical.dm"
 #include "nsv13\code\game\mecha\weapons.dm"
 #include "nsv13\code\game\mecha\work_tools.dm"
+#include "nsv13\code\game\objects\fluff.dm"
 #include "nsv13\code\game\objects\effects\custom_landmarks.dm"
 #include "nsv13\code\game\objects\effects\decals\alt_guideline.dm"
 #include "nsv13\code\game\objects\effects\decals\plutonium_sludge.dm"

--- a/nsv13/code/game/objects/fluff.dm
+++ b/nsv13/code/game/objects/fluff.dm
@@ -1,0 +1,23 @@
+//Fluff objects that don't really fit into any other file.
+
+/obj/machinery/smartfridge/drinks/pretender_stormdrive
+	name = "Ruined stormdrive"
+	desc = "Abandoned for ages. Could probably be used to store your beer."
+	icon = 'nsv13/goonstation/icons/reactor.dmi'
+	icon_state = "broken"
+	use_power = NO_POWER_USE
+
+/obj/machinery/smartfridge/drinks/pretender_stormdrive/update_icon()
+	return
+
+/obj/machinery/smartfridge/drinks/pretender_stormdrive/default_deconstruction_screwdriver(mob/user, icon_state_open, icon_state_closed, obj/item/I)
+	return
+
+/obj/machinery/smartfridge/drinks/pretender_stormdrive/default_unfasten_wrench(mob/user, obj/item/I, time)
+	return
+
+/obj/machinery/smartfridge/drinks/pretender_stormdrive/default_deconstruction_crowbar(obj/item/I, ignore_panel)
+	return
+
+/obj/machinery/smartfridge/drinks/pretender_stormdrive/default_pry_open(obj/item/I)
+	return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. Had some inconvenient interactions with what it is under the hood.

This fixes #1885 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
Had some very basic testing done.

## Changelog
:cl:
fix: An asteroid ruin's ruined stormdrive isn't invisible anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
