### PR TITLE
Some more random fixes.

### DIFF
--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -60,7 +60,7 @@
 	if(passed_mode == RCD_FLOORWALL)
 		to_chat(user, "<span class='notice'>You build a floor.</span>")
 		var/turf/T = src.loc
-		if(isspaceturf(T))
+		if(isspaceturf(T) || istype(T, /turf/open/openspace)) //NSV13: Also accounts for openspace.
 			T.PlaceOnTop(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
 			qdel(src)
 			return TRUE

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/flak.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/flak.dm
@@ -168,9 +168,9 @@
 			OM = checking.overmap_ship
 		else
 			OM = firer
-
-		var/sound/chosen = pick('nsv13/sound/effects/ship/torpedo_detonate.ogg','nsv13/sound/effects/ship/freespace2/impacts/boom_2.wav','nsv13/sound/effects/ship/freespace2/impacts/boom_3.wav','nsv13/sound/effects/ship/freespace2/impacts/subhit.wav','nsv13/sound/effects/ship/freespace2/impacts/subhit2.wav','nsv13/sound/effects/ship/freespace2/impacts/m_hit.wav','nsv13/sound/effects/ship/freespace2/impacts/hit_1.wav')
-		OM.relay_to_nearby(chosen)
+		if(isovermap(OM) && !QDELETED(OM))
+			var/sound/chosen = pick('nsv13/sound/effects/ship/torpedo_detonate.ogg','nsv13/sound/effects/ship/freespace2/impacts/boom_2.wav','nsv13/sound/effects/ship/freespace2/impacts/boom_3.wav','nsv13/sound/effects/ship/freespace2/impacts/subhit.wav','nsv13/sound/effects/ship/freespace2/impacts/subhit2.wav','nsv13/sound/effects/ship/freespace2/impacts/m_hit.wav','nsv13/sound/effects/ship/freespace2/impacts/hit_1.wav')
+			OM.relay_to_nearby(chosen) //Okay this way of handling it is kind of cursed, but I don't feel like digging into it.
 	new shotdown_effect_type(get_turf(src)) //Exploding effect
 	qdel(src)
 	return FALSE

--- a/nsv13/code/modules/power/stormdrive.dm
+++ b/nsv13/code/modules/power/stormdrive.dm
@@ -227,7 +227,7 @@ Control Rods
 						to_chat(user, "<span class='notice'>You begin mounting the [I.name] to the reactor control coupling...</span>")
 						to_chat(user, "<span class='danger'>A blue glow envelopes your hands!</span>")
 						control_rod_installation = TRUE
-						empulse(3, 5)
+						empulse(src, 3, 5)
 						user.radiation += 250 * radiation_modifier
 						radiation_pulse(src, 1000 * radiation_modifier, 5)
 						playsound(src, 'sound/items/welder.ogg', 100, TRUE) //temp - find a better sound
@@ -239,7 +239,7 @@ Control Rods
 						control_rods += I
 						I.forceMove(src)
 						update_icon()
-						empulse(3, 5)
+						empulse(src, 3, 5)
 						user.radiation += 250 * radiation_modifier
 						radiation_pulse(src, 1000 * radiation_modifier, 5)
 						playsound(src, 'sound/items/welder.ogg', 100, TRUE) //temp - find a better sound
@@ -391,11 +391,12 @@ Control Rods
 						handle_control_rod_efficiency()
 						handle_control_rod_integrity()
 				if(REACTOR_STATE_RUNNING)
-					if(alert("[src] is not in maintenance mode! Manually inserting a control rod into an active nuclear reaction would probably be fatal.",name,"Continue","Reconsider") != "Continue" && Adjacent(usr))
+					if(alert("[src] is not in maintenance mode! Manually removing a control rod from an active nuclear reaction would probably be fatal.",name,"Continue","Reconsider") != "Continue" || !Adjacent(usr))
+						return
+					else
 						if(control_rods.len <= 0)
 							to_chat(usr, "<span class='notice'> [src] has no control rods mounted.</span>")
 							return
-					else
 						var/prot = 0
 						var/mob/living/carbon/human/H = usr
 						if(H.gloves)
@@ -409,7 +410,7 @@ Control Rods
 							var/obj/item/bodypart/affecting = H.get_bodypart("[(usr.active_hand_index % 2 == 0) ? "r" : "l" ]_arm")
 							if(affecting && affecting.receive_damage( 0, 20 )) // partially damage the hand
 								H.update_damage_overlays()
-							empulse(3, 5)
+							empulse(src, 3, 5)
 							H.radiation += (heat/2) * radiation_modifier
 							radiation_pulse(src, (heat * 2) * radiation_modifier, 5)
 							playsound(src, 'sound/items/welder.ogg', 100, TRUE) //temp - find a better sound
@@ -424,7 +425,7 @@ Control Rods
 							control_rod_installation = FALSE
 							if(affecting && affecting.receive_damage( 0, 20 )) //damage it even more
 								H.update_damage_overlays()
-							empulse(3, 5)
+							empulse(src, 3, 5)
 							H.radiation += (heat/2) * radiation_modifier
 							radiation_pulse(src, (heat * 2) * radiation_modifier, 5)
 							playsound(src, 'sound/items/welder.ogg', 100, TRUE) //temp - find a better sound


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
What it says on the tin.

Lattice used to not let you RCD floors over it when clicking it directly, if positioned over openspace;
Successful overmap projectile intercepts could runtime when trying to play their sounds relative to an overmap that wasn't there;
The stormdrive didn't trigger its unsafe-handling EMPs correctly and had a tiny amount of typoing / logic linkage issues.

This fixes those.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
The lattice RCDing has been tested; The rest has been analyzed and shouldn't be complex enough for me to need to test.

## Changelog
:cl:
fix: RCDing over Lattices that are over openspace no longer misbehaves.
fix: Overmap projectiles shouldn't cause runtimes in regards to their sounds for being intercepted anymore.
fix: The EMPs caused by an unsafely approached Stormdrive are no longer broken.
spellcheck: Fixed some typos in the text for unsafe SD rod removal.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
