### PR TITLE
Fixes most of the munition's computers missing names and descriptions

### DIFF
--- a/nsv13/code/game/machinery/computer/munitions.dm
+++ b/nsv13/code/game/machinery/computer/munitions.dm
@@ -1,6 +1,6 @@
 //Standard munitions console
 /obj/machinery/computer/ship/munitions_computer
-	name = "munitions control computer
+	name = "munitions control computer"
 	desc = "This console allows you to control and monitor a linked ship weapon."
 	icon = 'nsv13/icons/obj/munitions.dmi'
 	icon_state = "munitions_console"

--- a/nsv13/code/game/machinery/computer/munitions.dm
+++ b/nsv13/code/game/machinery/computer/munitions.dm
@@ -1,6 +1,7 @@
 //Standard munitions console
 /obj/machinery/computer/ship/munitions_computer
 	name = "munitions control computer"
+	desc = "This console allows you to control and monitor a linked ship weapon. From here, you can perform actions such as loading and unloading the weapon, chambering rounds, and toggling the safety. You can also link and unlink the console from a weapon using a multitool. Make sure to keep an eye on the ammo count and maintenance requirements of your weapon to ensure it operates effectively in combat."
 	icon = 'nsv13/icons/obj/munitions.dmi'
 	icon_state = "munitions_console"
 	density = TRUE

--- a/nsv13/code/game/machinery/computer/munitions.dm
+++ b/nsv13/code/game/machinery/computer/munitions.dm
@@ -1,7 +1,7 @@
 //Standard munitions console
 /obj/machinery/computer/ship/munitions_computer
-	name = "munitions control computer"
-	desc = "This console allows you to control and monitor a linked ship weapon. From here, you can perform actions such as loading and unloading the weapon, chambering rounds, and toggling the safety. You can also link and unlink the console from a weapon using a multitool. Make sure to keep an eye on the ammo count and maintenance requirements of your weapon to ensure it operates effectively in combat."
+	name = "munitions control computer
+	desc = "This console allows you to control and monitor a linked ship weapon."
 	icon = 'nsv13/icons/obj/munitions.dmi'
 	icon_state = "munitions_console"
 	density = TRUE

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
@@ -145,7 +145,7 @@
 
 /obj/machinery/computer/deckgun
 	name = "Deck Gun Control Console"
-	desc = "A control console for a deck gun. From here, you can monitor the status of the gun and its components, as well as perform actions such as loading shells and powder, and firing the gun."
+	desc = "A control console for a deck gun."
 	icon = 'nsv13/icons/obj/munitions/deck_gun.dmi'
 	icon_state = "gun_control"
 	icon_screen = "screen_guncontrol"

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
@@ -144,6 +144,8 @@
 	return FALSE
 
 /obj/machinery/computer/deckgun
+	name = "Deck Gun Control Console"
+	desc = "A control console for a deck gun. From here, you can monitor the status of the gun and its components, as well as perform actions such as loading shells and powder, and firing the gun. Ensure that the gun is properly loaded and maintained before attempting to fire, as misfires can be dangerous."
 	icon = 'nsv13/icons/obj/munitions/deck_gun.dmi'
 	icon_state = "gun_control"
 	icon_screen = "screen_guncontrol"

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/deck_guns.dm
@@ -145,7 +145,7 @@
 
 /obj/machinery/computer/deckgun
 	name = "Deck Gun Control Console"
-	desc = "A control console for a deck gun. From here, you can monitor the status of the gun and its components, as well as perform actions such as loading shells and powder, and firing the gun. Ensure that the gun is properly loaded and maintained before attempting to fire, as misfires can be dangerous."
+	desc = "A control console for a deck gun. From here, you can monitor the status of the gun and its components, as well as perform actions such as loading shells and powder, and firing the gun."
 	icon = 'nsv13/icons/obj/munitions/deck_gun.dmi'
 	icon_state = "gun_control"
 	icon_screen = "screen_guncontrol"

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/ammo_rack.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/ammo_rack.dm
@@ -118,7 +118,7 @@
 // The ammo rack itself
 /obj/machinery/ammo_sorter
 	name = "Ammo Rack"
