### PR TITLE
Payload gates work when unwrenched again

### DIFF
--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
@@ -382,8 +382,6 @@
 				var/obj/machinery/deck_turret/payload_gate/maybe_payload_gate = maybe_machine
 				if(maybe_payload_gate.core)
 					continue
-				if(!maybe_payload_gate.anchored)
-					continue
 				payload_gate = maybe_payload_gate
 				maybe_payload_gate.core = src
 				break


### PR DESCRIPTION
AKA Re-enables The Revolver
## About The Pull Request

Payload gates work when unsecured/unwrenched.
## Why It's Good For The Game

There are so many fun things you can make with these, easily adds more gameplay to munitions.

## Testing Photographs and Procedure


<details>
<summary>Screenshots&Videos</summary>

<img width="537" height="722" alt="image" src="https://github.com/user-attachments/assets/e4c2b819-13d6-4774-8be1-1fade1fc17c7" />

</details>

## Changelog
:cl:
tweak: Payload gates work while unwrenched again.
/:cl: