### PR TITLE
Fixes regression in deckgun construction

### DIFF
--- a/nsv13/code/game/objects/items/nsv_circuitboards.dm
+++ b/nsv13/code/game/objects/items/nsv_circuitboards.dm
@@ -226,7 +226,7 @@
 	build_path = /obj/machinery/computer/deckgun
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
 
-/obj/item/circuitboard/machine/deck_gun/
+/obj/item/circuitboard/machine/deck_gun
 	needs_anchored = FALSE
 
 /obj/item/circuitboard/machine/deck_gun/core


### PR DESCRIPTION
## About The Pull Request

Deckgun component circuit boards can be placed in unanchored machine frames again.

## Why It's Good For The Game

Any machine with an anchored and unanchored state should have ``needs_anchored = FALSE`` on its circuitboard.
This allows players to construct the machine in either state.
This got broken in PR #2726.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

<img width="425" height="407" alt="image" src="https://github.com/user-attachments/assets/106788f4-81aa-4680-8961-e80b32f26d3a" />

</details>

## Changelog
:cl:
fix: Fixed a regression in NAC component construction
/:cl: