### PR TITLE
Fixes dummy pilot handling

### DIFF
--- a/nsv13.dme
+++ b/nsv13.dme
@@ -3944,6 +3944,7 @@
 #include "nsv13\code\modules\mob\mob_helpers.dm"
 #include "nsv13\code\modules\mob\dead\new_player\sprite_accessories.dm"
 #include "nsv13\code\modules\mob\dead\observer\oberserver.dm"
+#include "nsv13\code\modules\mob\living\dummy_pilot.dm"
 #include "nsv13\code\modules\mob\living\nsv_life.dm"
 #include "nsv13\code\modules\mob\living\carbon\carbon.dm"
 #include "nsv13\code\modules\mob\living\carbon\examine_tgui.dm"

--- a/nsv13/code/modules/mob/living/dummy_pilot.dm
+++ b/nsv13/code/modules/mob/living/dummy_pilot.dm
@@ -1,0 +1,15 @@
+
+//Should never actually exist outside of a ship, this is used for ships to have a mob to fire their guns.
+/mob/living/dummy_pilot
+	name = "Dummy AI pilot"
+	mouse_opacity = FALSE
+	alpha = 0
+
+///Registers a dummy AI pilot's ship being destroyed and removes them.
+/mob/living/dummy_pilot/proc/destroy_dummy_pilot(obj/structure/overmap/piloted_overmap)
+	SIGNAL_HANDLER
+	UnregisterSignal(piloted_overmap, COMSIG_PARENT_QDELETING)
+	piloted_overmap.pilot = null
+	piloted_overmap.gunner = null
+	overmap_ship = null
+	qdel(src)

--- a/nsv13/code/modules/overmap/ai-skynet.dm
+++ b/nsv13/code/modules/overmap/ai-skynet.dm
@@ -1502,12 +1502,9 @@ Seek a ship thich we'll station ourselves around
 		return	//Timeout.
 	choose_goal()
 	if(!pilot) //AI ships need a pilot so that they aren't hit by their own bullets. Projectiles.dm's can_hit needs a mob to be the firer, so here we are.
-		pilot = new /mob/living(get_turf(src))
+		pilot = new /mob/living/dummy_pilot(src)
+		pilot.RegisterSignal(src, COMSIG_PARENT_QDELETING, TYPE_PROC_REF(/mob/living/dummy_pilot, destroy_dummy_pilot), src)
 		pilot.overmap_ship = src
-		pilot.name = "Dummy AI pilot"
-		pilot.mouse_opacity = FALSE
-		pilot.alpha = FALSE
-		pilot.forceMove(src)
 		gunner = pilot
 	if(last_target) //Have we got a target?
 		var/obj/structure/overmap/OM = last_target


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Did you know that since some point in the past, dummy pilots (AI ships use to not runtime) have been getting dropped somewhere in space instead of being put into their ships?
Did you know that they also have never been refcleaned properly when the ship got destroyed?
Now you do!
This fixes both of those. Thanks Ivan...........
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
This was tested for simple cases.

## Changelog
:cl:
fix: Dummy pilots no longer end up in space and are also properly destroyed on ship destruction.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