-	desc = "A machine that allows you to compartmentalise your ship's ammo stores, controlled by a central console. Drag and drop items onto it to load them."
+	desc = "A machine that allows you to compartmentalise your ship's ammo stores, controlled by a central console."
 	icon = 'nsv13/icons/obj/munitions.dmi'
 	icon_state = "ammorack"
 	circuit = /obj/item/circuitboard/machine/ammo_sorter

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/ammo_rack.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/ammo_rack.dm
@@ -118,7 +118,7 @@
 // The ammo rack itself
 /obj/machinery/ammo_sorter
 	name = "Ammo Rack"
-	desc = "A machine that allows you to compartmentalise your ship's ammo stores, controlled by a central console."
+	desc = "A machine that allows you to compartmentalise the ship's ammo stores, controlled by a central console."
 	icon = 'nsv13/icons/obj/munitions.dmi'
 	icon_state = "ammorack"
 	circuit = /obj/item/circuitboard/machine/ammo_sorter

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/ammo_rack.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/ammo_rack.dm
@@ -7,6 +7,7 @@
 // Ammo rack control console
 /obj/machinery/computer/ammo_sorter
 	name = "ammo rack control console"
+	desc = "This console allows you to manage and control linked ammo racks. From here, you can monitor the status of each rack, unload them remotely, and rearrange their order. Make sure to keep an eye on the durability of your racks and perform maintenance as needed to prevent jams."
 	icon_screen = "ammorack"
 	circuit = /obj/item/circuitboard/computer/ammo_sorter
 	var/id = null

--- a/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/ammo_rack.dm
+++ b/nsv13/code/modules/munitions/ship_weapons/ballistic_weapons/revision2/ammo_rack.dm
@@ -7,7 +7,7 @@
 // Ammo rack control console
 /obj/machinery/computer/ammo_sorter
 	name = "ammo rack control console"
-	desc = "This console allows you to manage and control linked ammo racks. From here, you can monitor the status of each rack, unload them remotely, and rearrange their order. Make sure to keep an eye on the durability of your racks and perform maintenance as needed to prevent jams."
+	desc = "This console allows you to manage and control linked ammo racks. From here, you can monitor the status of each rack, unload them remotely, and rearrange their order."
 	icon_screen = "ammorack"
 	circuit = /obj/item/circuitboard/computer/ammo_sorter
 	var/id = null

--- a/nsv13/code/modules/overmap/weapons/delta_overmap_ship_weapons/autonomy.dm
+++ b/nsv13/code/modules/overmap/weapons/delta_overmap_ship_weapons/autonomy.dm
@@ -136,6 +136,7 @@
 /obj/machinery/computer/ams
 	name = "AMS control console"
 	icon_screen = "ams"
+	desc = "The Anti-Missile System (AMS) is a computer system that can automatically target and fire upon threats to the ship, such as incoming missiles or enemy ships. It can be configured to use different modes, which determine how it selects targets and when it fires. The AMS is an essential part of the ship's defenses, especially against missile attacks."
 	circuit = /obj/item/circuitboard/computer/ams
 
 /obj/machinery/computer/ams/Destroy()

--- a/nsv13/code/modules/overmap/weapons/delta_overmap_ship_weapons/autonomy.dm
+++ b/nsv13/code/modules/overmap/weapons/delta_overmap_ship_weapons/autonomy.dm
@@ -124,7 +124,7 @@
 
 /datum/ams_mode/countermeasures
 	name = "Anti-missile countermeasures"
-	desc = "This mode will target oncoming missiles and attempt to counter them with the ship's own missile complement. Recommended for usage exclusively with ECM missiles."
+	desc = "This mode will target oncoming missiles and attempt to counter them with the ship's own missile complement."
 	max_range = 10
 
 //Only aims at locked targets because the previous code was horrendously processing intensive. Anything dangerous will have you locked anyways.
@@ -136,7 +136,7 @@
 /obj/machinery/computer/ams
 	name = "AMS control console"
 	icon_screen = "ams"
-	desc = "The Anti-Missile System (AMS) is a computer system that can automatically target and fire upon threats to the ship, such as incoming missiles or enemy ships. It can be configured to use different modes, which determine how it selects targets and when it fires. The AMS is an essential part of the ship's defenses, especially against missile attacks."
+	desc = "The Anti-Missile System (AMS) is a computer system that can automatically target and fire upon threats to the ship, such as incoming missiles or enemy ships. "
 	circuit = /obj/item/circuitboard/computer/ams
 
 /obj/machinery/computer/ams/Destroy()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Missing names and descriptions are bad and fixes #2841 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No more getting confused on what machine does what
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: Fixed the names and descriptions of AMS, ammo rack, and deck gun and munitions control computer consoles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
